### PR TITLE
ci: fast release pipeline — auto-tag, CI fast path, release script

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -1,0 +1,91 @@
+name: Auto Tag Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: auto-tag-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    name: Tag Release Commit
+    if: "${{ startsWith(github.event.head_commit.message, 'chore(release): v') }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate release commit
+        id: prep
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tag="${COMMIT_MESSAGE#chore(release): }"
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*$ ]]; then
+            echo "::error::Release commits must use 'chore(release): vX.Y.Z' style tags."
+            exit 1
+          fi
+
+          version="${tag#v}"
+          cargo_version="$(
+            awk '
+              /^\[workspace\.package\]$/ { in_section = 1; next }
+              /^\[/ { in_section = 0 }
+              in_section && $1 == "version" {
+                gsub(/"/, "", $3)
+                print $3
+                exit
+              }
+            ' Cargo.toml
+          )"
+          if [[ -z "$cargo_version" ]]; then
+            echo "::error::Could not read workspace version from Cargo.toml."
+            exit 1
+          fi
+          if [[ "$cargo_version" != "$version" ]]; then
+            echo "::error::Commit tag ${tag} does not match Cargo.toml version ${cargo_version}."
+            exit 1
+          fi
+
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git
+        if: steps.prep.outputs.exists != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create and push tag
+        if: steps.prep.outputs.exists != 'true'
+        env:
+          RELEASE_AUTOMATION_TOKEN: ${{ secrets.RELEASE_AUTOMATION_TOKEN }}
+          TAG: ${{ steps.prep.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${RELEASE_AUTOMATION_TOKEN:-}" ]]; then
+            echo "::error::RELEASE_AUTOMATION_TOKEN is required. Use a fine-grained PAT or GitHub App token so the tag push can trigger downstream workflows."
+            exit 1
+          fi
+
+          git remote set-url origin "https://x-access-token:${RELEASE_AUTOMATION_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git tag "${TAG}" "${GITHUB_SHA}"
+          git push origin "refs/tags/${TAG}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,63 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  changes:
+    name: Detect Release-Only Changes
+    runs-on: ubuntu-latest
+    outputs:
+      release_only: ${{ steps.detect.outputs.release_only }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: detect
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          case "${GITHUB_EVENT_NAME}" in
+            pull_request)
+              base="${{ github.event.pull_request.base.sha }}"
+              head="${{ github.event.pull_request.head.sha }}"
+              ;;
+            push)
+              base="${{ github.event.before }}"
+              head="${{ github.sha }}"
+              ;;
+            *)
+              echo "release_only=false" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+
+          if [[ -z "$base" || "$base" == "0000000000000000000000000000000000000000" ]]; then
+            echo "release_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          mapfile -t files < <(git diff --name-only "$base" "$head")
+          if ((${#files[@]} == 0)); then
+            echo "release_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          release_only=true
+          for file in "${files[@]}"; do
+            case "$file" in
+              Cargo.toml|Cargo.lock|CHANGELOG.md) ;;
+              *)
+                release_only=false
+                break
+                ;;
+            esac
+          done
+
+          echo "release_only=$release_only" >> "$GITHUB_OUTPUT"
+
   browser-scripts:
     name: Browser Scripts
+    needs: changes
+    if: needs.changes.outputs.release_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -56,6 +111,8 @@ jobs:
 
   clippy:
     name: Clippy
+    needs: changes
+    if: needs.changes.outputs.release_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -78,6 +135,8 @@ jobs:
 
   msrv:
     name: MSRV (1.88)
+    needs: changes
+    if: needs.changes.outputs.release_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -90,6 +149,8 @@ jobs:
 
   doc:
     name: Documentation
+    needs: changes
+    if: needs.changes.outputs.release_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -102,6 +163,8 @@ jobs:
 
   deny:
     name: Cargo Deny
+    needs: changes
+    if: needs.changes.outputs.release_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -114,6 +177,8 @@ jobs:
 
   gitleaks:
     name: Gitleaks
+    needs: changes
+    if: needs.changes.outputs.release_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -125,18 +190,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: .gitleaks.toml
 
-  changelog:
-    name: Changelog
-    if: github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v6
-      - name: Verify CHANGELOG.md exists
-        run: test -s CHANGELOG.md || { echo "::error::CHANGELOG.md is missing or empty"; exit 1; }
-
   build:
     name: Build (${{ matrix.os }})
+    needs: changes
+    if: needs.changes.outputs.release_only != 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,39 @@ cargo clippy                   # Lint
 
 Tests use WireMock for HTTP mocking - no API keys needed for `cargo test`.
 
+## Release
+
+Use the fast release path:
+
+```bash
+./scripts/release.sh 0.2.24
+```
+
+This script bumps `[workspace.package].version`, runs `cargo check --workspace`,
+creates `release/vX.Y.Z`, commits `chore(release): vX.Y.Z`, pushes the branch,
+and opens a PR with `gh`.
+
+After the release PR merges:
+- `.github/workflows/auto-tag-release.yml` detects the `chore(release): vX.Y.Z`
+  commit on `main` and pushes the matching tag automatically
+- `.github/workflows/release.yml` publishes artifacts, generates release notes
+  with `git-cliff`, and updates Homebrew/Scoop
+
+Repository setup for the fast path:
+- `RELEASE_AUTOMATION_TOKEN` secret: fine-grained PAT or GitHub App token with
+  permission to push tags so the downstream `release.yml` workflow is triggered
+- `gh auth login`: needed locally if you want `./scripts/release.sh` to open the
+  PR automatically after pushing the release branch
+
+`CHANGELOG.md` is no longer part of manual release prep. GitHub release notes
+generated in CI are the source of truth.
+
+We intentionally keep the custom GitHub Actions release flow instead of adopting
+`release-plz`/`release-please` wholesale: this repo ships GitHub release
+artifacts plus Homebrew/Scoop updates, but does not use crates.io publishing as
+its primary release path. The fastest fit here is automating tag handoff and
+cutting duplicate CI, not replacing the release pipeline.
+
 ## Code Style
 
 - Rust 2021 edition, MSRV 1.88

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/release.sh <version>
+
+Examples:
+  ./scripts/release.sh 0.2.24
+  ./scripts/release.sh v0.2.24
+
+This script:
+1. Verifies you are on a clean, up-to-date main branch
+2. Creates release/vX.Y.Z
+3. Bumps [workspace.package].version in Cargo.toml
+4. Runs cargo check --workspace
+5. Commits the release bump as chore(release): vX.Y.Z
+6. Pushes the branch
+7. Creates a GitHub PR with gh
+
+After the PR merges, the auto-tag workflow creates vX.Y.Z automatically and
+the Release workflow publishes artifacts and release notes.
+EOF
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+normalize_version() {
+  local raw="$1"
+  if [[ "$raw" =~ ^v ]]; then
+    raw="${raw#v}"
+  fi
+  if [[ ! "$raw" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*$ ]]; then
+    echo "error: version must look like 0.2.24 or v0.2.24" >&2
+    exit 1
+  fi
+  printf '%s\n' "$raw"
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -ne 1 ]]; then
+  usage >&2
+  exit 1
+fi
+
+require_command git
+require_command cargo
+require_command perl
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+VERSION="$(normalize_version "$1")"
+TAG="v${VERSION}"
+BRANCH="release/${TAG}"
+
+if [[ -n "$(git status --short)" ]]; then
+  echo "error: working tree is not clean" >&2
+  exit 1
+fi
+
+CURRENT_BRANCH="$(git branch --show-current)"
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "error: release prep must start from main (current: ${CURRENT_BRANCH})" >&2
+  exit 1
+fi
+
+git fetch origin main --tags
+
+LOCAL_MAIN="$(git rev-parse HEAD)"
+REMOTE_MAIN="$(git rev-parse origin/main)"
+if [[ "$LOCAL_MAIN" != "$REMOTE_MAIN" ]]; then
+  echo "error: main is not up to date with origin/main; run git pull --ff-only first" >&2
+  exit 1
+fi
+
+if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+  echo "error: branch already exists locally: ${BRANCH}" >&2
+  exit 1
+fi
+if git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
+  echo "error: branch already exists on origin: ${BRANCH}" >&2
+  exit 1
+fi
+if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
+  echo "error: tag already exists locally: ${TAG}" >&2
+  exit 1
+fi
+if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+  echo "error: tag already exists on origin: ${TAG}" >&2
+  exit 1
+fi
+
+git switch -c "${BRANCH}"
+
+YOETZ_VERSION="${VERSION}" perl -0pi -e '
+  s/(\[workspace\.package\]\n(?:[^\[]*\n)*?version = ")[^"]+(")/${1}$ENV{YOETZ_VERSION}$2/s
+    or die "failed to update [workspace.package].version\n";
+' Cargo.toml
+
+cargo check --workspace
+
+git add Cargo.toml Cargo.lock
+if git diff --cached --quiet; then
+  echo "error: release prep produced no staged changes" >&2
+  exit 1
+fi
+
+git commit -m "chore(release): ${TAG}"
+git push -u origin "${BRANCH}"
+
+PR_BODY=$(
+  cat <<EOF
+## Release
+
+- bumps workspace version to \`${VERSION}\`
+- relies on the auto-tag workflow after merge
+- release notes are generated in CI from git-cliff during the tag-driven release
+EOF
+)
+
+if command -v gh >/dev/null 2>&1; then
+  gh pr create \
+    --base main \
+    --head "${BRANCH}" \
+    --title "chore(release): ${TAG}" \
+    --body "${PR_BODY}"
+else
+  cat <<EOF
+Branch pushed: ${BRANCH}
+
+Install/authenticate GitHub CLI to create the PR automatically, then run:
+  gh pr create --base main --head "${BRANCH}" --title "chore(release): ${TAG}"
+EOF
+fi


### PR DESCRIPTION
## Summary

- **Auto-tag workflow**: detects `chore(release): vX.Y.Z` on main push, validates against `Cargo.toml`, creates+pushes tag via PAT so `release.yml` triggers without manual handoff
- **CI fast path**: skips heavy jobs (clippy, MSRV, docs, cargo-deny, gitleaks, browser-scripts, 3-OS builds) for release-only PRs. Keeps fmt + test as fast blockers.
- **Removed changelog CI job**: release notes generated by git-cliff in release.yml
- **Release script**: `./scripts/release.sh 0.2.24` — one command for version bump, cargo check, commit, push, PR
- **CLAUDE.md**: documents new release flow and `RELEASE_AUTOMATION_TOKEN` prereq

## Test plan

- [x] Shell syntax verified (`bash -n scripts/release.sh`)
- [x] YAML syntax validated for all workflow files
- [x] `./scripts/release.sh --help` works
- [ ] First real release via new pipeline (will need `RELEASE_AUTOMATION_TOKEN` secret configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)