### PR TITLE
feat: make max_output_tokens optional to use provider defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2673,7 +2673,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoetz"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "yoetz-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/yoetz-core", "crates/yoetz-cli"]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/crates/yoetz-cli/src/commands/ask.rs
+++ b/crates/yoetz-cli/src/commands/ask.rs
@@ -94,7 +94,7 @@ pub(crate) async fn handle_ask(
         .as_ref()
         .map(|b| b.stats.estimated_tokens)
         .unwrap_or_else(|| estimate_tokens(prompt.len()));
-    let output_tokens = max_output_tokens;
+    let output_tokens = max_output_tokens.unwrap_or(4096);
     let mut pricing = if let Some(model_id) = registry_model_id.as_deref() {
         registry::estimate_pricing(
             registry_cache.as_ref(),
@@ -255,9 +255,12 @@ pub(crate) async fn handle_ask(
                 .and_then(|e| e.max_output_tokens)
                 .map(|m| format!(" (model supports up to {m})"))
                 .unwrap_or_default();
+            let current_display = max_output_tokens
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "default".to_string());
             eprintln!(
                 "warning: gemini returned empty content but used {thoughts} thought tokens; \
-                 try increasing --max-output-tokens (current: {max_output_tokens}){model_max_hint}"
+                 try increasing --max-output-tokens (current: {current_display}){model_max_hint}"
             );
         }
     }

--- a/crates/yoetz-cli/src/commands/review.rs
+++ b/crates/yoetz-cli/src/commands/review.rs
@@ -64,11 +64,12 @@ async fn handle_review_diff(
 
     let review_prompt = build_review_diff_prompt(&diff, args.prompt.as_deref());
     let input_tokens = estimate_tokens(review_prompt.len());
+    let output_tokens = max_output_tokens.unwrap_or(4096);
     let pricing = registry::estimate_pricing(
         registry_cache.as_ref(),
         registry_id.as_deref().unwrap_or(&model),
         input_tokens,
-        max_output_tokens,
+        output_tokens,
     )?;
 
     let budget_enabled = args.max_cost_usd.is_some() || args.daily_budget_usd.is_some();
@@ -213,11 +214,12 @@ async fn handle_review_file(
         args.prompt.as_deref(),
     );
     let input_tokens = estimate_tokens(review_prompt.len());
+    let output_tokens = max_output_tokens.unwrap_or(4096);
     let pricing = registry::estimate_pricing(
         registry_cache.as_ref(),
         registry_id.as_deref().unwrap_or(&model),
         input_tokens,
-        max_output_tokens,
+        output_tokens,
     )?;
 
     let budget_enabled = args.max_cost_usd.is_some() || args.daily_budget_usd.is_some();

--- a/crates/yoetz-cli/src/providers/openai.rs
+++ b/crates/yoetz-cli/src/providers/openai.rs
@@ -33,7 +33,7 @@ pub async fn call_responses_vision(
     images: &[MediaInput],
     response_format: Option<Value>,
     temperature: f32,
-    max_output_tokens: usize,
+    max_output_tokens: Option<usize>,
 ) -> Result<OpenAITextResult> {
     if model.contains("gpt-image") {
         return Err(anyhow!(
@@ -56,8 +56,10 @@ pub async fn call_responses_vision(
         "model": model,
         "input": [{ "role": "user", "content": content }],
         "temperature": temperature,
-        "max_output_tokens": max_output_tokens,
     });
+    if let Some(max) = max_output_tokens {
+        body["max_output_tokens"] = serde_json::json!(max);
+    }
     if let Some(format) = response_format {
         body["response_format"] = format;
     }


### PR DESCRIPTION
## Summary
- `resolve_max_output_tokens` now returns `Option<usize>` — `None` means "use provider default"
- API calls omit `max_output_tokens`/`maxOutputTokens` when unset, letting models use their full output budget (critical for reasoning models like Gemini 3 Pro that consume thinking tokens)
- Council command resolves per-model and takes the maximum across mixed models
- Pricing estimation uses `unwrap_or(4096)` for cost display only, not for the API call
- Removes hardcoded `DEFAULT_MAX_OUTPUT_TOKENS = 1024`

## Test plan
- [x] All 37 tests pass (20 unit + 11 CLI + 6 core)
- [x] Zero clippy warnings
- [x] `cargo fmt --check` clean
- [x] Verified all 7 call sites, 4 function signatures, and 4 test assertions are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)