### PR TITLE
feat(browser): default to file attachment delivery in ChatGPT recipe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2982,7 +2982,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoetz"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "yoetz-core"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/yoetz-core", "crates/yoetz-cli"]
 
 [workspace.package]
-version = "0.2.27"
+version = "0.2.28"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -7,16 +7,14 @@ name: chatgpt
 #   model    — model slug (e.g., "gpt-5-4-pro"). Omit to keep current.
 #   extended — set to "false" to disable Extended Pro. Default: leave as-is.
 #   prompt   — prompt text to send with the attachment.
-#
-# Content delivery:
-#   Small bundles (≤10k chars) — pasted directly into the composer textarea.
-#   Large bundles (>10k chars)  — uploaded as file attachment; recipe polls
-#   until the upload spinner disappears before sending.
+#   paste    — set to "true" to paste bundle text into textarea instead of
+#              uploading as file. Default: "false" (always upload).
 
 defaults:
   prompt: Review the attached file and provide your analysis.
   model: ""
   extended: ""
+  paste: "false"
 
 steps:
   # Navigate to a fresh ChatGPT conversation. Append a timestamp query param
@@ -104,16 +102,13 @@ steps:
         })()
   - sleep_ms: 500
 
-  # Decide delivery mode: paste small bundles (≤10k chars) directly into the
-  # textarea; upload large bundles as file attachments.
+  # Delivery mode: always upload as file attachment unless --var paste=true.
   - action: eval
     args:
       - |
         (() => {
-          const text = {{bundle_text|json}};
-          const THRESHOLD = 10000;
-          window.__yoetz_use_attachment = text.length > THRESHOLD;
-          return "bundle " + text.length + " chars → " +
+          window.__yoetz_use_attachment = ("{{paste}}" !== "true");
+          return "delivery mode → " +
             (window.__yoetz_use_attachment ? "attachment" : "paste");
         })()
 
@@ -137,8 +132,8 @@ steps:
           return "pasted prompt+bundle (" + combined.length + " chars)";
         })()
 
-  # --- Large-bundle path: upload as file attachment ---
-  # Steps below use skip_if to run only when the bundle exceeds the threshold.
+  # --- File attachment path (default) ---
+  # Steps below are skipped only when --var paste=true.
 
   # Open the attachment menu (button is "composer-plus-btn").
   - skip_if: "!window.__yoetz_use_attachment"


### PR DESCRIPTION
## Summary
- ChatGPT browser recipe now **always uploads the bundle as a file attachment** instead of pasting text into the textarea
- Previous behavior: size-based threshold (≤10k paste, >10k upload) caused agents to dump huge text walls into the composer
- New `paste` recipe variable (`--var paste=true`) opts into the old paste behavior when needed
- Reviewed with Codex via AMQ — agreed on recipe-var approach over CLI flag (delivery mode is UI policy, not a browser primitive)

## What changed
- `recipes/chatgpt.yaml`: replaced 10k-char threshold with `paste` variable (default `"false"`)
- No Rust code changes — delivery mode logic lives entirely in the recipe layer

## Follow-up (separate PRs)
- `claude.yaml` / `gemini.yaml` upload paths (need authenticated DOM capture for selectors)
- Lazy `bundle_text` loading in `RecipeContext` (minor perf: pre-scan still reads file for skipped paste steps)

## Test plan
- [x] `cargo check --workspace`
- [x] `cargo test --workspace` — 151 tests pass
- [x] `cargo clippy --workspace` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)