### PR TITLE
fix(recipe): add model selection, preserve Extended Pro, use send button

### DIFF
--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -2,11 +2,15 @@ name: chatgpt
 # Auth: resolved automatically (CDP > auto_connect > cookie > profile).
 # Falls back to cookie sync if no live browser session is available.
 #
-# ChatGPT's home page restores the last-used model. This recipe avoids forced
-# reselection and assumes the desired model is already active in ChatGPT.
+# Variables:
+#   model    — ChatGPT display name to select (e.g., "Pro 5.4"). Omit to keep current.
+#   extended — set to "false" to disable Extended Pro. Default: leave as-is.
+#   prompt   — prompt text to send with the attachment.
 
 defaults:
   prompt: Review the attached file and provide your analysis.
+  model: ""
+  extended: ""
 
 steps:
   # Open ChatGPT
@@ -16,11 +20,51 @@ steps:
     args: ["--load", "domcontentloaded"]
   - sleep_ms: 2000
 
-  # Disable extended thinking for faster responses
-  # Only click if extended thinking is currently enabled (aria-label contains
-  # "click to remove"). ChatGPT's current UI labels this as "Extended Pro".
+  # Select model if --var model is provided (e.g., --var model="Pro 5.4")
   - action: eval
-    args: ["document.querySelector('button[aria-label*=\"click to remove\"][aria-label*=\"Extended\"]')?.click()"]
+    args:
+      - |
+        (() => {
+          const model = "{{model}}";
+          if (!model) return "skipped: no model specified";
+          const btn = document.querySelector('button[aria-label*="Model selector"]');
+          if (!btn) throw new Error("model selector button not found");
+          btn.click();
+          return "opened model selector";
+        })()
+  - sleep_ms: 800
+  - action: eval
+    args:
+      - |
+        (() => {
+          const model = "{{model}}";
+          if (!model) return "skipped: no model specified";
+          const items = Array.from(document.querySelectorAll(
+            '[role="menuitem"], [role="option"], [data-testid*="model"]'
+          ));
+          const match = items.find(el =>
+            (el.textContent || "").trim().includes(model)
+          );
+          if (!match) throw new Error("model '" + model + "' not found in selector");
+          match.click();
+          return "selected model: " + model;
+        })()
+  - sleep_ms: 500
+
+  # Disable Extended Pro only when explicitly requested (--var extended=false).
+  # Default: leave Extended Pro as-is.
+  - action: eval
+    args:
+      - |
+        (() => {
+          const extended = "{{extended}}";
+          if (extended !== "false") return "skipped: extended not disabled";
+          const btn = document.querySelector(
+            'button[aria-label*="click to remove"][aria-label*="Extended"]'
+          );
+          if (btn) { btn.click(); return "disabled Extended Pro"; }
+          return "Extended Pro already off";
+        })()
   - sleep_ms: 500
 
   # Prime the visible attachment flow before targeting the underlying file input.
@@ -68,10 +112,10 @@ steps:
     args: ["#prompt-textarea", "{{prompt}}"]
   - sleep_ms: 500
 
-  # Send the message. The Send button locator becomes brittle after upload +
-  # typing, but Enter reliably submits the prompt in ChatGPT.
-  - action: press
-    args: ["Enter"]
+  # Send the message. Click the send button instead of pressing Enter, which
+  # can be interpreted as a newline when a file is attached.
+  - action: click
+    args: ['button[aria-label="Send prompt"]']
 
   # Wait for ChatGPT to finish generating (2 minutes for large bundles)
   - sleep_ms: 120000

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -3,7 +3,7 @@ name: chatgpt
 # Falls back to cookie sync if no live browser session is available.
 #
 # Variables:
-#   model    — ChatGPT display name to select (e.g., "Pro 5.4"). Omit to keep current.
+#   model    — model slug or display name (e.g., "gpt-5-4-pro" or "Pro 5.4"). Omit to keep current.
 #   extended — set to "false" to disable Extended Pro. Default: leave as-is.
 #   prompt   — prompt text to send with the attachment.
 
@@ -20,13 +20,14 @@ steps:
     args: ["--load", "domcontentloaded"]
   - sleep_ms: 2000
 
-  # Select model if --var model is provided (e.g., --var model="Pro 5.4")
+  # Select model if --var model is provided. Accepts slug (gpt-5-4-pro) or
+  # display name ("Pro 5.4"). Known slugs are normalized to display names.
   - action: eval
     args:
       - |
         (() => {
-          const model = "{{model}}";
-          if (!model) return "skipped: no model specified";
+          const raw = "{{model}}";
+          if (!raw) return "skipped: no model specified";
           const btn = document.querySelector('button[aria-label*="Model selector"]');
           if (!btn) throw new Error("model selector button not found");
           btn.click();
@@ -37,17 +38,25 @@ steps:
     args:
       - |
         (() => {
-          const model = "{{model}}";
-          if (!model) return "skipped: no model specified";
+          const raw = "{{model}}";
+          if (!raw) return "skipped: no model specified";
+          const slugs = {
+            "gpt-5-4-pro": "Pro 5.4",
+            "gpt-4o": "4o",
+            "o3": "o3",
+            "o4-mini": "o4-mini",
+            "o4-mini-high": "o4-mini-high",
+          };
+          const display = slugs[raw.toLowerCase()] || raw;
           const items = Array.from(document.querySelectorAll(
             '[role="menuitem"], [role="option"], [data-testid*="model"]'
           ));
           const match = items.find(el =>
-            (el.textContent || "").trim().includes(model)
+            (el.textContent || "").trim().includes(display)
           );
-          if (!match) throw new Error("model '" + model + "' not found in selector");
+          if (!match) throw new Error("model '" + display + "' not found in selector");
           match.click();
-          return "selected model: " + model;
+          return "selected model: " + display;
         })()
   - sleep_ms: 500
 


### PR DESCRIPTION
## Summary
- Add `--var model` support to select ChatGPT model by slug (`gpt-5-4-pro`) or display name (`"Pro 5.4"`) with slug-to-display-name normalization
- Invert Extended Pro behavior: leave as-is by default, only disable when `--var extended=false` is explicitly passed
- Replace `press Enter` with `click button[aria-label="Send prompt"]` for reliable submission when files are attached

Closes #54

## Test plan
- [ ] `cargo test` passes (no Rust changes, recipe-only)
- [ ] `yoetz browser recipe --recipe chatgpt --bundle test.md --var model=gpt-5-4-pro` selects Pro 5.4
- [ ] `yoetz browser recipe --recipe chatgpt --bundle test.md --var model="Pro 5.4"` selects Pro 5.4
- [ ] `yoetz browser recipe --recipe chatgpt --bundle test.md` skips model selection (keeps current)
- [ ] Extended Pro left enabled by default
- [ ] `--var extended=false` disables Extended Pro
- [ ] Send button reliably submits with file attachment

## Review
Reviewed by Codex via AMQ — approved with no further findings after slug compatibility fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)