### PR TITLE
chore(release): v0.2.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.2.23] - 2026-03-22
+
+### Bug Fixes
+
+- **browser**: Chatgpt recipe ProseMirror fill bypass (#70)
+
 ## [0.2.22] - 2026-03-22
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2982,7 +2982,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoetz"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "yoetz-core"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/yoetz-core", "crates/yoetz-cli"]
 
 [workspace.package]
-version = "0.2.22"
+version = "0.2.23"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Fix ChatGPT recipe send button disabled — ProseMirror fill bypass (`execCommand('insertText')`)
- Add `{{var|json}}` filter to recipe interpolation for safe JS embedding

## Test plan

- [x] 151 tests pass, zero clippy warnings
- [x] Verified against live ChatGPT DOM
- [x] Codex reviewed (4 rounds, LGTM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)