### PR TITLE
chore(release): fix CHANGELOG.md for v0.2.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,9 +162,9 @@ jobs:
           fi
 
           echo "diff_range=$RANGE" >> "$GITHUB_OUTPUT"
-          # Only trigger changelog validation when version-related files change.
-          # Exclude CHANGELOG.md itself to avoid circular validation loops.
-          CHANGED="$(git diff --name-only "$RANGE" -- Cargo.toml Cargo.lock cliff.toml .github/workflows/release.yml)"
+          # Only trigger changelog validation when version/changelog config changes.
+          # Exclude CHANGELOG.md (circular) and release.yml (triggers on non-release PRs).
+          CHANGED="$(git diff --name-only "$RANGE" -- Cargo.toml Cargo.lock cliff.toml)"
           if [ -n "$CHANGED" ]; then
             echo "should_validate=true" >> "$GITHUB_OUTPUT"
             printf 'Release metadata changed in %s:\n%s\n' "$RANGE" "$CHANGED"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.2.10] - 2026-03-14
 
-### Bug Fixes
-
-- Global cookie fallback uses deep import for ESM-only package, CI asserts exports
-
 ### Features
 
-- Bundle browser cookie extractor, improve auth polling, and package scripts in releases
+- Bundle browser cookie extractor and improve auth polling (#42)
 
 ## [0.2.9] - 2026-03-14
 


### PR DESCRIPTION
Fix squash-merge changelog mismatch and narrow changelog trigger to exclude release.yml.