### PR TITLE
fix: stabilize flaky socket test + auto-bump plugin.json in release

### DIFF
--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -2785,6 +2785,8 @@ mod tests {
         {
             let _listener = UnixListener::bind(&sock_path).unwrap();
         }
+        // Allow the kernel to fully release the socket after the listener drops.
+        thread::sleep(Duration::from_millis(50));
         assert!(!is_daemon_socket_healthy(&sock_path));
     }
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -107,9 +107,17 @@ YOETZ_VERSION="${VERSION}" perl -0pi -e '
     or die "failed to update [workspace.package].version\n";
 ' Cargo.toml
 
+# Bump .codex-plugin/plugin.json if it exists.
+PLUGIN_JSON=".codex-plugin/plugin.json"
+if [[ -f "$PLUGIN_JSON" ]]; then
+  sed -i '' "s/\"version\": \"[^\"]*\"/\"version\": \"${VERSION}\"/" "$PLUGIN_JSON" 2>/dev/null \
+    || sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"${VERSION}\"/" "$PLUGIN_JSON"
+fi
+
 cargo check --workspace
 
 git add Cargo.toml Cargo.lock
+[[ -f "$PLUGIN_JSON" ]] && git add "$PLUGIN_JSON"
 if git diff --cached --quiet; then
   echo "error: release prep produced no staged changes" >&2
   exit 1


### PR DESCRIPTION
## Summary
- Fix flaky `daemon_socket_health_rejects_stale_socket` test (~1 in 5 failure rate) — kernel socket teardown race after dropping UnixListener
- Auto-bump `.codex-plugin/plugin.json` version in `release.sh` so releases don't require manual intervention

## Test plan
- [x] Flaky test passed 10/10 consecutive runs after fix
- [x] Zero clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)