### PR TITLE
chore(release): v0.2.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,13 +118,15 @@ jobs:
         uses: taiki-e/install-action@git-cliff
       - name: Verify tagged releases in CHANGELOG
         run: |
-          git-cliff --output CHANGELOG.check.md
+          # Use workspace version as pending tag so release PRs match
+          VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          git-cliff --tag "v${VERSION}" --output CHANGELOG.check.md
           # Compare only tagged release sections — the [Unreleased] section
           # naturally drifts on PR branches (includes the PR's own commits).
           ACTUAL=$(sed -n '/^## \[[0-9]/,$p' CHANGELOG.md)
           EXPECTED=$(sed -n '/^## \[[0-9]/,$p' CHANGELOG.check.md)
           if [ "$ACTUAL" != "$EXPECTED" ]; then
-            echo "::error::CHANGELOG.md tagged releases are stale. Run 'git-cliff -o CHANGELOG.md' and commit."
+            echo "::error::CHANGELOG.md tagged releases are stale. Run 'git-cliff --tag vX.Y.Z -o CHANGELOG.md' and commit."
             diff <(echo "$ACTUAL") <(echo "$EXPECTED") || true
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.2.3] - 2026-02-12
 
 ### Bug Fixes
 
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **deps**: Bump rand from 0.8.5 to 0.9.2
 - **deps**: Bump jsonschema from 0.17.1 to 0.41.0
 - Allow MIT-0 license (borrow-or-share dependency of jsonschema 0.41)
-- OSS polish — GitHub topics, changelog, README, CI enforcement
+- OSS polish — topics, changelog, README, CI (#10)
 
 ## [0.2.2] - 2026-02-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,7 +2731,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoetz"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "yoetz-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/yoetz-core", "crates/yoetz-cli"]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Dependency updates: jsonschema 0.41, rand 0.9, thiserror 2.0, toml 0.9
- OSS polish: GitHub topics, changelog CI enforcement, README improvements, docs.rs metadata
- MSRV fix: revert to 1.88 after Dependabot misidentified Rust version

## Release checklist

- [x] `cargo test && cargo clippy && cargo fmt --check` — clean
- [x] Version bumped to 0.2.3
- [x] `Cargo.lock` regenerated
- [x] `CHANGELOG.md` regenerated with `git-cliff --tag v0.2.3`
- [ ] Merge PR → tag `v0.2.3` → push tag → release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)