### PR TITLE
chore(release): v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.2.3] - 2026-02-14
+## [0.2.4] - 2026-02-14
 
 ### Bug Fixes
 
-- Em-dash parsing (#13, #14) and model discovery (#12)
-- Wire auto-prefix through provider resolution (Codex review)
+- Em-dash parsing and model discovery (#12, #13, #14) (#15)
 
-### Miscellaneous
-
-- Regenerate CHANGELOG.md for CI
-
-## [0.2.3] - 2026-02-14
+## [0.2.3] - 2026-02-12
 
 ### Bug Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,7 +2731,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoetz"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "yoetz-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/yoetz-core", "crates/yoetz-cli"]
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to 0.2.4
- Regenerate CHANGELOG.md

### Changes in v0.2.4
- fix: em-dash parsing in prompt args (#13, #14) — `allow_hyphen_values = true`
- fix: model discovery auto-prefix (#12) — `yoetz models list --search`, auto-resolve `openrouter/` from registry
- fix: wire auto-prefix through provider resolution (Codex review)

Closes #12, closes #13, closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)