### PR TITLE
chore(release): v0.2.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2982,7 +2982,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoetz"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "yoetz-core"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/yoetz-core", "crates/yoetz-cli"]
 
 [workspace.package]
-version = "0.2.23"
+version = "0.2.24"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"


### PR DESCRIPTION
## Release

- bumps workspace version to `0.2.24`
- relies on the auto-tag workflow after merge
- release notes are generated in CI from git-cliff during the tag-driven release

🤖 Generated with [Claude Code](https://claude.com/claude-code)