### PR TITLE
fix(browser): chatgpt recipe ProseMirror fill bypass

### DIFF
--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -1652,8 +1652,8 @@ fn interpolate(value: &str, ctx: &RecipeContext, bundle_text: Option<&str>) -> R
     let mut out = value.to_string();
     if let Some(path) = &ctx.bundle_path {
         if out.contains("{{bundle_path|json}}") {
-            let json_value = serde_json::to_string(path.as_str())
-                .unwrap_or_else(|_| format!("\"{}\"", path));
+            let json_value =
+                serde_json::to_string(path.as_str()).unwrap_or_else(|_| format!("\"{}\"", path));
             out = out.replace("{{bundle_path|json}}", &json_value);
         }
         out = out.replace("{{bundle_path}}", path);
@@ -1938,8 +1938,7 @@ mod tests {
     #[test]
     fn interpolate_json_filter_coexists_with_plain_var() {
         let mut ctx = recipe_context();
-        ctx.vars
-            .insert("prompt".to_string(), "hello".to_string());
+        ctx.vars.insert("prompt".to_string(), "hello".to_string());
         let result = interpolate("{{prompt|json}} {{prompt}}", &ctx, None).unwrap();
         assert_eq!(result, r#""hello" hello"#);
     }

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -1612,10 +1612,14 @@ fn chunk_text(text: &str, max_bytes: usize) -> Vec<String> {
 }
 
 fn interpolate(value: &str, ctx: &RecipeContext, bundle_text: Option<&str>) -> Result<String> {
-    if value.contains("{{bundle_path}}") && ctx.bundle_path.is_none() {
+    if (value.contains("{{bundle_path}}") || value.contains("{{bundle_path|json}}"))
+        && ctx.bundle_path.is_none()
+    {
         return Err(anyhow!("bundle path requested but no bundle provided"));
     }
-    if value.contains("{{bundle_text}}") && bundle_text.is_none() {
+    if (value.contains("{{bundle_text}}") || value.contains("{{bundle_text|json}}"))
+        && bundle_text.is_none()
+    {
         return Err(anyhow!("bundle text requested but no bundle provided"));
     }
 
@@ -1630,9 +1634,11 @@ fn interpolate(value: &str, ctx: &RecipeContext, bundle_text: Option<&str>) -> R
         let rest = &scan[start + 2..];
         if let Some(end) = rest.find("}}") {
             let placeholder = rest[..end].trim();
-            if !placeholder.is_empty() && !known_vars.contains(placeholder) {
+            // Strip |json filter before checking known vars
+            let base_name = placeholder.strip_suffix("|json").unwrap_or(placeholder);
+            if !base_name.is_empty() && !known_vars.contains(base_name) {
                 return Err(anyhow!(
-                    "recipe variable {{{{{placeholder}}}}} not provided. Pass `--var {placeholder}=...` or add it under `defaults:` in the recipe."
+                    "recipe variable {{{{{base_name}}}}} not provided. Pass `--var {base_name}=...` or add it under `defaults:` in the recipe."
                 ));
             }
             scan = &rest[end + 2..];
@@ -1641,16 +1647,33 @@ fn interpolate(value: &str, ctx: &RecipeContext, bundle_text: Option<&str>) -> R
         }
     }
 
-    // Perform substitutions
+    // Perform substitutions — process |json filtered variants first so they
+    // aren't consumed by the plain replacement pass.
     let mut out = value.to_string();
     if let Some(path) = &ctx.bundle_path {
+        if out.contains("{{bundle_path|json}}") {
+            let json_value = serde_json::to_string(path.as_str())
+                .unwrap_or_else(|_| format!("\"{}\"", path));
+            out = out.replace("{{bundle_path|json}}", &json_value);
+        }
         out = out.replace("{{bundle_path}}", path);
     }
     for (key, value) in &ctx.vars {
+        let json_needle = format!("{{{{{key}|json}}}}");
+        if out.contains(&json_needle) {
+            let json_value =
+                serde_json::to_string(value).unwrap_or_else(|_| format!("\"{}\"", value));
+            out = out.replace(&json_needle, &json_value);
+        }
         let needle = format!("{{{{{key}}}}}");
         out = out.replace(&needle, value);
     }
     if let Some(text) = bundle_text {
+        if out.contains("{{bundle_text|json}}") {
+            let json_value =
+                serde_json::to_string(text).unwrap_or_else(|_| format!("\"{}\"", text));
+            out = out.replace("{{bundle_text|json}}", &json_value);
+        }
         out = out.replace("{{bundle_text}}", text);
     }
     Ok(out)
@@ -1899,6 +1922,63 @@ mod tests {
         let ctx = recipe_context();
         let result = interpolate("{{bundle_text}}", &ctx, Some("literal {{model}}")).unwrap();
         assert_eq!(result, "literal {{model}}");
+    }
+
+    #[test]
+    fn interpolate_json_filter_escapes_quotes_and_newlines() {
+        let mut ctx = recipe_context();
+        ctx.vars.insert(
+            "prompt".to_string(),
+            "line 1\nline \"2\"\nline \\3".to_string(),
+        );
+        let result = interpolate("const t = {{prompt|json}};", &ctx, None).unwrap();
+        assert_eq!(result, r#"const t = "line 1\nline \"2\"\nline \\3";"#);
+    }
+
+    #[test]
+    fn interpolate_json_filter_coexists_with_plain_var() {
+        let mut ctx = recipe_context();
+        ctx.vars
+            .insert("prompt".to_string(), "hello".to_string());
+        let result = interpolate("{{prompt|json}} {{prompt}}", &ctx, None).unwrap();
+        assert_eq!(result, r#""hello" hello"#);
+    }
+
+    #[test]
+    fn interpolate_json_filter_missing_var_reports_base_name() {
+        let ctx = recipe_context();
+        let err = interpolate("{{missing|json}}", &ctx, None).unwrap_err();
+        assert!(err.to_string().contains("--var missing="));
+    }
+
+    #[test]
+    fn interpolate_json_filter_works_for_bundle_path() {
+        let ctx = recipe_context();
+        let result = interpolate("path = {{bundle_path|json}}", &ctx, None).unwrap();
+        assert_eq!(result, r#"path = "/tmp/bundle.md""#);
+    }
+
+    #[test]
+    fn interpolate_json_filter_works_for_bundle_text() {
+        let ctx = recipe_context();
+        let result =
+            interpolate("text = {{bundle_text|json}}", &ctx, Some("line 1\nline 2")).unwrap();
+        assert_eq!(result, r#"text = "line 1\nline 2""#);
+    }
+
+    #[test]
+    fn interpolate_json_filter_errors_on_missing_bundle_path() {
+        let mut ctx = recipe_context();
+        ctx.bundle_path = None;
+        let err = interpolate("{{bundle_path|json}}", &ctx, None).unwrap_err();
+        assert!(err.to_string().contains("bundle path requested"));
+    }
+
+    #[test]
+    fn interpolate_json_filter_errors_on_missing_bundle_text() {
+        let ctx = recipe_context();
+        let err = interpolate("{{bundle_text|json}}", &ctx, None).unwrap_err();
+        assert!(err.to_string().contains("bundle text requested"));
     }
 
     #[test]

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -106,31 +106,44 @@ steps:
     args: ["input[type='file']", "{{bundle_path}}"]
   - sleep_ms: 2000
 
-  # Clear the textarea before entering the prompt. Prevents accumulation
-  # across runs when auto-connect reuses the same tab.
+  # Clear the textarea before entering the prompt. Uses execCommand so the
+  # edit goes through ProseMirror's transaction system (innerHTML= bypasses it).
   - action: eval
     args:
       - |
         (() => {
           const el = document.querySelector("#prompt-textarea");
-          el.innerHTML = "";
-          el.dispatchEvent(new InputEvent("input", { bubbles: true }));
+          el.focus();
+          if (el.textContent.trim()) {
+            document.execCommand('selectAll');
+            document.execCommand('delete');
+          }
           return "cleared";
         })()
 
-  # Type only the prompt text. The bundle now travels as an uploaded file.
-  - action: fill
-    args: ["#prompt-textarea", "{{prompt}}"]
-  - sleep_ms: 500
-
-  # Trigger React state update and send. eval click works where native
-  # agent-browser click does not (React event handler binding).
+  # Insert prompt via execCommand('insertText') which fires beforeinput/input
+  # events that ProseMirror intercepts. Playwright fill() sets innerHTML
+  # directly, bypassing ProseMirror state — leaving the send button disabled.
+  # {{prompt|json}} produces a JSON-escaped string literal (with quotes),
+  # safe for embedding in JS source regardless of quotes/newlines.
   - action: eval
     args:
       - |
         (() => {
           const el = document.querySelector("#prompt-textarea");
-          el.dispatchEvent(new InputEvent("input", { bubbles: true }));
+          el.focus();
+          const text = {{prompt|json}};
+          document.execCommand('insertText', false, text);
+          return "inserted prompt (" + text.length + " chars)";
+        })()
+  - sleep_ms: 500
+
+  # Click send. ProseMirror already processed the execCommand so React
+  # state is in sync — no extra InputEvent dispatch needed.
+  - action: eval
+    args:
+      - |
+        (() => {
           const btn = document.querySelector("button[data-testid='send-button']");
           if (!btn) throw new Error("send button not found");
           if (btn.disabled) throw new Error("send button disabled — text may not have been injected");


### PR DESCRIPTION
## Summary

- ChatGPT's `#prompt-textarea` is a ProseMirror contenteditable `<div>`. Playwright's `fill()` sets `innerHTML` directly, bypassing ProseMirror's internal state — so React never enables the send button (bug #4 reported today).
- Replace `fill` with `execCommand('insertText')` which fires `beforeinput` events that ProseMirror intercepts. Clear step also switched from `innerHTML=""` to `execCommand('selectAll'/'delete')`.
- Add `{{var|json}}` filter to recipe interpolation so prompt text can be safely embedded in JS source (handles quotes, newlines, backslashes via `serde_json`). Filter works for recipe vars, `bundle_path`, and `bundle_text` with consistent missing-value error handling.

## Test plan

- [x] 151 tests pass (97 CLI + 23 integration + 31 core), zero clippy warnings
- [x] 7 new tests for `|json` filter (escaping, coexistence, missing var, built-ins, missing built-ins)
- [x] Verified against live ChatGPT DOM: `execCommand('insertText')` updates ProseMirror state, send button enabled
- [x] Codex reviewed — 4 rounds, all blocking issues resolved (LGTM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)