### PR TITLE
chore(release): v0.2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.2.16] - 2026-03-17
+
+### Bug Fixes
+
+- **recipe**: Add model selection, preserve Extended Pro, use send button (#55)
+
 ## [0.2.15] - 2026-03-16
 
 ### Bug Fixes
 
 - **ci**: Regenerate CHANGELOG.md for v0.2.14
+- Harden browser automation, security, and release engineering (v0.2.15) (#53)
 
 ## [0.2.14] - 2026-03-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2788,7 +2788,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoetz"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "yoetz-core"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/yoetz-core", "crates/yoetz-cli"]
 
 [workspace.package]
-version = "0.2.15"
+version = "0.2.16"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to 0.2.16
- Regenerate CHANGELOG.md with git-cliff

Release includes fix from #55: chatgpt recipe model selection, Extended Pro preservation, send button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)