### PR TITLE
fix(browser): ChatGPT Radix UI click + completion detection

### DIFF
--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -737,9 +737,14 @@ fn detect_chatgpt_response_issue(snapshot: &str) -> Option<&'static str> {
 }
 
 fn chatgpt_response_complete(snapshot_changed: bool, dom: ChatgptDomState) -> bool {
-    dom.send_state == ChatgptSendState::Enabled
-        && !dom.has_stop_button
-        && (dom.copy_button_count > 0 || snapshot_changed)
+    // After response completes, ChatGPT may show the voice button instead of
+    // the send button — so `send_state` is `Missing`, not `Enabled`.  Both
+    // states indicate the composer is idle (not generating).
+    let send_idle = matches!(
+        dom.send_state,
+        ChatgptSendState::Enabled | ChatgptSendState::Missing
+    );
+    send_idle && !dom.has_stop_button && (dom.copy_button_count > 0 || snapshot_changed)
 }
 
 pub fn resolve_profile_dir(config: &Config, override_profile: Option<&PathBuf>) -> Result<PathBuf> {
@@ -2290,7 +2295,7 @@ mod tests {
     }
 
     #[test]
-    fn chatgpt_response_complete_requires_enabled_send_and_progress() {
+    fn chatgpt_response_complete_requires_idle_send_and_progress() {
         let dom = ChatgptDomState {
             send_state: ChatgptSendState::Enabled,
             has_stop_button: false,
@@ -2309,6 +2314,33 @@ mod tests {
             ChatgptDomState {
                 send_state: ChatgptSendState::Disabled,
                 ..dom
+            }
+        ));
+        // Missing send button (voice button shown instead) is also idle.
+        assert!(chatgpt_response_complete(
+            true,
+            ChatgptDomState {
+                send_state: ChatgptSendState::Missing,
+                has_stop_button: false,
+                copy_button_count: 0,
+            }
+        ));
+        // Missing + copy buttons (no snapshot change needed).
+        assert!(chatgpt_response_complete(
+            false,
+            ChatgptDomState {
+                send_state: ChatgptSendState::Missing,
+                has_stop_button: false,
+                copy_button_count: 1,
+            }
+        ));
+        // Missing + stop button still means generating.
+        assert!(!chatgpt_response_complete(
+            true,
+            ChatgptDomState {
+                send_state: ChatgptSendState::Missing,
+                has_stop_button: true,
+                copy_button_count: 0,
             }
         ));
     }

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -39,6 +39,9 @@ steps:
   - sleep_ms: 2000
 
   # Select model if --var model is provided.
+  # ChatGPT uses Radix UI for the dropdown — .click() alone does NOT open it.
+  # A full pointer event sequence (pointerdown→mousedown→pointerup→mouseup→click)
+  # is required, matching what a real mouse click dispatches.
   - action: eval
     args:
       - |
@@ -50,7 +53,11 @@ steps:
             'button[aria-label="Model selector"]'
           );
           if (!btn) throw new Error("model selector button not found — ChatGPT may have changed their UI. Inspect the model picker for data-testid or aria-label attributes.");
-          btn.click();
+          btn.dispatchEvent(new PointerEvent('pointerdown', {bubbles: true, cancelable: true, pointerId: 1}));
+          btn.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, cancelable: true}));
+          btn.dispatchEvent(new PointerEvent('pointerup', {bubbles: true, cancelable: true, pointerId: 1}));
+          btn.dispatchEvent(new MouseEvent('mouseup', {bubbles: true, cancelable: true}));
+          btn.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}));
           return "opened model selector";
         })()
   - sleep_ms: 1200
@@ -61,13 +68,20 @@ steps:
           const raw = "{{model}}";
           if (!raw) return "skipped: no model specified";
           const slug = raw.toLowerCase();
+          function realClick(el) {
+            el.dispatchEvent(new PointerEvent('pointerdown', {bubbles: true, cancelable: true, pointerId: 1}));
+            el.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, cancelable: true}));
+            el.dispatchEvent(new PointerEvent('pointerup', {bubbles: true, cancelable: true, pointerId: 1}));
+            el.dispatchEvent(new MouseEvent('mouseup', {bubbles: true, cancelable: true}));
+            el.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}));
+          }
           const byTestId = document.querySelector('[data-testid="model-switcher-' + slug + '"]');
-          if (byTestId) { byTestId.click(); return "selected: " + slug; }
+          if (byTestId) { realClick(byTestId); return "selected: " + slug; }
           const names = {"gpt-5-4-pro":"pro","gpt-5-4-thinking":"thinking","gpt-5-3":"instant","pro":"pro","thinking":"thinking","instant":"instant"};
           const target = names[slug] || slug;
           const items = Array.from(document.querySelectorAll('[role="menuitem"]'));
           const match = items.find(el => (el.textContent||"").trim().toLowerCase().includes(target));
-          if (match) { match.click(); return "selected: " + target; }
+          if (match) { realClick(match); return "selected: " + target; }
           throw new Error("model '" + slug + "' not found");
         })()
   - sleep_ms: 500
@@ -85,13 +99,14 @@ steps:
         })()
   - sleep_ms: 500
 
-  # Open the attachment UI if ChatGPT hides the file input until the user
-  # clicks its paperclip button.
+  # Open the attachment UI. The button changed from "Attach" to "Add files
+  # and more" (data-testid="composer-plus-btn") — try both selectors.
   - action: eval
     args:
       - |
         (() => {
           const btn = document.querySelector(
+            'button[data-testid="composer-plus-btn"], ' +
             'button[aria-label*="Attach"], button[aria-label*="attach"], button[data-testid*="attach"]'
           );
           if (!btn) return "skipped: attach button not found";


### PR DESCRIPTION
## Summary
- **Model selector fix**: ChatGPT uses Radix UI which ignores `.click()` — dispatch full pointer event sequence (`pointerdown→mousedown→pointerup→mouseup→click`) to open dropdown and select models
- **Completion detection fix**: After GPT-5.4 Pro responds, send button disappears (voice button replaces it) — treat `Missing` send state as idle, not "still generating"
- **Attach button selector**: Updated from `Attach` to `composer-plus-btn` (ChatGPT DOM change)

Both bugs verified live against ChatGPT Pro DOM via Chrome MCP. Test renamed and 3 new assertions added for `Missing` send state path.

## Test plan
- [x] 97 CLI tests pass (including renamed + expanded completion detection test)
- [x] 31 core tests pass
- [x] Zero clippy warnings
- [x] Verified model selector opens via pointer events (live ChatGPT DOM)
- [x] Verified model selection works (Pro → Thinking → Pro)
- [x] Verified `execCommand('insertText')` + send button `.click()` → GPT-5.4 Pro responds
- [x] Verified response completion: send button absent, copy buttons present, stop button absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)