### PR TITLE
fix(browser): ChatGPT upload selector + connection retry

### DIFF
--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -372,16 +372,32 @@ pub struct TabInfo {
 }
 
 /// Check if Chrome is reachable and dev-browser can connect to it.
+/// Uses a short first probe; retries once with a longer timeout only when the
+/// first failure looks like a timeout (slow CDP handshake with many tabs).
 pub fn check_connection() -> Result<()> {
     let script = r#"
 const pages = await browser.listPages();
 console.log("ok:" + pages.length);
 "#;
-    let stdout = run_script_connect(script, Some(10))?;
-    if stdout.trim().starts_with("ok:") {
-        Ok(())
-    } else {
-        Err(anyhow!("dev-browser connection check failed: {stdout}"))
+    match run_script_connect(script, Some(10)) {
+        Ok(stdout) if stdout.trim().starts_with("ok:") => Ok(()),
+        Ok(stdout) => Err(anyhow!("dev-browser connection check failed: {stdout}")),
+        Err(first_err) => {
+            let msg = format!("{first_err:#}");
+            let is_timeout = msg.contains("Timeout") || msg.contains("timed out");
+            if !is_timeout {
+                return Err(first_err.context("dev-browser connection check failed"));
+            }
+            eprintln!("info: dev-browser connection timed out, retrying with longer timeout");
+            std::thread::sleep(std::time::Duration::from_secs(2));
+            let stdout = run_script_connect(script, Some(45))
+                .context("dev-browser connection check failed after retry")?;
+            if stdout.trim().starts_with("ok:") {
+                Ok(())
+            } else {
+                Err(anyhow!("dev-browser connection check failed: {stdout}"))
+            }
+        }
     }
 }
 

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -159,7 +159,7 @@ steps:
   # Upload the bundle file.
   - skip_if: "!window.__yoetz_use_attachment"
     action: upload
-    args: ["input[type='file']", "{{bundle_path}}"]
+    args: ["#upload-files", "{{bundle_path}}"]
 
   # Poll until the upload spinner disappears. Short-burst Rust-side polling
   # keeps each eval under the agent-browser IPC ceiling (25s).


### PR DESCRIPTION
## Summary
- **chatgpt.yaml**: Use `#upload-files` instead of `input[type='file']` — ChatGPT DOM has 3 file inputs (`#upload-files`, `#upload-photos`, `#upload-camera`), generic selector was ambiguous
- **dev_browser.rs**: Retry `check_connection` with longer timeout (45s) only on timeout-like failures; keeps fast bail on non-transient errors

## Context
Chrome 146 + many open tabs causes Playwright's `connectOverCDP` to exceed its 30s default timeout. The retry scoped to timeout failures avoids adding ~90s delay for non-timeout errors (per Codex review feedback).

## Test plan
- [x] `cargo test --workspace` — 180 tests pass
- [x] `cargo clippy --workspace` — zero warnings
- [x] `cargo fmt --check` — clean
- [ ] Manual: run `yoetz browser recipe chatgpt` with dev-browser available and many Chrome tabs open

🤖 Generated with [Claude Code](https://claude.com/claude-code)