### PR TITLE
chore: bump plugin.json version to 0.2.33

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.2.32",
+  "version": "0.2.33",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",


### PR DESCRIPTION
Release fix — plugin.json was still at 0.2.32, causing release workflow to fail.