### PR TITLE
ci: scope changelog validation to release prep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,9 +116,45 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Detect release metadata changes
+        id: release_meta
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "should_validate=true" >> "$GITHUB_OUTPUT"
+            echo "diff_range=manual" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            RANGE="origin/${BASE_REF}...HEAD"
+          elif [ -n "${BEFORE_SHA:-}" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+            RANGE="${BEFORE_SHA}...${HEAD_SHA}"
+          else
+            RANGE="$(git rev-list --max-parents=0 HEAD | tail -1)...HEAD"
+          fi
+
+          echo "diff_range=$RANGE" >> "$GITHUB_OUTPUT"
+          CHANGED="$(git diff --name-only "$RANGE" -- Cargo.toml Cargo.lock CHANGELOG.md cliff.toml .github/workflows/release.yml)"
+          if [ -n "$CHANGED" ]; then
+            echo "should_validate=true" >> "$GITHUB_OUTPUT"
+            printf 'Release metadata changed in %s:\n%s\n' "$RANGE" "$CHANGED"
+          else
+            echo "should_validate=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install git-cliff
+        if: steps.release_meta.outputs.should_validate == 'true'
         uses: taiki-e/install-action@git-cliff
       - name: Verify tagged releases in CHANGELOG
+        if: steps.release_meta.outputs.should_validate == 'true'
         run: |
           # Use workspace version as pending tag so release PRs match
           VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
@@ -132,6 +168,9 @@ jobs:
             diff <(echo "$ACTUAL") <(echo "$EXPECTED") || true
             exit 1
           fi
+      - name: Skip changelog validation
+        if: steps.release_meta.outputs.should_validate != 'true'
+        run: echo "No release metadata changes detected; skipping changelog validation."
 
   build:
     name: Build (${{ matrix.os }})

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,19 @@ yoetz/
 6. Push to your fork
 7. Open a Pull Request
 
+## Release Process
+
+- Keep feature PRs feature-only. Do not edit `Cargo.toml`, `Cargo.lock`, or `CHANGELOG.md`
+  in ordinary feature branches.
+- Prepare releases in a dedicated `release/vX.Y.Z` branch or PR from `main`.
+- In the release PR:
+  - bump the workspace version in `Cargo.toml`
+  - update `Cargo.lock`
+  - regenerate `CHANGELOG.md` with `git-cliff --tag vX.Y.Z -o CHANGELOG.md`
+- Merge the release PR, then tag that merge commit as `vX.Y.Z` to trigger the release workflow.
+- CI only validates the changelog when release metadata changes, so feature PRs are not
+  blocked on release prep.
+
 ## Commit Messages
 
 Use clear, descriptive commit messages:


### PR DESCRIPTION
## Summary
- scope changelog validation to release-prep changes only
- skip the git-cliff check on ordinary feature PRs
- document the intended release PR flow in CONTRIBUTING.md

## Why
The current changelog CI runs on every PR and treats every feature branch as a pending release. That makes feature PRs fail when the workspace version already has a tag, and squash merges can invalidate a pre-merge changelog line anyway. This change keeps the existing tag-driven release workflow, but only validates CHANGELOG.md when release metadata changes.

## What changed
- `.github/workflows/ci.yml`: detect changes to `Cargo.toml`, `Cargo.lock`, `CHANGELOG.md`, `cliff.toml`, or `.github/workflows/release.yml`
- run `git-cliff` validation only when those files changed, otherwise skip cleanly
- `CONTRIBUTING.md`: document feature PR vs release PR expectations

## Validation
- `git diff --check`
- local smoke test of the gating logic from a clean worktree off `origin/main` showed `should_validate=false` for a non-release branch
