### PR TITLE
feat(browser): prioritize auto-connect, add Chrome 136+ CDP warning

### DIFF
--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -918,9 +918,32 @@ pub fn try_cdp_attach(endpoint: &str, target_url: &str) -> Result<()> {
 }
 
 /// Returns true if the endpoint targets localhost (affected by Chrome 136+ changes).
+/// Extracts the host portion to avoid false positives on remote hostnames.
 fn is_localhost_endpoint(endpoint: &str) -> bool {
-    let lower = endpoint.to_lowercase();
-    lower.contains("127.0.0.1") || lower.contains("localhost") || lower.contains("[::1]")
+    // Strip scheme (http://, ws://, etc.) to get authority.
+    let authority = endpoint
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(endpoint);
+    // Strip path, query, fragment.
+    let host_port = authority.split('/').next().unwrap_or(authority);
+    // Strip port.
+    let host = if host_port.starts_with('[') {
+        // IPv6: [::1]:9222 → [::1]
+        host_port
+            .split_once(']')
+            .map(|(h, _)| h.trim_start_matches('['))
+            .unwrap_or(host_port)
+    } else {
+        host_port
+            .rsplit_once(':')
+            .map(|(h, _)| h)
+            .unwrap_or(host_port)
+    };
+    matches!(
+        host.to_lowercase().as_str(),
+        "127.0.0.1" | "localhost" | "::1"
+    )
 }
 
 /// Warning message explaining the Chrome 136+ breaking change for local CDP.
@@ -1918,6 +1941,10 @@ steps:
         assert!(is_localhost_endpoint("http://[::1]:9222"));
         assert!(!is_localhost_endpoint("http://192.168.1.5:9222"));
         assert!(!is_localhost_endpoint("ws://remote-host:9222"));
+        // Must not false-positive on hostnames containing "localhost"
+        assert!(!is_localhost_endpoint(
+            "http://not-localhost.example.com:9222"
+        ));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -908,7 +908,37 @@ pub fn try_cdp_attach(endpoint: &str, target_url: &str) -> Result<()> {
     let connection = BrowserConnection::Cdp {
         endpoint: endpoint.to_string(),
     };
-    verify_auth_cdp(target_url, &connection)
+    verify_auth_cdp(target_url, &connection).map_err(|e| {
+        if is_localhost_endpoint(endpoint) {
+            e.context(chrome136_cdp_warning(endpoint))
+        } else {
+            e
+        }
+    })
+}
+
+/// Returns true if the endpoint targets localhost (affected by Chrome 136+ changes).
+fn is_localhost_endpoint(endpoint: &str) -> bool {
+    let lower = endpoint.to_lowercase();
+    lower.contains("127.0.0.1") || lower.contains("localhost") || lower.contains("[::1]")
+}
+
+/// Warning message explaining the Chrome 136+ breaking change for local CDP.
+fn chrome136_cdp_warning(endpoint: &str) -> String {
+    format!(
+        "Chrome 136+ ignores --remote-debugging-port on the default profile.\n\
+         \n\
+         If '{endpoint}' is unreachable, try one of these:\n\
+         \n\
+         1. Enable chrome://inspect/#remote-debugging in Chrome (recommended, Chrome 144+)\n\
+            Then use: yoetz browser attach   (auto-discovers the debug port)\n\
+         \n\
+         2. Launch Chrome with a non-default profile:\n\
+            chrome --remote-debugging-port=9222 --user-data-dir=/tmp/chrome-debug\n\
+         \n\
+         3. Use Chrome for Testing (exempt from this restriction):\n\
+            https://developer.chrome.com/blog/chrome-for-testing"
+    )
 }
 
 pub fn try_auto_connect(target_url: &str) -> Result<()> {
@@ -1878,5 +1908,25 @@ steps:
             OutputFormat::Text,
         )
         .unwrap();
+    }
+
+    #[test]
+    fn is_localhost_endpoint_matches_common_local_addresses() {
+        assert!(is_localhost_endpoint("http://127.0.0.1:9222"));
+        assert!(is_localhost_endpoint("http://localhost:9222"));
+        assert!(is_localhost_endpoint("http://LOCALHOST:9222"));
+        assert!(is_localhost_endpoint("http://[::1]:9222"));
+        assert!(!is_localhost_endpoint("http://192.168.1.5:9222"));
+        assert!(!is_localhost_endpoint("ws://remote-host:9222"));
+    }
+
+    #[test]
+    fn chrome136_cdp_warning_includes_endpoint_and_guidance() {
+        let warning = chrome136_cdp_warning("http://127.0.0.1:9222");
+        assert!(warning.contains("127.0.0.1:9222"));
+        assert!(warning.contains("Chrome 136+"));
+        assert!(warning.contains("chrome://inspect/#remote-debugging"));
+        assert!(warning.contains("--user-data-dir"));
+        assert!(warning.contains("Chrome for Testing"));
     }
 }

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -253,16 +253,16 @@ struct BrowserLoginArgs {
 struct BrowserCheckArgs {
     #[arg(long)]
     profile: Option<PathBuf>,
-    /// Explicit CDP endpoint (e.g. http://127.0.0.1:9222). Omit to auto-discover
-    /// via chrome://inspect/#remote-debugging (recommended for Chrome 144+).
+    /// CDP endpoint (e.g. http://127.0.0.1:9222). Falls back to YOETZ_BROWSER_CDP env
+    /// or config, then chrome://inspect auto-connect (Chrome 144+).
     #[arg(long)]
     cdp: Option<String>,
 }
 
 #[derive(Args)]
 struct BrowserAttachArgs {
-    /// Explicit CDP endpoint (e.g. http://127.0.0.1:9222). Omit to auto-discover
-    /// via chrome://inspect/#remote-debugging (recommended for Chrome 144+).
+    /// CDP endpoint (e.g. http://127.0.0.1:9222). Falls back to YOETZ_BROWSER_CDP env
+    /// or config, then chrome://inspect auto-connect (Chrome 144+).
     #[arg(long)]
     cdp: Option<String>,
 }

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -210,7 +210,8 @@ enum BrowserCommand {
     Check(BrowserCheckArgs),
     /// Sync cookies from Chrome to agent-browser (bypasses Cloudflare)
     SyncCookies(BrowserSyncCookiesArgs),
-    /// Attach to a running Chrome instance via CDP and verify authentication
+    /// Attach to a running Chrome instance and verify authentication.
+    /// Auto-discovers via chrome://inspect (Chrome 144+), or use --cdp for explicit endpoint.
     Attach(BrowserAttachArgs),
 }
 
@@ -252,14 +253,16 @@ struct BrowserLoginArgs {
 struct BrowserCheckArgs {
     #[arg(long)]
     profile: Option<PathBuf>,
-    /// Connect to Chrome via CDP endpoint (e.g. http://127.0.0.1:9222)
+    /// Explicit CDP endpoint (e.g. http://127.0.0.1:9222). Omit to auto-discover
+    /// via chrome://inspect/#remote-debugging (recommended for Chrome 144+).
     #[arg(long)]
     cdp: Option<String>,
 }
 
 #[derive(Args)]
 struct BrowserAttachArgs {
-    /// CDP endpoint (e.g. http://127.0.0.1:9222). Auto-discovers if omitted.
+    /// Explicit CDP endpoint (e.g. http://127.0.0.1:9222). Omit to auto-discover
+    /// via chrome://inspect/#remote-debugging (recommended for Chrome 144+).
     #[arg(long)]
     cdp: Option<String>,
 }
@@ -1112,7 +1115,11 @@ fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputFormat) -> 
             }
 
             Err(anyhow!(
-                "could not attach to any Chrome instance. Enable remote debugging at chrome://inspect/#remote-debugging or pass --cdp <url>"
+                "could not attach to any Chrome instance.\n\n\
+                 Recommended: enable remote debugging at chrome://inspect/#remote-debugging (Chrome 144+)\n\
+                 Alternative: pass --cdp <url> with Chrome launched using --user-data-dir\n\n\
+                 Note: since Chrome 136, --remote-debugging-port is ignored on the default profile.\n\
+                 See: https://developer.chrome.com/blog/remote-debugging-port"
             ))
         }
     }

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -1,6 +1,7 @@
 name: chatgpt
-# Auth: resolved automatically (CDP > auto_connect > cookie > profile).
-# Falls back to cookie sync if no live browser session is available.
+# Auth: resolved automatically (explicit CDP > auto_connect > cookie > profile).
+# Recommended: enable chrome://inspect/#remote-debugging (Chrome 144+) for auto-connect.
+# Note: Chrome 136+ ignores --remote-debugging-port on the default profile.
 #
 # Variables:
 #   model    — model slug (e.g., "gpt-5-4-pro"). Omit to keep current.


### PR DESCRIPTION
## Summary
- Add Chrome 136+ warning when localhost CDP connection fails, explaining the breaking change and recommending `chrome://inspect/#remote-debugging` (Chrome 144+)
- Update CLI help text to lead with auto-connect as the primary method, `--cdp` as explicit override
- Update attach error message with version-specific guidance and link to Chrome docs
- Update `chatgpt.yaml` header to document recommended setup

## Context
Chrome 136+ (March 2025) silently ignores `--remote-debugging-port` when using the default user data directory. This broke local CDP connections for users who hadn't launched Chrome with `--user-data-dir`. The `chrome://inspect/#remote-debugging` toggle (Chrome 144+) provides a user-approved alternative that works with the default profile.

## Test plan
- [x] `cargo test` — all 92 tests pass (2 new: `is_localhost_endpoint_matches_common_local_addresses`, `chrome136_cdp_warning_includes_endpoint_and_guidance`)
- [x] `cargo clippy` — zero warnings
- [x] `cargo fmt --check` — clean
- [ ] Manual: `yoetz browser attach` with Chrome 146 and `chrome://inspect/#remote-debugging` enabled
- [ ] Manual: `yoetz browser attach --cdp http://127.0.0.1:9222` on default profile → verify Chrome 136 warning appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)