### PR TITLE
feat(models): add models frontier — live-derived rankings

### DIFF
--- a/.agents/skills/yoetz/SKILL.md
+++ b/.agents/skills/yoetz/SKILL.md
@@ -8,7 +8,7 @@ description: >
   "second opinion" or "ask another model" requests.
 metadata:
   short-description: LLM council and multimodal gateway CLI
-  compatibility: Codex, codex-cli
+  compatibility: claude-code, codex-cli
 ---
 
 # Yoetz Skill
@@ -47,20 +47,23 @@ Prefer Homebrew when available — pre-built binaries, fastest install.
 - Set `YOETZ_AGENT=1` environment variable
 - Parse JSON results and present summary to user
 - For large bundles, run `yoetz bundle` first to inspect size
-- Always resolve uncertain model IDs with `yoetz models resolve` before calling
+- **NEVER type a model ID from memory.** Your training data model names are WRONG. Always resolve first.
 
-## Model Discovery
+## Model Resolution Protocol (MANDATORY)
 
-Before using an unfamiliar model ID, resolve it against the synced registry:
+**NEVER type a model ID from memory.** Agent training data contains stale model names. Always query the live registry.
 
+**To find the current frontier model per provider:**
 ```bash
-yoetz models resolve "grok-4.1" --format json
+yoetz models frontier --format json
 ```
 
-Example output:
-```json
-[{"id":"x-ai/grok-4","score":800,"provider":"openrouter","context_length":131072,"max_output_tokens":16384}]
+**To find a specific model:**
+```bash
+yoetz models resolve "grok" --format json
 ```
+
+**Use the returned ID verbatim in your commands.** Do not modify, shorten, or guess model IDs.
 
 If the registry is stale or empty, sync first:
 ```bash
@@ -69,27 +72,29 @@ yoetz models sync
 
 Search for models by keyword:
 ```bash
-yoetz models list -s Codex --format json
+yoetz models list -s claude --format json
 ```
 
 ## Quick Reference
 
 | Task | Command |
 |------|---------|
-| Ask single model | `yoetz ask -p "question" -f src/*.rs --provider openai --model gpt-5.2 --format json` |
-| Council vote | `yoetz council -p "question" --models openai/gpt-5.2,gemini/gemini-3-pro-preview,openrouter/xai/grok-4.1 --format json` |
+| Find frontier model per provider | `yoetz models frontier --format json` |
+| Find frontier model for a provider | `yoetz models frontier --family openai --format json` |
+| Resolve a model ID | `yoetz models resolve "grok" --format json` |
+| Search models | `yoetz models list -s claude --format json` |
+| Ask single model | `yoetz ask -p "question" -f src/*.rs --provider openai --model MODEL_ID --format json` |
+| Council vote | `yoetz council -p "question" --models MODEL1,MODEL2,MODEL3 --format json` |
 | Review staged diff | `yoetz review diff --staged --format json` |
 | Review file | `yoetz review file --path src/main.rs --format json` |
 | Bundle files | `yoetz bundle -p "context" -f src/**/*.rs --format json` |
-| Generate image | `yoetz generate image -p "description" --provider openai --model gpt-image-1 --format json` |
-| Resolve model ID | `yoetz models resolve "grok-4.1" --format json` |
-| Search models | `yoetz models list -s Codex --format json` |
-| Estimate cost | `yoetz pricing estimate --model gpt-5.2 --input-tokens 1000 --output-tokens 500` |
+| Generate image | `yoetz generate image -p "description" --provider openai --model MODEL_ID --format json` |
+| Estimate cost | `yoetz pricing estimate --model MODEL_ID --input-tokens 1000 --output-tokens 500` |
 | Browser login | `yoetz browser login` |
 | Browser check | `yoetz browser check` |
 | Browser cookie sync | `yoetz browser sync-cookies` |
 
-See [commands reference](references/commands.md) for full details.
+**Replace MODEL_ID with IDs from `yoetz models frontier` or `yoetz models resolve`.**
 
 ## Council (Multi-Model Consensus)
 
@@ -99,13 +104,13 @@ Get opinions from multiple LLMs in parallel. **`--models` is required.**
 yoetz council \
   -p "Should we use async traits or callbacks for this API?" \
   -f src/lib.rs -f src/api/*.rs \
-  --models openai/gpt-5.2,gemini/gemini-3-pro-preview,openrouter/xai/grok-4.1 \
+  --models openai/gpt-5.4,gemini/gemini-3.1-pro-preview,openrouter/xai/grok-4.20-multi-agent-beta \
   --format json
 ```
 
 **Example council sets:**
-- Cross-provider: `openai/gpt-5.2,gemini/gemini-3-pro-preview,openrouter/xai/grok-4.1`
-- Via OpenRouter only: `openrouter/openai/gpt-5.2,openrouter/anthropic/Codex-sonnet-4,openrouter/google/gemini-3-pro-preview`
+- Cross-provider: `openai/gpt-5.4,gemini/gemini-3.1-pro-preview,openrouter/xai/grok-4.20-multi-agent-beta`
+- Via OpenRouter only: `openrouter/openai/gpt-5.4,openrouter/anthropic/claude-sonnet-4.6,openrouter/google/gemini-3.1-pro-preview`
 
 ## Ask (Single Model)
 
@@ -115,14 +120,14 @@ Quick question with file context:
 yoetz ask \
   -p "What's the bug in this error handling?" \
   -f src/error.rs \
-  --provider openai --model gpt-5.2 \
+  --provider openai --model gpt-5.4 \
   --format json
 ```
 
 **For Anthropic/XAI models**, use OpenRouter (no extra config needed):
 ```bash
 yoetz ask -p "Review this" -f src/*.rs \
-  --provider openrouter --model anthropic/Codex-sonnet-4 \
+  --provider openrouter --model anthropic/claude-sonnet-4.6 \
   --format json
 ```
 
@@ -140,7 +145,7 @@ yoetz review file --path src/main.rs --format json
 
 ### With custom model
 ```bash
-yoetz review diff --staged --provider openai --model gpt-5.2 --format json
+yoetz review diff --staged --provider openai --model gpt-5.4 --format json
 ```
 
 ## Bundle (for manual paste or browser mode)
@@ -170,9 +175,10 @@ For web-only models like ChatGPT Pro that lack API access. Uses Oracle-style coo
 ### Prerequisites
 
 ```bash
-# Node >=22 required. agent-browser is auto-resolved via npx if not in PATH.
-# Install sweet-cookie for cookie extraction
-npm install -g @steipete/sweet-cookie
+# Node >=24.4 required for Chrome cookie sync. agent-browser is auto-resolved via npx if not in PATH.
+# Homebrew and GitHub release installs bundle the cookie extractor dependency.
+# If you're running from a source checkout, install it once:
+npm ci --prefix scripts
 ```
 
 ### Profile location
@@ -199,6 +205,7 @@ yoetz browser sync-cookies
 
 This extracts your authenticated cookies from Chrome and saves them for agent-browser.
 State file is stored at `~/.config/yoetz/browser-profile/state.json` (or your overridden profile path).
+If macOS shows a Keychain prompt for `Chrome Safe Storage`, click `Always Allow`.
 
 **Step 3: Verify authentication**
 ```bash
@@ -222,6 +229,9 @@ BUNDLE=$(yoetz bundle -p "Review this code" -f src/*.rs --format json | jq -r .a
 
 # Send to ChatGPT
 yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE"
+
+# Override the built-in model selection if needed
+yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE" --var model=gpt-5-4-pro
 ```
 
 ### Combined workflow: API + Browser
@@ -229,7 +239,7 @@ yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE"
 ```bash
 # Get fast API results first
 yoetz council -p "Review" -f src/*.rs \
-  --models openai/gpt-5.2,gemini/gemini-3-pro-preview --format json > api.json
+  --models openai/gpt-5.4,gemini/gemini-3.1-pro-preview --format json > api.json
 
 # Then get ChatGPT Pro opinion
 BUNDLE=$(yoetz bundle -p "Review" -f src/*.rs --format json | jq -r .artifacts.bundle_md)
@@ -248,22 +258,22 @@ yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE"
 yoetz browser recipe --recipe ./my-recipes/custom.yaml --bundle "$BUNDLE"
 ```
 
-Built-in recipes: `chatgpt`, `Codex`, `gemini`.
+Built-in recipes: `chatgpt`, `claude`, `gemini`.
 
 ### Troubleshooting
 
 | Symptom | Fix |
 |---------|-----|
-| `extract-cookies.mjs not found` | Run `npm install -g @steipete/sweet-cookie` and `brew reinstall yoetz` (v0.2.6+) |
-| `cookie extraction failed` | Ensure Node >= 22, log into ChatGPT in real Chrome, close Chrome, retry |
+| `extract-cookies.mjs not found` | Reinstall yoetz so the bundled browser scripts are present |
+| `cookie extraction failed` | Ensure Node >= 24.4, and if you're running from a source checkout run `npm ci --prefix scripts`. Then log into ChatGPT in real Chrome, close Chrome, and if macOS shows a `Chrome Safe Storage` prompt click `Always Allow` |
 | `cloudflare challenge detected` | Re-sync: log into ChatGPT in Chrome, close Chrome, `yoetz browser sync-cookies` |
 | `chatgpt login required` | Run `yoetz browser login` for manual auth, or sync cookies |
 | `agent-browser failed` | Ensure `npx agent-browser --version` works, or `npm install -g agent-browser` |
 | Recipe not found | Use `--recipe chatgpt` (name) or full path. Check `brew --prefix`/share/yoetz/recipes/ |
 
-### Codex-in-Chrome MCP Fallback
+### Claude-in-Chrome MCP Fallback
 
-When `yoetz browser` pipeline fails (agent-browser issues, cookie extraction errors), use Codex-in-Chrome MCP tools directly:
+When `yoetz browser` pipeline fails (agent-browser issues, cookie extraction errors), use Claude-in-Chrome MCP tools directly:
 
 1. **Create bundle**: `yoetz bundle -p "Review" -f src/**/*.ts --format json`
 2. **Copy to clipboard as file**: Use macOS `osascript` to put the bundle.md on clipboard:
@@ -293,19 +303,19 @@ The browser module uses stealth techniques to avoid Cloudflare detection:
 - `openrouter` - `OPENROUTER_API_KEY`
 
 **Via OpenRouter** (recommended for Anthropic/XAI - no extra config):
-- `openrouter/anthropic/Codex-sonnet-4`
-- `openrouter/xai/grok-4.1`
+- `openrouter/anthropic/claude-sonnet-4.6`
+- `openrouter/xai/grok-4.20-multi-agent-beta`
 
 **Model format:** `provider/model`
-- `openai/gpt-5.2`
-- `gemini/gemini-3-pro-preview`
-- `openrouter/anthropic/Codex-sonnet-4` (nested for OpenRouter)
+- `openai/gpt-5.4`
+- `gemini/gemini-3.1-pro-preview`
+- `openrouter/anthropic/claude-sonnet-4.6` (nested for OpenRouter)
 
 ## Cost Control
 
 ```bash
 # Estimate before running
-yoetz pricing estimate --model gpt-5.2 --input-tokens 12000 --output-tokens 800
+yoetz pricing estimate --model gpt-5.4 --input-tokens 12000 --output-tokens 800
 
 # Set limits
 yoetz ask -p "Review" --max-cost-usd 1.00 --daily-budget-usd 5.00 --format json

--- a/.claude/skills/yoetz/SKILL.md
+++ b/.claude/skills/yoetz/SKILL.md
@@ -47,20 +47,23 @@ Prefer Homebrew when available — pre-built binaries, fastest install.
 - Set `YOETZ_AGENT=1` environment variable
 - Parse JSON results and present summary to user
 - For large bundles, run `yoetz bundle` first to inspect size
-- Always resolve uncertain model IDs with `yoetz models resolve` before calling
+- **NEVER type a model ID from memory.** Your training data model names are WRONG. Always resolve first.
 
-## Model Discovery
+## Model Resolution Protocol (MANDATORY)
 
-Before using an unfamiliar model ID, resolve it against the synced registry:
+**NEVER type a model ID from memory.** Agent training data contains stale model names. Always query the live registry.
 
+**To find the current frontier model per provider:**
 ```bash
-yoetz models resolve "grok-4.1" --format json
+yoetz models frontier --format json
 ```
 
-Example output:
-```json
-[{"id":"x-ai/grok-4","score":800,"provider":"openrouter","context_length":131072,"max_output_tokens":16384}]
+**To find a specific model:**
+```bash
+yoetz models resolve "grok" --format json
 ```
+
+**Use the returned ID verbatim in your commands.** Do not modify, shorten, or guess model IDs.
 
 If the registry is stale or empty, sync first:
 ```bash
@@ -76,20 +79,22 @@ yoetz models list -s claude --format json
 
 | Task | Command |
 |------|---------|
-| Ask single model | `yoetz ask -p "question" -f src/*.rs --provider openai --model gpt-5.2 --format json` |
-| Council vote | `yoetz council -p "question" --models openai/gpt-5.2,gemini/gemini-3-pro-preview,openrouter/xai/grok-4.1 --format json` |
+| Find frontier model per provider | `yoetz models frontier --format json` |
+| Find frontier model for a provider | `yoetz models frontier --family openai --format json` |
+| Resolve a model ID | `yoetz models resolve "grok" --format json` |
+| Search models | `yoetz models list -s claude --format json` |
+| Ask single model | `yoetz ask -p "question" -f src/*.rs --provider openai --model MODEL_ID --format json` |
+| Council vote | `yoetz council -p "question" --models MODEL1,MODEL2,MODEL3 --format json` |
 | Review staged diff | `yoetz review diff --staged --format json` |
 | Review file | `yoetz review file --path src/main.rs --format json` |
 | Bundle files | `yoetz bundle -p "context" -f src/**/*.rs --format json` |
-| Generate image | `yoetz generate image -p "description" --provider openai --model gpt-image-1 --format json` |
-| Resolve model ID | `yoetz models resolve "grok-4.1" --format json` |
-| Search models | `yoetz models list -s claude --format json` |
-| Estimate cost | `yoetz pricing estimate --model gpt-5.2 --input-tokens 1000 --output-tokens 500` |
+| Generate image | `yoetz generate image -p "description" --provider openai --model MODEL_ID --format json` |
+| Estimate cost | `yoetz pricing estimate --model MODEL_ID --input-tokens 1000 --output-tokens 500` |
 | Browser login | `yoetz browser login` |
 | Browser check | `yoetz browser check` |
 | Browser cookie sync | `yoetz browser sync-cookies` |
 
-See [commands reference](references/commands.md) for full details.
+**Replace MODEL_ID with IDs from `yoetz models frontier` or `yoetz models resolve`.**
 
 ## Council (Multi-Model Consensus)
 
@@ -99,13 +104,13 @@ Get opinions from multiple LLMs in parallel. **`--models` is required.**
 yoetz council \
   -p "Should we use async traits or callbacks for this API?" \
   -f src/lib.rs -f src/api/*.rs \
-  --models openai/gpt-5.2,gemini/gemini-3-pro-preview,openrouter/xai/grok-4.1 \
+  --models openai/gpt-5.4,gemini/gemini-3.1-pro-preview,openrouter/xai/grok-4.20-multi-agent-beta \
   --format json
 ```
 
 **Example council sets:**
-- Cross-provider: `openai/gpt-5.2,gemini/gemini-3-pro-preview,openrouter/xai/grok-4.1`
-- Via OpenRouter only: `openrouter/openai/gpt-5.2,openrouter/anthropic/claude-sonnet-4,openrouter/google/gemini-3-pro-preview`
+- Cross-provider: `openai/gpt-5.4,gemini/gemini-3.1-pro-preview,openrouter/xai/grok-4.20-multi-agent-beta`
+- Via OpenRouter only: `openrouter/openai/gpt-5.4,openrouter/anthropic/claude-sonnet-4.6,openrouter/google/gemini-3.1-pro-preview`
 
 ## Ask (Single Model)
 
@@ -115,14 +120,14 @@ Quick question with file context:
 yoetz ask \
   -p "What's the bug in this error handling?" \
   -f src/error.rs \
-  --provider openai --model gpt-5.2 \
+  --provider openai --model gpt-5.4 \
   --format json
 ```
 
 **For Anthropic/XAI models**, use OpenRouter (no extra config needed):
 ```bash
 yoetz ask -p "Review this" -f src/*.rs \
-  --provider openrouter --model anthropic/claude-sonnet-4 \
+  --provider openrouter --model anthropic/claude-sonnet-4.6 \
   --format json
 ```
 
@@ -140,7 +145,7 @@ yoetz review file --path src/main.rs --format json
 
 ### With custom model
 ```bash
-yoetz review diff --staged --provider openai --model gpt-5.2 --format json
+yoetz review diff --staged --provider openai --model gpt-5.4 --format json
 ```
 
 ## Bundle (for manual paste or browser mode)
@@ -170,9 +175,10 @@ For web-only models like ChatGPT Pro that lack API access. Uses Oracle-style coo
 ### Prerequisites
 
 ```bash
-# Node >=22 required. agent-browser is auto-resolved via npx if not in PATH.
-# Install sweet-cookie for cookie extraction
-npm install -g @steipete/sweet-cookie
+# Node >=24.4 required for Chrome cookie sync. agent-browser is auto-resolved via npx if not in PATH.
+# Homebrew and GitHub release installs bundle the cookie extractor dependency.
+# If you're running from a source checkout, install it once:
+npm ci --prefix scripts
 ```
 
 ### Profile location
@@ -199,6 +205,7 @@ yoetz browser sync-cookies
 
 This extracts your authenticated cookies from Chrome and saves them for agent-browser.
 State file is stored at `~/.config/yoetz/browser-profile/state.json` (or your overridden profile path).
+If macOS shows a Keychain prompt for `Chrome Safe Storage`, click `Always Allow`.
 
 **Step 3: Verify authentication**
 ```bash
@@ -222,6 +229,9 @@ BUNDLE=$(yoetz bundle -p "Review this code" -f src/*.rs --format json | jq -r .a
 
 # Send to ChatGPT
 yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE"
+
+# Override the built-in model selection if needed
+yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE" --var model=gpt-5-4-pro
 ```
 
 ### Combined workflow: API + Browser
@@ -229,7 +239,7 @@ yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE"
 ```bash
 # Get fast API results first
 yoetz council -p "Review" -f src/*.rs \
-  --models openai/gpt-5.2,gemini/gemini-3-pro-preview --format json > api.json
+  --models openai/gpt-5.4,gemini/gemini-3.1-pro-preview --format json > api.json
 
 # Then get ChatGPT Pro opinion
 BUNDLE=$(yoetz bundle -p "Review" -f src/*.rs --format json | jq -r .artifacts.bundle_md)
@@ -254,8 +264,8 @@ Built-in recipes: `chatgpt`, `claude`, `gemini`.
 
 | Symptom | Fix |
 |---------|-----|
-| `extract-cookies.mjs not found` | Run `npm install -g @steipete/sweet-cookie` and `brew reinstall yoetz` (v0.2.6+) |
-| `cookie extraction failed` | Ensure Node >= 22, log into ChatGPT in real Chrome, close Chrome, retry |
+| `extract-cookies.mjs not found` | Reinstall yoetz so the bundled browser scripts are present |
+| `cookie extraction failed` | Ensure Node >= 24.4, and if you're running from a source checkout run `npm ci --prefix scripts`. Then log into ChatGPT in real Chrome, close Chrome, and if macOS shows a `Chrome Safe Storage` prompt click `Always Allow` |
 | `cloudflare challenge detected` | Re-sync: log into ChatGPT in Chrome, close Chrome, `yoetz browser sync-cookies` |
 | `chatgpt login required` | Run `yoetz browser login` for manual auth, or sync cookies |
 | `agent-browser failed` | Ensure `npx agent-browser --version` works, or `npm install -g agent-browser` |
@@ -293,19 +303,19 @@ The browser module uses stealth techniques to avoid Cloudflare detection:
 - `openrouter` - `OPENROUTER_API_KEY`
 
 **Via OpenRouter** (recommended for Anthropic/XAI - no extra config):
-- `openrouter/anthropic/claude-sonnet-4`
-- `openrouter/xai/grok-4.1`
+- `openrouter/anthropic/claude-sonnet-4.6`
+- `openrouter/xai/grok-4.20-multi-agent-beta`
 
 **Model format:** `provider/model`
-- `openai/gpt-5.2`
-- `gemini/gemini-3-pro-preview`
-- `openrouter/anthropic/claude-sonnet-4` (nested for OpenRouter)
+- `openai/gpt-5.4`
+- `gemini/gemini-3.1-pro-preview`
+- `openrouter/anthropic/claude-sonnet-4.6` (nested for OpenRouter)
 
 ## Cost Control
 
 ```bash
 # Estimate before running
-yoetz pricing estimate --model gpt-5.2 --input-tokens 12000 --output-tokens 800
+yoetz pricing estimate --model gpt-5.4 --input-tokens 12000 --output-tokens 800
 
 # Set limits
 yoetz ask -p "Review" --max-cost-usd 1.00 --daily-budget-usd 5.00 --format json

--- a/.codex/skills/yoetz/SKILL.md
+++ b/.codex/skills/yoetz/SKILL.md
@@ -47,20 +47,23 @@ Prefer Homebrew when available — pre-built binaries, fastest install.
 - Set `YOETZ_AGENT=1` environment variable
 - Parse JSON results and present summary to user
 - For large bundles, run `yoetz bundle` first to inspect size
-- Always resolve uncertain model IDs with `yoetz models resolve` before calling
+- **NEVER type a model ID from memory.** Your training data model names are WRONG. Always resolve first.
 
-## Model Discovery
+## Model Resolution Protocol (MANDATORY)
 
-Before using an unfamiliar model ID, resolve it against the synced registry:
+**NEVER type a model ID from memory.** Agent training data contains stale model names. Always query the live registry.
 
+**To find the current frontier model per provider:**
 ```bash
-yoetz models resolve "grok-4.1" --format json
+yoetz models frontier --format json
 ```
 
-Example output:
-```json
-[{"id":"x-ai/grok-4","score":800,"provider":"openrouter","context_length":131072,"max_output_tokens":16384}]
+**To find a specific model:**
+```bash
+yoetz models resolve "grok" --format json
 ```
+
+**Use the returned ID verbatim in your commands.** Do not modify, shorten, or guess model IDs.
 
 If the registry is stale or empty, sync first:
 ```bash
@@ -76,15 +79,22 @@ yoetz models list -s claude --format json
 
 | Task | Command |
 |------|---------|
-| Ask single model | `yoetz ask -p "question" -f src/*.rs --provider openai --model gpt-5.2 --format json` |
-| Council vote | `yoetz council -p "question" --models openai/gpt-5.2,gemini/gemini-3-pro-preview,openrouter/xai/grok-4.1 --format json` |
+| Find frontier model per provider | `yoetz models frontier --format json` |
+| Find frontier model for a provider | `yoetz models frontier --family openai --format json` |
+| Resolve a model ID | `yoetz models resolve "grok" --format json` |
+| Search models | `yoetz models list -s claude --format json` |
+| Ask single model | `yoetz ask -p "question" -f src/*.rs --provider openai --model MODEL_ID --format json` |
+| Council vote | `yoetz council -p "question" --models MODEL1,MODEL2,MODEL3 --format json` |
 | Review staged diff | `yoetz review diff --staged --format json` |
 | Review file | `yoetz review file --path src/main.rs --format json` |
 | Bundle files | `yoetz bundle -p "context" -f src/**/*.rs --format json` |
-| Generate image | `yoetz generate image -p "description" --provider openai --model gpt-image-1 --format json` |
-| Resolve model ID | `yoetz models resolve "grok-4.1" --format json` |
-| Search models | `yoetz models list -s claude --format json` |
-| Estimate cost | `yoetz pricing estimate --model gpt-5.2 --input-tokens 1000 --output-tokens 500` |
+| Generate image | `yoetz generate image -p "description" --provider openai --model MODEL_ID --format json` |
+| Estimate cost | `yoetz pricing estimate --model MODEL_ID --input-tokens 1000 --output-tokens 500` |
+| Browser login | `yoetz browser login` |
+| Browser check | `yoetz browser check` |
+| Browser cookie sync | `yoetz browser sync-cookies` |
+
+**Replace MODEL_ID with IDs from `yoetz models frontier` or `yoetz models resolve`.**
 
 ## Council (Multi-Model Consensus)
 
@@ -94,32 +104,196 @@ Get opinions from multiple LLMs in parallel. **`--models` is required.**
 yoetz council \
   -p "Should we use async traits or callbacks for this API?" \
   -f src/lib.rs -f src/api/*.rs \
-  --models openai/gpt-5.2,gemini/gemini-3-pro-preview,openrouter/xai/grok-4.1 \
+  --models openai/gpt-5.4,gemini/gemini-3.1-pro-preview,openrouter/xai/grok-4.20-multi-agent-beta \
   --format json
 ```
 
+**Example council sets:**
+- Cross-provider: `openai/gpt-5.4,gemini/gemini-3.1-pro-preview,openrouter/xai/grok-4.20-multi-agent-beta`
+- Via OpenRouter only: `openrouter/openai/gpt-5.4,openrouter/anthropic/claude-sonnet-4.6,openrouter/google/gemini-3.1-pro-preview`
+
 ## Ask (Single Model)
+
+Quick question with file context:
 
 ```bash
 yoetz ask \
   -p "What's the bug in this error handling?" \
   -f src/error.rs \
-  --provider openai --model gpt-5.2 \
+  --provider openai --model gpt-5.4 \
+  --format json
+```
+
+**For Anthropic/XAI models**, use OpenRouter (no extra config needed):
+```bash
+yoetz ask -p "Review this" -f src/*.rs \
+  --provider openrouter --model anthropic/claude-sonnet-4.6 \
   --format json
 ```
 
 ## Review
 
+### Staged changes
 ```bash
 yoetz review diff --staged --format json
+```
+
+### Specific file
+```bash
 yoetz review file --path src/main.rs --format json
 ```
 
-## Bundle
+### With custom model
+```bash
+yoetz review diff --staged --provider openai --model gpt-5.4 --format json
+```
+
+## Bundle (for manual paste or browser mode)
+
+Bundle creates a session with files at `~/.yoetz/sessions/<id>/bundle.md`.
 
 ```bash
-yoetz bundle -p "context" -f src/**/*.rs --format json
+# Get bundle path from JSON output
+yoetz bundle -p "Explain this" -f src/**/*.rs --format json
+# Output includes: {"artifacts":{"bundle_md":"/Users/.../.yoetz/sessions/.../bundle.md",...},...}
+
+# Extract bundle_md path directly
+BUNDLE=$(yoetz bundle -p "Review" -f src/*.rs --format json | jq -r .artifacts.bundle_md)
+cat "$BUNDLE"
 ```
+
+**For browser workflows**, pass the bundle.md path:
+```bash
+BUNDLE=$(yoetz bundle -p "Review" -f src/*.rs --format json | jq -r .artifacts.bundle_md)
+yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE"
+```
+
+## Browser Fallback (Experimental)
+
+For web-only models like ChatGPT Pro that lack API access. Uses Oracle-style cookie extraction from real Chrome to bypass Cloudflare challenges.
+
+### Prerequisites
+
+```bash
+# Node >=24.4 required for Chrome cookie sync. agent-browser is auto-resolved via npx if not in PATH.
+# Homebrew and GitHub release installs bundle the cookie extractor dependency.
+# If you're running from a source checkout, install it once:
+npm ci --prefix scripts
+```
+
+### Profile location
+
+Default profile dir: `~/.config/yoetz/browser-profile/`
+
+Override per machine:
+```bash
+export YOETZ_BROWSER_PROFILE=/path/to/profile
+```
+
+### First-time setup
+
+**Step 1: Log into ChatGPT in real Chrome**
+1. Open Chrome (the real browser, not Playwright)
+2. Navigate to https://chatgpt.com/
+3. Log in with your account
+4. Close Chrome completely
+
+**Step 2: Sync cookies to agent-browser**
+```bash
+yoetz browser sync-cookies
+```
+
+This extracts your authenticated cookies from Chrome and saves them for agent-browser.
+State file is stored at `~/.config/yoetz/browser-profile/state.json` (or your overridden profile path).
+If macOS shows a Keychain prompt for `Chrome Safe Storage`, click `Always Allow`.
+
+**Step 3: Verify authentication**
+```bash
+yoetz browser check
+```
+
+### Re-sync when sessions expire
+
+If you see Cloudflare challenges or login prompts, re-sync:
+```bash
+# Log into ChatGPT in real Chrome, close Chrome, then:
+yoetz browser sync-cookies
+yoetz browser check
+```
+
+### Use ChatGPT Pro via recipe
+
+```bash
+# Create bundle and get bundle.md path
+BUNDLE=$(yoetz bundle -p "Review this code" -f src/*.rs --format json | jq -r .artifacts.bundle_md)
+
+# Send to ChatGPT
+yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE"
+
+# Override the built-in model selection if needed
+yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE" --var model=gpt-5-4-pro
+```
+
+### Combined workflow: API + Browser
+
+```bash
+# Get fast API results first
+yoetz council -p "Review" -f src/*.rs \
+  --models openai/gpt-5.4,gemini/gemini-3.1-pro-preview --format json > api.json
+
+# Then get ChatGPT Pro opinion
+BUNDLE=$(yoetz bundle -p "Review" -f src/*.rs --format json | jq -r .artifacts.bundle_md)
+yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE"
+```
+
+### Recipe name resolution
+
+Recipes can be specified by name (resolved from installed locations) or by path:
+
+```bash
+# By name (searches Homebrew share, XDG, etc.)
+yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE"
+
+# By explicit path
+yoetz browser recipe --recipe ./my-recipes/custom.yaml --bundle "$BUNDLE"
+```
+
+Built-in recipes: `chatgpt`, `claude`, `gemini`.
+
+### Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `extract-cookies.mjs not found` | Reinstall yoetz so the bundled browser scripts are present |
+| `cookie extraction failed` | Ensure Node >= 24.4, and if you're running from a source checkout run `npm ci --prefix scripts`. Then log into ChatGPT in real Chrome, close Chrome, and if macOS shows a `Chrome Safe Storage` prompt click `Always Allow` |
+| `cloudflare challenge detected` | Re-sync: log into ChatGPT in Chrome, close Chrome, `yoetz browser sync-cookies` |
+| `chatgpt login required` | Run `yoetz browser login` for manual auth, or sync cookies |
+| `agent-browser failed` | Ensure `npx agent-browser --version` works, or `npm install -g agent-browser` |
+| Recipe not found | Use `--recipe chatgpt` (name) or full path. Check `brew --prefix`/share/yoetz/recipes/ |
+
+### Claude-in-Chrome MCP Fallback
+
+When `yoetz browser` pipeline fails (agent-browser issues, cookie extraction errors), use Claude-in-Chrome MCP tools directly:
+
+1. **Create bundle**: `yoetz bundle -p "Review" -f src/**/*.ts --format json`
+2. **Copy to clipboard as file**: Use macOS `osascript` to put the bundle.md on clipboard:
+   ```bash
+   osascript -e 'set the clipboard to POSIX file "/path/to/bundle.md"'
+   ```
+3. **Navigate to ChatGPT**: Use `mcp__claude-in-chrome__navigate` to open chatgpt.com
+4. **Paste file**: Click the input area, then Cmd+V to paste the file from clipboard
+5. **Type prompt**: Use `mcp__claude-in-chrome__form_input` or `computer` tool to type the review prompt
+6. **Wait and extract**: Use `mcp__claude-in-chrome__get_page_text` to extract the response
+
+This bypasses agent-browser entirely and works with any browser-based LLM the user is logged into.
+
+### How it works
+
+The browser module uses stealth techniques to avoid Cloudflare detection:
+- Extracts real cookies from Chrome's encrypted cookie store
+- Injects them into Playwright via `--state`
+- Uses realistic User-Agent headers
+- Disables automation detection flags (`--disable-blink-features=AutomationControlled`)
 
 ## Provider Configuration
 
@@ -128,11 +302,29 @@ yoetz bundle -p "context" -f src/**/*.rs --format json
 - `gemini` - `GEMINI_API_KEY`
 - `openrouter` - `OPENROUTER_API_KEY`
 
-**Model format:** `provider/model` (e.g., `openai/gpt-5.2`, `openrouter/anthropic/claude-sonnet-4`)
+**Via OpenRouter** (recommended for Anthropic/XAI - no extra config):
+- `openrouter/anthropic/claude-sonnet-4.6`
+- `openrouter/xai/grok-4.20-multi-agent-beta`
+
+**Model format:** `provider/model`
+- `openai/gpt-5.4`
+- `gemini/gemini-3.1-pro-preview`
+- `openrouter/anthropic/claude-sonnet-4.6` (nested for OpenRouter)
 
 ## Cost Control
 
 ```bash
-yoetz pricing estimate --model gpt-5.2 --input-tokens 12000 --output-tokens 800
+# Estimate before running
+yoetz pricing estimate --model gpt-5.4 --input-tokens 12000 --output-tokens 800
+
+# Set limits
 yoetz ask -p "Review" --max-cost-usd 1.00 --daily-budget-usd 5.00 --format json
 ```
+
+## Tips
+
+- Use `--debug` to capture raw responses during troubleshooting
+- Gemini may return empty content if `--max-output-tokens` is too low
+- Session artifacts stored in `~/.yoetz/sessions/<id>/`
+- For image inputs: `yoetz ask -p "Describe" --image photo.png --format json`
+- ChatGPT recipe placeholder may vary by locale; check snapshot output if fill fails

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,9 +1726,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,9 +149,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -159,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",

--- a/crates/yoetz-cli/src/commands/ask.rs
+++ b/crates/yoetz-cli/src/commands/ask.rs
@@ -95,7 +95,7 @@ pub(crate) async fn handle_ask(
         registry_cache.as_ref(),
     );
     if let Some(ref reg_id) = registry_model_id {
-        crate::validate_model_or_suggest(reg_id, registry_cache.as_ref())?;
+        crate::validate_model_or_suggest(reg_id, registry_cache.as_ref(), ctx.allow_unknown)?;
     }
     let max_output_tokens = resolve_max_output_tokens(
         args.max_output_tokens,

--- a/crates/yoetz-cli/src/commands/council.rs
+++ b/crates/yoetz-cli/src/commands/council.rs
@@ -89,7 +89,7 @@ pub(crate) async fn handle_council(
         let reg_id =
             resolve_registry_model_id(Some(_provider), Some(model), registry_cache.as_ref());
         if let Some(ref id) = reg_id {
-            crate::validate_model_or_suggest(id, registry_cache.as_ref())?;
+            crate::validate_model_or_suggest(id, registry_cache.as_ref(), ctx.allow_unknown)?;
         }
     }
     // Resolve registry IDs up front so we can derive model-aware max_output_tokens

--- a/crates/yoetz-cli/src/commands/generate.rs
+++ b/crates/yoetz-cli/src/commands/generate.rs
@@ -6,8 +6,8 @@ use std::path::PathBuf;
 use crate::providers::{gemini, openai, resolve_provider_auth};
 use crate::{
     build_model_spec, maybe_write_output, normalize_model_name_with_aliases, parse_media_inputs,
-    resolve_prompt, usage_from_litellm, AppContext, GenerateArgs, GenerateCommand,
-    GenerateImageArgs, GenerateVideoArgs,
+    registry, resolve_prompt, resolve_registry_model_id, usage_from_litellm, AppContext,
+    GenerateArgs, GenerateCommand, GenerateImageArgs, GenerateVideoArgs,
 };
 use litellm_rust::{ImageEditRequest, ImageInputData, ImageRequest};
 use yoetz_core::media::{MediaSource, MediaType};
@@ -47,6 +47,17 @@ async fn handle_generate_image(
             .ok_or_else(|| anyhow!("model is required"))?,
         &config.aliases,
     );
+
+    // Validate model against registry (generation models may not be in registry, so use allow_unknown)
+    let registry_cache = registry::load_registry_with_auto_sync(&ctx.client, &ctx.config)
+        .await
+        .ok()
+        .flatten();
+    let reg_id = resolve_registry_model_id(Some(&provider), Some(&model), registry_cache.as_ref());
+    if let Some(ref reg_id) = reg_id {
+        // Generation models are often not in the registry, so default to allowing unknown
+        crate::validate_model_or_suggest(reg_id, registry_cache.as_ref(), true)?;
+    }
 
     let images = parse_media_inputs(&args.image, &args.image_mime, MediaType::Image)?;
 

--- a/crates/yoetz-cli/src/commands/models.rs
+++ b/crates/yoetz-cli/src/commands/models.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 
 use crate::fuzzy;
 use crate::{
-    maybe_write_output, registry, AppContext, ModelsArgs, ModelsCommand, ModelsListArgs,
-    ModelsResolveArgs,
+    maybe_write_output, registry, AppContext, ModelsArgs, ModelsCommand, ModelsFrontierArgs,
+    ModelsListArgs, ModelsResolveArgs,
 };
 use yoetz_core::output::{write_json, write_jsonl, OutputFormat};
 use yoetz_core::registry::ModelRegistry;
@@ -18,7 +18,8 @@ pub(crate) async fn handle_models(
         ModelsCommand::List(list_args) => {
             let registry = registry::load_registry_with_auto_sync(&ctx.client, &ctx.config)
                 .await?
-                .unwrap_or_default();
+                .unwrap_or_default()
+                .with_inferred_tiers();
             let filtered = filter_registry(&registry, &list_args);
             maybe_write_output(ctx, &filtered)?;
             match format {
@@ -27,7 +28,12 @@ pub(crate) async fn handle_models(
                 OutputFormat::Text | OutputFormat::Markdown => {
                     for model in &filtered.models {
                         let provider = model.provider.as_deref().unwrap_or("-");
-                        println!("{:<14}{}", provider, model.id);
+                        let tier_str = model.tier.map(|t| t.to_string()).unwrap_or_default();
+                        if tier_str.is_empty() {
+                            println!("{:<14}{}", provider, model.id);
+                        } else {
+                            println!("{:<14}{:<43}{}", provider, model.id, tier_str);
+                        }
                     }
                     Ok(())
                 }
@@ -62,6 +68,7 @@ pub(crate) async fn handle_models(
             }
         }
         ModelsCommand::Resolve(resolve_args) => handle_resolve(ctx, resolve_args, format).await,
+        ModelsCommand::Frontier(frontier_args) => handle_frontier(ctx, frontier_args, format).await,
     }
 }
 
@@ -72,7 +79,8 @@ async fn handle_resolve(
 ) -> Result<()> {
     let registry = registry::load_registry_with_auto_sync(&ctx.client, &ctx.config)
         .await?
-        .unwrap_or_default();
+        .unwrap_or_default()
+        .with_inferred_tiers();
     let results = fuzzy::fuzzy_search(&registry, &args.query, args.max_results);
     maybe_write_output(ctx, &results)?;
     match format {
@@ -84,11 +92,114 @@ async fn handle_resolve(
             } else {
                 for m in &results {
                     let provider = m.provider.as_deref().unwrap_or("-");
-                    println!("{:<14}{:<40} (score: {})", provider, m.id, m.score);
+                    let tier_str = m.tier.map(|t| format!("  {t}")).unwrap_or_default();
+                    println!(
+                        "{:<14}{:<40} (score: {}){tier_str}",
+                        provider, m.id, m.score,
+                    );
                 }
             }
             Ok(())
         }
+    }
+}
+
+/// Major frontier lab families, in display order.
+/// Last reviewed: 2026-03-20. Update when a new frontier lab emerges.
+const MAJOR_FAMILIES: &[&str] = &[
+    "openai",
+    "anthropic",
+    "google",
+    "x-ai",
+    "meta-llama",
+    "deepseek",
+    "mistralai",
+    "qwen",
+    "moonshotai",
+];
+
+const FAMILY_ALIASES: &[(&str, &str)] = &[
+    ("xai", "x-ai"),
+    ("meta", "meta-llama"),
+    ("moonshot", "moonshotai"),
+    ("mistral", "mistralai"),
+    ("alibaba", "qwen"),
+];
+
+async fn handle_frontier(
+    ctx: &AppContext,
+    args: ModelsFrontierArgs,
+    format: OutputFormat,
+) -> Result<()> {
+    let registry = registry::load_registry_with_auto_sync(&ctx.client, &ctx.config)
+        .await?
+        .unwrap_or_default();
+    let all_entries = registry.frontier();
+
+    let entries: Vec<_> = if let Some(ref family) = args.family {
+        // --family bypasses the default filter.
+        let family_lower = normalize_family_name(family);
+        all_entries
+            .into_iter()
+            .filter(|e| e.family.eq_ignore_ascii_case(&family_lower))
+            .collect()
+    } else if args.all {
+        all_entries
+    } else {
+        // Default: curated major labs in fixed order
+        MAJOR_FAMILIES
+            .iter()
+            .filter_map(|&fam| all_entries.iter().find(|e| e.family == fam).cloned())
+            .collect()
+    };
+
+    maybe_write_output(ctx, &entries)?;
+    match format {
+        OutputFormat::Json => write_json(&entries),
+        OutputFormat::Jsonl => write_jsonl("models_frontier", &entries),
+        OutputFormat::Text | OutputFormat::Markdown => {
+            if entries.is_empty() {
+                println!(
+                    "No frontier models found (registry may be empty — try `yoetz models sync`)"
+                );
+            } else {
+                println!("{:<13}{:<43}{:<9}$/1k-out", "FAMILY", "MODEL", "CTX");
+                for e in &entries {
+                    let ctx_str = e
+                        .model
+                        .context_length
+                        .map(format_context_length)
+                        .unwrap_or_else(|| "-".to_string());
+                    let price_str = e
+                        .model
+                        .pricing
+                        .completion_per_1k
+                        .map(|p| format!("${:.3}", p))
+                        .unwrap_or_else(|| "-".to_string());
+                    println!(
+                        "{:<13}{:<43}{:<9}{}",
+                        e.family, e.model.id, ctx_str, price_str
+                    );
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+fn normalize_family_name(family: &str) -> String {
+    let family_lower = family.to_lowercase();
+    FAMILY_ALIASES
+        .iter()
+        .find_map(|(alias, canonical)| (*alias == family_lower).then(|| (*canonical).to_string()))
+        .unwrap_or(family_lower)
+}
+
+fn format_context_length(tokens: usize) -> String {
+    if tokens >= 1_000_000 {
+        format!("{}m", tokens / 1_000_000)
+    } else {
+        format!("{}k", tokens / 1000)
     }
 }
 

--- a/crates/yoetz-cli/src/commands/pricing.rs
+++ b/crates/yoetz-cli/src/commands/pricing.rs
@@ -20,7 +20,7 @@ pub(crate) async fn handle_pricing(
                 .unwrap_or_default();
             let registry_id = resolve_registry_model_id(None, Some(&model), Some(&registry));
             if let Some(ref reg_id) = registry_id {
-                crate::validate_model_or_suggest(reg_id, Some(&registry))?;
+                crate::validate_model_or_suggest(reg_id, Some(&registry), ctx.allow_unknown)?;
             }
             let estimate = registry::estimate_pricing(
                 Some(&registry),

--- a/crates/yoetz-cli/src/commands/review.rs
+++ b/crates/yoetz-cli/src/commands/review.rs
@@ -63,7 +63,7 @@ async fn handle_review_diff(
     let registry_id =
         resolve_registry_model_id(Some(&provider), Some(&model), registry_cache.as_ref());
     if let Some(ref reg_id) = registry_id {
-        crate::validate_model_or_suggest(reg_id, registry_cache.as_ref())?;
+        crate::validate_model_or_suggest(reg_id, registry_cache.as_ref(), ctx.allow_unknown)?;
     }
     let max_output_tokens = resolve_max_output_tokens(
         args.max_output_tokens,
@@ -264,7 +264,7 @@ async fn handle_review_file(
     let registry_id =
         resolve_registry_model_id(Some(&provider), Some(&model), registry_cache.as_ref());
     if let Some(ref reg_id) = registry_id {
-        crate::validate_model_or_suggest(reg_id, registry_cache.as_ref())?;
+        crate::validate_model_or_suggest(reg_id, registry_cache.as_ref(), ctx.allow_unknown)?;
     }
     let max_output_tokens = resolve_max_output_tokens(
         args.max_output_tokens,

--- a/crates/yoetz-cli/src/fuzzy.rs
+++ b/crates/yoetz-cli/src/fuzzy.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use yoetz_core::registry::ModelRegistry;
+use yoetz_core::registry::{ModelRegistry, ModelTier};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct FuzzyMatch {
@@ -11,6 +11,8 @@ pub struct FuzzyMatch {
     pub context_length: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_output_tokens: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tier: Option<ModelTier>,
 }
 
 /// Search the registry for models matching `query`, returning up to `max_results`
@@ -28,6 +30,7 @@ pub fn fuzzy_search(registry: &ModelRegistry, query: &str, max_results: usize) -
                     provider: entry.provider.clone(),
                     context_length: entry.context_length,
                     max_output_tokens: entry.max_output_tokens,
+                    tier: entry.tier,
                 })
             } else {
                 None

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -63,6 +63,10 @@ struct Cli {
     #[arg(long, global = true, default_value = "60")]
     timeout_secs: u64,
 
+    /// Allow unrecognized model IDs (for self-hosted models not in the registry)
+    #[arg(long, global = true)]
+    allow_unknown: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -74,6 +78,7 @@ struct AppContext {
     output_final: Option<PathBuf>,
     output_schema: Option<PathBuf>,
     debug: bool,
+    allow_unknown: bool,
 }
 
 #[derive(Subcommand)]
@@ -547,6 +552,8 @@ enum ModelsCommand {
     Sync,
     /// Fuzzy-resolve a model ID query against the registry
     Resolve(ModelsResolveArgs),
+    /// Show the frontier model per major provider family
+    Frontier(ModelsFrontierArgs),
 }
 
 #[derive(Args)]
@@ -568,6 +575,17 @@ struct ModelsResolveArgs {
     /// Maximum number of results to return
     #[arg(long, short = 'n', default_value = "5")]
     max_results: usize,
+}
+
+#[derive(Args)]
+struct ModelsFrontierArgs {
+    /// Filter to a specific provider family (e.g. "openai", "anthropic")
+    #[arg(long)]
+    family: Option<String>,
+
+    /// Show all provider families (default: major frontier labs only)
+    #[arg(long)]
+    all: bool,
 }
 
 #[derive(Args)]
@@ -706,6 +724,7 @@ async fn main() -> Result<()> {
         output_final: cli.output_final,
         output_schema: cli.output_schema,
         debug: cli.debug,
+        allow_unknown: cli.allow_unknown,
     };
 
     match cli.command {
@@ -1592,6 +1611,7 @@ mod tests {
             pricing: Default::default(),
             provider: None,
             capability: None,
+            tier: None,
         });
         registry.rebuild_index();
         // Should cap at 16384
@@ -1617,6 +1637,7 @@ mod tests {
             pricing: Default::default(),
             provider: None,
             capability: None,
+            tier: None,
         });
         registry.rebuild_index();
         // Model max (4096) is less than cap (16384), so use model max
@@ -1651,6 +1672,7 @@ mod tests {
             pricing: Default::default(),
             provider: Some("openrouter".to_string()),
             capability: None,
+            tier: None,
         });
         registry.rebuild_index();
         let result = build_model_spec(None, "x-ai/grok-4", Some(&registry)).unwrap();
@@ -1680,6 +1702,7 @@ mod tests {
             pricing: Default::default(),
             provider: Some("gemini".to_string()),
             capability: None,
+            tier: None,
         });
         registry.rebuild_index();
         // Model with non-openrouter provider should NOT be auto-prefixed
@@ -1698,6 +1721,7 @@ mod tests {
             pricing: Default::default(),
             provider: Some("openrouter".to_string()),
             capability: None,
+            tier: None,
         });
         registry.rebuild_index();
         // Model without slash should NOT be auto-prefixed even if in registry
@@ -1725,11 +1749,17 @@ mod tests {
     }
 }
 
-/// Validate a model ID against the registry, returning an error with suggestions
-/// if the model is not found but close matches exist.
+/// Validate a model ID against the registry.
+///
+/// - Exact match: pass.
+/// - Fuzzy matches: error with "Did you mean?" suggestions.
+/// - No matches at all: error with sync hint.
+///
+/// When `allow_unknown` is true, unknown models pass silently (for self-hosted models).
 pub(crate) fn validate_model_or_suggest(
     model_id: &str,
     registry: Option<&yoetz_core::registry::ModelRegistry>,
+    allow_unknown: bool,
 ) -> Result<()> {
     let Some(registry) = registry else {
         return Ok(());
@@ -1741,8 +1771,15 @@ pub(crate) fn validate_model_or_suggest(
     // Try fuzzy search
     let matches = fuzzy::fuzzy_search(registry, model_id, 3);
     if matches.is_empty() {
-        // No matches at all — don't block; the model might just not be synced
-        return Ok(());
+        if allow_unknown {
+            return Ok(());
+        }
+        return Err(anyhow!(
+            "model '{}' not found in registry.\n\
+             Hint: run `yoetz models sync` to update the registry, \
+             or use --allow-unknown for self-hosted models.",
+            model_id,
+        ));
     }
     let suggestions: Vec<String> = matches.iter().map(|m| m.id.clone()).collect();
     Err(anyhow!(

--- a/crates/yoetz-cli/src/registry.rs
+++ b/crates/yoetz-cli/src/registry.rs
@@ -217,6 +217,7 @@ fn embedded_gemini_registry() -> Result<ModelRegistry> {
             },
             provider: pricing.provider.clone(),
             capability: None,
+            tier: None,
         });
     }
     registry.rebuild_index();
@@ -325,6 +326,7 @@ fn parse_openrouter_models(value: &Value) -> ModelRegistry {
             pricing,
             provider: Some("openrouter".to_string()),
             capability,
+            tier: None,
         });
     }
 
@@ -384,6 +386,7 @@ fn parse_litellm_models(value: &Value) -> ModelRegistry {
             },
             provider: Some("litellm".to_string()),
             capability: None,
+            tier: None,
         });
     }
 

--- a/crates/yoetz-cli/tests/cli.rs
+++ b/crates/yoetz-cli/tests/cli.rs
@@ -1,9 +1,147 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
+use std::fs;
+use std::path::PathBuf;
+use tempfile::TempDir;
 
 fn yoetz() -> Command {
     #[allow(deprecated)]
     Command::cargo_bin("yoetz").unwrap()
+}
+
+struct FrontierFixture {
+    _dir: TempDir,
+    config_path: PathBuf,
+    registry_path: PathBuf,
+}
+
+fn frontier_fixture() -> FrontierFixture {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("yoetz.toml");
+    let registry_path = dir.path().join("registry.json");
+
+    fs::write(
+        &config_path,
+        r#"
+[registry]
+auto_sync_secs = 0
+"#,
+    )
+    .unwrap();
+
+    fs::write(&registry_path, frontier_registry_json()).unwrap();
+
+    FrontierFixture {
+        _dir: dir,
+        config_path,
+        registry_path,
+    }
+}
+
+fn frontier_registry_json() -> String {
+    serde_json::json!({
+        "version": 1,
+        "updated_at": "2026-03-21T00:00:00Z",
+        "models": [
+            {
+                "id": "openai/gpt-5.4-pro",
+                "context_length": 256000,
+                "max_output_tokens": 16384,
+                "pricing": {"completion_per_1k": 0.18},
+                "provider": "openrouter"
+            },
+            {
+                "id": "openai/gpt-5.4-mini",
+                "context_length": 128000,
+                "max_output_tokens": 8192,
+                "pricing": {"completion_per_1k": 0.02},
+                "provider": "openrouter"
+            },
+            {
+                "id": "anthropic/claude-opus-4-6",
+                "context_length": 1000000,
+                "max_output_tokens": 32000,
+                "pricing": {"completion_per_1k": 0.025},
+                "provider": "openrouter"
+            },
+            {
+                "id": "anthropic/claude-sonnet-4-6",
+                "context_length": 200000,
+                "max_output_tokens": 16384,
+                "pricing": {"completion_per_1k": 0.012},
+                "provider": "openrouter"
+            },
+            {
+                "id": "google/gemini-3.1-pro-preview",
+                "context_length": 1000000,
+                "max_output_tokens": 8192,
+                "pricing": {"completion_per_1k": 0.012},
+                "provider": "openrouter"
+            },
+            {
+                "id": "x-ai/grok-4.20-beta",
+                "context_length": 200000,
+                "max_output_tokens": 16384,
+                "pricing": {"completion_per_1k": 0.006},
+                "provider": "openrouter"
+            },
+            {
+                "id": "meta-llama/llama-3.1-405b",
+                "context_length": 32000,
+                "max_output_tokens": 8192,
+                "pricing": {"completion_per_1k": 0.004},
+                "provider": "openrouter"
+            },
+            {
+                "id": "deepseek/deepseek-v3.2-speciale",
+                "context_length": 163840,
+                "max_output_tokens": 8192,
+                "pricing": {"completion_per_1k": 0.001},
+                "provider": "openrouter"
+            },
+            {
+                "id": "mistralai/mistral-large-2411",
+                "context_length": 131072,
+                "max_output_tokens": 8192,
+                "pricing": {"completion_per_1k": 0.006},
+                "provider": "openrouter"
+            },
+            {
+                "id": "qwen/qwen-max",
+                "context_length": 32768,
+                "max_output_tokens": 8192,
+                "pricing": {"completion_per_1k": 0.004},
+                "provider": "openrouter"
+            },
+            {
+                "id": "moonshotai/kimi-k2",
+                "context_length": 128000,
+                "max_output_tokens": 8192,
+                "pricing": {"completion_per_1k": 0.003},
+                "provider": "openrouter"
+            },
+            {
+                "id": "reseller/one-off-model",
+                "context_length": 64000,
+                "max_output_tokens": 4096,
+                "pricing": {"completion_per_1k": 0.123},
+                "provider": "reseller"
+            }
+        ]
+    })
+    .to_string()
+}
+
+fn yoetz_with_frontier_fixture(fixture: &FrontierFixture) -> Command {
+    let mut cmd = yoetz();
+    cmd.env("YOETZ_CONFIG_PATH", &fixture.config_path)
+        .env("YOETZ_REGISTRY_PATH", &fixture.registry_path)
+        .env_remove("OPENAI_API_KEY")
+        .env_remove("ANTHROPIC_API_KEY")
+        .env_remove("GEMINI_API_KEY")
+        .env_remove("OPENROUTER_API_KEY")
+        .env_remove("XAI_API_KEY");
+    cmd
 }
 
 #[test]
@@ -177,4 +315,60 @@ fn council_em_dash_in_prompt_parses() {
         .env_remove("XAI_API_KEY")
         .assert();
     result.stderr(predicate::str::contains("unexpected argument").not());
+}
+
+#[test]
+fn models_frontier_help_shows_flags() {
+    yoetz()
+        .args(["models", "frontier", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--family"))
+        .stdout(predicate::str::contains("--all"));
+}
+
+#[test]
+fn models_frontier_default_output_is_curated() {
+    let fixture = frontier_fixture();
+    yoetz_with_frontier_fixture(&fixture)
+        .args(["models", "frontier"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("FAMILY"))
+        .stdout(predicate::str::contains("MODEL"))
+        .stdout(predicate::str::contains("openai/gpt-5.4-pro"))
+        .stdout(predicate::str::contains("reseller/one-off-model").not());
+}
+
+#[test]
+fn models_frontier_family_filter_limits_output() {
+    let fixture = frontier_fixture();
+    yoetz_with_frontier_fixture(&fixture)
+        .args(["models", "frontier", "--family", "openai"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("openai/gpt-5.4-pro"))
+        .stdout(predicate::str::contains("anthropic/claude-opus-4-6").not())
+        .stdout(predicate::str::contains("reseller/one-off-model").not());
+}
+
+#[test]
+fn models_frontier_all_shows_every_family() {
+    let fixture = frontier_fixture();
+    yoetz_with_frontier_fixture(&fixture)
+        .args(["models", "frontier", "--all"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("openai/gpt-5.4-pro"))
+        .stdout(predicate::str::contains("anthropic/claude-opus-4-6"))
+        .stdout(predicate::str::contains("reseller/one-off-model"));
+}
+
+#[test]
+fn allow_unknown_flag_accepted() {
+    yoetz()
+        .args(["--allow-unknown", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--allow-unknown"));
 }

--- a/crates/yoetz-core/src/registry.rs
+++ b/crates/yoetz-core/src/registry.rs
@@ -1,6 +1,33 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ModelTier {
+    Mini,
+    Preview,
+    Standard,
+    Flagship,
+}
+
+impl std::fmt::Display for ModelTier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ModelTier::Flagship => write!(f, "flagship"),
+            ModelTier::Standard => write!(f, "standard"),
+            ModelTier::Mini => write!(f, "mini"),
+            ModelTier::Preview => write!(f, "preview"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FrontierEntry {
+    pub family: String,
+    pub model: ModelEntry,
+    pub tier: ModelTier,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ModelPricing {
     pub prompt_per_1k: Option<f64>,
@@ -41,6 +68,8 @@ pub struct ModelEntry {
     pub pricing: ModelPricing,
     pub provider: Option<String>,
     pub capability: Option<ModelCapability>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub tier: Option<ModelTier>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -82,6 +111,14 @@ impl ModelEntry {
             (None, Some(other)) => self.capability = Some(other),
             _ => {}
         }
+        if other.tier.is_some() {
+            self.tier = other.tier;
+        }
+    }
+
+    /// Extract the provider family from the model ID (first segment before `/`).
+    pub fn family(&self) -> &str {
+        self.id.split('/').next().unwrap_or(&self.id)
     }
 }
 
@@ -126,6 +163,219 @@ impl ModelRegistry {
             self.index.insert(model.id.clone(), idx);
         }
     }
+
+    pub fn with_inferred_tiers(mut self) -> Self {
+        self.infer_tiers();
+        self
+    }
+
+    /// Infer tier for each model based on pricing and name patterns.
+    /// Name patterns define Mini/Preview/explicit Flagship labels; pricing only
+    /// promotes Standard models to Flagship within a family.
+    pub fn infer_tiers(&mut self) {
+        // Group models by family
+        let mut families: HashMap<String, Vec<usize>> = HashMap::new();
+        for (idx, model) in self.models.iter().enumerate() {
+            let family = model.family().to_string();
+            families.entry(family).or_default().push(idx);
+        }
+
+        for indices in families.values() {
+            if indices.is_empty() {
+                continue;
+            }
+
+            // Classify each model by name pattern first
+            for &idx in indices {
+                let model = &self.models[idx];
+                let name_lower = model.id.to_lowercase();
+                let tier = infer_tier_from_name(&name_lower);
+                self.models[idx].tier = Some(tier);
+            }
+
+            // If we have pricing data, use it to refine:
+            // within the family, the most expensive Standard model can be promoted
+            // to Flagship. We never demote a model to Mini based on relative price.
+            let mut priced: Vec<(usize, f64)> = indices
+                .iter()
+                .filter_map(|&idx| self.models[idx].pricing.completion_per_1k.map(|p| (idx, p)))
+                .collect();
+
+            if priced.len() >= 2 {
+                priced.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+                // Exclude reasoning models from price-based promotion (they're expensive
+                // due to thinking tokens, not because they're general-purpose flagships)
+                let non_reasoning_priced: Vec<(usize, f64)> = priced
+                    .iter()
+                    .filter(|&&(idx, _)| !is_reasoning_model(&self.models[idx].id))
+                    .copied()
+                    .collect();
+
+                if non_reasoning_priced.len() >= 2 {
+                    let max_price = non_reasoning_priced[0].1;
+                    let min_price = non_reasoning_priced.last().unwrap().1;
+
+                    if max_price > min_price {
+                        for &(idx, price) in &non_reasoning_priced {
+                            let name_tier = self.models[idx].tier.unwrap_or(ModelTier::Standard);
+                            if name_tier == ModelTier::Standard && price == max_price {
+                                self.models[idx].tier = Some(ModelTier::Flagship);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Return the frontier model per provider family.
+    /// Tiers are inferred internally so callers do not depend on call order.
+    /// Only considers properly namespaced models (`provider/model` format).
+    pub fn frontier(&self) -> Vec<FrontierEntry> {
+        let registry = self.clone().with_inferred_tiers();
+        let mut best: HashMap<String, FrontierEntry> = HashMap::new();
+
+        for model in &registry.models {
+            // Skip models without provider/model format (litellm duplicates)
+            if !model.id.contains('/') {
+                continue;
+            }
+            let tier = match model.tier {
+                Some(t) => t,
+                None => continue,
+            };
+            // Skip mini-tier models — they're explicitly small/cheap, not frontier picks.
+            if tier == ModelTier::Mini {
+                continue;
+            }
+            let family = model.family().to_string();
+            let dominated = best.get(&family).is_some_and(|existing| {
+                let existing_ver = extract_version(&existing.model.id);
+                let new_ver = extract_version(&model.id);
+
+                // Primary: higher version number wins (newer model is the frontier pick)
+                if existing_ver != new_ver {
+                    return existing_ver >= new_ver;
+                }
+                // Same version: higher tier wins (flagship > preview of same version)
+                if existing.tier != tier {
+                    return existing.tier > tier;
+                }
+                // Same version + tier: higher context length wins
+                let existing_ctx = existing.model.context_length.unwrap_or(0);
+                let new_ctx = model.context_length.unwrap_or(0);
+                if existing_ctx != new_ctx {
+                    return existing_ctx >= new_ctx;
+                }
+                // Same everything: shorter name wins (base model over specialized variant)
+                existing.model.id.len() <= model.id.len()
+            });
+            if !dominated {
+                best.insert(
+                    family.clone(),
+                    FrontierEntry {
+                        family,
+                        model: model.clone(),
+                        tier,
+                    },
+                );
+            }
+        }
+
+        let mut entries: Vec<FrontierEntry> = best.into_values().collect();
+        entries.sort_by(|a, b| a.family.cmp(&b.family));
+        entries
+    }
+}
+
+/// Extract version numbers from a model ID for comparison.
+/// E.g. "anthropic/claude-opus-4.6" → [4, 6], "openai/gpt-5.4-pro" → [5, 4]
+/// Only extracts from pure numeric tokens and dotted versions.
+/// Skips date suffixes (4+ digit numbers) and parameter counts (e.g. "70b").
+fn extract_version(id: &str) -> Vec<u32> {
+    let name_part = id.rsplit('/').next().unwrap_or(id);
+    let name_part = name_part.split(':').next().unwrap_or(name_part);
+    let mut versions = Vec::new();
+    for token in name_part.split(['-', '_']) {
+        // Stop at date-like tokens (4+ digit pure numbers like 2024, 0528)
+        if token.len() >= 4 && token.chars().all(|c| c.is_ascii_digit()) {
+            break;
+        }
+        // Strip leading 'v' prefix (e.g. "v3.2" → "3.2")
+        let token = token.strip_prefix('v').unwrap_or(token);
+        // Dotted version like "5.4" or "3.1"
+        if token.contains('.') {
+            for part in token.split('.') {
+                if let Ok(n) = part.parse::<u32>() {
+                    versions.push(n);
+                }
+            }
+        } else if let Ok(n) = token.parse::<u32>() {
+            // Pure number token (e.g. "4" in "grok-4")
+            if n < 100 {
+                versions.push(n);
+            }
+        }
+        // Skip mixed tokens like "4o", "20b", "70b" — not version numbers
+    }
+    versions
+}
+
+/// Check if a model is a reasoning-specific model (expensive due to thinking tokens).
+fn is_reasoning_model(id: &str) -> bool {
+    let name_part = id.to_lowercase();
+    let name_part = name_part.rsplit('/').next().unwrap_or(&name_part);
+    let tokens: Vec<&str> = name_part.split(['-', '.', '_', ':']).collect();
+    tokens
+        .iter()
+        .any(|t| matches!(*t, "o1" | "o3" | "o4" | "r1" | "r1t2"))
+}
+
+/// Infer tier from name patterns. Returns Standard when no clear signal.
+/// Mini signals take priority over preview (a flash-preview is still Mini).
+fn infer_tier_from_name(name_lower: &str) -> ModelTier {
+    // Extract the part after the last `/` for pattern matching
+    let name_part = name_lower.rsplit('/').next().unwrap_or(name_lower);
+    // Strip version suffixes like :free, :extended
+    let name_part = name_part.split(':').next().unwrap_or(name_part);
+
+    // Tokenize on `-` and `.` for word-boundary matching
+    let tokens: Vec<&str> = name_part.split(['-', '.', '_']).collect();
+
+    // Mini signals first — a flash-preview or haiku-beta is still Mini
+    if tokens
+        .iter()
+        .any(|t| matches!(*t, "mini" | "flash" | "nano" | "lite" | "haiku" | "instant"))
+    {
+        return ModelTier::Mini;
+    }
+
+    // Preview signals (after mini check)
+    if tokens
+        .iter()
+        .any(|t| matches!(*t, "preview" | "beta" | "exp"))
+    {
+        return ModelTier::Preview;
+    }
+
+    // Reasoning models — expensive due to thinking tokens, not general flagship
+    if tokens
+        .iter()
+        .any(|t| matches!(*t, "o1" | "o3" | "o4" | "r1" | "r1t2"))
+    {
+        return ModelTier::Standard;
+    }
+
+    // Flagship signals
+    if tokens
+        .iter()
+        .any(|t| matches!(*t, "opus" | "ultra" | "heavy" | "pro"))
+    {
+        return ModelTier::Flagship;
+    }
+
+    ModelTier::Standard
 }
 
 #[cfg(test)]
@@ -150,6 +400,7 @@ mod tests {
                     reasoning: None,
                     web_search: Some(false),
                 }),
+                tier: None,
             }],
             ..Default::default()
         };
@@ -171,6 +422,7 @@ mod tests {
                     reasoning: Some(true),
                     web_search: None,
                 }),
+                tier: None,
             }],
             ..Default::default()
         };
@@ -190,5 +442,317 @@ mod tests {
         assert_eq!(capability.vision, Some(true));
         assert_eq!(capability.reasoning, Some(true));
         assert_eq!(capability.web_search, Some(false));
+    }
+
+    fn multi_provider_registry() -> ModelRegistry {
+        let mut reg = ModelRegistry {
+            models: vec![
+                ModelEntry {
+                    id: "openai/gpt-5.4".to_string(),
+                    pricing: ModelPricing {
+                        completion_per_1k: Some(0.060),
+                        ..Default::default()
+                    },
+                    context_length: Some(128_000),
+                    ..Default::default()
+                },
+                ModelEntry {
+                    id: "openai/gpt-5.4-mini".to_string(),
+                    pricing: ModelPricing {
+                        completion_per_1k: Some(0.002),
+                        ..Default::default()
+                    },
+                    context_length: Some(128_000),
+                    ..Default::default()
+                },
+                ModelEntry {
+                    id: "openai/gpt-5.3".to_string(),
+                    pricing: ModelPricing {
+                        completion_per_1k: Some(0.030),
+                        ..Default::default()
+                    },
+                    context_length: Some(128_000),
+                    ..Default::default()
+                },
+                ModelEntry {
+                    id: "anthropic/claude-opus-4-6".to_string(),
+                    pricing: ModelPricing {
+                        completion_per_1k: Some(0.075),
+                        ..Default::default()
+                    },
+                    context_length: Some(1_000_000),
+                    ..Default::default()
+                },
+                ModelEntry {
+                    id: "anthropic/claude-sonnet-4-6".to_string(),
+                    pricing: ModelPricing {
+                        completion_per_1k: Some(0.015),
+                        ..Default::default()
+                    },
+                    context_length: Some(200_000),
+                    ..Default::default()
+                },
+                ModelEntry {
+                    id: "anthropic/claude-haiku-4-5".to_string(),
+                    pricing: ModelPricing {
+                        completion_per_1k: Some(0.005),
+                        ..Default::default()
+                    },
+                    context_length: Some(200_000),
+                    ..Default::default()
+                },
+                ModelEntry {
+                    id: "google/gemini-2.5-pro".to_string(),
+                    pricing: ModelPricing {
+                        completion_per_1k: Some(0.010),
+                        ..Default::default()
+                    },
+                    context_length: Some(1_000_000),
+                    ..Default::default()
+                },
+                ModelEntry {
+                    id: "google/gemini-2.5-flash".to_string(),
+                    pricing: ModelPricing {
+                        completion_per_1k: Some(0.001),
+                        ..Default::default()
+                    },
+                    context_length: Some(1_000_000),
+                    ..Default::default()
+                },
+                ModelEntry {
+                    id: "google/gemini-3.1-pro-preview".to_string(),
+                    pricing: ModelPricing {
+                        completion_per_1k: Some(0.012),
+                        ..Default::default()
+                    },
+                    context_length: Some(1_000_000),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        reg.rebuild_index();
+        reg
+    }
+
+    #[test]
+    fn infer_tiers_name_patterns() {
+        assert_eq!(infer_tier_from_name("openai/gpt-5.4"), ModelTier::Standard);
+        assert_eq!(infer_tier_from_name("openai/gpt-5.4-mini"), ModelTier::Mini);
+        assert_eq!(
+            infer_tier_from_name("anthropic/claude-opus-4-6"),
+            ModelTier::Flagship
+        );
+        assert_eq!(
+            infer_tier_from_name("anthropic/claude-haiku-4-5"),
+            ModelTier::Mini
+        );
+        assert_eq!(
+            infer_tier_from_name("google/gemini-3.1-flash"),
+            ModelTier::Mini
+        );
+        assert_eq!(
+            infer_tier_from_name("google/gemini-3.1-pro"),
+            ModelTier::Flagship
+        );
+        assert_eq!(
+            infer_tier_from_name("google/gemini-3.2-pro-preview"),
+            ModelTier::Preview
+        );
+        // flash-lite-preview is Mini (mini signals take priority over preview)
+        assert_eq!(
+            infer_tier_from_name("google/gemini-3.1-flash-lite-preview"),
+            ModelTier::Mini
+        );
+    }
+
+    #[test]
+    fn infer_tiers_price_promotes_flagship_only() {
+        let mut reg = multi_provider_registry();
+        reg.infer_tiers();
+
+        // gpt-5.4 is Standard by name but most expensive in openai family → Flagship
+        let gpt54 = reg.find("openai/gpt-5.4").unwrap();
+        assert_eq!(gpt54.tier, Some(ModelTier::Flagship));
+
+        // gpt-5.4-mini is Mini by name — price doesn't override
+        let gpt54_mini = reg.find("openai/gpt-5.4-mini").unwrap();
+        assert_eq!(gpt54_mini.tier, Some(ModelTier::Mini));
+
+        // gpt-5.3: mid-price, no name signal → stays Standard.
+        let gpt53 = reg.find("openai/gpt-5.3").unwrap();
+        assert_eq!(gpt53.tier, Some(ModelTier::Standard));
+
+        // opus is Flagship by name
+        let opus = reg.find("anthropic/claude-opus-4-6").unwrap();
+        assert_eq!(opus.tier, Some(ModelTier::Flagship));
+
+        // haiku is Mini by name
+        let haiku = reg.find("anthropic/claude-haiku-4-5").unwrap();
+        assert_eq!(haiku.tier, Some(ModelTier::Mini));
+    }
+
+    #[test]
+    fn frontier_returns_one_per_family() {
+        let reg = multi_provider_registry();
+        let frontier = reg.frontier();
+
+        let families: Vec<&str> = frontier.iter().map(|e| e.family.as_str()).collect();
+        // Should have openai, anthropic, google
+        assert!(families.contains(&"openai"));
+        assert!(families.contains(&"anthropic"));
+        assert!(families.contains(&"google"));
+
+        // Each family appears exactly once
+        assert_eq!(
+            families.len(),
+            families
+                .iter()
+                .collect::<std::collections::HashSet<_>>()
+                .len()
+        );
+
+        // OpenAI frontier should be gpt-5.4 (Flagship by price)
+        let openai_frontier = frontier.iter().find(|e| e.family == "openai").unwrap();
+        assert_eq!(openai_frontier.model.id, "openai/gpt-5.4");
+        assert_eq!(openai_frontier.tier, ModelTier::Flagship);
+
+        // Anthropic frontier should be opus (Flagship by name)
+        let anthropic_frontier = frontier.iter().find(|e| e.family == "anthropic").unwrap();
+        assert_eq!(anthropic_frontier.model.id, "anthropic/claude-opus-4-6");
+        assert_eq!(anthropic_frontier.tier, ModelTier::Flagship);
+
+        // Google frontier: gemini-3.1-pro-preview (version 3.1) beats gemini-2.5-pro (version 2.5)
+        // because version is the primary signal — newer preview > older stable
+        let google_frontier = frontier.iter().find(|e| e.family == "google").unwrap();
+        assert_eq!(google_frontier.model.id, "google/gemini-3.1-pro-preview");
+        assert_eq!(google_frontier.tier, ModelTier::Preview);
+    }
+
+    #[test]
+    fn two_model_family_does_not_infer_false_mini() {
+        let mut reg = ModelRegistry {
+            models: vec![
+                ModelEntry {
+                    id: "anthropic/claude-opus-4-6".to_string(),
+                    pricing: ModelPricing {
+                        completion_per_1k: Some(0.075),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                ModelEntry {
+                    id: "anthropic/claude-sonnet-4-6".to_string(),
+                    pricing: ModelPricing {
+                        completion_per_1k: Some(0.015),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        reg.rebuild_index();
+        reg.infer_tiers();
+
+        assert_eq!(
+            reg.find("anthropic/claude-opus-4-6").and_then(|m| m.tier),
+            Some(ModelTier::Flagship)
+        );
+        assert_eq!(
+            reg.find("anthropic/claude-sonnet-4-6").and_then(|m| m.tier),
+            Some(ModelTier::Standard)
+        );
+    }
+
+    #[test]
+    fn frontier_is_self_contained_without_prior_infer_tiers_call() {
+        let reg = multi_provider_registry();
+        let frontier = reg.frontier();
+
+        let openai = frontier.iter().find(|e| e.family == "openai").unwrap();
+        assert_eq!(openai.model.id, "openai/gpt-5.4");
+        assert_eq!(openai.tier, ModelTier::Flagship);
+    }
+
+    #[test]
+    fn tier_serialization_roundtrip() {
+        let entry = ModelEntry {
+            id: "test/model".to_string(),
+            tier: Some(ModelTier::Flagship),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(json.contains("\"tier\":\"flagship\""));
+
+        let roundtrip: ModelEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(roundtrip.tier, Some(ModelTier::Flagship));
+
+        // None tier should not appear in JSON
+        let entry_no_tier = ModelEntry {
+            id: "test/model2".to_string(),
+            ..Default::default()
+        };
+        let json2 = serde_json::to_string(&entry_no_tier).unwrap();
+        assert!(!json2.contains("tier"));
+
+        // Deserializing old JSON without tier field should work
+        let old_json = r#"{"id":"test/old","pricing":{}}"#;
+        let old_entry: ModelEntry = serde_json::from_str(old_json).unwrap();
+        assert_eq!(old_entry.tier, None);
+    }
+
+    #[test]
+    fn extract_version_dotted() {
+        assert_eq!(extract_version("openai/gpt-5.4-pro"), vec![5, 4]);
+        assert_eq!(extract_version("anthropic/claude-opus-4.6"), vec![4, 6]);
+        assert_eq!(extract_version("google/gemini-3.1-pro-preview"), vec![3, 1]);
+        assert_eq!(extract_version("x-ai/grok-4.20-beta"), vec![4, 20]);
+    }
+
+    #[test]
+    fn extract_version_bare_numbers() {
+        assert_eq!(extract_version("x-ai/grok-4"), vec![4]);
+        assert_eq!(extract_version("anthropic/claude-opus-4-6"), vec![4, 6]);
+    }
+
+    #[test]
+    fn extract_version_v_prefix() {
+        assert_eq!(
+            extract_version("deepseek/deepseek-v3.2-speciale"),
+            vec![3, 2]
+        );
+        assert_eq!(extract_version("deepseek/deepseek-v3-chat"), vec![3]);
+    }
+
+    #[test]
+    fn extract_version_stops_at_dates() {
+        // Date suffix should not contribute to version
+        assert_eq!(
+            extract_version("openai/gpt-4o-2024-11-20"),
+            Vec::<u32>::new()
+        );
+        assert_eq!(extract_version("deepseek/deepseek-chat-v3-0324"), vec![3]);
+        assert_eq!(
+            extract_version("mistralai/mistral-large-2411"),
+            Vec::<u32>::new()
+        );
+    }
+
+    #[test]
+    fn extract_version_skips_param_counts() {
+        // "70b", "20b", "27b", "405b" are parameter counts, not versions
+        assert_eq!(extract_version("meta-llama/llama-3.1-405b"), vec![3, 1]);
+        assert_eq!(
+            extract_version("deepseek/deepseek-r1-distill-llama-70b"),
+            Vec::<u32>::new() // "r1" is a series name, not a version
+        );
+        assert_eq!(extract_version("google/gemma-3-27b-it"), vec![3]);
+    }
+
+    #[test]
+    fn extract_version_empty() {
+        assert_eq!(extract_version("openai/gpt-oss"), Vec::<u32>::new());
+        assert_eq!(extract_version("mancer/weaver"), Vec::<u32>::new());
     }
 }

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -47,20 +47,23 @@ Prefer Homebrew when available — pre-built binaries, fastest install.
 - Set `YOETZ_AGENT=1` environment variable
 - Parse JSON results and present summary to user
 - For large bundles, run `yoetz bundle` first to inspect size
-- Always resolve uncertain model IDs with `yoetz models resolve` before calling
+- **NEVER type a model ID from memory.** Your training data model names are WRONG. Always resolve first.
 
-## Model Discovery
+## Model Resolution Protocol (MANDATORY)
 
-Before using an unfamiliar model ID, resolve it against the synced registry:
+**NEVER type a model ID from memory.** Agent training data contains stale model names. Always query the live registry.
 
+**To find the current frontier model per provider:**
 ```bash
-yoetz models resolve "grok-4" --format json
+yoetz models frontier --format json
 ```
 
-Example output:
-```json
-[{"id":"x-ai/grok-4","score":800,"provider":"openrouter","context_length":131072,"max_output_tokens":16384}]
+**To find a specific model:**
+```bash
+yoetz models resolve "grok" --format json
 ```
+
+**Use the returned ID verbatim in your commands.** Do not modify, shorten, or guess model IDs.
 
 If the registry is stale or empty, sync first:
 ```bash
@@ -76,18 +79,22 @@ yoetz models list -s claude --format json
 
 | Task | Command |
 |------|---------|
-| Ask single model | `yoetz ask -p "question" -f src/*.rs --provider openai --model gpt-5.4 --format json` |
-| Council vote | `yoetz council -p "question" --models openai/gpt-5.4,gemini/gemini-3.1-pro-preview,openrouter/xai/grok-4.20-multi-agent-beta --format json` |
+| Find frontier model per provider | `yoetz models frontier --format json` |
+| Find frontier model for a provider | `yoetz models frontier --family openai --format json` |
+| Resolve a model ID | `yoetz models resolve "grok" --format json` |
+| Search models | `yoetz models list -s claude --format json` |
+| Ask single model | `yoetz ask -p "question" -f src/*.rs --provider openai --model MODEL_ID --format json` |
+| Council vote | `yoetz council -p "question" --models MODEL1,MODEL2,MODEL3 --format json` |
 | Review staged diff | `yoetz review diff --staged --format json` |
 | Review file | `yoetz review file --path src/main.rs --format json` |
 | Bundle files | `yoetz bundle -p "context" -f src/**/*.rs --format json` |
-| Generate image | `yoetz generate image -p "description" --provider openai --model gpt-5-image --format json` |
-| Resolve model ID | `yoetz models resolve "grok-4" --format json` |
-| Search models | `yoetz models list -s claude --format json` |
-| Estimate cost | `yoetz pricing estimate --model gpt-5.4 --input-tokens 1000 --output-tokens 500` |
+| Generate image | `yoetz generate image -p "description" --provider openai --model MODEL_ID --format json` |
+| Estimate cost | `yoetz pricing estimate --model MODEL_ID --input-tokens 1000 --output-tokens 500` |
 | Browser login | `yoetz browser login` |
 | Browser check | `yoetz browser check` |
 | Browser cookie sync | `yoetz browser sync-cookies` |
+
+**Replace MODEL_ID with IDs from `yoetz models frontier` or `yoetz models resolve`.**
 
 ## Council (Multi-Model Consensus)
 


### PR DESCRIPTION
## Summary

- Adds `yoetz models frontier` — answers "what's the best model per provider?" by deriving rankings from the live OpenRouter registry
- Tier inference from name patterns (opus→Flagship, flash→Mini) + pricing (most expensive Standard→Flagship)
- Version-based SOTA ranking: newer preview beats older stable (gemini-3.1-preview > gemini-2.5-pro)
- Curated 9 major lab families by default, `--all` for everything, `--family` for any family
- Family aliases: `xai`→`x-ai`, `meta`→`meta-llama`, etc.
- Strengthened model validation: unknown IDs now hard-error with `--allow-unknown` escape hatch
- Tier display in `models list` and `models resolve` output

Design principles:
- **No hardcoded model names** — rankings derived from live registry data
- **Mini = name signals only** — price never demotes Standard→Mini (GPT-5.4 Pro review finding)
- **`frontier()` is self-contained** — no hidden `infer_tiers()` precondition
- **"frontier" not "sota"** — honest about what the heuristic does (Codex + GPT review consensus)

Reviewed by: GPT-5.4 Pro Extended (22min thinking), Codex CLI, Claude Opus 4.6

## Test plan

- [x] `cargo test` — 135 tests pass (81 unit + 23 CLI integration + 31 core)
- [x] `cargo clippy` — zero warnings
- [x] `cargo fmt --check` — clean
- [x] `yoetz models frontier` — shows 9 curated families with correct SOTA picks
- [x] `yoetz models frontier --family xai` — alias resolves correctly
- [x] `yoetz models frontier --all` — shows all families
- [x] CLI fixture tests with temp registry (default, --family, --all)
- [x] Unit tests: 2-model family false-Mini regression, self-contained frontier(), version extraction edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)