### PR TITLE
chore(release): v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.2.4] - 2026-02-19
+## [0.2.5] - 2026-02-19
 
 ### Features
 
-- Fuzzy model resolution and discovery CLI
+- Fuzzy model resolution and discovery CLI (#23)
 
-## [0.2.4] - 2026-02-19
+## [0.2.4] - 2026-02-14
 
 ### Bug Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,7 +2731,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoetz"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "yoetz-core"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/yoetz-core", "crates/yoetz-cli"]
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version to 0.2.5
- Regenerate Cargo.lock and CHANGELOG.md

### What's in v0.2.5

- **Fuzzy model resolution and discovery CLI** (#23) — `yoetz models resolve`, fuzzy `models list -s`, call-time model validation with "Did you mean?" suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)