### PR TITLE
chore(release): v0.2.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.2.21] - 2026-03-22
+
+### Features
+
+- **browser**: Prioritize auto-connect, add Chrome 136+ CDP warning (#65)
+- Upload chatgpt bundles and poll for completion (#66)
+
 ## [0.2.20] - 2026-03-21
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2788,7 +2788,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoetz"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "yoetz-core"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/yoetz-core", "crates/yoetz-cli"]
 
 [workspace.package]
-version = "0.2.20"
+version = "0.2.21"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"


### PR DESCRIPTION
## Summary
- feat(browser): prioritize auto-connect, add Chrome 136+ CDP warning (#65)
- feat(browser): upload ChatGPT bundles and poll for completion (#66)

## Changes in v0.2.21
- **Chrome 136+ fix**: auto-connect via `chrome://inspect/#remote-debugging` is now the recommended connection method. Explicit `--cdp` on localhost shows actionable warning explaining the Chrome 136 breaking change.
- **File upload**: ChatGPT recipe now uploads bundles as file attachments via `agent-browser upload` instead of injecting text into the textarea in 4KB chunks.
- **Polling**: Replaced fixed 3-minute sleep with bounded polling (30 attempts x 15s intervals) that inspects DOM state (send button, stop button, copy buttons) for completion detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)