### PR TITLE
fix(security): harden trust boundaries, budget accounting, and browser recipe

### DIFF
--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -94,15 +94,16 @@ impl BrowserConnection {
 }
 
 /// Cached agent-browser resolution. Probed once per process, reused for all calls.
-static AGENT_BROWSER: OnceLock<(String, Vec<String>)> = OnceLock::new();
+static AGENT_BROWSER: OnceLock<Result<(String, Vec<String>), String>> = OnceLock::new();
 
 /// Returns (program, extra_prefix_args) for launching agent-browser.
-/// Checks YOETZ_AGENT_BROWSER_BIN env, then PATH, then falls back to npx.
+/// Checks YOETZ_AGENT_BROWSER_BIN env, then PATH, then falls back to npx
+/// (only if `YOETZ_ALLOW_NPX_FALLBACK=1` is set).
 /// Result is cached for the lifetime of the process.
-fn resolve_agent_browser() -> (String, Vec<String>) {
+fn resolve_agent_browser() -> Result<(String, Vec<String>)> {
     let cached = AGENT_BROWSER.get_or_init(|| {
         if let Ok(bin) = env::var("YOETZ_AGENT_BROWSER_BIN") {
-            return (bin, vec![]);
+            return Ok((bin, vec![]));
         }
         // Check if agent-browser is in PATH
         if Command::new("agent-browser")
@@ -112,15 +113,26 @@ fn resolve_agent_browser() -> (String, Vec<String>) {
             .status()
             .is_ok_and(|s| s.success())
         {
-            return ("agent-browser".to_string(), vec![]);
+            return Ok(("agent-browser".to_string(), vec![]));
         }
-        // Fall back to npx (handles npm cache / npx-installed packages)
-        (
-            "npx".to_string(),
-            vec!["--yes".to_string(), "agent-browser".to_string()],
-        )
+        // Fall back to npx only if explicitly allowed — downloading and executing
+        // arbitrary npm code at runtime is a security risk.
+        if env::var("YOETZ_ALLOW_NPX_FALLBACK").as_deref() == Ok("1") {
+            eprintln!("warning: agent-browser not found in PATH; falling back to `npx --yes agent-browser`. Set YOETZ_AGENT_BROWSER_BIN or install agent-browser globally to avoid this.");
+            return Ok((
+                "npx".to_string(),
+                vec!["--yes".to_string(), "agent-browser".to_string()],
+            ));
+        }
+        Err("agent-browser not found in PATH and npx fallback is disabled.\n\
+             Install it globally:  npm install -g agent-browser\n\
+             Or allow npx fallback: export YOETZ_ALLOW_NPX_FALLBACK=1"
+            .to_string())
     });
-    cached.clone()
+    match cached {
+        Ok(v) => Ok(v.clone()),
+        Err(msg) => Err(anyhow!("{msg}")),
+    }
 }
 
 pub fn run_agent_browser(
@@ -248,7 +260,7 @@ fn run_agent_browser_with_connection(
     use_stealth: bool,
     headed: bool,
 ) -> Result<String> {
-    let (bin, prefix_args) = resolve_agent_browser();
+    let (bin, prefix_args) = resolve_agent_browser()?;
     let mut cmd = Command::new(&bin);
     let final_args = build_agent_browser_args(args, format, connection, use_stealth, headed);
     let mut all_args = prefix_args;
@@ -485,6 +497,12 @@ fn expand_tilde(path: &Path) -> Result<PathBuf> {
 
 pub fn login(profile_dir: &Path) -> Result<()> {
     fs::create_dir_all(profile_dir).with_context(|| format!("create {}", profile_dir.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(profile_dir, fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("chmod 700 {}", profile_dir.display()))?;
+    }
     clear_state_file(profile_dir)?;
     // Close any existing daemon to ensure fresh options
     let _ = close_browser();
@@ -507,7 +525,7 @@ pub fn close_browser() -> Result<()> {
 
 pub fn close_browser_for_connection(connection: &BrowserConnection) -> Result<()> {
     if connection.is_live_attach() {
-        let (bin, prefix_args) = resolve_agent_browser();
+        let (bin, prefix_args) = resolve_agent_browser()?;
         let mut cmd = Command::new(bin);
         cmd.args(prefix_args);
         match cmd.args(["--session", CDP_SESSION_NAME, "close"]).output() {
@@ -524,7 +542,7 @@ pub fn close_browser_for_connection(connection: &BrowserConnection) -> Result<()
 }
 
 fn close_browser_daemon() -> Result<()> {
-    let (bin, prefix_args) = resolve_agent_browser();
+    let (bin, prefix_args) = resolve_agent_browser()?;
     let mut cmd = Command::new(bin);
     cmd.args(prefix_args);
     let _ = cmd.arg("close").output();
@@ -552,6 +570,12 @@ pub fn clear_state_file(profile_dir: &Path) -> Result<()> {
 /// in Playwright storageState format for agent-browser to use.
 pub fn sync_cookies(profile_dir: &Path) -> Result<(usize, Vec<String>)> {
     fs::create_dir_all(profile_dir).with_context(|| format!("create {}", profile_dir.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(profile_dir, fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("chmod 700 {}", profile_dir.display()))?;
+    }
     ensure_supported_node_for_cookie_sync()?;
 
     let state_file = state_file(profile_dir);
@@ -597,6 +621,16 @@ pub fn sync_cookies(profile_dir: &Path) -> Result<(usize, Vec<String>)> {
     if let Err(err) = validate_cookie_sync_result(cookie_count, &warnings) {
         let _ = fs::remove_file(&state_file);
         return Err(err);
+    }
+
+    // Restrict state file permissions — it contains session cookies.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if state_file.exists() {
+            fs::set_permissions(&state_file, fs::Permissions::from_mode(0o600))
+                .with_context(|| format!("chmod 600 {}", state_file.display()))?;
+        }
     }
 
     Ok((cookie_count, warnings))
@@ -1219,21 +1253,46 @@ fn chunk_text(text: &str, max_bytes: usize) -> Vec<String> {
 }
 
 fn interpolate(value: &str, ctx: &RecipeContext, bundle_text: Option<&str>) -> Result<String> {
+    if value.contains("{{bundle_path}}") && ctx.bundle_path.is_none() {
+        return Err(anyhow!("bundle path requested but no bundle provided"));
+    }
+    if value.contains("{{bundle_text}}") && bundle_text.is_none() {
+        return Err(anyhow!("bundle text requested but no bundle provided"));
+    }
+
+    // Check for unresolved placeholders in the ORIGINAL template (before substitution)
+    // so that {{...}} patterns inside bundle_text don't trigger false errors.
+    let mut known_vars: std::collections::HashSet<&str> =
+        ctx.vars.keys().map(|s| s.as_str()).collect();
+    known_vars.insert("bundle_path");
+    known_vars.insert("bundle_text");
+    let mut scan = value;
+    while let Some(start) = scan.find("{{") {
+        let rest = &scan[start + 2..];
+        if let Some(end) = rest.find("}}") {
+            let placeholder = rest[..end].trim();
+            if !placeholder.is_empty() && !known_vars.contains(placeholder) {
+                return Err(anyhow!(
+                    "recipe variable {{{{{placeholder}}}}} not provided. Pass `--var {placeholder}=...` or add it under `defaults:` in the recipe."
+                ));
+            }
+            scan = &rest[end + 2..];
+        } else {
+            break;
+        }
+    }
+
+    // Perform substitutions
     let mut out = value.to_string();
     if let Some(path) = &ctx.bundle_path {
         out = out.replace("{{bundle_path}}", path);
-    }
-    if let Some(text) = bundle_text {
-        out = out.replace("{{bundle_text}}", text);
     }
     for (key, value) in &ctx.vars {
         let needle = format!("{{{{{key}}}}}");
         out = out.replace(&needle, value);
     }
-    if let Some(var) = first_unresolved_placeholder(&out) {
-        return Err(anyhow!(
-            "recipe variable {{{{{var}}}}} not provided. Pass `--var {var}=...` or add it under `defaults:` in the recipe."
-        ));
+    if let Some(text) = bundle_text {
+        out = out.replace("{{bundle_text}}", text);
     }
     Ok(out)
 }
@@ -1247,18 +1306,6 @@ fn parse_recipe_var(entry: &str) -> Result<(String, String)> {
         return Err(anyhow!("invalid --var `{entry}` (key cannot be empty)"));
     }
     Ok((key.to_string(), value.to_string()))
-}
-
-fn first_unresolved_placeholder(value: &str) -> Option<&str> {
-    let start = value.find("{{")?;
-    let rest = &value[start + 2..];
-    let end = rest.find("}}")?;
-    let placeholder = rest[..end].trim();
-    if placeholder.is_empty() {
-        None
-    } else {
-        Some(placeholder)
-    }
 }
 
 #[cfg(test)]
@@ -1456,6 +1503,23 @@ mod tests {
         let ctx = recipe_context();
         let err = interpolate("{{missing}}", &ctx, None).unwrap_err();
         assert!(err.to_string().contains("--var missing="));
+    }
+
+    #[test]
+    fn interpolate_bundle_text_with_template_syntax_no_false_positive() {
+        let ctx = recipe_context();
+        // bundle_text contains {{handlebars}} template syntax — must not trigger an error
+        let bundle = "function render() { return `{{user_name}}`; }";
+        let result = interpolate("Review this code:\n{{bundle_text}}", &ctx, Some(bundle)).unwrap();
+        assert!(result.contains("{{user_name}}"));
+        assert!(result.contains("Review this code:"));
+    }
+
+    #[test]
+    fn interpolate_does_not_expand_recipe_vars_inside_bundle_text() {
+        let ctx = recipe_context();
+        let result = interpolate("{{bundle_text}}", &ctx, Some("literal {{model}}")).unwrap();
+        assert_eq!(result, "literal {{model}}");
     }
 
     #[test]

--- a/crates/yoetz-cli/src/commands/ask.rs
+++ b/crates/yoetz-cli/src/commands/ask.rs
@@ -281,9 +281,11 @@ pub(crate) async fn handle_ask(
     if budget_enabled {
         if let Some(spend) = usage.cost_usd.or(pricing.estimate_usd) {
             if let Some(reservation) = budget_reservation {
-                let _ = reservation.commit(spend);
-            } else {
-                let _ = budget::record_spend_standalone(spend);
+                if let Err(e) = reservation.commit(spend) {
+                    eprintln!("warning: budget commit failed: {e}");
+                }
+            } else if let Err(e) = budget::record_spend_standalone(spend) {
+                eprintln!("warning: budget commit failed: {e}");
             }
         }
     }

--- a/crates/yoetz-cli/src/commands/council.rs
+++ b/crates/yoetz-cli/src/commands/council.rs
@@ -99,28 +99,25 @@ pub(crate) async fn handle_council(
             resolve_registry_model_id(Some(provider), Some(model), registry_cache.as_ref())
         })
         .collect();
-    // Resolve per-model and take the maximum so no model gets starved in mixed councils.
-    let max_output_tokens: Option<usize> = {
-        let mut best: Option<usize> = None;
-        for reg_id in &resolved_registry_ids {
-            if let Some(val) = resolve_max_output_tokens(
+    // Resolve per-model max_output_tokens so each model gets its own limit.
+    let per_model_max_output_tokens: Vec<Option<usize>> = resolved_registry_ids
+        .iter()
+        .map(|reg_id| {
+            resolve_max_output_tokens(
                 args.max_output_tokens,
                 config,
                 registry_cache.as_ref(),
                 reg_id.as_deref(),
-            ) {
-                best = Some(best.map_or(val, |b: usize| b.max(val)));
-            }
-        }
-        best
-    };
-    let output_tokens = max_output_tokens.unwrap_or(4096);
+            )
+        })
+        .collect();
 
     let mut per_model = Vec::new();
     let mut estimate_sum = 0.0;
     let mut estimate_complete = true;
     for (idx, (model, _provider)) in resolved_models.iter().enumerate() {
         let registry_id = &resolved_registry_ids[idx];
+        let output_tokens = per_model_max_output_tokens[idx].unwrap_or(4096);
         let estimate = registry::estimate_pricing(
             registry_cache.as_ref(),
             registry_id.as_deref().unwrap_or(model),
@@ -174,9 +171,10 @@ pub(crate) async fn handle_council(
     });
 
     if args.dry_run {
-        for (model, provider) in &resolved_models {
+        for (idx, (model, provider)) in resolved_models.iter().enumerate() {
             let registry_id =
                 resolve_registry_model_id(Some(provider), Some(model), registry_cache.as_ref());
+            let output_tokens = per_model_max_output_tokens[idx].unwrap_or(4096);
             results.push(CouncilModelResult {
                 model: model.clone(),
                 content: "(dry-run) no provider call executed".to_string(),
@@ -201,6 +199,7 @@ pub(crate) async fn handle_council(
             let semaphore = std::sync::Arc::clone(&semaphore);
             let temperature = args.temperature;
             let response_format = response_format.clone();
+            let model_max_output_tokens = per_model_max_output_tokens[idx];
             join_set.spawn(async move {
                 let _permit = semaphore.acquire_owned().await?;
                 let call = call_litellm(
@@ -209,7 +208,7 @@ pub(crate) async fn handle_council(
                     &model,
                     prompt.as_str(),
                     temperature,
-                    max_output_tokens,
+                    model_max_output_tokens,
                     response_format,
                     &[],
                     None,
@@ -239,6 +238,7 @@ pub(crate) async fn handle_council(
 
             let registry_id =
                 resolve_registry_model_id(Some(&provider), Some(&model), registry_cache.as_ref());
+            let output_tokens = per_model_max_output_tokens[idx].unwrap_or(4096);
             let pricing = registry::estimate_pricing(
                 registry_cache.as_ref(),
                 registry_id.as_deref().unwrap_or(&model),

--- a/crates/yoetz-cli/src/commands/generate.rs
+++ b/crates/yoetz-cli/src/commands/generate.rs
@@ -226,13 +226,13 @@ async fn handle_generate_video(
 
     let output_path = media_dir.join("video.mp4");
 
-    let outputs = if args.dry_run {
-        Vec::new()
+    let (outputs, usage) = if args.dry_run {
+        (Vec::new(), Usage::default())
     } else {
-        let output = match provider.as_str() {
+        let (output, usage) = match provider.as_str() {
             "openai" => {
                 let auth = resolve_provider_auth(config, &provider)?;
-                openai::generate_video_sora(
+                let result = openai::generate_video_sora(
                     &ctx.client,
                     &auth,
                     &prompt,
@@ -242,11 +242,12 @@ async fn handle_generate_video(
                     images.first(),
                     &output_path,
                 )
-                .await?
+                .await?;
+                (result.output, result.usage)
             }
             "gemini" => {
                 let auth = resolve_provider_auth(config, &provider)?;
-                gemini::generate_video_veo(
+                let result = gemini::generate_video_veo(
                     &ctx.client,
                     &auth,
                     &prompt,
@@ -258,7 +259,8 @@ async fn handle_generate_video(
                     args.negative_prompt.as_deref(),
                     &output_path,
                 )
-                .await?
+                .await?;
+                (result.output, result.usage)
             }
             _ => {
                 return Err(anyhow!(
@@ -266,7 +268,7 @@ async fn handle_generate_video(
                 ))
             }
         };
-        vec![output]
+        (vec![output], usage)
     };
 
     let mut result = MediaGenerationResult {
@@ -274,7 +276,7 @@ async fn handle_generate_video(
         provider: Some(provider),
         model: Some(model),
         prompt,
-        usage: Usage::default(),
+        usage,
         artifacts: artifacts.clone(),
         outputs,
     };

--- a/crates/yoetz-cli/src/commands/review.rs
+++ b/crates/yoetz-cli/src/commands/review.rs
@@ -14,6 +14,8 @@ use yoetz_core::output::{write_json, write_jsonl, OutputFormat};
 use yoetz_core::session::{create_session_dir, write_json as write_json_file, write_text};
 use yoetz_core::types::{ArtifactPaths, Usage};
 
+const MAX_REVIEW_DIFF_TOKENS: usize = 50_000;
+
 pub(crate) async fn handle_review(
     ctx: &AppContext,
     args: ReviewArgs,
@@ -70,13 +72,29 @@ async fn handle_review_diff(
         registry_id.as_deref(),
     );
 
-    let diff = git_diff(args.staged, &args.paths)?;
+    let mut diff = git_diff(args.staged, &args.paths)?;
     if diff.trim().is_empty() {
         return Err(anyhow!("diff is empty"));
     }
 
+    let max_diff_bytes = args.max_diff_bytes;
+    if diff.len() > max_diff_bytes {
+        eprintln!(
+            "warning: diff is {} bytes, truncating to {max_diff_bytes} bytes",
+            diff.len()
+        );
+        // Truncate on a char boundary
+        let mut end = max_diff_bytes;
+        while end > 0 && !diff.is_char_boundary(end) {
+            end -= 1;
+        }
+        diff.truncate(end);
+        diff.push_str("\n\n... [diff truncated — exceeded --max-diff-bytes limit]");
+    }
+
     let review_prompt = build_review_diff_prompt(&diff, args.prompt.as_deref());
     let input_tokens = estimate_tokens(review_prompt.len());
+    ensure_review_diff_size(input_tokens)?;
     let output_tokens = max_output_tokens.unwrap_or(4096);
     let pricing = registry::estimate_pricing(
         registry_cache.as_ref(),
@@ -146,9 +164,11 @@ async fn handle_review_diff(
     if budget_enabled {
         if let Some(spend) = usage.cost_usd.or(pricing.estimate_usd) {
             if let Some(reservation) = budget_reservation {
-                let _ = reservation.commit(spend);
-            } else {
-                let _ = budget::record_spend_standalone(spend);
+                if let Err(e) = reservation.commit(spend) {
+                    eprintln!("warning: budget commit failed: {e}");
+                }
+            } else if let Err(e) = budget::record_spend_standalone(spend) {
+                eprintln!("warning: budget commit failed: {e}");
             }
         }
     }
@@ -180,6 +200,31 @@ async fn handle_review_diff(
             println!("{}", result.content);
             Ok(())
         }
+    }
+}
+
+fn ensure_review_diff_size(input_tokens: usize) -> Result<()> {
+    if input_tokens > MAX_REVIEW_DIFF_TOKENS {
+        return Err(anyhow!(
+            "diff too large for `yoetz review diff` (~{input_tokens} tokens > {MAX_REVIEW_DIFF_TOKENS}); narrow `--paths` or split the review into smaller chunks"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn review_diff_guardrail_rejects_large_prompts() {
+        let err = ensure_review_diff_size(MAX_REVIEW_DIFF_TOKENS + 1).unwrap_err();
+        assert!(err.to_string().contains("diff too large"));
+    }
+
+    #[test]
+    fn review_diff_guardrail_allows_limit_boundary() {
+        ensure_review_diff_size(MAX_REVIEW_DIFF_TOKENS).unwrap();
     }
 }
 
@@ -308,9 +353,11 @@ async fn handle_review_file(
     if budget_enabled {
         if let Some(spend) = usage.cost_usd.or(pricing.estimate_usd) {
             if let Some(reservation) = budget_reservation {
-                let _ = reservation.commit(spend);
-            } else {
-                let _ = budget::record_spend_standalone(spend);
+                if let Err(e) = reservation.commit(spend) {
+                    eprintln!("warning: budget commit failed: {e}");
+                }
+            } else if let Err(e) = budget::record_spend_standalone(spend) {
+                eprintln!("warning: budget commit failed: {e}");
             }
         }
     }

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -484,6 +484,10 @@ struct ReviewDiffArgs {
 
     #[arg(long)]
     response_schema_name: Option<String>,
+
+    /// Maximum diff size in bytes before truncation (default: 500000)
+    #[arg(long, default_value = "500000")]
+    max_diff_bytes: usize,
 }
 
 #[derive(Args)]
@@ -643,9 +647,23 @@ struct ModelEstimate {
 #[tokio::main]
 async fn main() -> Result<()> {
     // Capture security-sensitive env vars before dotenv loading.
-    // CWD .env files must not override executable paths (supply-chain risk).
+    // CWD .env files must not override executable paths (supply-chain risk)
+    // or redirect API keys to attacker-controlled endpoints.
     let pre_agent_bin = env::var("YOETZ_AGENT_BROWSER_BIN").ok();
     let pre_scripts_dir = env::var("YOETZ_SCRIPTS_DIR").ok();
+
+    // Capture API key env vars so CWD .env cannot silently replace them.
+    const PROTECTED_API_KEYS: &[&str] = &[
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GEMINI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "XAI_API_KEY",
+    ];
+    let pre_api_keys: Vec<(&str, Option<String>)> = PROTECTED_API_KEYS
+        .iter()
+        .map(|&k| (k, env::var(k).ok()))
+        .collect();
 
     // Load environment files (.env.local takes precedence over .env)
     dotenvy::from_filename(".env.local").ok();
@@ -657,6 +675,18 @@ async fn main() -> Result<()> {
     }
     if pre_scripts_dir.is_none() {
         env::remove_var("YOETZ_SCRIPTS_DIR");
+    }
+
+    // Restore API key env vars if .env changed them (prevent credential hijack)
+    for (key, pre_value) in &pre_api_keys {
+        let post_value = env::var(key).ok();
+        if post_value != *pre_value {
+            match pre_value {
+                Some(v) => env::set_var(key, v),
+                None => env::remove_var(key),
+            }
+            eprintln!("warning: CWD .env tried to override {key}, ignored");
+        }
     }
 
     let cli = Cli::parse();

--- a/crates/yoetz-cli/src/providers/gemini.rs
+++ b/crates/yoetz-cli/src/providers/gemini.rs
@@ -20,6 +20,12 @@ pub struct GeminiTextResult {
     pub raw: Value,
 }
 
+#[derive(Debug, Clone)]
+pub struct GeminiVideoResult {
+    pub output: MediaOutput,
+    pub usage: Usage,
+}
+
 pub async fn generate_content(
     client: &Client,
     auth: &ProviderAuth,
@@ -81,7 +87,7 @@ pub async fn generate_video_veo(
     resolution: Option<&str>,
     negative_prompt: Option<&str>,
     output_path: &Path,
-) -> Result<MediaOutput> {
+) -> Result<GeminiVideoResult> {
     let mut parameters = serde_json::json!({});
     if let Some(duration) = duration_secs {
         parameters["durationSeconds"] = Value::from(duration as i64);
@@ -175,17 +181,20 @@ pub async fn generate_video_veo(
     std::fs::write(output_path, &bytes)
         .with_context(|| format!("write {}", output_path.display()))?;
 
-    Ok(MediaOutput {
-        media_type: MediaType::Video,
-        path: output_path.to_path_buf(),
-        url: Some(uri),
-        metadata: MediaMetadata {
-            width: None,
-            height: None,
-            duration_secs: duration_secs.map(|d| d as f32),
-            model: model.to_string(),
-            revised_prompt: None,
+    Ok(GeminiVideoResult {
+        output: MediaOutput {
+            media_type: MediaType::Video,
+            path: output_path.to_path_buf(),
+            url: Some(uri),
+            metadata: MediaMetadata {
+                width: None,
+                height: None,
+                duration_secs: duration_secs.map(|d| d as f32),
+                model: model.to_string(),
+                revised_prompt: None,
+            },
         },
+        usage: parse_usage(&response),
     })
 }
 
@@ -365,7 +374,15 @@ fn extract_text(resp: &Value) -> String {
 }
 
 fn parse_usage(resp: &Value) -> Usage {
-    if let Some(meta) = resp.get("usageMetadata").and_then(|v| v.as_object()) {
+    if let Some(meta) = resp
+        .get("usageMetadata")
+        .and_then(|v| v.as_object())
+        .or_else(|| {
+            resp.get("response")
+                .and_then(|v| v.get("usageMetadata"))
+                .and_then(|v| v.as_object())
+        })
+    {
         return Usage {
             input_tokens: meta.get("promptTokenCount").and_then(|v| v.as_u64()),
             output_tokens: meta.get("candidatesTokenCount").and_then(|v| v.as_u64()),
@@ -431,5 +448,24 @@ mod tests {
             extract_video_uri(&resp),
             Some("gs://bucket/video.mp4".to_string())
         );
+    }
+
+    #[test]
+    fn parse_usage_reads_nested_operation_response_usage() {
+        let resp = json!({
+            "response": {
+                "usageMetadata": {
+                    "promptTokenCount": 11,
+                    "candidatesTokenCount": 7,
+                    "thoughtsTokenCount": 3,
+                    "totalTokenCount": 21
+                }
+            }
+        });
+        let usage = parse_usage(&resp);
+        assert_eq!(usage.input_tokens, Some(11));
+        assert_eq!(usage.output_tokens, Some(7));
+        assert_eq!(usage.thoughts_tokens, Some(3));
+        assert_eq!(usage.total_tokens, Some(21));
     }
 }

--- a/crates/yoetz-cli/src/providers/openai.rs
+++ b/crates/yoetz-cli/src/providers/openai.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use base64::{engine::general_purpose, Engine as _};
 use reqwest::multipart::{Form, Part};
-use reqwest::Client;
+use reqwest::{Client, RequestBuilder, Url};
 use serde_json::Value;
 use std::path::Path;
 use tokio::time::{sleep, Duration};
@@ -11,6 +11,82 @@ use yoetz_core::types::Usage;
 
 use crate::http::send_json;
 use crate::providers::ProviderAuth;
+
+/// Maximum download size for media files (100 MiB).
+const MAX_MEDIA_DOWNLOAD_BYTES: usize = 100 * 1024 * 1024;
+
+/// Known OpenAI hosts that are safe to receive bearer tokens.
+const OPENAI_ALLOWED_HOSTS: &[&str] = &[
+    "api.openai.com",
+    "oaidalleapiprodscus.blob.core.windows.net",
+];
+
+/// Wildcard suffixes: any host ending with these (including exact match) is allowed.
+const OPENAI_ALLOWED_SUFFIXES: &[&str] = &[".oaiusercontent.com"];
+
+/// Returns `true` when `url` points to a known OpenAI-controlled host.
+fn is_openai_host(url: &str) -> bool {
+    let parsed = match Url::parse(url) {
+        Ok(u) => u,
+        Err(_) => return false,
+    };
+    let host = match parsed.host_str() {
+        Some(h) => h,
+        None => return false,
+    };
+    // Exact matches
+    if OPENAI_ALLOWED_HOSTS.contains(&host) {
+        return true;
+    }
+    // Wildcard suffix matches (e.g. anything.oaiusercontent.com)
+    for suffix in OPENAI_ALLOWED_SUFFIXES {
+        if host == &suffix[1..] || host.ends_with(suffix) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Build a GET request, attaching the bearer token **only** if the URL belongs to
+/// a known OpenAI host.  This prevents leaking API keys to arbitrary servers whose
+/// URLs appear in API response payloads.
+fn safe_image_get(client: &Client, url: &str, api_key: &str) -> RequestBuilder {
+    let rb = client.get(url);
+    if is_openai_host(url) {
+        rb.bearer_auth(api_key)
+    } else {
+        rb
+    }
+}
+
+/// Download a response body while enforcing [`MAX_MEDIA_DOWNLOAD_BYTES`].
+/// Checks `Content-Length` up-front when available and also counts bytes during
+/// streaming to guard against servers that lie about (or omit) the header.
+async fn download_with_limit(resp: reqwest::Response, url: &str) -> Result<Vec<u8>> {
+    if let Some(cl) = resp.content_length() {
+        if cl as usize > MAX_MEDIA_DOWNLOAD_BYTES {
+            return Err(anyhow!(
+                "download from {} refused: Content-Length {} exceeds {} byte limit",
+                url,
+                cl,
+                MAX_MEDIA_DOWNLOAD_BYTES
+            ));
+        }
+    }
+    let mut buf = Vec::new();
+    let mut stream = resp;
+    while let Some(chunk) = stream.chunk().await? {
+        if buf.len() + chunk.len() > MAX_MEDIA_DOWNLOAD_BYTES {
+            return Err(anyhow!(
+                "download from {} aborted: exceeded {} byte limit",
+                url,
+                MAX_MEDIA_DOWNLOAD_BYTES
+            ));
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(buf)
+}
 
 #[derive(Debug, Clone)]
 pub struct OpenAITextResult {
@@ -22,6 +98,12 @@ pub struct OpenAITextResult {
 #[derive(Debug, Clone)]
 pub struct OpenAIMediaResult {
     pub outputs: Vec<MediaOutput>,
+    pub usage: Usage,
+}
+
+#[derive(Debug, Clone)]
+pub struct OpenAIVideoResult {
+    pub output: MediaOutput,
     pub usage: Usage,
 }
 
@@ -151,13 +233,12 @@ pub async fn generate_images(
                 .context("decode image base64")?;
             std::fs::write(&path, bytes).with_context(|| format!("write {}", path.display()))?;
         } else if let Some(url) = &payload.url {
-            let bytes = client
-                .get(url)
-                .bearer_auth(&auth.api_key)
+            let resp = safe_image_get(client, url, &auth.api_key)
                 .send()
                 .await?
-                .bytes()
-                .await?;
+                .error_for_status()
+                .with_context(|| format!("download {}", url))?;
+            let bytes = download_with_limit(resp, url).await?;
             std::fs::write(&path, bytes).with_context(|| format!("write {}", path.display()))?;
         } else {
             continue;
@@ -192,8 +273,7 @@ async fn load_media_bytes(client: &Client, media: &MediaInput) -> Result<Vec<u8>
                 .await?
                 .error_for_status()
                 .with_context(|| format!("download {}", url))?;
-            let bytes = resp.bytes().await?;
-            Ok(bytes.to_vec())
+            download_with_limit(resp, url).await
         }
         _ => media.read_bytes(),
     }
@@ -286,13 +366,12 @@ async fn generate_images_via_images_api(
                 .context("decode image base64")?;
             std::fs::write(&path, bytes).with_context(|| format!("write {}", path.display()))?;
         } else if let Some(url) = &payload.url {
-            let bytes = client
-                .get(url)
-                .bearer_auth(&auth.api_key)
+            let resp = safe_image_get(client, url, &auth.api_key)
                 .send()
                 .await?
-                .bytes()
-                .await?;
+                .error_for_status()
+                .with_context(|| format!("download {}", url))?;
+            let bytes = download_with_limit(resp, url).await?;
             std::fs::write(&path, bytes).with_context(|| format!("write {}", path.display()))?;
         } else {
             continue;
@@ -327,7 +406,7 @@ pub async fn generate_video_sora(
     size: Option<&str>,
     input_reference: Option<&MediaInput>,
     output_path: &Path,
-) -> Result<MediaOutput> {
+) -> Result<OpenAIVideoResult> {
     let url = format!("{}/videos", auth.base_url.trim_end_matches('/'));
 
     let mut form = Form::new()
@@ -356,6 +435,7 @@ pub async fn generate_video_sora(
 
     let (resp, _headers) =
         send_json::<Value>(client.post(url).bearer_auth(&auth.api_key).multipart(form)).await?;
+    let initial_usage = parse_usage(&resp);
 
     let video_id = resp
         .get("id")
@@ -369,7 +449,7 @@ pub async fn generate_video_sora(
     );
 
     let mut attempts = 0u32;
-    loop {
+    let final_usage = loop {
         let (status_resp, _headers) =
             send_json::<Value>(client.get(&status_url).bearer_auth(&auth.api_key)).await?;
         let status = status_resp
@@ -377,7 +457,7 @@ pub async fn generate_video_sora(
             .and_then(|v| v.as_str())
             .unwrap_or("unknown");
         match status {
-            "completed" => break,
+            "completed" => break parse_usage(&status_resp),
             "failed" => {
                 let msg = status_resp
                     .get("error")
@@ -393,7 +473,7 @@ pub async fn generate_video_sora(
                 sleep(Duration::from_secs(5)).await;
             }
         }
-    }
+    };
 
     let content_url = format!(
         "{}/videos/{}/content",
@@ -412,17 +492,20 @@ pub async fn generate_video_sora(
     std::fs::write(output_path, &bytes)
         .with_context(|| format!("write {}", output_path.display()))?;
 
-    Ok(MediaOutput {
-        media_type: MediaType::Video,
-        path: output_path.to_path_buf(),
-        url: None,
-        metadata: MediaMetadata {
-            width: None,
-            height: None,
-            duration_secs: seconds.map(|s| s as f32),
-            model: model.to_string(),
-            revised_prompt: None,
+    Ok(OpenAIVideoResult {
+        output: MediaOutput {
+            media_type: MediaType::Video,
+            path: output_path.to_path_buf(),
+            url: None,
+            metadata: MediaMetadata {
+                width: None,
+                height: None,
+                duration_secs: seconds.map(|s| s as f32),
+                model: model.to_string(),
+                revised_prompt: None,
+            },
         },
+        usage: fill_missing_usage(final_usage, initial_usage),
     })
 }
 
@@ -466,6 +549,25 @@ fn parse_usage(resp: &Value) -> Usage {
     } else {
         Usage::default()
     }
+}
+
+fn fill_missing_usage(mut usage: Usage, fallback: Usage) -> Usage {
+    if usage.input_tokens.is_none() {
+        usage.input_tokens = fallback.input_tokens;
+    }
+    if usage.output_tokens.is_none() {
+        usage.output_tokens = fallback.output_tokens;
+    }
+    if usage.thoughts_tokens.is_none() {
+        usage.thoughts_tokens = fallback.thoughts_tokens;
+    }
+    if usage.total_tokens.is_none() {
+        usage.total_tokens = fallback.total_tokens;
+    }
+    if usage.cost_usd.is_none() {
+        usage.cost_usd = fallback.cost_usd;
+    }
+    usage
 }
 
 struct ImagePayload {
@@ -590,5 +692,67 @@ mod tests {
         assert_eq!(images.len(), 1);
         assert_eq!(images[0].b64_json.as_deref(), Some("dGVzdA=="));
         assert_eq!(images[0].revised_prompt.as_deref(), Some("test"));
+    }
+
+    #[test]
+    fn is_openai_host_known_hosts() {
+        assert!(is_openai_host("https://api.openai.com/v1/images"));
+        assert!(is_openai_host(
+            "https://oaidalleapiprodscus.blob.core.windows.net/img/abc.png"
+        ));
+    }
+
+    #[test]
+    fn is_openai_host_wildcard_suffix() {
+        // Subdomain of oaiusercontent.com
+        assert!(is_openai_host(
+            "https://files.oaiusercontent.com/file-abc123?se=2024"
+        ));
+        // Bare oaiusercontent.com (exact match on the suffix minus the dot)
+        assert!(is_openai_host("https://oaiusercontent.com/file.png"));
+    }
+
+    #[test]
+    fn is_openai_host_rejects_unknown() {
+        assert!(!is_openai_host("https://evil.com/img.png"));
+        assert!(!is_openai_host("https://example.org/something"));
+        assert!(!is_openai_host("http://localhost:8080/test"));
+    }
+
+    #[test]
+    fn is_openai_host_rejects_spoofing() {
+        // Subdomain spoofing: attacker owns evil-api.openai.com.evil.com
+        assert!(!is_openai_host("https://api.openai.com.evil.com/steal"));
+        // Suffix spoofing: not-oaiusercontent.com
+        assert!(!is_openai_host("https://not-oaiusercontent.com/file.png"));
+        // Path spoofing
+        assert!(!is_openai_host("https://evil.com/api.openai.com"));
+        // Invalid URL
+        assert!(!is_openai_host("not-a-url"));
+    }
+
+    #[test]
+    fn fill_missing_usage_keeps_primary_values() {
+        let usage = fill_missing_usage(
+            Usage {
+                input_tokens: Some(10),
+                output_tokens: None,
+                thoughts_tokens: None,
+                total_tokens: None,
+                cost_usd: None,
+            },
+            Usage {
+                input_tokens: Some(1),
+                output_tokens: Some(2),
+                thoughts_tokens: Some(3),
+                total_tokens: Some(4),
+                cost_usd: Some(5.0),
+            },
+        );
+        assert_eq!(usage.input_tokens, Some(10));
+        assert_eq!(usage.output_tokens, Some(2));
+        assert_eq!(usage.thoughts_tokens, Some(3));
+        assert_eq!(usage.total_tokens, Some(4));
+        assert_eq!(usage.cost_usd, Some(5.0));
     }
 }

--- a/crates/yoetz-cli/src/registry.rs
+++ b/crates/yoetz-cli/src/registry.rs
@@ -203,10 +203,7 @@ fn embedded_gemini_registry() -> Result<ModelRegistry> {
             continue;
         }
 
-        let context_length = pricing
-            .max_input_tokens
-            .or(pricing.max_output_tokens)
-            .map(|v| v as usize);
+        let context_length = pricing.max_input_tokens.map(|v| v as usize);
         let max_output_tokens = pricing.max_output_tokens.map(|v| v as usize);
 
         registry.models.push(ModelEntry {

--- a/crates/yoetz-core/src/bundle.rs
+++ b/crates/yoetz-core/src/bundle.rs
@@ -3,6 +3,7 @@ use anyhow::{Context, Result};
 use ignore::overrides::OverrideBuilder;
 use ignore::WalkBuilder;
 use sha2::{Digest, Sha256};
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -125,6 +126,7 @@ pub fn build_bundle(prompt: &str, options: BundleOptions) -> Result<Bundle> {
     let exclude_expanded: Vec<String> = options.exclude.iter().map(|p| expand_tilde(p)).collect();
 
     let mut files = Vec::new();
+    let mut seen_files = HashSet::new();
     let mut total_bytes = 0usize;
     let mut total_chars = 0usize;
 
@@ -135,6 +137,11 @@ pub fn build_bundle(prompt: &str, options: BundleOptions) -> Result<Bundle> {
                 "-f path not found or not a file: {}",
                 file_path.display()
             ));
+        }
+        let identity = file_identity(file_path)
+            .with_context(|| format!("resolve file {}", file_path.display()))?;
+        if !seen_files.insert(identity) {
+            continue;
         }
         let display_path = file_path.to_string_lossy().to_string();
         let (bf, consumed) = process_file(
@@ -178,6 +185,11 @@ pub fn build_bundle(prompt: &str, options: BundleOptions) -> Result<Bundle> {
             }
 
             let path = entry.path();
+            let identity =
+                file_identity(path).with_context(|| format!("resolve file {}", path.display()))?;
+            if !seen_files.insert(identity) {
+                continue;
+            }
             let rel_path = path
                 .strip_prefix(&options.root)
                 .unwrap_or(path)
@@ -212,6 +224,11 @@ pub fn build_bundle(prompt: &str, options: BundleOptions) -> Result<Bundle> {
         files,
         stats,
     })
+}
+
+fn file_identity(path: &Path) -> Result<PathBuf> {
+    path.canonicalize()
+        .with_context(|| format!("canonicalize {}", path.display()))
 }
 
 fn extract_text(
@@ -441,6 +458,31 @@ mod tests {
 
         let bundle = build_bundle("prompt", options).unwrap();
         assert_eq!(bundle.files.len(), 2);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn bundle_dedups_same_file_across_direct_and_glob_inputs() {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("yoetz_dedup_test_{nanos}"));
+        fs::create_dir_all(&root).unwrap();
+
+        let local = root.join("local.txt");
+        fs::write(&local, "local").unwrap();
+
+        let options = BundleOptions {
+            root: root.clone(),
+            include: vec![local.to_string_lossy().to_string(), "*.txt".to_string()],
+            ..BundleOptions::default()
+        };
+
+        let bundle = build_bundle("prompt", options).unwrap();
+        assert_eq!(bundle.files.len(), 1);
+        assert_eq!(bundle.stats.file_count, 1);
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/crates/yoetz-core/src/config.rs
+++ b/crates/yoetz-core/src/config.rs
@@ -63,29 +63,43 @@ impl Config {
     /// Load configuration with an optional profile overlay.
     pub fn load_with_profile(profile: Option<&str>) -> Result<Self> {
         let mut config = Config::default();
-        for path in default_config_paths(profile) {
+        for (path, trusted) in default_config_paths(profile) {
             if path.exists() {
                 let file = load_config_file(&path)?;
-                config.merge(file);
+                config.merge(file, trusted, &path);
             }
         }
         Ok(config)
     }
 
-    fn merge(&mut self, other: ConfigFile) {
+    fn merge(&mut self, other: ConfigFile, trusted: bool, source: &Path) {
         if let Some(defaults) = other.defaults {
             merge_defaults(&mut self.defaults, defaults);
         }
         if let Some(providers) = other.providers {
-            for (k, v) in providers {
-                self.providers
-                    .entry(k)
-                    .and_modify(|existing| merge_provider(existing, &v))
-                    .or_insert(v);
+            if trusted {
+                for (k, v) in providers {
+                    self.providers
+                        .entry(k)
+                        .and_modify(|existing| merge_provider(existing, &v))
+                        .or_insert(v);
+                }
+            } else {
+                eprintln!(
+                    "warning: ignoring [providers] from untrusted config {}",
+                    source.display()
+                );
             }
         }
         if let Some(registry) = other.registry {
-            merge_registry(&mut self.registry, registry);
+            if trusted {
+                merge_registry(&mut self.registry, registry);
+            } else {
+                eprintln!(
+                    "warning: ignoring [registry] from untrusted config {}",
+                    source.display()
+                );
+            }
         }
         if let Some(aliases) = other.aliases {
             self.aliases.extend(aliases);
@@ -101,38 +115,47 @@ fn load_config_file(path: &Path) -> Result<ConfigFile> {
     Ok(parsed)
 }
 
-fn default_config_paths(profile: Option<&str>) -> Vec<PathBuf> {
-    let mut paths = Vec::new();
+/// Returns `(path, trusted)` pairs. Paths under the user's home config dirs and
+/// `YOETZ_CONFIG_PATH` are trusted; CWD-relative paths (repo-local) are untrusted.
+fn default_config_paths(profile: Option<&str>) -> Vec<(PathBuf, bool)> {
+    let mut paths: Vec<(PathBuf, bool)> = Vec::new();
 
     if let Some(home) = home_dir() {
-        paths.push(home.join(".yoetz/config.toml"));
-        paths.push(home.join(".config/yoetz/config.toml"));
+        paths.push((home.join(".yoetz/config.toml"), true));
+        paths.push((home.join(".config/yoetz/config.toml"), true));
     }
     if let Ok(xdg) = env::var("XDG_CONFIG_HOME") {
-        paths.push(PathBuf::from(xdg).join("yoetz/config.toml"));
+        paths.push((PathBuf::from(xdg).join("yoetz/config.toml"), true));
     }
-    paths.push(PathBuf::from("./yoetz.toml"));
+    // Repo-local config — untrusted (may come from a cloned repo)
+    paths.push((PathBuf::from("./yoetz.toml"), false));
 
     if let Ok(custom) = env::var("YOETZ_CONFIG_PATH") {
-        paths.push(PathBuf::from(custom));
+        paths.push((PathBuf::from(custom), true));
     }
 
     if let Some(name) = profile {
         if let Some(home) = home_dir() {
-            paths.push(home.join(".yoetz/profiles").join(format!("{name}.toml")));
-            paths.push(
+            paths.push((
+                home.join(".yoetz/profiles").join(format!("{name}.toml")),
+                true,
+            ));
+            paths.push((
                 home.join(".config/yoetz/profiles")
                     .join(format!("{name}.toml")),
-            );
+                true,
+            ));
         }
         if let Ok(xdg) = env::var("XDG_CONFIG_HOME") {
-            paths.push(
+            paths.push((
                 PathBuf::from(xdg)
                     .join("yoetz/profiles")
                     .join(format!("{name}.toml")),
-            );
+                true,
+            ));
         }
-        paths.push(PathBuf::from(format!("./yoetz.{name}.toml")));
+        // Repo-local profile config — untrusted
+        paths.push((PathBuf::from(format!("./yoetz.{name}.toml")), false));
     }
     paths
 }
@@ -194,6 +217,71 @@ model = "gpt-5-4-pro"
         };
         merge_defaults(&mut target, other);
         assert_eq!(target.browser_cdp.as_deref(), Some("http://127.0.0.1:9222"));
+    }
+
+    #[test]
+    fn untrusted_config_skips_providers_and_registry() {
+        let mut config = Config::default();
+        let file = ConfigFile {
+            defaults: Some(Defaults {
+                model: Some("gpt-5-4-pro".to_string()),
+                ..Default::default()
+            }),
+            providers: Some(HashMap::from([(
+                "evil".to_string(),
+                ProviderConfig {
+                    base_url: Some("http://evil.example.com".to_string()),
+                    api_key_env: Some("EVIL_KEY".to_string()),
+                    kind: None,
+                },
+            )])),
+            registry: Some(RegistryConfig {
+                openrouter_models_url: Some("http://evil.example.com/models".to_string()),
+                ..Default::default()
+            }),
+            aliases: Some(HashMap::from([(
+                "fast".to_string(),
+                "gpt-5-4-pro".to_string(),
+            )])),
+        };
+        config.merge(file, false, Path::new("./yoetz.toml"));
+        // Safe fields applied
+        assert_eq!(config.defaults.model.as_deref(), Some("gpt-5-4-pro"));
+        assert_eq!(
+            config.aliases.get("fast").map(|s| s.as_str()),
+            Some("gpt-5-4-pro")
+        );
+        // Restricted fields skipped
+        assert!(config.providers.is_empty());
+        assert!(config.registry.openrouter_models_url.is_none());
+    }
+
+    #[test]
+    fn trusted_config_applies_providers_and_registry() {
+        let mut config = Config::default();
+        let file = ConfigFile {
+            defaults: None,
+            providers: Some(HashMap::from([(
+                "openai".to_string(),
+                ProviderConfig {
+                    base_url: Some("https://api.openai.com".to_string()),
+                    api_key_env: Some("OPENAI_API_KEY".to_string()),
+                    kind: None,
+                },
+            )])),
+            registry: Some(RegistryConfig {
+                openrouter_models_url: Some("https://openrouter.ai/api/v1/models".to_string()),
+                ..Default::default()
+            }),
+            aliases: None,
+        };
+        config.merge(
+            file,
+            true,
+            Path::new("/home/user/.config/yoetz/config.toml"),
+        );
+        assert!(config.providers.contains_key("openai"));
+        assert!(config.registry.openrouter_models_url.is_some());
     }
 }
 

--- a/crates/yoetz-core/src/registry.rs
+++ b/crates/yoetz-core/src/registry.rs
@@ -19,6 +19,18 @@ impl ModelPricing {
         let request_cost = self.request.unwrap_or(0.0);
         Some(prompt_cost + completion_cost + request_cost)
     }
+
+    fn merge_from(&mut self, other: ModelPricing) {
+        if other.prompt_per_1k.is_some() {
+            self.prompt_per_1k = other.prompt_per_1k;
+        }
+        if other.completion_per_1k.is_some() {
+            self.completion_per_1k = other.completion_per_1k;
+        }
+        if other.request.is_some() {
+            self.request = other.request;
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -36,6 +48,41 @@ pub struct ModelCapability {
     pub vision: Option<bool>,
     pub reasoning: Option<bool>,
     pub web_search: Option<bool>,
+}
+
+impl ModelCapability {
+    fn merge_from(&mut self, other: ModelCapability) {
+        if other.vision.is_some() {
+            self.vision = other.vision;
+        }
+        if other.reasoning.is_some() {
+            self.reasoning = other.reasoning;
+        }
+        if other.web_search.is_some() {
+            self.web_search = other.web_search;
+        }
+    }
+}
+
+impl ModelEntry {
+    fn merge_from(&mut self, other: ModelEntry) {
+        debug_assert_eq!(self.id, other.id);
+        if other.context_length.is_some() {
+            self.context_length = other.context_length;
+        }
+        if other.max_output_tokens.is_some() {
+            self.max_output_tokens = other.max_output_tokens;
+        }
+        self.pricing.merge_from(other.pricing);
+        if other.provider.is_some() {
+            self.provider = other.provider;
+        }
+        match (&mut self.capability, other.capability) {
+            (Some(existing), Some(other)) => existing.merge_from(other),
+            (None, Some(other)) => self.capability = Some(other),
+            _ => {}
+        }
+    }
 }
 
 /// In-memory model registry with pricing and capability data.
@@ -63,7 +110,7 @@ impl ModelRegistry {
         for m in other.models {
             if let Some(idx) = self.index.get(&m.id).copied() {
                 if let Some(existing) = self.models.get_mut(idx) {
-                    *existing = m;
+                    existing.merge_from(m);
                 }
             } else {
                 self.models.push(m);
@@ -78,5 +125,70 @@ impl ModelRegistry {
         for (idx, model) in self.models.iter().enumerate() {
             self.index.insert(model.id.clone(), idx);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_preserves_existing_fields_when_new_entry_is_partial() {
+        let mut base = ModelRegistry {
+            models: vec![ModelEntry {
+                id: "openai/gpt-5".to_string(),
+                context_length: Some(128_000),
+                max_output_tokens: Some(16_384),
+                pricing: ModelPricing {
+                    prompt_per_1k: Some(0.01),
+                    completion_per_1k: Some(0.02),
+                    request: None,
+                },
+                provider: Some("openrouter".to_string()),
+                capability: Some(ModelCapability {
+                    vision: Some(true),
+                    reasoning: None,
+                    web_search: Some(false),
+                }),
+            }],
+            ..Default::default()
+        };
+        base.rebuild_index();
+
+        let mut update = ModelRegistry {
+            models: vec![ModelEntry {
+                id: "openai/gpt-5".to_string(),
+                context_length: None,
+                max_output_tokens: Some(8_192),
+                pricing: ModelPricing {
+                    prompt_per_1k: None,
+                    completion_per_1k: None,
+                    request: Some(0.1),
+                },
+                provider: None,
+                capability: Some(ModelCapability {
+                    vision: None,
+                    reasoning: Some(true),
+                    web_search: None,
+                }),
+            }],
+            ..Default::default()
+        };
+        update.rebuild_index();
+
+        base.merge(update);
+
+        let entry = base.find("openai/gpt-5").unwrap();
+        assert_eq!(entry.context_length, Some(128_000));
+        assert_eq!(entry.max_output_tokens, Some(8_192));
+        assert_eq!(entry.pricing.prompt_per_1k, Some(0.01));
+        assert_eq!(entry.pricing.completion_per_1k, Some(0.02));
+        assert_eq!(entry.pricing.request, Some(0.1));
+        assert_eq!(entry.provider.as_deref(), Some("openrouter"));
+
+        let capability = entry.capability.as_ref().unwrap();
+        assert_eq!(capability.vision, Some(true));
+        assert_eq!(capability.reasoning, Some(true));
+        assert_eq!(capability.web_search, Some(false));
     }
 }

--- a/crates/yoetz-core/src/session.rs
+++ b/crates/yoetz-core/src/session.rs
@@ -14,6 +14,12 @@ static TS_FORMAT: &[FormatItem<'static>] =
 pub fn create_session_dir() -> Result<SessionInfo> {
     let base = session_base_dir();
     fs::create_dir_all(&base).with_context(|| format!("create sessions dir {}", base.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&base, fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("chmod 700 {}", base.display()))?;
+    }
 
     let ts = OffsetDateTime::now_utc()
         .format(TS_FORMAT)
@@ -26,6 +32,12 @@ pub fn create_session_dir() -> Result<SessionInfo> {
     let id = format!("{ts}_{rand}");
     let path = base.join(&id);
     fs::create_dir_all(&path).with_context(|| format!("create session {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("chmod 700 {}", path.display()))?;
+    }
 
     Ok(SessionInfo { id, path })
 }


### PR DESCRIPTION
## Summary

Addresses all 10 findings from a GPT 5.4 Pro Extended in-depth code review (48 minutes of thinking on the full codebase bundle).

### Security (High)
- **Repo-local config trust**: CWD `.env`/`yoetz.toml` can no longer override provider endpoints or API keys; sensitive env vars protected from dotenv injection
- **Browser npx fallback**: Gated behind `YOETZ_ALLOW_NPX_FALLBACK=1`; cookie state and session dirs now 0600/0700
- **OpenAI API key leak**: `bearer_auth` stripped from non-OpenAI image download URLs; 100MB streaming download limit enforced
- **Council token limits**: Per-model `max_output_tokens` instead of shared maximum across all models

### Budget & Correctness
- Budget commit failures now warn on stderr instead of silent `let _ =`
- Partial council failures collect all results before reporting; spend committed for succeeded models
- Video generation (Sora/Veo) propagates real usage instead of `Usage::default()`

### Data Quality
- Field-wise registry merge preserves existing metadata from richer sources
- `context_length` no longer incorrectly falls back to `max_output_tokens`
- Bundle deduplicates files across direct paths and glob walker
- Review diff capped at 500KB by default (`--max-diff-bytes`)
- Recipe `{{...}}` interpolation no longer false-positives on bundle content

### Browser Recipe (chatgpt.yaml)
- `fill` instead of `type` to avoid doubled text
- `find role button` instead of `aria-label` CSS selector for reliable send

## Test plan
- [x] 116 tests pass (26 new), up from 90
- [x] `cargo clippy` — 0 warnings
- [x] `cargo fmt --check` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)