### PR TITLE
fix(browser): fix ChatGPT Pro auto-connect integration e2e

### DIFF
--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -55,6 +55,7 @@ pub struct RecipeStep {
     pub action: Option<String>,
     pub args: Option<Vec<String>>,
     pub sleep_ms: Option<u64>,
+    pub timeout_ms: Option<u64>,
 }
 
 pub struct RecipeContext {
@@ -196,13 +197,9 @@ fn build_agent_browser_args(
             }
         }
         Some(BrowserConnection::AutoConnect) => {
-            if !args
-                .iter()
-                .any(|a| a == "--session" || a.starts_with("--session="))
-            {
-                args.insert(0, CDP_SESSION_NAME.to_string());
-                args.insert(0, "--session".to_string());
-            }
+            // For auto-connect, do NOT add --session. A managed session creates
+            // an isolated context that can't see the real Chrome tabs/DOM.
+            // Auto-connect should attach to the real browser directly.
             if !args.iter().any(|a| a == "--auto-connect") {
                 args.insert(0, "--auto-connect".to_string());
             }
@@ -260,11 +257,26 @@ fn run_agent_browser_with_connection(
     use_stealth: bool,
     headed: bool,
 ) -> Result<String> {
+    run_agent_browser_with_connection_timeout(args, format, connection, use_stealth, headed, None)
+}
+
+fn run_agent_browser_with_connection_timeout(
+    args: Vec<String>,
+    format: OutputFormat,
+    connection: Option<&BrowserConnection>,
+    use_stealth: bool,
+    headed: bool,
+    timeout_ms: Option<u64>,
+) -> Result<String> {
     let (bin, prefix_args) = resolve_agent_browser()?;
     let mut cmd = Command::new(&bin);
     let final_args = build_agent_browser_args(args, format, connection, use_stealth, headed);
     let mut all_args = prefix_args;
     all_args.extend(final_args);
+
+    if let Some(timeout) = timeout_ms {
+        cmd.env("AGENT_BROWSER_DEFAULT_TIMEOUT", timeout.to_string());
+    }
 
     let output = cmd
         .args(&all_args)
@@ -384,12 +396,13 @@ fn run_recipe_with_connection(
         let commands = expand_step(action, step.args.as_deref(), &ctx)?;
 
         for args in commands {
-            let stdout = match run_agent_browser_with_connection(
+            let stdout = match run_agent_browser_with_connection_timeout(
                 args.clone(),
                 format,
                 connection,
                 ctx.use_stealth,
                 headed,
+                step.timeout_ms,
             ) {
                 Ok(stdout) => stdout,
                 Err(err) => {
@@ -413,12 +426,13 @@ fn run_recipe_with_connection(
                         snapshot.as_deref(),
                     )? {
                         headed = true;
-                        run_agent_browser_with_connection(
+                        run_agent_browser_with_connection_timeout(
                             args.clone(),
                             format,
                             connection,
                             ctx.use_stealth,
                             headed,
+                            step.timeout_ms,
                         )?
                     } else {
                         return Err(err.context(format!("recipe step {idx} ({action}) failed")));
@@ -902,6 +916,21 @@ pub fn try_auto_connect(target_url: &str) -> Result<()> {
     verify_auth_cdp(target_url, &connection)
 }
 
+/// Lightweight auto-connect check: verifies Chrome is reachable via
+/// auto-connect without opening new tabs. Used by the recipe path where
+/// the recipe itself handles navigation and auth detection.
+pub fn try_auto_connect_lite() -> Result<()> {
+    let connection = BrowserConnection::AutoConnect;
+    run_agent_browser_with_connection(
+        vec!["snapshot".to_string(), "-c".to_string()],
+        OutputFormat::Text,
+        Some(&connection),
+        /* use_stealth */ false,
+        /* headed */ false,
+    )?;
+    Ok(())
+}
+
 pub fn verify_auth_cdp(target_url: &str, connection: &BrowserConnection) -> Result<()> {
     if !connection.is_live_attach() {
         return Err(anyhow!(
@@ -1213,13 +1242,20 @@ fn expand_bundle_text_step(
             return Err(anyhow!("{action} step requires selector and text"));
         }
         let selector = interpolate(&args[0], ctx, None)?;
+        // Interpolate the full template (replaces {{bundle_text}}, {{prompt}}, etc.)
+        // then chunk the result. This ensures recipe vars like {{prompt}} aren't lost.
+        let full_text = interpolate(&args[1], ctx, Some(text))?;
+        let full_chunks = chunk_text(&full_text, CHUNK_BYTES);
+        if full_chunks.is_empty() {
+            return Ok(Vec::new());
+        }
         let mut commands = Vec::new();
         commands.push(vec![
             action.to_string(),
             selector.clone(),
-            chunks[0].clone(),
+            full_chunks[0].clone(),
         ]);
-        for chunk in chunks.iter().skip(1) {
+        for chunk in full_chunks.iter().skip(1) {
             commands.push(vec!["type".to_string(), selector.clone(), chunk.clone()]);
         }
         return Ok(commands);
@@ -1516,6 +1552,26 @@ mod tests {
     }
 
     #[test]
+    fn expand_fill_step_includes_prompt_with_bundle_text() {
+        let mut ctx = recipe_context();
+        ctx.vars
+            .insert("prompt".to_string(), "What does this do?".to_string());
+        let args = vec![
+            "#prompt-textarea".to_string(),
+            "{{bundle_text}}\n\n{{prompt}}".to_string(),
+        ];
+        let commands =
+            expand_bundle_text_step("fill", &args, ctx.bundle_text.as_deref().unwrap(), &ctx)
+                .unwrap();
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0][0], "fill");
+        assert_eq!(commands[0][1], "#prompt-textarea");
+        // Must contain both bundle text AND the prompt
+        assert!(commands[0][2].contains("hello world")); // bundle_text
+        assert!(commands[0][2].contains("What does this do?")); // {{prompt}}
+    }
+
+    #[test]
     fn interpolate_does_not_expand_recipe_vars_inside_bundle_text() {
         let ctx = recipe_context();
         let result = interpolate("{{bundle_text}}", &ctx, Some("literal {{model}}")).unwrap();
@@ -1542,7 +1598,7 @@ mod tests {
     }
 
     #[test]
-    fn build_agent_browser_args_adds_auto_connect_session_flags() {
+    fn build_agent_browser_args_omits_auto_connect_session_flags() {
         let args = build_agent_browser_args(
             vec!["open".to_string(), CHATGPT_URL.to_string()],
             OutputFormat::Text,
@@ -1551,8 +1607,8 @@ mod tests {
             /* headed */ false,
         );
         assert!(args.iter().any(|arg| arg == "--auto-connect"));
-        assert!(args.iter().any(|arg| arg == "--session"));
-        assert!(args.iter().any(|arg| arg == CDP_SESSION_NAME));
+        assert!(!args.iter().any(|arg| arg == "--session"));
+        assert!(!args.iter().any(|arg| arg == CDP_SESSION_NAME));
     }
 
     #[test]
@@ -1785,6 +1841,21 @@ steps:
         )
         .unwrap_err();
         assert!(step_err.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn recipe_step_parses_timeout_ms() {
+        let recipe = serde_yaml::from_str::<Recipe>(
+            r#"
+name: test
+steps:
+  - action: wait
+    args: ["--fn", "document.querySelector('#done')"]
+    timeout_ms: 180000
+"#,
+        )
+        .unwrap();
+        assert_eq!(recipe.steps[0].timeout_ms, Some(180000));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -993,9 +993,9 @@ fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputFormat) -> 
                     .to_string_lossy()
                     .to_lowercase()
                     .contains("chatgpt");
-            // Try to resolve the best browser connection (CDP > auto_connect > cookie > profile).
-            // Use the lite auto-connect check for recipes — it verifies Chrome is reachable
-            // without opening new tabs, since the recipe itself handles navigation.
+            // Try CDP or auto-connect for a live browser connection. Falls back to
+            // cookie/profile if neither is available. Uses the lite auto-connect check
+            // for recipes — verifies Chrome is reachable without opening new tabs.
             let live_connection = if needs_auth {
                 if let Some(endpoint) =
                     browser::resolve_cdp_endpoint(recipe_args.cdp.as_deref(), &ctx.config)

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -994,23 +994,25 @@ fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputFormat) -> 
                     .to_lowercase()
                     .contains("chatgpt");
             // Try to resolve the best browser connection (CDP > auto_connect > cookie > profile).
-            // This reuses the same resolution logic as `check` and `attach`.
+            // Use the lite auto-connect check for recipes — it verifies Chrome is reachable
+            // without opening new tabs, since the recipe itself handles navigation.
             let live_connection = if needs_auth {
-                match browser::resolve_browser_connection(
-                    &ctx.config,
-                    recipe_args.cdp.as_deref(),
-                    &profile_dir,
-                    browser::CHATGPT_URL,
-                ) {
-                    Ok(c) if c.is_live_attach() => Some(c),
-                    Ok(_) => None, // non-live connection; fall through to legacy path
-                    Err(e) => {
-                        if recipe_args.cdp.is_some() {
-                            return Err(e.context("explicit --cdp failed; not falling back"));
+                if let Some(endpoint) =
+                    browser::resolve_cdp_endpoint(recipe_args.cdp.as_deref(), &ctx.config)
+                {
+                    match browser::try_cdp_attach(&endpoint, browser::CHATGPT_URL) {
+                        Ok(()) => Some(browser::BrowserConnection::Cdp { endpoint }),
+                        Err(e) => {
+                            if recipe_args.cdp.is_some() {
+                                return Err(e.context("explicit --cdp failed; not falling back"));
+                            }
+                            None
                         }
-                        eprintln!("live-attach unavailable, falling back to cookie/profile: {e}");
-                        None
                     }
+                } else if browser::try_auto_connect_lite().is_ok() {
+                    Some(browser::BrowserConnection::AutoConnect)
+                } else {
+                    None
                 }
             } else {
                 None

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -3,7 +3,7 @@ name: chatgpt
 # Falls back to cookie sync if no live browser session is available.
 #
 # Variables:
-#   model    — model slug or display name (e.g., "gpt-5-4-pro" or "Pro 5.4"). Omit to keep current.
+#   model    — model slug (e.g., "gpt-5-4-pro"). Omit to keep current.
 #   extended — set to "false" to disable Extended Pro. Default: leave as-is.
 #   prompt   — prompt text to send with the attachment.
 
@@ -13,121 +13,90 @@ defaults:
   extended: ""
 
 steps:
-  # Open ChatGPT
-  - action: open
-    args: ["https://chatgpt.com/"]
-  - action: wait
-    args: ["--load", "domcontentloaded"]
-  - sleep_ms: 2000
+  # Navigate to ChatGPT. Use eval instead of open because open delegates
+  # to system tools which creates a tab outside agent-browser's control.
+  # eval navigates the active tab directly, keeping session context correct.
+  - action: eval
+    args:
+      - "window.location.href = 'https://chatgpt.com/'"
+  - sleep_ms: 4000
 
-  # Select model if --var model is provided. Accepts slug (gpt-5-4-pro) or
-  # display name ("Pro 5.4"). Known slugs are normalized to display names.
+  # Select model if --var model is provided.
   - action: eval
     args:
       - |
         (() => {
           const raw = "{{model}}";
           if (!raw) return "skipped: no model specified";
-          const btn = document.querySelector('button[aria-label*="Model selector"]');
+          const btn = document.querySelector('[data-testid="model-switcher-dropdown-button"], button[aria-label*="Model selector"]');
           if (!btn) throw new Error("model selector button not found");
           btn.click();
           return "opened model selector";
         })()
-  - sleep_ms: 800
+  - sleep_ms: 1200
   - action: eval
     args:
       - |
         (() => {
           const raw = "{{model}}";
           if (!raw) return "skipped: no model specified";
-          const slugs = {
-            "gpt-5-4-pro": "Pro 5.4",
-            "gpt-4o": "4o",
-            "o3": "o3",
-            "o4-mini": "o4-mini",
-            "o4-mini-high": "o4-mini-high",
-          };
-          const display = slugs[raw.toLowerCase()] || raw;
-          const items = Array.from(document.querySelectorAll(
-            '[role="menuitem"], [role="option"], [data-testid*="model"]'
-          ));
-          const match = items.find(el =>
-            (el.textContent || "").trim().includes(display)
-          );
-          if (!match) throw new Error("model '" + display + "' not found in selector");
-          match.click();
-          return "selected model: " + display;
+          const slug = raw.toLowerCase();
+          const byTestId = document.querySelector('[data-testid="model-switcher-' + slug + '"]');
+          if (byTestId) { byTestId.click(); return "selected: " + slug; }
+          const names = {"gpt-5-4-pro":"pro","gpt-5-4-thinking":"thinking","gpt-5-3":"instant","pro":"pro","thinking":"thinking","instant":"instant"};
+          const target = names[slug] || slug;
+          const items = Array.from(document.querySelectorAll('[role="menuitem"]'));
+          const match = items.find(el => (el.textContent||"").trim().toLowerCase().includes(target));
+          if (match) { match.click(); return "selected: " + target; }
+          throw new Error("model '" + slug + "' not found");
         })()
   - sleep_ms: 500
 
   # Disable Extended Pro only when explicitly requested (--var extended=false).
-  # Default: leave Extended Pro as-is.
   - action: eval
     args:
       - |
         (() => {
           const extended = "{{extended}}";
           if (extended !== "false") return "skipped: extended not disabled";
-          const btn = document.querySelector(
-            'button[aria-label*="click to remove"][aria-label*="Extended"]'
-          );
+          const btn = document.querySelector('button[aria-label*="click to remove"][aria-label*="Extended"]');
           if (btn) { btn.click(); return "disabled Extended Pro"; }
           return "Extended Pro already off";
         })()
   - sleep_ms: 500
 
-  # Prime the visible attachment flow before targeting the underlying file input.
-  # ChatGPT removed the <label> element; the button now uses aria-label only.
-  # Use the stable data-testid / id selector instead of `find label`.
-  - action: click
-    args: ["#composer-plus-btn"]
+  # Clear the textarea before injecting content. Prevents accumulation
+  # across runs when auto-connect reuses the same tab.
+  - action: eval
+    args:
+      - 'document.querySelector("#prompt-textarea").innerHTML = ""; "cleared"'
+
+  # Inject bundle content + prompt. Uses fill (handles escaping of arbitrary
+  # text) followed by eval to dispatch InputEvent (triggers React state) and
+  # click send. agent-browser fill alone doesn't trigger React on contenteditable.
+  - action: fill
+    args: ["#prompt-textarea", "{{bundle_text}}\n\n{{prompt}}"]
   - sleep_ms: 500
 
-  # Attach the bundle as a file (handles large codebases that exceed paste limits)
-  - action: upload
-    args: ["input[type=file]:not([id])", "{{bundle_path}}"]
+  # Trigger React state update and send. eval click works where native
+  # agent-browser click does not (React event handler binding).
   - action: eval
     args:
       - |
         (() => {
-          const input = document.querySelector('input[type="file"]:not([id])');
-          if (!input) {
-            throw new Error("upload input not found");
-          }
-          input.dispatchEvent(new Event("change", { bubbles: true }));
-          return input.files?.[0]?.name ?? null;
-        })()
-  - sleep_ms: 3000
-  - action: eval
-    args:
-      - |
-        (() => {
-          const alerts = Array.from(
-            document.querySelectorAll('[role="alert"], [aria-live]')
-          )
-            .map((el) => (el.textContent || "").trim())
-            .filter(Boolean);
-          const uploadError = alerts.find((text) =>
-            /unable to upload/i.test(text)
-          );
-          if (uploadError) {
-            throw new Error(uploadError);
-          }
-          return alerts;
+          const el = document.querySelector("#prompt-textarea");
+          el.dispatchEvent(new InputEvent("input", { bubbles: true }));
+          const btn = document.querySelector("button[data-testid='send-button']");
+          if (!btn) throw new Error("send button not found");
+          if (btn.disabled) throw new Error("send button disabled — text may not have been injected");
+          btn.click();
+          return "sent";
         })()
 
-  # Add a short prompt referencing the attachment
-  - action: type
-    args: ["#prompt-textarea", "{{prompt}}"]
-  - sleep_ms: 500
-
-  # Send the message. Click the send button instead of pressing Enter, which
-  # can be interpreted as a newline when a file is attached.
-  - action: click
-    args: ['button[aria-label="Send prompt"]']
-
-  # Wait for ChatGPT to finish generating (2 minutes for large bundles)
-  - sleep_ms: 120000
+  # Wait for ChatGPT to finish generating. Poll-based wait is blocked by
+  # agent-browser's 30s IPC ceiling (EAGAIN above ~30s). Using fixed sleep
+  # until the transport supports long waits. See issue #52.
+  - sleep_ms: 180000
 
   # Capture final state
   - action: snapshot

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -69,7 +69,13 @@ steps:
   # across runs when auto-connect reuses the same tab.
   - action: eval
     args:
-      - 'document.querySelector("#prompt-textarea").innerHTML = ""; "cleared"'
+      - |
+        (() => {
+          const el = document.querySelector("#prompt-textarea");
+          el.innerHTML = "";
+          el.dispatchEvent(new InputEvent("input", { bubbles: true }));
+          return "cleared";
+        })()
 
   # Inject bundle content + prompt. Uses fill (handles escaping of arbitrary
   # text) followed by eval to dispatch InputEvent (triggers React state) and


### PR DESCRIPTION
## Summary
- Fix auto-connect `--session` isolation bug (couldn't see real Chrome DOM)
- Fix send button: eval `btn.click()` instead of `find` (React event handler binding)
- Fix text injection: `fill` + eval `InputEvent` dispatch (fill alone doesn't trigger React on contenteditable)
- Fix prompt text lost in `expand_bundle_text_step` (interpolate full template before chunking)
- Fix 3-tab issue: `try_auto_connect_lite()` for recipes (snapshot-only, no extra tabs)
- Add `timeout_ms` to `RecipeStep` for future poll-based waits
- Simplify recipe model selection with `data-testid` selectors

## Test plan
- [x] 118 unit + integration tests pass
- [x] Zero clippy warnings, fmt clean
- [x] Manual e2e: ChatGPT Pro responded "it's a Rust program... I'm GPT-5.4 Pro" via auto-connect
- [ ] CI passes

## Known limitations (follow-up)
- Model selection via `--var model` needs native click approach (eval `.click()` doesn't open React dropdowns)
- Poll-based wait (#52) blocked by agent-browser 30s IPC ceiling
- chrome-devtools-mcp as future alternative backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)