### PR TITLE
ci: decouple MSRV action ref from Rust version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@1.88
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.88.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace
 


### PR DESCRIPTION
## Summary
- Uses `dtolnay/rust-toolchain@master` with explicit `toolchain: 1.88.0` instead of `@1.88` ref
- Prevents Dependabot from accidentally bumping the MSRV when updating the action version
- Closes the root cause behind #31

## Context
Dependabot treated the `@1.88` ref as an action version and bumped it to `@1.100`, which changed the MSRV test from Rust 1.88 to 1.100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)