### PR TITLE
chore(release): prepare v0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.2.8] - 2026-03-12
+
+### Miscellaneous
+
+- **deps**: Bump the minor-and-patch group across 1 directory with 3 updates (#37)
+- **deps**: Bump litellm-rust from `178e728` to `241c57b` (#36)
+- **deps**: Bump the actions group with 2 updates (#34)
+
 ## [0.2.7] - 2026-03-12
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2788,7 +2788,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoetz"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "yoetz-core"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/yoetz-core", "crates/yoetz-cli"]
 
 [workspace.package]
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump workspace version 0.2.7 → 0.2.8
- Regenerate CHANGELOG.md to include post-v0.2.7 dependabot updates (#34, #36, #37)
- Fixes CI changelog check failures on main (3 consecutive failures since dependabot merges)

## Test plan
- [ ] CI changelog job passes (the only failing job)
- [ ] All other CI jobs remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)