### PR TITLE
feat: move ChatGPT dev-browser flow to micro-scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,9 +84,10 @@ recipe flows, treat `dev-browser` as a QuickJS/WASM runner, not Node.js:
   Node features such as `require`, arbitrary `fs`, or `fetch`.
 - For contenteditable ChatGPT inputs, use typing APIs such as
   `pressSequentially` instead of `fill()`.
-- For file upload in `dev-browser`, prefer the host-level `uploadFile(page, tempName, options)`
-  helper against a staged file in `~/.dev-browser/tmp/` rather than building
-  Playwright file buffers inside QuickJS.
+- For file upload, the ChatGPT recipe uses macOS clipboard paste via `osascript`
+  (set clipboard to POSIX file, then `Meta+v` in the composer). This avoids
+  QuickJS buffer limitations and native file dialog issues with `setInputFiles`.
+  Non-macOS platforms currently fall back to paste mode (inline text).
 - The QuickJS GC crash recovery in `dev_browser.rs` can salvage stdout from a
   completed script, but recipe correctness must not depend on that recovery.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ cargo fmt                      # Format code
 cargo clippy                   # Lint
 ```
 
-Tests use WireMock for HTTP mocking - no API keys needed for `cargo test`.
+Tests use `assert_cmd`, `predicates`, and `serial_test` — no API keys needed for `cargo test`.
 
 ## Release
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,27 @@ commit drive the entire pipeline, not replacing the release pipeline.
 - Async with `tokio`
 - Follow existing patterns in the crate you're modifying
 
+## dev-browser Recipe Constraints
+
+When editing `crates/yoetz-cli/src/dev_browser.rs` or adding new ChatGPT/browser
+recipe flows, treat `dev-browser` as a QuickJS/WASM runner, not Node.js:
+
+- The sandbox is QuickJS. Keep recipe scripts small and linear.
+- Avoid large generated scripts, nested async helpers, or closure-heavy control
+  flow. Prefer micro-scripts orchestrated from Rust.
+- Use named pages via `browser.getPage(name)` / `browser.listPages()` to carry
+  state across scripts.
+- Use `console.log(JSON.stringify(...))` as the script-to-Rust IPC boundary.
+- Prefer Playwright actions on the page plus Rust orchestration. Do not assume
+  Node features such as `require`, arbitrary `fs`, or `fetch`.
+- For contenteditable ChatGPT inputs, use typing APIs such as
+  `pressSequentially` instead of `fill()`.
+- For file upload in `dev-browser`, prefer the host-level `uploadFile(page, tempName, options)`
+  helper against a staged file in `~/.dev-browser/tmp/` rather than building
+  Playwright file buffers inside QuickJS.
+- The QuickJS GC crash recovery in `dev_browser.rs` can salvage stdout from a
+  completed script, but recipe correctness must not depend on that recovery.
+
 ## Provider Configuration
 
 API keys via environment variables:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,6 +1616,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +373,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +517,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float-cmp"
@@ -836,7 +861,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1188,6 +1213,16 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1616,7 +1651,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -1648,7 +1682,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1730,6 +1764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -1998,6 +2033,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -2386,6 +2427,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2616,6 +2673,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3007,6 +3073,7 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
+ "ureq",
  "yoetz-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,15 +367,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,16 +502,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "float-cmp"
@@ -861,7 +836,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1223,16 +1198,6 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
 ]
 
 [[package]]
@@ -1661,6 +1626,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -1692,7 +1658,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1774,7 +1740,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2045,12 +2010,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -2433,22 +2392,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64",
- "flate2",
- "log",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "url",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2679,15 +2622,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3079,7 +3013,6 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
- "ureq",
  "yoetz-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,6 +1141,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,7 +1159,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 [[package]]
 name = "litellm-rust"
 version = "0.1.1"
-source = "git+https://github.com/avivsinai/litellm-rust?branch=main#241c57b3bf043a03150763c4ff4f88e1c8ae3f66"
+source = "git+https://github.com/avivsinai/litellm-rust?rev=241c57b3bf043a03150763c4ff4f88e1c8ae3f66#241c57b3bf043a03150763c4ff4f88e1c8ae3f66"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1979,16 +1989,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yml"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
 dependencies = [
  "indexmap",
  "itoa",
+ "libyml",
+ "memchr",
  "ryu",
  "serde",
- "unsafe-libyaml",
+ "version_check",
 ]
 
 [[package]]
@@ -2413,12 +2425,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -3068,7 +3074,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yml",
  "serial_test",
  "tempfile",
  "time",

--- a/crates/yoetz-cli/Cargo.toml
+++ b/crates/yoetz-cli/Cargo.toml
@@ -21,7 +21,7 @@ workspace = true
 
 [dependencies]
 yoetz-core = { path = "../yoetz-core" }
-litellm-rust = { git = "https://github.com/avivsinai/litellm-rust", branch = "main" }
+litellm-rust = { git = "https://github.com/avivsinai/litellm-rust", rev = "241c57b3bf043a03150763c4ff4f88e1c8ae3f66" }
 
 anyhow.workspace = true
 dotenvy.workspace = true
@@ -37,7 +37,7 @@ reqwest = { version = "0.12", default-features = false, features = [
     "multipart",
 ] }
 tokio = { version = "1.50", features = ["rt-multi-thread", "macros", "time"] }
-serde_yaml = "0.9"
+serde_yml = "0.0.12"
 tempfile = "3.27"
 jsonschema = "0.45"
 fs2 = "0.4"

--- a/crates/yoetz-cli/Cargo.toml
+++ b/crates/yoetz-cli/Cargo.toml
@@ -32,6 +32,7 @@ time.workspace = true
 
 clap = { version = "4.6", features = ["derive"] }
 reqwest = { version = "0.12", default-features = false, features = [
+    "blocking",
     "json",
     "rustls-tls",
     "multipart",

--- a/crates/yoetz-cli/Cargo.toml
+++ b/crates/yoetz-cli/Cargo.toml
@@ -32,7 +32,6 @@ time.workspace = true
 
 clap = { version = "4.6", features = ["derive"] }
 reqwest = { version = "0.12", default-features = false, features = [
-    "blocking",
     "json",
     "rustls-tls",
     "multipart",
@@ -42,6 +41,7 @@ serde_yaml = "0.9"
 tempfile = "3.27"
 jsonschema = "0.45"
 fs2 = "0.4"
+ureq = "2.12"
 
 [dev-dependencies]
 serial_test = "3.4"

--- a/crates/yoetz-cli/Cargo.toml
+++ b/crates/yoetz-cli/Cargo.toml
@@ -35,13 +35,13 @@ reqwest = { version = "0.12", default-features = false, features = [
     "json",
     "rustls-tls",
     "multipart",
+    "blocking",
 ] }
 tokio = { version = "1.50", features = ["rt-multi-thread", "macros", "time"] }
 serde_yml = "0.0.12"
 tempfile = "3.27"
 jsonschema = "0.45"
 fs2 = "0.4"
-ureq = "2.12"
 
 [dev-dependencies]
 serial_test = "3.4"

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -1,9 +1,10 @@
 use anyhow::{anyhow, Context, Result};
+use fs2::FileExt;
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use std::env;
-use std::fs;
+use std::fs::{self, File, OpenOptions};
 use std::io::{self, IsTerminal, Read as _};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -35,6 +36,7 @@ const CHATGPT_UPLOAD_POLL_INTERVAL_MS_DEFAULT: u64 = 1_000;
 const DAEMON_APPROVAL_GRACE_WINDOW: Duration = Duration::from_secs(30);
 const LIVE_ATTACH_COMMAND_TIMEOUT_MS: u64 = 30_000;
 const CDP_SESSION_NAME: &str = "yoetz-cdp";
+const CHROME_APPROVAL_LOCK_FILENAME: &str = "chrome-approval.lock";
 pub const CHATGPT_URL: &str = "https://chatgpt.com/";
 const COOKIE_SYNC_NODE_MIN_VERSION: NodeVersion = NodeVersion {
     major: 24,
@@ -1083,6 +1085,65 @@ pub enum DaemonRecoveryAction {
     Healthy,
     AwaitingApproval,
     KilledStale,
+}
+
+#[derive(Debug)]
+pub struct ChromeApprovalLock {
+    _lock_file: File,
+    waited: bool,
+}
+
+impl ChromeApprovalLock {
+    pub fn waited(&self) -> bool {
+        self.waited
+    }
+}
+
+fn chrome_approval_lock_path() -> PathBuf {
+    if let Some(home) = home_dir() {
+        return home.join(".yoetz").join(CHROME_APPROVAL_LOCK_FILENAME);
+    }
+    PathBuf::from(".yoetz").join(CHROME_APPROVAL_LOCK_FILENAME)
+}
+
+pub fn acquire_chrome_approval_lock() -> Result<ChromeApprovalLock> {
+    let lock_path = chrome_approval_lock_path();
+    if let Some(parent) = lock_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create {}", parent.display()))?;
+    }
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .with_context(|| format!("open browser approval lock {}", lock_path.display()))?;
+
+    let waited = match file.try_lock_exclusive() {
+        Ok(()) => false,
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+            file.lock_exclusive()
+                .with_context(|| format!("lock browser approval {}", lock_path.display()))?;
+            true
+        }
+        Err(err) => {
+            return Err(err).with_context(|| {
+                format!("lock browser approval {}", lock_path.display())
+            });
+        }
+    };
+
+    Ok(ChromeApprovalLock {
+        _lock_file: file,
+        waited,
+    })
+}
+
+pub fn is_chrome_approval_wait_error(err: &anyhow::Error) -> bool {
+    format!("{err:#}")
+        .to_lowercase()
+        .contains("allow remote debugging")
 }
 
 fn close_browser_daemon() -> Result<()> {
@@ -2961,6 +3022,13 @@ mod tests {
 
         let err = try_cdp_attach("http://127.0.0.1:9222", CHATGPT_URL).unwrap_err();
         assert!(allow_dialog_error(&err), "unexpected error: {err}");
+        assert!(is_chrome_approval_wait_error(&err));
+    }
+
+    #[test]
+    fn is_chrome_approval_wait_error_rejects_non_approval_timeouts() {
+        let err = anyhow!("ChatGPT response timed out after 900000ms");
+        assert!(!is_chrome_approval_wait_error(&err));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -3226,7 +3226,7 @@ mod tests {
 
     #[test]
     fn recipe_yaml_rejects_unknown_keys() {
-        let top_level_err = serde_yaml::from_str::<Recipe>(
+        let top_level_err = serde_yml::from_str::<Recipe>(
             r#"
 name: chatgpt
 oops: true
@@ -3238,7 +3238,7 @@ steps:
         .unwrap_err();
         assert!(top_level_err.to_string().contains("unknown field"));
 
-        let step_err = serde_yaml::from_str::<Recipe>(
+        let step_err = serde_yml::from_str::<Recipe>(
             r#"
 name: chatgpt
 steps:
@@ -3253,7 +3253,7 @@ steps:
 
     #[test]
     fn recipe_yaml_parses_transport_order() {
-        let recipe = serde_yaml::from_str::<Recipe>(
+        let recipe = serde_yml::from_str::<Recipe>(
             r#"
 name: chatgpt
 transports: [dev-browser, agent-browser, manual]
@@ -3276,7 +3276,7 @@ steps:
 
     #[test]
     fn recipe_transports_default_to_dev_browser_for_chatgpt() {
-        let recipe = serde_yaml::from_str::<Recipe>(
+        let recipe = serde_yml::from_str::<Recipe>(
             r#"
 name: chatgpt
 steps:
@@ -3298,7 +3298,7 @@ steps:
 
     #[test]
     fn recipe_step_parses_timeout_ms() {
-        let recipe = serde_yaml::from_str::<Recipe>(
+        let recipe = serde_yml::from_str::<Recipe>(
             r#"
 name: test
 steps:
@@ -3313,7 +3313,7 @@ steps:
 
     #[test]
     fn recipe_step_with_sleep_and_action_prefers_sleep() {
-        let recipe = serde_yaml::from_str::<Recipe>(
+        let recipe = serde_yml::from_str::<Recipe>(
             r#"
 name: noop
 steps:

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -1143,6 +1143,32 @@ fn process_is_alive(_pid: u32) -> bool {
     false
 }
 
+#[cfg(unix)]
+fn process_command_line(pid: u32) -> Option<String> {
+    let output = Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "command="])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let command = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if command.is_empty() {
+        None
+    } else {
+        Some(command)
+    }
+}
+
+#[cfg(not(unix))]
+fn process_command_line(_pid: u32) -> Option<String> {
+    None
+}
+
+fn process_looks_like_agent_browser(pid: u32) -> bool {
+    process_command_line(pid).is_some_and(|command| command.contains("agent-browser"))
+}
+
 fn socket_is_recent(sock_path: &Path, grace_window: Duration) -> bool {
     let Ok(metadata) = fs::metadata(sock_path) else {
         return false;
@@ -1169,10 +1195,23 @@ fn force_kill_stale_daemon_with_paths(
     }
 
     if let Some(pid) = read_daemon_pid(pid_path) {
-        if process_is_alive(pid) && socket_is_recent(sock_path, grace_window) {
+        if process_is_alive(pid)
+            && process_looks_like_agent_browser(pid)
+            && socket_is_recent(sock_path, grace_window)
+        {
             return DaemonRecoveryAction::AwaitingApproval;
         }
-        let _ = Command::new("kill").args(["-9", &pid.to_string()]).output();
+        if process_is_alive(pid) {
+            if process_looks_like_agent_browser(pid) {
+                let _ = Command::new("kill").args(["-9", &pid.to_string()]).output();
+            } else {
+                eprintln!(
+                    "warning: refusing to SIGKILL pid {} from {} because it does not look like agent-browser",
+                    pid,
+                    pid_path.display()
+                );
+            }
+        }
     }
 
     let _ = fs::remove_file(pid_path);
@@ -2812,6 +2851,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn force_kill_stale_daemon_preserves_recent_live_process() {
+        use std::os::unix::fs::PermissionsExt;
         use std::os::unix::net::UnixListener;
 
         let dir = unique_unix_socket_dir("daemon_grace");
@@ -2821,13 +2861,46 @@ mod tests {
             let _listener = UnixListener::bind(&sock_path).unwrap();
         }
 
-        let mut child = Command::new("sh").args(["-c", "sleep 30"]).spawn().unwrap();
+        let script_path = dir.join("agent-browser");
+        fs::write(&script_path, "#!/bin/sh\nsleep 30\n").unwrap();
+        let mut perms = fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o700);
+        fs::set_permissions(&script_path, perms).unwrap();
+
+        let mut child = Command::new(&script_path).spawn().unwrap();
         fs::write(&pid_path, child.id().to_string()).unwrap();
 
         let action =
             force_kill_stale_daemon_with_paths(&pid_path, &sock_path, Duration::from_secs(30));
         assert_eq!(action, DaemonRecoveryAction::AwaitingApproval);
         assert!(process_is_alive(child.id()));
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn force_kill_stale_daemon_refuses_unverified_pid() {
+        use std::os::unix::net::UnixListener;
+
+        let dir = unique_unix_socket_dir("daemon_refuse_unverified");
+        let pid_path = dir.join("default.pid");
+        let sock_path = dir.join("default.sock");
+        {
+            let _listener = UnixListener::bind(&sock_path).unwrap();
+        }
+        thread::sleep(Duration::from_millis(50));
+
+        let mut child = Command::new("sh").args(["-c", "sleep 30"]).spawn().unwrap();
+        fs::write(&pid_path, child.id().to_string()).unwrap();
+
+        let action =
+            force_kill_stale_daemon_with_paths(&pid_path, &sock_path, Duration::from_secs(0));
+        assert_eq!(action, DaemonRecoveryAction::KilledStale);
+        assert!(process_is_alive(child.id()));
+        assert!(!pid_path.exists());
+        assert!(!sock_path.exists());
 
         let _ = child.kill();
         let _ = child.wait();

--- a/crates/yoetz-cli/src/commands/council.rs
+++ b/crates/yoetz-cli/src/commands/council.rs
@@ -1,6 +1,5 @@
 use anyhow::{anyhow, Result};
 
-use crate::CouncilResult;
 use crate::{
     add_usage, call_litellm, maybe_write_output, normalize_model_name_with_aliases,
     render_bundle_md, resolve_max_output_tokens, resolve_prompt, resolve_provider_from_registry,
@@ -8,6 +7,7 @@ use crate::{
     CouncilModelResult, CouncilPricing, ModelEstimate,
 };
 use crate::{budget, registry};
+use crate::{CouncilModelError, CouncilResult};
 use std::collections::BTreeSet;
 use std::path::PathBuf;
 use yoetz_core::bundle::{build_bundle, estimate_tokens, BundleOptions};
@@ -164,6 +164,7 @@ pub(crate) async fn handle_council(
 
     let mut results = Vec::new();
     let mut total_usage = Usage::default();
+    let mut errors = Vec::new();
     let model_prompt = std::sync::Arc::new(if let Some(bundle_ref) = &bundle {
         render_bundle_md(bundle_ref)
     } else {
@@ -201,7 +202,13 @@ pub(crate) async fn handle_council(
             let response_format = response_format.clone();
             let model_max_output_tokens = per_model_max_output_tokens[idx];
             join_set.spawn(async move {
-                let _permit = semaphore.acquire_owned().await?;
+                let _permit = semaphore.acquire_owned().await.map_err(|err| {
+                    (
+                        model.clone(),
+                        provider.clone(),
+                        anyhow!("failed to acquire council permit: {err}"),
+                    )
+                })?;
                 let call = call_litellm(
                     &litellm,
                     Some(&provider),
@@ -213,49 +220,82 @@ pub(crate) async fn handle_council(
                     &[],
                     None,
                 )
-                .await?;
-                Ok::<_, anyhow::Error>((idx, model, provider, call))
+                .await;
+                match call {
+                    Ok(call) => Ok((idx, model, provider, call)),
+                    Err(err) => Err((model, provider, err)),
+                }
             });
         }
 
         let mut ordered: Vec<Option<CouncilModelResult>> =
-            (0..args.models.len()).map(|_| None).collect();
+            (0..resolved_models.len()).map(|_| None).collect();
         while let Some(res) = join_set.join_next().await {
-            let (idx, model, provider, call) = res??;
-            let mut usage = call.usage;
-            if usage.cost_usd.is_none() {
-                usage.cost_usd = call.header_cost;
-            }
-            if usage.cost_usd.is_none() && provider == "openrouter" {
-                if let Some(id) = call.response_id.as_deref() {
-                    if let Ok(cost) = crate::fetch_openrouter_cost(&ctx.client, config, id).await {
-                        usage.cost_usd = cost;
+            match res {
+                Ok(Ok((idx, model, provider, call))) => {
+                    let mut usage = call.usage;
+                    if usage.cost_usd.is_none() {
+                        usage.cost_usd = call.header_cost;
                     }
+                    if usage.cost_usd.is_none() && provider == "openrouter" {
+                        if let Some(id) = call.response_id.as_deref() {
+                            if let Ok(cost) =
+                                crate::fetch_openrouter_cost(&ctx.client, config, id).await
+                            {
+                                usage.cost_usd = cost;
+                            }
+                        }
+                    }
+
+                    total_usage = add_usage(total_usage, &usage);
+
+                    let registry_id = resolve_registry_model_id(
+                        Some(&provider),
+                        Some(&model),
+                        registry_cache.as_ref(),
+                    );
+                    let output_tokens = per_model_max_output_tokens[idx].unwrap_or(4096);
+                    let pricing = registry::estimate_pricing(
+                        registry_cache.as_ref(),
+                        registry_id.as_deref().unwrap_or(&model),
+                        input_tokens,
+                        output_tokens,
+                    )?;
+
+                    ordered[idx] = Some(CouncilModelResult {
+                        model,
+                        content: call.content,
+                        usage,
+                        pricing,
+                        response_id: call.response_id,
+                    });
+                }
+                Ok(Err((model, provider, err))) => {
+                    errors.push(CouncilModelError {
+                        model,
+                        provider,
+                        error: err.to_string(),
+                    });
+                }
+                Err(err) => {
+                    errors.push(CouncilModelError {
+                        model: "<task>".to_string(),
+                        provider: "internal".to_string(),
+                        error: err.to_string(),
+                    });
                 }
             }
-
-            total_usage = add_usage(total_usage, &usage);
-
-            let registry_id =
-                resolve_registry_model_id(Some(&provider), Some(&model), registry_cache.as_ref());
-            let output_tokens = per_model_max_output_tokens[idx].unwrap_or(4096);
-            let pricing = registry::estimate_pricing(
-                registry_cache.as_ref(),
-                registry_id.as_deref().unwrap_or(&model),
-                input_tokens,
-                output_tokens,
-            )?;
-
-            ordered[idx] = Some(CouncilModelResult {
-                model,
-                content: call.content,
-                usage,
-                pricing,
-                response_id: call.response_id,
-            });
         }
 
         results = ordered.into_iter().flatten().collect();
+        if results.is_empty() && !errors.is_empty() {
+            let joined = errors
+                .iter()
+                .map(|error| format!("- {} ({}): {}", error.model, error.provider, error.error))
+                .collect::<Vec<_>>()
+                .join("\n");
+            return Err(anyhow!("all council models failed:\n{joined}"));
+        }
     }
 
     if budget_enabled && !args.dry_run {
@@ -281,6 +321,7 @@ pub(crate) async fn handle_council(
         provider: council_provider,
         bundle,
         results,
+        errors,
         pricing: CouncilPricing {
             estimate_usd_total: total_estimate,
             per_model,
@@ -305,11 +346,25 @@ pub(crate) async fn handle_council(
             for r in &council.results {
                 println!("## {}\n{}\n", r.model, r.content);
             }
+            if !council.errors.is_empty() {
+                println!("## Errors");
+                for error in &council.errors {
+                    println!("- {} ({}): {}", error.model, error.provider, error.error);
+                }
+                println!();
+            }
             Ok(())
         }
         OutputFormat::Markdown => {
             for r in &council.results {
                 println!("## {}\n{}\n", r.model, r.content);
+            }
+            if !council.errors.is_empty() {
+                println!("## Errors");
+                for error in &council.errors {
+                    println!("- {} ({}): {}", error.model, error.provider, error.error);
+                }
+                println!();
             }
             Ok(())
         }

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -13,20 +13,15 @@
 //! - Daemon-managed browser instances with auto-reconnect
 //! - Single script executes batch operations (fewer IPC round-trips)
 
-#[allow(unused_imports)]
 use anyhow::{anyhow, Context, Result};
-#[allow(unused_imports)]
-use serde_json::{json, Value};
-#[allow(unused_imports)]
+use serde_json::Value;
 use std::collections::BTreeMap;
 use std::env;
 use std::fs;
-#[allow(unused_imports)]
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::OnceLock;
 
-use reqwest::blocking::Client;
 use reqwest::Url;
 use yoetz_core::paths::home_dir;
 
@@ -73,8 +68,6 @@ struct CdpCandidate {
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct ResolvedCdpEndpoint {
     ws_url: String,
-    probe_url: String,
-    source: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -489,31 +482,33 @@ fn probe_cdp_candidate(candidate: &CdpCandidate) -> CdpProbeOutcome {
         Err(err) => return CdpProbeOutcome::Unavailable(err.to_string()),
     };
 
-    let client = match Client::builder().timeout(CDP_HEALTH_TIMEOUT).build() {
-        Ok(client) => client,
-        Err(err) => return CdpProbeOutcome::Unavailable(err.to_string()),
-    };
-
-    let response = match client
-        .get(probe_url.clone())
-        .header(reqwest::header::ACCEPT, "application/json")
-        .send()
+    let agent = ureq::AgentBuilder::new()
+        .timeout(CDP_HEALTH_TIMEOUT)
+        .build();
+    let response = match agent
+        .get(probe_url.as_str())
+        .set("Accept", "application/json")
+        .call()
     {
         Ok(response) => response,
-        Err(err) => return CdpProbeOutcome::Unavailable(err.to_string()),
+        Err(ureq::Error::Status(status, response)) => {
+            if status == 404 && is_localhost_url(&probe_url) {
+                return CdpProbeOutcome::Poisoned(build_half_state_diagnostic(
+                    candidate,
+                    probe_url.as_str(),
+                    "GET /json/version returned HTTP 404 from a localhost Chrome endpoint",
+                ));
+            }
+            response
+        }
+        Err(ureq::Error::Transport(err)) => {
+            return CdpProbeOutcome::Unavailable(err.to_string());
+        }
     };
 
     // Chrome 136+ can leave localhost CDP in a half-state where DevTools is
     // listening but HTTP discovery on the real profile returns 404.
-    if response.status() == reqwest::StatusCode::NOT_FOUND && is_localhost_url(&probe_url) {
-        return CdpProbeOutcome::Poisoned(build_half_state_diagnostic(
-            candidate,
-            probe_url.as_str(),
-            "GET /json/version returned HTTP 404 from a localhost Chrome endpoint",
-        ));
-    }
-
-    if !response.status().is_success() {
+    if !(200..=299).contains(&response.status()) {
         return CdpProbeOutcome::Unavailable(format!(
             "HTTP {} from {}",
             response.status(),
@@ -521,7 +516,7 @@ fn probe_cdp_candidate(candidate: &CdpCandidate) -> CdpProbeOutcome {
         ));
     }
 
-    let body = match response.text() {
+    let body = match response.into_string() {
         Ok(body) => body,
         Err(err) => return CdpProbeOutcome::Unavailable(err.to_string()),
     };
@@ -555,11 +550,7 @@ fn probe_cdp_candidate(candidate: &CdpCandidate) -> CdpProbeOutcome {
         ));
     };
 
-    CdpProbeOutcome::Healthy(ResolvedCdpEndpoint {
-        ws_url,
-        probe_url: probe_url.to_string(),
-        source: candidate.source.clone(),
-    })
+    CdpProbeOutcome::Healthy(ResolvedCdpEndpoint { ws_url })
 }
 
 fn resolve_dev_browser_connect_endpoint(cdp_endpoint: Option<&str>) -> Result<Option<String>> {
@@ -677,64 +668,9 @@ pub fn run_script_connect_with_endpoint(
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
-/// Run a dev-browser script with a managed (non-connect) browser instance.
-/// Uses the named browser instance for isolation.
-#[allow(dead_code)]
-pub fn run_script_managed(
-    script: &str,
-    browser_name: &str,
-    timeout_secs: Option<u64>,
-) -> Result<String> {
-    let bin = resolve_dev_browser()?;
-    let timeout = timeout_secs.unwrap_or(DEFAULT_SCRIPT_TIMEOUT_SECS);
-
-    let output = Command::new(&bin)
-        .args(["--browser", browser_name, "--timeout", &timeout.to_string()])
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .and_then(|mut child| {
-            use std::io::Write;
-            if let Some(ref mut stdin) = child.stdin {
-                stdin.write_all(script.as_bytes())?;
-            }
-            drop(child.stdin.take());
-            child.wait_with_output()
-        })
-        .with_context(|| format!("failed to run dev-browser (via {bin})"))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let detail = if !stderr.is_empty() {
-            stderr.to_string()
-        } else if !stdout.is_empty() {
-            stdout.to_string()
-        } else {
-            format!("exit code {:?}", output.status.code())
-        };
-        return Err(anyhow!("dev-browser script failed: {detail}"));
-    }
-
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
-}
-
 /// Stage a file into dev-browser's tmp directory so scripts can read it
 /// via `readFile(name)`.
 pub fn stage_file(name: &str, content: &str) -> Result<PathBuf> {
-    let tmp_dir = dev_browser_tmp_dir();
-    fs::create_dir_all(&tmp_dir)
-        .with_context(|| format!("create dev-browser tmp dir: {}", tmp_dir.display()))?;
-    let path = tmp_dir.join(name);
-    fs::write(&path, content).with_context(|| format!("write staged file: {}", path.display()))?;
-    set_staged_file_permissions(&path)?;
-    Ok(path)
-}
-
-/// Stage a binary file into dev-browser's tmp directory.
-#[allow(dead_code)]
-pub fn stage_file_bytes(name: &str, content: &[u8]) -> Result<PathBuf> {
     let tmp_dir = dev_browser_tmp_dir();
     fs::create_dir_all(&tmp_dir)
         .with_context(|| format!("create dev-browser tmp dir: {}", tmp_dir.display()))?;
@@ -758,36 +694,9 @@ fn set_staged_file_permissions(path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// List all browser tabs visible to dev-browser (via --connect).
-pub fn list_tabs() -> Result<Vec<TabInfo>> {
-    let script = r#"
-const pages = await browser.listPages();
-console.log(JSON.stringify(pages));
-"#;
-    let stdout = run_script_connect(script, Some(10))?;
-    let tabs: Vec<TabInfo> =
-        serde_json::from_str(stdout.trim()).context("parse dev-browser listPages")?;
-    Ok(tabs)
-}
-
-/// Tab information from dev-browser.
-#[allow(dead_code)]
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
-pub struct TabInfo {
-    pub id: String,
-    pub url: String,
-    pub title: String,
-    pub name: Option<String>,
-}
-
 /// Check if Chrome is reachable and dev-browser can connect to it.
 /// Uses a short first probe; retries once with a longer timeout only when the
 /// first failure looks like a timeout (slow CDP handshake with many tabs).
-#[allow(dead_code)]
-pub fn check_connection() -> Result<()> {
-    check_connection_with_endpoint(None)
-}
-
 pub fn check_connection_with_endpoint(cdp_endpoint: Option<&str>) -> Result<()> {
     let script = r#"
 const pages = await browser.listPages();
@@ -816,24 +725,6 @@ console.log("ok:" + pages.length);
             }
         }
     }
-}
-
-/// Find a ChatGPT tab in the connected browser.
-/// Returns the tab ID of the best candidate.
-#[allow(dead_code)]
-pub fn find_chatgpt_tab() -> Result<Option<String>> {
-    let tabs = list_tabs()?;
-    let chatgpt_tab = tabs
-        .iter()
-        .find(|t| t.url.contains("chatgpt.com") && !t.url.contains("/c/"))
-        .or_else(|| tabs.iter().find(|t| t.url.contains("chatgpt.com")));
-    Ok(chatgpt_tab.map(|t| t.id.clone()))
-}
-
-/// Check authentication status on ChatGPT in the connected browser.
-#[allow(dead_code)]
-pub fn check_chatgpt_auth() -> Result<bool> {
-    check_chatgpt_auth_with_endpoint(None)
 }
 
 pub fn check_chatgpt_auth_with_endpoint(cdp_endpoint: Option<&str>) -> Result<bool> {
@@ -867,11 +758,6 @@ try {
 /// Only checks dev-browser daemon connectivity — opening a separate page
 /// to verify auth causes interference with the recipe's named page.
 /// If not authenticated, the recipe will fail with a clear error.
-#[allow(dead_code)]
-pub fn ensure_chatgpt_auth() -> Result<()> {
-    ensure_chatgpt_auth_with_endpoint(None)
-}
-
 pub fn ensure_chatgpt_auth_with_endpoint(cdp_endpoint: Option<&str>) -> Result<()> {
     check_connection_with_endpoint(cdp_endpoint).context(
         "dev-browser cannot connect to Chrome. Enable remote debugging: chrome://inspect/#remote-debugging",
@@ -883,12 +769,6 @@ pub fn ensure_chatgpt_auth_with_endpoint(cdp_endpoint: Option<&str>) -> Result<(
 
 /// Ensure the connected Chrome session can reach an authenticated ChatGPT page.
 /// Opens a temporary page — use only when not immediately followed by a recipe.
-#[allow(dead_code)]
-pub fn ensure_chatgpt_auth_with_page_check() -> Result<()> {
-    ensure_chatgpt_auth_with_page_check_and_endpoint(None)
-}
-
-#[allow(dead_code)]
 pub fn ensure_chatgpt_auth_with_page_check_and_endpoint(cdp_endpoint: Option<&str>) -> Result<()> {
     check_connection_with_endpoint(cdp_endpoint).context(
         "dev-browser cannot connect to Chrome. Enable remote debugging: chrome://inspect/#remote-debugging",
@@ -1132,7 +1012,7 @@ const POLL_INTERVAL_MS = {poll_interval_ms};
 const ALLOW_EMPTY_RESPONSE = {allow_empty_response};
 const page = await browser.getPage(PAGE_NAME);
 const start = Date.now();
-let lastResponseLength = null;
+let lastResponseText = null;
 while (Date.now() - start < POLL_TIMEOUT_MS) {{
   const state = await page.evaluate((baselineCount) => {{
     const errorEl = document.querySelector("[role='alert'], [data-testid*='error']");
@@ -1157,13 +1037,13 @@ while (Date.now() - start < POLL_TIMEOUT_MS) {{
     state.newAssistantCount > 0 &&
     (ALLOW_EMPTY_RESPONSE || state.response.length > 0);
   if (completionCandidate) {{
-    if (lastResponseLength !== null && state.response.length === lastResponseLength) {{
+    if (lastResponseText !== null && state.response === lastResponseText) {{
       console.log(JSON.stringify({{ status: "ok", response: state.response }}));
       return;
     }}
-    lastResponseLength = state.response.length;
+    lastResponseText = state.response;
   }} else {{
-    lastResponseLength = null;
+    lastResponseText = null;
   }}
   await page.waitForTimeout(POLL_INTERVAL_MS);
 }}
@@ -1395,128 +1275,6 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<String> {
     Ok(response)
 }
 
-/// Run a generic dev-browser recipe from a YAML recipe file.
-/// Converts each YAML step into equivalent Playwright JS and executes
-/// as a single script.
-#[allow(dead_code)]
-pub fn run_yaml_recipe(
-    recipe_steps: &[(String, Option<Vec<String>>)],
-    vars: &BTreeMap<String, String>,
-    bundle_path: Option<&Path>,
-    timeout_secs: Option<u64>,
-) -> Result<String> {
-    let mut script_parts = Vec::new();
-    let mut staged_files = Vec::new();
-
-    // Open a named page for persistence
-    script_parts.push("const page = await browser.getPage('yoetz-recipe');".to_string());
-
-    for (action, args) in recipe_steps {
-        let args_ref = args.as_deref().unwrap_or_default();
-        match action.as_str() {
-            "eval" => {
-                if let Some(code) = args_ref.first() {
-                    let mut interpolated = code.clone();
-                    for (key, value) in vars {
-                        let json_needle = format!("{{{{{key}|json}}}}");
-                        interpolated = interpolated
-                            .replace(&json_needle, &serde_json::to_string(value).unwrap());
-                        let needle = format!("{{{{{key}}}}}");
-                        interpolated = interpolated.replace(&needle, value);
-                    }
-                    script_parts.push(format!(
-                        "await page.evaluate(() => {{ {} }});",
-                        interpolated
-                    ));
-                }
-            }
-            "snapshot" => {
-                script_parts.push(
-                    "const snap = await page.evaluate(() => document.body.innerText); console.log(snap);".to_string()
-                );
-            }
-            "upload" => {
-                if args_ref.len() >= 2 {
-                    if let Some(bp) = bundle_path {
-                        let content = fs::read_to_string(bp)?;
-                        let name = bp
-                            .file_name()
-                            .and_then(|n| n.to_str())
-                            .unwrap_or("upload.txt");
-                        let path = stage_file(name, &content)?;
-                        staged_files.push(StagedFileGuard::new(path));
-                        let name_json = serde_json::to_string(name).unwrap();
-                        script_parts.push(format!(
-                            r#"{{
-    const content = await readFile({name_json});
-    await page.evaluate((args) => {{
-        const [c, n] = args;
-        const f = new File([c], n, {{ type: "text/plain" }});
-        const dt = new DataTransfer();
-        dt.items.add(f);
-        const input = document.querySelector({selector_json});
-        if (input) {{ input.files = dt.files; input.dispatchEvent(new Event('change', {{ bubbles: true }})); }}
-    }}, [content, {name_json}]);
-}}"#,
-                            name_json = name_json,
-                            selector_json = serde_json::to_string(&args_ref[0]).unwrap(),
-                        ));
-                    }
-                }
-            }
-            _ => {
-                // For unknown actions, try as page method call
-                eprintln!("warn: unknown recipe action '{action}', skipping");
-            }
-        }
-    }
-
-    let full_script = script_parts.join("\n");
-    run_script_connect(&full_script, timeout_secs)
-}
-
-/// Take a screenshot of the current page via dev-browser.
-#[allow(dead_code)]
-pub fn take_screenshot(name: &str) -> Result<PathBuf> {
-    let name_json = serde_json::to_string(name).unwrap();
-    let script = format!(
-        r#"
-const pages = await browser.listPages();
-const chatgpt = pages.find(p => p.url.includes("chatgpt.com"));
-if (chatgpt) {{
-    const page = await browser.getPage(chatgpt.id);
-    const buf = await page.screenshot();
-    const path = await saveScreenshot(buf, {name_json});
-    console.log(path);
-}} else {{
-    const page = await browser.newPage();
-    const buf = await page.screenshot();
-    const path = await saveScreenshot(buf, {name_json});
-    console.log(path);
-}}
-"#,
-    );
-    let stdout = run_script_connect(&script, Some(15))?;
-    Ok(PathBuf::from(stdout.trim()))
-}
-
-/// Get the text content of the current ChatGPT page.
-#[allow(dead_code)]
-pub fn get_chatgpt_page_text() -> Result<String> {
-    let script = r#"
-const pages = await browser.listPages();
-const chatgpt = pages.find(p => p.url.includes("chatgpt.com"));
-if (chatgpt) {
-    const page = await browser.getPage(chatgpt.id);
-    const text = await page.evaluate(() => document.body.innerText);
-    console.log(text);
-} else {
-    console.log("");
-}
-"#;
-    run_script_connect(script, Some(15))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1535,16 +1293,6 @@ mod tests {
         assert!(path.exists());
         let content = fs::read_to_string(&path).unwrap();
         assert_eq!(content, "hello world");
-        let _ = fs::remove_file(&path);
-    }
-
-    #[test]
-    fn test_stage_file_bytes() {
-        let data = b"binary content \x00\x01\x02";
-        let path = stage_file_bytes("test_binary.bin", data).unwrap();
-        assert!(path.exists());
-        let content = fs::read(&path).unwrap();
-        assert_eq!(content, data);
         let _ = fs::remove_file(&path);
     }
 
@@ -1756,12 +1504,12 @@ mod tests {
         assert!(script.contains("const POLL_TIMEOUT_MS = 900000;"));
         assert!(script.contains("const POLL_INTERVAL_MS = 45000;"));
         assert!(script.contains("const ALLOW_EMPTY_RESPONSE = false;"));
-        assert!(script.contains("let lastResponseLength = null;"));
+        assert!(script.contains("let lastResponseText = null;"));
         assert!(script.contains(".result-thinking, [data-testid*='thinking']"));
         assert!(script.contains("[data-testid='stop-button']"));
         assert!(script.contains("[data-message-author-role='assistant']"));
         assert!(script.contains("!state.hasThinkingIndicator"));
-        assert!(script.contains("state.response.length === lastResponseLength"));
+        assert!(script.contains("state.response === lastResponseText"));
         assert!(script.contains("status: \"ok\""));
         assert!(script.contains("status: \"timeout\""));
     }

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -55,11 +55,6 @@ impl Default for ChatgptPollSettings {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct StagedFileGuard {
-    path: PathBuf,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
 struct CdpCandidate {
     endpoint: String,
     source: String,
@@ -83,19 +78,9 @@ enum CdpProbeOutcome {
     Poisoned(String),
 }
 
-impl StagedFileGuard {
-    fn new(path: PathBuf) -> Self {
-        Self { path }
-    }
-}
-
-impl Drop for StagedFileGuard {
-    fn drop(&mut self) {
-        let _ = fs::remove_file(&self.path);
-    }
-}
-
 /// dev-browser tmp directory for file staging.
+#[cfg(test)]
+#[allow(dead_code)]
 fn dev_browser_tmp_dir() -> PathBuf {
     home_dir()
         .unwrap_or_else(|| PathBuf::from("/tmp"))
@@ -595,8 +580,17 @@ fn resolve_dev_browser_connect_endpoint(cdp_endpoint: Option<&str>) -> Result<Op
     }
 }
 
-fn connect_args(timeout_secs: u64, cdp_endpoint: Option<&str>) -> Vec<String> {
-    let mut args = vec!["--connect".to_string()];
+fn connect_args(
+    timeout_secs: u64,
+    browser_name: Option<&str>,
+    cdp_endpoint: Option<&str>,
+) -> Vec<String> {
+    let mut args = Vec::new();
+    if let Some(browser_name) = browser_name {
+        args.push("--browser".to_string());
+        args.push(browser_name.to_string());
+    }
+    args.push("--connect".to_string());
     if let Some(endpoint) = cdp_endpoint {
         args.push(endpoint.to_string());
     }
@@ -605,17 +599,16 @@ fn connect_args(timeout_secs: u64, cdp_endpoint: Option<&str>) -> Vec<String> {
     args
 }
 
-/// Run a dev-browser script against a live Chrome instance, optionally via an
-/// explicit CDP endpoint.
-pub fn run_script_connect_with_endpoint(
+fn run_script_connect_with_browser_and_endpoint(
     script: &str,
     timeout_secs: Option<u64>,
+    browser_name: Option<&str>,
     cdp_endpoint: Option<&str>,
 ) -> Result<String> {
     let bin = resolve_dev_browser()?;
     let timeout = timeout_secs.unwrap_or(DEFAULT_SCRIPT_TIMEOUT_SECS);
     let resolved_endpoint = resolve_dev_browser_connect_endpoint(cdp_endpoint)?;
-    let args = connect_args(timeout, resolved_endpoint.as_deref());
+    let args = connect_args(timeout, browser_name, resolved_endpoint.as_deref());
 
     let output = Command::new(&bin)
         .args(&args)
@@ -668,8 +661,20 @@ pub fn run_script_connect_with_endpoint(
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
+/// Run a dev-browser script against a live Chrome instance, optionally via an
+/// explicit CDP endpoint.
+pub fn run_script_connect_with_endpoint(
+    script: &str,
+    timeout_secs: Option<u64>,
+    cdp_endpoint: Option<&str>,
+) -> Result<String> {
+    run_script_connect_with_browser_and_endpoint(script, timeout_secs, None, cdp_endpoint)
+}
+
 /// Stage a file into dev-browser's tmp directory so scripts can read it
 /// via `readFile(name)`.
+#[cfg(test)]
+#[allow(dead_code)]
 pub fn stage_file(name: &str, content: &str) -> Result<PathBuf> {
     let tmp_dir = dev_browser_tmp_dir();
     fs::create_dir_all(&tmp_dir)
@@ -680,6 +685,8 @@ pub fn stage_file(name: &str, content: &str) -> Result<PathBuf> {
     Ok(path)
 }
 
+#[cfg(test)]
+#[allow(dead_code)]
 fn set_staged_file_permissions(path: &Path) -> Result<()> {
     #[cfg(unix)]
     {
@@ -777,7 +784,7 @@ pub fn ensure_chatgpt_auth_with_page_check_and_endpoint(cdp_endpoint: Option<&st
 /// split into micro-scripts with JSON stdout handoffs instead of generating one
 /// large helper-heavy script.
 pub struct DevBrowserRecipeContext {
-    /// Path to the bundle file on disk (will be staged to dev-browser tmp).
+    /// Path to the bundle file on disk (used for macOS clipboard file upload).
     pub bundle_path: Option<PathBuf>,
     /// Bundle text content (for paste mode).
     pub bundle_text: Option<String>,
@@ -913,20 +920,17 @@ fn build_chatgpt_send_script(
     page_name: &str,
     prompt: &str,
     delivery_text: &str,
-    staged_file_name: Option<&str>,
-    upload_file_name: Option<&str>,
+    file_on_clipboard: bool,
     disable_extended: bool,
 ) -> String {
     let page_name_json = serde_json::to_string(page_name).unwrap();
-    let staged_file_name_json = serde_json::to_string(&staged_file_name).unwrap();
-    let upload_file_name_json = serde_json::to_string(&upload_file_name).unwrap();
+    let file_on_clipboard_json = serde_json::to_string(&file_on_clipboard).unwrap();
     let delivery_text_json = serde_json::to_string(delivery_text).unwrap();
     let prompt_json = serde_json::to_string(prompt).unwrap();
     format!(
         r#"
 const PAGE_NAME = {page_name_json};
-const STAGED_FILE_NAME = {staged_file_name_json};
-const UPLOAD_FILE_NAME = {upload_file_name_json};
+const FILE_ON_CLIPBOARD = {file_on_clipboard_json};
 const DELIVERY_TEXT = {delivery_text_json};
 const PROMPT = {prompt_json};
 const DISABLE_EXTENDED = {disable_extended};
@@ -941,20 +945,20 @@ if (DISABLE_EXTENDED) {{
     warning = "extended disable requested but toggle not found";
   }}
 }}
-if (STAGED_FILE_NAME) {{
-  await page.locator("[data-testid='composer-plus-btn']").first().click();
-  await page.waitForTimeout(500);
-  const menuItem = page.locator("[role='menuitem']").filter({{ hasText: /Add photos/i }}).first();
-  await menuItem.waitFor({{ state: "visible", timeout: 5000 }});
-  await menuItem.click();
-  await uploadFile(page, STAGED_FILE_NAME, {{
-    selector: "input[type='file']",
-    name: UPLOAD_FILE_NAME || undefined,
-    mimeType: "text/markdown",
-  }});
-  await page.locator("img[alt*='attachment' i], [data-testid*='attachment' i], [aria-label*='attachment' i]").first().waitFor({{ state: "visible", timeout: 10000 }}).catch(() => {{}});
-}}
 const composer = page.locator("[role='textbox']").first();
+if (FILE_ON_CLIPBOARD) {{
+  await composer.waitFor({{ state: "visible", timeout: 15000 }});
+  await composer.click();
+  await page.keyboard.press("Meta+v");
+  await page.waitForTimeout(5000);
+  const attached = await page.evaluate(() => {{
+    return !!document.querySelector("[class*='file-tile'], [data-testid*='attachment']");
+  }});
+  if (!attached) {{
+    throw new Error("file not attached after clipboard paste");
+  }}
+}}
+await composer.waitFor({{ state: "visible", timeout: 15000 }});
 await composer.click();
 await composer.pressSequentially(DELIVERY_TEXT, {{ delay: 15 }});
 const sendBtn = page.locator("[data-testid='send-button']").first();
@@ -975,12 +979,58 @@ console.log(JSON.stringify({{
 }}));
 "#,
         page_name_json = page_name_json,
-        staged_file_name_json = staged_file_name_json,
-        upload_file_name_json = upload_file_name_json,
+        file_on_clipboard_json = file_on_clipboard_json,
         delivery_text_json = delivery_text_json,
         prompt_json = prompt_json,
         disable_extended = disable_extended,
     )
+}
+
+fn set_file_on_clipboard(path: &Path) -> Result<()> {
+    let canonical_path = path
+        .canonicalize()
+        .with_context(|| format!("resolve bundle path: {}", path.display()))?;
+
+    #[cfg(target_os = "macos")]
+    {
+        let output = Command::new("osascript")
+            .args([
+                "-e",
+                "on run argv",
+                "-e",
+                "set the clipboard to (POSIX file (item 1 of argv))",
+                "-e",
+                "end run",
+            ])
+            .arg(&canonical_path)
+            .output()
+            .context("failed to run osascript for ChatGPT file upload")?;
+        if output.status.success() {
+            return Ok(());
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if !stderr.is_empty() {
+            stderr
+        } else if !stdout.is_empty() {
+            stdout
+        } else {
+            format!("exit code {:?}", output.status.code())
+        };
+        Err(anyhow!(
+            "failed to set macOS clipboard to bundle file `{}`: {detail}",
+            canonical_path.display()
+        ))
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = canonical_path;
+        Err(anyhow!(
+            "dev-browser file upload via clipboard currently requires macOS"
+        ))
+    }
 }
 
 fn build_chatgpt_poll_script(
@@ -1142,36 +1192,25 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<String> {
             .unwrap_or_default()
             .as_millis()
     );
-    let page_name = format!("yoetz-chatgpt-{unique_prefix}");
-    let mut staged_file_guard = None;
-    let mut staged_file_name = None;
-    let mut upload_file_name = None;
-    if !ctx.paste_mode {
-        if let Some(bundle_path) = &ctx.bundle_path {
-            let content = fs::read_to_string(bundle_path)
-                .with_context(|| format!("read bundle: {}", bundle_path.display()))?;
-            let base_name = bundle_path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("bundle.txt");
-            let name = format!("{unique_prefix}_{base_name}");
-            let path = stage_file(&name, &content)?;
-            staged_file_name = Some(name);
-            upload_file_name = Some(base_name.to_string());
-            staged_file_guard = Some(StagedFileGuard::new(path));
-        } else if let Some(text) = &ctx.bundle_text {
-            let name = format!("{unique_prefix}_bundle.md");
-            let path = stage_file(&name, text)?;
-            staged_file_name = Some(name);
-            upload_file_name = Some("bundle.md".to_string());
-            staged_file_guard = Some(StagedFileGuard::new(path));
-        }
-    }
-
+    let browser_name = format!("yoetz-chatgpt-browser-{unique_prefix}");
+    let page_name = format!("yoetz-chatgpt-page-{unique_prefix}");
     let cdp_endpoint = ctx.cdp_endpoint.as_deref();
+    let run_script = |script: &str, timeout_secs: Option<u64>| {
+        run_script_connect_with_browser_and_endpoint(
+            script,
+            timeout_secs,
+            Some(browser_name.as_str()),
+            cdp_endpoint,
+        )
+    };
     let cleanup = |cdp_endpoint| -> Result<()> {
         let cleanup_script = build_chatgpt_cleanup_script(&page_name);
-        match run_script_connect_with_endpoint(&cleanup_script, Some(15), cdp_endpoint) {
+        match run_script_connect_with_browser_and_endpoint(
+            &cleanup_script,
+            Some(15),
+            Some(browser_name.as_str()),
+            cdp_endpoint,
+        ) {
             Ok(_) => Ok(()),
             Err(err) => {
                 eprintln!("warn: failed to clean up dev-browser recipe page `{page_name}`: {err}");
@@ -1182,6 +1221,18 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<String> {
 
     let result = (|| -> Result<(String, Vec<String>)> {
         let mut warnings = Vec::new();
+        let file_on_clipboard = if ctx.paste_mode {
+            false
+        } else if let Some(bundle_path) = &ctx.bundle_path {
+            set_file_on_clipboard(bundle_path)?;
+            true
+        } else if ctx.bundle_text.is_some() {
+            return Err(anyhow!(
+                "dev-browser file upload requires a bundle path on disk; use `--var paste=true` for text-only delivery"
+            ));
+        } else {
+            false
+        };
         let delivery_text = if ctx.paste_mode {
             format!(
                 "{}\n\n{}",
@@ -1193,8 +1244,7 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<String> {
         };
 
         let prepare_script = build_chatgpt_prepare_script(&page_name, &ctx.model);
-        let prepare_stdout =
-            run_script_connect_with_endpoint(&prepare_script, Some(60), cdp_endpoint)?;
+        let prepare_stdout = run_script(&prepare_script, Some(60))?;
         let prepare: ChatgptPrepareResult =
             parse_script_json("parse chatgpt prepare result", &prepare_stdout)?;
         match prepare.status.as_str() {
@@ -1222,11 +1272,10 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<String> {
             &page_name,
             &ctx.prompt,
             &delivery_text,
-            staged_file_name.as_deref(),
-            upload_file_name.as_deref(),
+            file_on_clipboard,
             ctx.disable_extended,
         );
-        let send_stdout = run_script_connect_with_endpoint(&send_script, Some(90), cdp_endpoint)?;
+        let send_stdout = run_script(&send_script, Some(90))?;
         let send: ChatgptSendResult = parse_script_json("parse chatgpt send result", &send_stdout)?;
         if send.status != "sent" {
             return Err(anyhow!("unexpected ChatGPT send status `{}`", send.status));
@@ -1241,18 +1290,15 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<String> {
             ctx.poll_settings,
             ctx.allow_empty_response,
         );
-        let poll_stdout = run_script_connect_with_endpoint(
+        let poll_stdout = run_script(
             &poll_script,
             Some(chatgpt_script_timeout_secs(ctx.poll_settings.timeout_ms)),
-            cdp_endpoint,
         )?;
         let (response, mut poll_warnings) =
             parse_chatgpt_recipe_result(&poll_stdout, ctx.poll_settings.timeout_ms)?;
         warnings.append(&mut poll_warnings);
         Ok((response, warnings))
     })();
-
-    drop(staged_file_guard);
     cleanup(cdp_endpoint)?;
 
     let (response, warnings) = result?;
@@ -1332,8 +1378,14 @@ mod tests {
     #[test]
     fn connect_args_include_optional_endpoint() {
         assert_eq!(
-            connect_args(30, Some("http://127.0.0.1:9222")),
+            connect_args(
+                30,
+                Some("yoetz-chatgpt-browser"),
+                Some("http://127.0.0.1:9222"),
+            ),
             vec![
+                "--browser".to_string(),
+                "yoetz-chatgpt-browser".to_string(),
                 "--connect".to_string(),
                 "http://127.0.0.1:9222".to_string(),
                 "--timeout".to_string(),
@@ -1341,7 +1393,7 @@ mod tests {
             ]
         );
         assert_eq!(
-            connect_args(45, None),
+            connect_args(45, None, None),
             vec![
                 "--connect".to_string(),
                 "--timeout".to_string(),
@@ -1438,25 +1490,21 @@ mod tests {
     }
 
     #[test]
-    fn build_chatgpt_send_script_uses_file_path_and_press_sequentially() {
+    fn build_chatgpt_send_script_uses_clipboard_upload_and_press_sequentially() {
         let script = build_chatgpt_send_script(
             "yoetz-chatgpt-test",
             "Review this file.",
             "Review this file.",
-            Some("upload_123_bundle.md"),
-            Some("bundle.md"),
+            true,
             true,
         );
 
         assert!(script.contains("const PAGE_NAME = \"yoetz-chatgpt-test\";"));
-        assert!(script.contains("const STAGED_FILE_NAME = \"upload_123_bundle.md\";"));
-        assert!(script.contains("const UPLOAD_FILE_NAME = \"bundle.md\";"));
-        assert!(script.contains("[data-testid='composer-plus-btn']"));
-        assert!(script.contains("[role='menuitem']"));
-        assert!(script.contains("hasText: /Add photos/i"));
-        assert!(script.contains("await uploadFile(page, STAGED_FILE_NAME"));
-        assert!(script.contains("selector: \"input[type='file']\""));
-        assert!(script.contains("mimeType: \"text/markdown\""));
+        assert!(script.contains("const FILE_ON_CLIPBOARD = true;"));
+        assert!(script.contains("await composer.waitFor({ state: \"visible\", timeout: 15000 });"));
+        assert!(script.contains("await page.keyboard.press(\"Meta+v\");"));
+        assert!(script.contains("file not attached after clipboard paste"));
+        assert!(script.contains("[class*='file-tile'], [data-testid*='attachment']"));
         assert!(script.contains("pressSequentially(DELIVERY_TEXT, { delay: 15 })"));
         assert!(script.contains("status: \"sent\""));
     }

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -8,7 +8,7 @@
 //!
 //! Key advantages over agent-browser:
 //! - Full Playwright Page API (goto, click, fill, locator, evaluate, etc.)
-//! - File upload via native filechooser + setFiles(FilePayload)
+//! - File upload via host-level sandbox helper backed by Node Playwright
 //! - Persistent named pages across script runs
 //! - Daemon-managed browser instances with auto-reconnect
 //! - Single script executes batch operations (fewer IPC round-trips)
@@ -26,6 +26,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::OnceLock;
 
+use reqwest::blocking::Client;
+use reqwest::Url;
 use yoetz_core::paths::home_dir;
 
 /// Cached dev-browser resolution.
@@ -33,6 +35,10 @@ static DEV_BROWSER: OnceLock<String> = OnceLock::new();
 
 /// Default timeout for dev-browser scripts in seconds.
 const DEFAULT_SCRIPT_TIMEOUT_SECS: u64 = 30;
+const CDP_HEALTH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+const CHROME_EXPLICIT_REMOTE_DEBUGGING_PORT: u16 = 9222;
+const CDP_HALF_STATE_MARKER: &str =
+    "Chrome CDP endpoint is reachable but not responding to protocol commands";
 
 /// Extended timeout for ChatGPT response polling (30 minutes by default).
 const CHATGPT_POLL_TIMEOUT_MS_DEFAULT: u64 = 1_800_000;
@@ -56,6 +62,32 @@ impl Default for ChatgptPollSettings {
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct StagedFileGuard {
     path: PathBuf,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CdpCandidate {
+    endpoint: String,
+    source: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ResolvedCdpEndpoint {
+    ws_url: String,
+    probe_url: String,
+    source: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct DevToolsActivePortEntry {
+    port: u16,
+    ws_url: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum CdpProbeOutcome {
+    Healthy(ResolvedCdpEndpoint),
+    Unavailable(String),
+    Poisoned(String),
 }
 
 impl StagedFileGuard {
@@ -217,6 +249,361 @@ pub fn run_script_connect(script: &str, timeout_secs: Option<u64>) -> Result<Str
     run_script_connect_with_endpoint(script, timeout_secs, None)
 }
 
+fn chrome_default_profile_cdp_guidance() -> String {
+    #[cfg(target_os = "macos")]
+    {
+        let profile_dir = home_dir()
+            .map(|home| {
+                home.join("Library")
+                    .join("Application Support")
+                    .join("Google")
+                    .join("Chrome")
+            })
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| "~/Library/Application Support/Google/Chrome".to_string());
+        format!(
+            "This is a known Chrome 136+ limitation when using the default profile.\n\
+             For a reliable explicit CDP endpoint, relaunch Chrome with:\n\
+               --remote-debugging-port={CHROME_EXPLICIT_REMOTE_DEBUGGING_PORT} --user-data-dir={profile_dir}\n\
+             Or use Chrome for Testing."
+        )
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        format!(
+        "This is a known Chrome 136+ limitation when using the default profile.\n\
+         For a reliable explicit CDP endpoint, relaunch Chrome with:\n\
+           --remote-debugging-port={CHROME_EXPLICIT_REMOTE_DEBUGGING_PORT} --user-data-dir=~/.config/yoetz/chrome-profile\n\
+         Or use Chrome for Testing."
+        )
+    }
+}
+
+fn is_poisoned_cdp_error(err: &anyhow::Error) -> bool {
+    err.to_string().contains(CDP_HALF_STATE_MARKER)
+}
+
+fn is_localhost_url(url: &Url) -> bool {
+    matches!(url.host_str(), Some("127.0.0.1" | "localhost" | "::1"))
+}
+
+fn endpoint_port(endpoint: &str) -> Option<u16> {
+    let url = Url::parse(endpoint).ok()?;
+    url.port_or_known_default()
+}
+
+fn standard_devtools_active_port_candidates() -> Vec<PathBuf> {
+    let Some(home_dir) = home_dir() else {
+        return Vec::new();
+    };
+
+    #[cfg(target_os = "macos")]
+    {
+        return vec![
+            home_dir
+                .join("Library")
+                .join("Application Support")
+                .join("Google")
+                .join("Chrome")
+                .join("DevToolsActivePort"),
+            home_dir
+                .join("Library")
+                .join("Application Support")
+                .join("Google")
+                .join("Chrome Canary")
+                .join("DevToolsActivePort"),
+            home_dir
+                .join("Library")
+                .join("Application Support")
+                .join("Chromium")
+                .join("DevToolsActivePort"),
+            home_dir
+                .join("Library")
+                .join("Application Support")
+                .join("BraveSoftware")
+                .join("Brave-Browser")
+                .join("DevToolsActivePort"),
+        ];
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        return vec![
+            home_dir
+                .join(".config")
+                .join("google-chrome")
+                .join("DevToolsActivePort"),
+            home_dir
+                .join(".config")
+                .join("chromium")
+                .join("DevToolsActivePort"),
+            home_dir
+                .join(".config")
+                .join("google-chrome-beta")
+                .join("DevToolsActivePort"),
+            home_dir
+                .join(".config")
+                .join("google-chrome-unstable")
+                .join("DevToolsActivePort"),
+            home_dir
+                .join(".config")
+                .join("BraveSoftware")
+                .join("Brave-Browser")
+                .join("DevToolsActivePort"),
+        ];
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        return vec![
+            home_dir
+                .join("AppData")
+                .join("Local")
+                .join("Google")
+                .join("Chrome")
+                .join("User Data")
+                .join("DevToolsActivePort"),
+            home_dir
+                .join("AppData")
+                .join("Local")
+                .join("Google")
+                .join("Chrome Beta")
+                .join("User Data")
+                .join("DevToolsActivePort"),
+            home_dir
+                .join("AppData")
+                .join("Local")
+                .join("Google")
+                .join("Chrome SxS")
+                .join("User Data")
+                .join("DevToolsActivePort"),
+            home_dir
+                .join("AppData")
+                .join("Local")
+                .join("Chromium")
+                .join("User Data")
+                .join("DevToolsActivePort"),
+            home_dir
+                .join("AppData")
+                .join("Local")
+                .join("BraveSoftware")
+                .join("Brave-Browser")
+                .join("User Data")
+                .join("DevToolsActivePort"),
+        ];
+    }
+
+    #[allow(unreachable_code)]
+    Vec::new()
+}
+
+fn parse_devtools_active_port(contents: &str) -> Option<DevToolsActivePortEntry> {
+    let lines = contents
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+    let port = lines.first()?.parse::<u16>().ok()?;
+    let ws_path = *lines.get(1)?;
+    if port == 0 || !ws_path.starts_with("/devtools/browser/") {
+        return None;
+    }
+    Some(DevToolsActivePortEntry {
+        port,
+        ws_url: format!("ws://127.0.0.1:{port}{ws_path}"),
+    })
+}
+
+fn devtools_active_port_entries() -> Vec<(PathBuf, DevToolsActivePortEntry)> {
+    standard_devtools_active_port_candidates()
+        .into_iter()
+        .filter_map(|path| {
+            let contents = fs::read_to_string(&path).ok()?;
+            let entry = parse_devtools_active_port(&contents)?;
+            Some((path, entry))
+        })
+        .collect()
+}
+
+fn matching_devtools_active_port_candidate(port: u16) -> Option<CdpCandidate> {
+    devtools_active_port_entries()
+        .into_iter()
+        .find_map(|(path, entry)| {
+            (entry.port == port).then_some(CdpCandidate {
+                endpoint: entry.ws_url,
+                source: format!("DevToolsActivePort ({})", path.display()),
+            })
+        })
+}
+
+fn json_version_url(endpoint: &str) -> Result<Url> {
+    let mut url = Url::parse(endpoint)
+        .with_context(|| format!("invalid Chrome CDP endpoint `{endpoint}`"))?;
+    match url.scheme() {
+        "http" | "https" => {}
+        "ws" => {
+            url.set_scheme("http")
+                .map_err(|_| anyhow!("invalid CDP endpoint scheme for `{endpoint}`"))?;
+        }
+        "wss" => {
+            url.set_scheme("https")
+                .map_err(|_| anyhow!("invalid CDP endpoint scheme for `{endpoint}`"))?;
+        }
+        other => {
+            return Err(anyhow!(
+                "unsupported Chrome CDP endpoint scheme `{other}` in `{endpoint}`"
+            ));
+        }
+    }
+    url.set_path("/json/version");
+    url.set_query(None);
+    url.set_fragment(None);
+    Ok(url)
+}
+
+#[derive(serde::Deserialize)]
+struct JsonVersionResponse {
+    #[serde(rename = "webSocketDebuggerUrl")]
+    web_socket_debugger_url: Option<String>,
+}
+
+fn build_half_state_diagnostic(candidate: &CdpCandidate, probe_url: &str, detail: &str) -> String {
+    format!(
+        "{CDP_HALF_STATE_MARKER}.\n\
+         Endpoint: {}\n\
+         Probe: {probe_url}\n\
+         Source: {}\n\
+         Observed: {detail}\n\
+         {}\n\
+         Restart Chrome with chrome://inspect/#remote-debugging enabled, then retry auto-connect or pass the exact ws:// CDP endpoint.",
+        candidate.endpoint,
+        candidate.source,
+        chrome_default_profile_cdp_guidance(),
+    )
+}
+
+fn probe_cdp_candidate(candidate: &CdpCandidate) -> CdpProbeOutcome {
+    let probe_url = match json_version_url(&candidate.endpoint) {
+        Ok(url) => url,
+        Err(err) => return CdpProbeOutcome::Unavailable(err.to_string()),
+    };
+
+    let client = match Client::builder().timeout(CDP_HEALTH_TIMEOUT).build() {
+        Ok(client) => client,
+        Err(err) => return CdpProbeOutcome::Unavailable(err.to_string()),
+    };
+
+    let response = match client
+        .get(probe_url.clone())
+        .header(reqwest::header::ACCEPT, "application/json")
+        .send()
+    {
+        Ok(response) => response,
+        Err(err) => return CdpProbeOutcome::Unavailable(err.to_string()),
+    };
+
+    // Chrome 136+ can leave localhost CDP in a half-state where DevTools is
+    // listening but HTTP discovery on the real profile returns 404.
+    if response.status() == reqwest::StatusCode::NOT_FOUND && is_localhost_url(&probe_url) {
+        return CdpProbeOutcome::Poisoned(build_half_state_diagnostic(
+            candidate,
+            probe_url.as_str(),
+            "GET /json/version returned HTTP 404 from a localhost Chrome endpoint",
+        ));
+    }
+
+    if !response.status().is_success() {
+        return CdpProbeOutcome::Unavailable(format!(
+            "HTTP {} from {}",
+            response.status(),
+            probe_url
+        ));
+    }
+
+    let body = match response.text() {
+        Ok(body) => body,
+        Err(err) => return CdpProbeOutcome::Unavailable(err.to_string()),
+    };
+    if body.trim().is_empty() {
+        return CdpProbeOutcome::Poisoned(build_half_state_diagnostic(
+            candidate,
+            probe_url.as_str(),
+            "GET /json/version returned an empty body",
+        ));
+    }
+
+    let payload: JsonVersionResponse = match serde_json::from_str(&body) {
+        Ok(payload) => payload,
+        Err(err) => {
+            return CdpProbeOutcome::Poisoned(build_half_state_diagnostic(
+                candidate,
+                probe_url.as_str(),
+                &format!("GET /json/version returned invalid JSON ({err})"),
+            ));
+        }
+    };
+
+    let Some(ws_url) = payload
+        .web_socket_debugger_url
+        .filter(|url| !url.trim().is_empty())
+    else {
+        return CdpProbeOutcome::Poisoned(build_half_state_diagnostic(
+            candidate,
+            probe_url.as_str(),
+            "GET /json/version did not include webSocketDebuggerUrl",
+        ));
+    };
+
+    CdpProbeOutcome::Healthy(ResolvedCdpEndpoint {
+        ws_url,
+        probe_url: probe_url.to_string(),
+        source: candidate.source.clone(),
+    })
+}
+
+fn resolve_dev_browser_connect_endpoint(cdp_endpoint: Option<&str>) -> Result<Option<String>> {
+    let Some(endpoint) = cdp_endpoint else {
+        // Let dev-browser own auto-connect discovery. It already knows how to
+        // read DevToolsActivePort without relying on /json/version.
+        return Ok(None);
+    };
+
+    let url = Url::parse(endpoint)
+        .with_context(|| format!("invalid Chrome CDP endpoint `{endpoint}`"))?;
+    match url.scheme() {
+        "ws" | "wss" => return Ok(Some(endpoint.to_string())),
+        "http" | "https" => {}
+        other => {
+            return Err(anyhow!(
+                "unsupported Chrome CDP endpoint scheme `{other}` in `{endpoint}`"
+            ));
+        }
+    }
+
+    let candidate = CdpCandidate {
+        endpoint: endpoint.to_string(),
+        source: "explicit --cdp".to_string(),
+    };
+    match probe_cdp_candidate(&candidate) {
+        CdpProbeOutcome::Healthy(resolved) => Ok(Some(resolved.ws_url)),
+        CdpProbeOutcome::Poisoned(detail) => {
+            if let Some(port) = endpoint_port(endpoint) {
+                if let Some(ws_candidate) = matching_devtools_active_port_candidate(port) {
+                    match probe_cdp_candidate(&ws_candidate) {
+                        CdpProbeOutcome::Healthy(resolved) => return Ok(Some(resolved.ws_url)),
+                        CdpProbeOutcome::Poisoned(_) | CdpProbeOutcome::Unavailable(_) => {}
+                    }
+                }
+            }
+            Err(anyhow!(detail))
+        }
+        CdpProbeOutcome::Unavailable(detail) => Err(anyhow!(
+            "dev-browser could not resolve a healthy Chrome CDP endpoint from `{endpoint}`: {detail}"
+        )),
+    }
+}
+
 fn connect_args(timeout_secs: u64, cdp_endpoint: Option<&str>) -> Vec<String> {
     let mut args = vec!["--connect".to_string()];
     if let Some(endpoint) = cdp_endpoint {
@@ -236,7 +623,8 @@ pub fn run_script_connect_with_endpoint(
 ) -> Result<String> {
     let bin = resolve_dev_browser()?;
     let timeout = timeout_secs.unwrap_or(DEFAULT_SCRIPT_TIMEOUT_SECS);
-    let args = connect_args(timeout, cdp_endpoint);
+    let resolved_endpoint = resolve_dev_browser_connect_endpoint(cdp_endpoint)?;
+    let args = connect_args(timeout, resolved_endpoint.as_deref());
 
     let output = Command::new(&bin)
         .args(&args)
@@ -409,6 +797,9 @@ console.log("ok:" + pages.length);
         Ok(stdout) if stdout.trim().starts_with("ok:") => Ok(()),
         Ok(stdout) => Err(anyhow!("dev-browser connection check failed: {stdout}")),
         Err(first_err) => {
+            if is_poisoned_cdp_error(&first_err) {
+                return Err(first_err.context("dev-browser connection check failed"));
+            }
             let msg = format!("{first_err:#}");
             let is_timeout = msg.contains("Timeout") || msg.contains("timed out");
             if !is_timeout {
@@ -513,6 +904,11 @@ pub fn ensure_chatgpt_auth_with_page_check_and_endpoint(cdp_endpoint: Option<&st
 }
 
 /// Context for running a ChatGPT recipe via dev-browser.
+///
+/// Recipe implementation note:
+/// dev-browser runs scripts inside QuickJS/WASM, not Node. Keep browser flows
+/// split into micro-scripts with JSON stdout handoffs instead of generating one
+/// large helper-heavy script.
 pub struct DevBrowserRecipeContext {
     /// Path to the bundle file on disk (will be staged to dev-browser tmp).
     pub bundle_path: Option<PathBuf>,
@@ -580,422 +976,222 @@ fn chatgpt_script_timeout_secs(poll_timeout_ms: u64) -> u64 {
     poll_timeout_ms.div_ceil(1000) + 60
 }
 
-fn build_chatgpt_recipe_script(ctx: &DevBrowserRecipeContext, staged_name: Option<&str>) -> String {
-    let model_json = serde_json::to_string(&ctx.model).unwrap();
-    let prompt_json = serde_json::to_string(&ctx.prompt).unwrap();
-    // Only embed bundle text in the script when paste mode is active.
-    // In attachment mode the content is staged to a file and read via
-    // readFile() — embedding it would bloat the script (500KB+) and crash
-    // the QuickJS WASM sandbox.
-    let bundle_text_for_script = if ctx.paste_mode {
-        ctx.bundle_text.as_deref().unwrap_or("")
-    } else {
-        ""
-    };
-    let bundle_text_json = serde_json::to_string(bundle_text_for_script).unwrap();
-    let staged_name_json = serde_json::to_string(&staged_name.unwrap_or("")).unwrap();
+#[derive(Debug, serde::Deserialize)]
+struct ChatgptPrepareResult {
+    status: String,
+    #[serde(rename = "loggedIn")]
+    logged_in: bool,
+    #[serde(rename = "composerReady")]
+    composer_ready: bool,
+    url: String,
+}
 
+#[derive(Debug, serde::Deserialize)]
+struct ChatgptSendResult {
+    status: String,
+    #[serde(rename = "assistantCountBeforeSend")]
+    assistant_count_before_send: usize,
+    warning: Option<String>,
+}
+
+fn parse_script_json<T: serde::de::DeserializeOwned>(label: &str, stdout: &str) -> Result<T> {
+    serde_json::from_str(stdout.trim())
+        .with_context(|| format!("{label}: malformed script output: {stdout}"))
+}
+
+fn build_chatgpt_prepare_script(page_name: &str, model: &str) -> String {
+    let page_name_json = serde_json::to_string(page_name).unwrap();
+    let model_json = serde_json::to_string(model).unwrap();
     format!(
-        r##"
+        r#"
+const PAGE_NAME = {page_name_json};
 const MODEL = {model_json};
+const page = await browser.getPage(PAGE_NAME);
+await page.goto("https://chatgpt.com/");
+let composerReady = true;
+try {{
+  await page.locator("[role='textbox']").first().waitFor({{ state: "visible", timeout: 20000 }});
+}} catch (_) {{
+  composerReady = false;
+}}
+const loggedIn = (await page.locator("[data-testid='login-button']").first().count()) === 0;
+if (loggedIn && composerReady && MODEL) {{
+  const modelBtn = page.locator("[data-testid='model-switcher-dropdown-button'], button[aria-label='Model selector']").first();
+  await modelBtn.waitFor({{ state: "visible", timeout: 5000 }});
+  await modelBtn.click({{ timeout: 5000 }});
+  const slug = MODEL.toLowerCase();
+  const byTestId = page.locator(`[data-testid="model-switcher-${{slug}}"]`).first();
+  if (await byTestId.count() > 0) {{
+    await byTestId.click({{ timeout: 5000 }});
+  }} else {{
+    const menuItem = page.locator("[role='menuitem']").filter({{ hasText: new RegExp(slug.includes("thinking") ? "thinking" : slug.includes("pro") ? "pro" : slug.includes("instant") || slug.includes("5-3") ? "instant" : slug, "i") }}).first();
+    await menuItem.waitFor({{ state: "visible", timeout: 5000 }});
+    await menuItem.click({{ timeout: 5000 }});
+  }}
+  await page.waitForTimeout(500);
+}}
+console.log(JSON.stringify({{
+  status: !loggedIn ? "login_required" : composerReady ? "ready" : "not_ready",
+  loggedIn,
+  composerReady,
+  url: page.url(),
+}}));
+"#,
+        page_name_json = page_name_json,
+        model_json = model_json,
+    )
+}
+
+fn build_chatgpt_send_script(
+    page_name: &str,
+    prompt: &str,
+    delivery_text: &str,
+    staged_file_name: Option<&str>,
+    upload_file_name: Option<&str>,
+    disable_extended: bool,
+) -> String {
+    let page_name_json = serde_json::to_string(page_name).unwrap();
+    let staged_file_name_json = serde_json::to_string(&staged_file_name).unwrap();
+    let upload_file_name_json = serde_json::to_string(&upload_file_name).unwrap();
+    let delivery_text_json = serde_json::to_string(delivery_text).unwrap();
+    let prompt_json = serde_json::to_string(prompt).unwrap();
+    format!(
+        r#"
+const PAGE_NAME = {page_name_json};
+const STAGED_FILE_NAME = {staged_file_name_json};
+const UPLOAD_FILE_NAME = {upload_file_name_json};
+const DELIVERY_TEXT = {delivery_text_json};
 const PROMPT = {prompt_json};
-const BUNDLE_TEXT = {bundle_text_json};
-const STAGED_FILE = {staged_name_json};
-const PASTE_MODE = {paste_mode};
 const DISABLE_EXTENDED = {disable_extended};
+const page = await browser.getPage(PAGE_NAME);
+let warning = null;
+if (DISABLE_EXTENDED) {{
+  const extButton = page.locator("button[aria-label*='click to remove'][aria-label*='Extended'], button[aria-label*='remove'][aria-label*='Extended']").first();
+  if (await extButton.count() > 0) {{
+    await extButton.click();
+    await page.waitForTimeout(500);
+  }} else {{
+    warning = "extended disable requested but toggle not found";
+  }}
+}}
+if (STAGED_FILE_NAME) {{
+  await page.locator("[data-testid='composer-plus-btn']").first().click();
+  await page.waitForTimeout(500);
+  const menuItem = page.locator("[role='menuitem']").filter({{ hasText: /Add photos/i }}).first();
+  await menuItem.waitFor({{ state: "visible", timeout: 5000 }});
+  await menuItem.click();
+  await uploadFile(page, STAGED_FILE_NAME, {{
+    selector: "input[type='file']",
+    name: UPLOAD_FILE_NAME || undefined,
+    mimeType: "text/markdown",
+  }});
+  await page.locator("img[alt*='attachment' i], [data-testid*='attachment' i], [aria-label*='attachment' i]").first().waitFor({{ state: "visible", timeout: 10000 }}).catch(() => {{}});
+}}
+const composer = page.locator("[role='textbox']").first();
+await composer.click();
+await composer.pressSequentially(DELIVERY_TEXT, {{ delay: 15 }});
+const sendBtn = page.locator("[data-testid='send-button']").first();
+const deadline = Date.now() + 30000;
+while (Date.now() < deadline) {{
+  if (await sendBtn.count() > 0 && await sendBtn.isEnabled()) break;
+  await page.waitForTimeout(1000);
+}}
+if (await sendBtn.count() === 0 || !(await sendBtn.isEnabled())) {{
+  throw new Error("send button did not become enabled for prompt: " + PROMPT.slice(0, 80));
+}}
+const assistantCountBeforeSend = await page.locator("[data-message-author-role='assistant']").count();
+await sendBtn.click();
+console.log(JSON.stringify({{
+        status: "sent",
+        assistantCountBeforeSend,
+        warning,
+}}));
+"#,
+        page_name_json = page_name_json,
+        staged_file_name_json = staged_file_name_json,
+        upload_file_name_json = upload_file_name_json,
+        delivery_text_json = delivery_text_json,
+        prompt_json = prompt_json,
+        disable_extended = disable_extended,
+    )
+}
+
+fn build_chatgpt_poll_script(
+    page_name: &str,
+    assistant_count_before_send: usize,
+    poll_settings: ChatgptPollSettings,
+    allow_empty_response: bool,
+) -> String {
+    let page_name_json = serde_json::to_string(page_name).unwrap();
+    format!(
+        r#"
+const PAGE_NAME = {page_name_json};
+const BASELINE = {assistant_count_before_send};
 const POLL_TIMEOUT_MS = {poll_timeout_ms};
 const POLL_INTERVAL_MS = {poll_interval_ms};
 const ALLOW_EMPTY_RESPONSE = {allow_empty_response};
-const warnings = [];
-const COMPOSER_READY_TIMEOUT_MS = 15000;
-const SEND_READY_TIMEOUT_MS = 30000;
-const SEND_READY_INTERVAL_MS = 1000;
-
-function warningSuffix() {{
-    return warnings.length ? " warnings=" + warnings.join(" | ") : "";
-}}
-
-async function waitForComposerReady(page) {{
-    try {{
-        await page.locator('#prompt-textarea').first().waitFor({{ state: 'visible', timeout: COMPOSER_READY_TIMEOUT_MS }});
-    }} catch (_) {{
-        await page.locator('[role="textbox"]').first().waitFor({{ state: 'visible', timeout: COMPOSER_READY_TIMEOUT_MS }});
-    }}
-}}
-
-async function getComposerLocator(page) {{
-    const prompt = page.locator('#prompt-textarea').first();
-    if (await prompt.count() > 0) {{
-        return prompt;
-    }}
-    return page.locator('[role="textbox"]').first();
-}}
-
-async function collectComposerDiagnostics(page) {{
-    return await page.evaluate(() => {{
-        const prompt =
-            document.querySelector('#prompt-textarea') ||
-            document.querySelector('[role="textbox"]');
-        const sendBtn = document.querySelector("button[data-testid='send-button']");
-        return {{
-            url: location.href,
-            promptLength: (prompt ? (prompt.textContent || "") : "").replace(/\s+/g, " ").trim().length,
-            attachmentCount: document.querySelectorAll(
-                'img[alt*="attachment" i], [data-testid*="attachment" i], [aria-label*="attachment" i]'
-            ).length,
-            assistantCount: document.querySelectorAll('[data-message-author-role="assistant"]').length,
-            sendState: !sendBtn ? "missing" : sendBtn.disabled ? "disabled" : "enabled",
-        }};
-    }});
-}}
-
-function formatDiagnostics(diag) {{
-    return "url=" + diag.url +
-        ", prompt_length=" + diag.promptLength +
-        ", attachment_tiles=" + diag.attachmentCount +
-        ", assistant_count=" + diag.assistantCount +
-        ", send=" + diag.sendState;
-}}
-
-async function waitForSendButtonReady(page) {{
-    const sendBtn = page.locator('button[data-testid="send-button"]').first();
-    const deadline = Date.now() + SEND_READY_TIMEOUT_MS;
-    let lastState = "missing";
-    while (Date.now() < deadline) {{
-        if (await sendBtn.count() > 0) {{
-            lastState = (await sendBtn.isEnabled()) ? "enabled" : "disabled";
-            if (lastState === "enabled") {{
-                return;
-            }}
-        }} else {{
-            lastState = "missing";
-        }}
-        await page.waitForTimeout(SEND_READY_INTERVAL_MS);
-    }}
-    const diagnostics = await collectComposerDiagnostics(page);
-    throw new Error(
-        "send button " + lastState +
-        " after waiting for ChatGPT to finish processing the prompt/attachment (" +
-        formatDiagnostics(diagnostics) + ")" +
-        warningSuffix()
-    );
-}}
-
-async function ensureFreshConversation(page) {{
-    for (let attempt = 0; attempt < 2; attempt++) {{
-        await page.goto("https://chatgpt.com/?_yoetz=" + Date.now());
-        await waitForComposerReady(page);
-
-        if (page.url().includes("/c/")) {{
-            const newChatBtn = page.locator(
-                'a[href="/"], button[data-testid="create-new-chat-button"], nav a[class*="new"]'
-            ).first();
-            if (await newChatBtn.count() > 0) {{
-                await newChatBtn.click();
-                await waitForComposerReady(page);
-            }} else {{
-                await page.goto("https://chatgpt.com/?_yoetz=" + Date.now());
-                await waitForComposerReady(page);
-            }}
-        }}
-
-        const assistantCount = await page.evaluate(() => {{
-            return document.querySelectorAll('[data-message-author-role="assistant"]').length;
-        }});
-        if (assistantCount === 0) {{
-            return;
-        }}
-    }}
-
-    const diagnostics = await collectComposerDiagnostics(page);
-    throw new Error(
-        "failed to reach a clean ChatGPT conversation before sending (" +
-        formatDiagnostics(diagnostics) + ")" +
-        warningSuffix()
-    );
-}}
-
-// --- Step 1: Navigate to fresh ChatGPT conversation ---
-// Use browser.newPage() for a clean page. Reusing existing ChatGPT tabs
-// would hijack the user's current conversation and risk picking the wrong
-// profile when multiple ChatGPT tabs are open.
-const page = await browser.newPage();
-await ensureFreshConversation(page);
-
-// --- Step 2: Select model if provided ---
-// Model selection is strict when explicitly requested.
-if (MODEL) {{
-    try {{
-        const modelBtn = page.locator(
-            '[data-testid="model-switcher-dropdown-button"], button[aria-label="Model selector"]'
-        ).first();
-        await modelBtn.waitFor({{ state: 'visible', timeout: 5000 }});
-        await modelBtn.click({{ timeout: 5000 }});
-
-        const slug = MODEL.toLowerCase();
-        const byTestId = page.locator(`[data-testid="model-switcher-${{slug}}"]`).first();
-        if (await byTestId.count() > 0) {{
-            await byTestId.waitFor({{ state: 'visible', timeout: 5000 }});
-            await byTestId.click({{ timeout: 5000 }});
-        }} else {{
-            const names = {{"gpt-5-4-pro":"pro","gpt-5-4-thinking":"thinking","gpt-5-3":"instant","pro":"pro","thinking":"thinking","instant":"instant"}};
-            const target = names[slug] || slug;
-            const menuItem = page.locator('[role="menuitem"]').filter({{ hasText: new RegExp(target, 'i') }}).first();
-            await menuItem.waitFor({{ state: 'visible', timeout: 5000 }});
-            await menuItem.click({{ timeout: 5000 }});
-        }}
-        await page.waitForTimeout(500);
-    }} catch (e) {{
-        const detail = e && typeof e.message === 'string' ? e.message : String(e);
-        await page.keyboard.press('Escape').catch(() => {{}});
-        await page.waitForTimeout(300);
-        throw new Error("model selection failed (" + detail + ")" + warningSuffix());
-    }}
-}}
-
-// --- Step 3: Disable Extended Pro if requested ---
-if (DISABLE_EXTENDED) {{
-    const extLocators = [
-        page.locator('button[aria-label*="click to remove"][aria-label*="Extended"]').first(),
-        page.locator('button[aria-label*="remove"][aria-label*="Extended"]').first(),
-        page.getByRole('button', {{ name: /extended.*remove|remove.*extended/i }}).first(),
-    ];
-    let extendedDisabled = false;
-    for (const extBtn of extLocators) {{
-        if (await extBtn.count() > 0) {{
-            await extBtn.click();
-            await page.waitForTimeout(500);
-            extendedDisabled = true;
-            break;
-        }}
-    }}
-    if (!extendedDisabled) {{
-        warnings.push("extended disable requested but toggle not found");
-    }}
-}}
-
-// --- Step 4: Deliver content (paste or file attachment) ---
-if (PASTE_MODE) {{
-    // Paste bundle text + prompt via keyboard.type — Playwright fill() and
-    // execCommand both bypass ProseMirror React state, leaving send disabled.
-    const composer = await getComposerLocator(page);
-    await composer.click();
-    await page.keyboard.type(PROMPT + "\n\n" + BUNDLE_TEXT);
-    await page.waitForTimeout(500);
-}} else if (STAGED_FILE) {{
-    // Upload via ChatGPT's native filechooser flow. DataTransfer hacks
-    // bypass React state and leave the send button disabled.
-    // Path: click + button → "Add photos & files" → filechooser →
-    // setFiles with FilePayload. Buffer must be constructed from a
-    // Uint8Array (not a string — QuickJS Buffer.from(string) is base64).
-    const fileContent = await readFile(STAGED_FILE);
-    const utf8Bytes = [];
-    for (const char of fileContent) {{
-        const code = char.codePointAt(0);
-        if (code <= 0x7F) utf8Bytes.push(code);
-        else if (code <= 0x7FF) utf8Bytes.push(0xC0|(code>>6), 0x80|(code&0x3F));
-        else if (code <= 0xFFFF) utf8Bytes.push(0xE0|(code>>12), 0x80|((code>>6)&0x3F), 0x80|(code&0x3F));
-        else utf8Bytes.push(0xF0|(code>>18), 0x80|((code>>12)&0x3F), 0x80|((code>>6)&0x3F), 0x80|(code&0x3F));
-    }}
-
-    await page.locator('button[data-testid="composer-plus-btn"]').click();
-    const addFilesMenuItem = page.getByRole('menuitem', {{ name: /add photos & files/i }}).first();
-    await addFilesMenuItem.waitFor({{ state: 'visible', timeout: 5000 }});
-    const [fileChooser] = await Promise.all([
-        page.waitForEvent('filechooser', {{ timeout: 10000 }}),
-        addFilesMenuItem.click(),
-    ]);
-    await fileChooser.setFiles({{
-        name: "bundle.md",
-        mimeType: "text/plain",
-        buffer: Buffer.from(new Uint8Array(utf8Bytes)),
-    }});
-
-    // Wait for upload to start before typing into the composer.
-    await page.waitForTimeout(5000);
-
-    // Type prompt via keyboard (Playwright fill()/execCommand bypass
-    // ProseMirror React state, leaving send button disabled).
-    const composer = await getComposerLocator(page);
-    await composer.click();
-    await page.keyboard.type(PROMPT, {{ delay: 5 }});
-    await page.waitForTimeout(500);
-}} else {{
-    // No bundle — just type the prompt
-    const composer = await getComposerLocator(page);
-    await composer.click();
-    await page.keyboard.type(PROMPT, {{ delay: 5 }});
-    await page.waitForTimeout(500);
-}}
-
-// ChatGPT keeps the send button disabled while it finishes attachment
-// processing. Large bundles can take several more seconds after prompt entry.
-await waitForSendButtonReady(page);
-
-const ASSISTANT_COUNT_BEFORE_SEND = await page.evaluate(() => {{
-    return document.querySelectorAll('[data-message-author-role="assistant"]').length;
-}});
-
-// --- Step 5: Click send ---
-const sendBtn = page.locator('button[data-testid="send-button"]').first();
-await sendBtn.click();
-// After clicking send, ChatGPT navigates (SPA) from / to /c/UUID.
-// Wait for navigation to settle before starting poll loop.
-await page.waitForURL('**/c/**', {{ timeout: 10000 }}).catch(() => {{}});
-
-// --- Step 6: Poll for response completion ---
-// Checks: new assistant response appeared, text is stable, send idle, no thinking indicator.
-const pollStart = Date.now();
-let completed = false;
-let pollError = null;
-let idleFingerprint = null;
-let lastPollState = null;
-
-while (Date.now() - pollStart < POLL_TIMEOUT_MS) {{
-    await page.waitForTimeout(POLL_INTERVAL_MS);
-
-    const pollState = await page.evaluate((baselineCount) => {{
-        // Scope error detection to actual error UI elements (toasts, alerts,
-        // error containers) — scanning document.body.innerText would match
-        // false positives from conversation text or page chrome.
-        const errEl = document.querySelector(
-            '[class*="error-toast"], [data-testid*="error"], [role="alert"]'
-        );
-        const errText = errEl ? errEl.innerText.substring(0, 200).toLowerCase() : "";
-        const errorMarkers = ["network error", "something went wrong", "error generating",
-                              "could not process", "rate limit", "too many requests",
-                              "attachment failed", "upload failed"];
-        const detectedError = errorMarkers.find(m => errText.includes(m)) || null;
-        if (detectedError) {{
-            return {{
-                error: detectedError,
-                url: location.href,
-                sendState: "unknown",
-                hasStopButton: false,
-                hasThinkingIndicator: false,
-                composerReady: false,
-                plusButtonReady: false,
-                newAssistantCount: 0,
-                assistantText: ""
-            }};
-        }}
-        const sendBtn = document.querySelector("button[data-testid='send-button']");
-        const stopBtn = document.querySelector("button[data-testid='stop-button'], button[aria-label*='Stop']");
-        const thinking = document.querySelector(
-            '.result-thinking, [class*="result-thinking"], [data-testid*="thinking"]'
-        );
-        const composer =
-            document.querySelector('#prompt-textarea') ||
-            document.querySelector('[role="textbox"]');
-        const plusBtn = document.querySelector('button[data-testid="composer-plus-btn"]');
-        const assistantMessages = Array.from(
-            document.querySelectorAll('[data-message-author-role="assistant"]')
-        );
-        const newAssistantMessages = assistantMessages.slice(baselineCount);
-        const assistantText = newAssistantMessages
-            .map((m) => m.innerText)
-            .join('\n---\n')
-            .trim();
-        return {{
-            error: null,
-            url: location.href,
-            sendState: !sendBtn ? "missing" : sendBtn.disabled ? "disabled" : "enabled",
-            hasStopButton: Boolean(stopBtn),
-            hasThinkingIndicator: Boolean(thinking),
-            composerReady: Boolean(composer),
-            plusButtonReady: Boolean(plusBtn),
-            newAssistantCount: newAssistantMessages.length,
-            assistantText
-        }};
-    }}, ASSISTANT_COUNT_BEFORE_SEND);
-    lastPollState = {{
-        url: pollState.url,
-        sendState: pollState.sendState,
-        hasStopButton: pollState.hasStopButton,
-        hasThinkingIndicator: pollState.hasThinkingIndicator,
-        composerReady: pollState.composerReady,
-        plusButtonReady: pollState.plusButtonReady,
-        newAssistantCount: pollState.newAssistantCount,
-        assistantTextLength: pollState.assistantText.length,
-    }};
-    if (pollState.error) {{
-        pollError = "ChatGPT error: " + pollState.error + warningSuffix();
-        break;
-    }}
-
-    const composerIdle =
-        pollState.sendState === "enabled" ||
-        (pollState.sendState === "missing" && pollState.composerReady && pollState.plusButtonReady);
-    const idle = composerIdle &&
-        !pollState.hasStopButton &&
-        !pollState.hasThinkingIndicator;
-    const hasResponse = pollState.newAssistantCount > 0 &&
-        (ALLOW_EMPTY_RESPONSE || pollState.assistantText.length > 0);
-
-    if (idle && hasResponse) {{
-        const fingerprint = `${{pollState.newAssistantCount}}:${{pollState.assistantText}}`;
-        if (idleFingerprint === fingerprint) {{
-            completed = true;
-            break;
-        }}
-        idleFingerprint = fingerprint;
-    }} else {{
-        idleFingerprint = null;
-    }}
-}}
-
-// --- Step 7: Extract response ---
-const responseState = await page.evaluate((baselineCount) => {{
-    const assistantMessages = Array.from(
-        document.querySelectorAll('[data-message-author-role="assistant"]')
-    );
-    const newAssistantMessages = assistantMessages.slice(baselineCount);
-    const responseText = newAssistantMessages.map((m) => m.innerText).join('\n---\n').trim();
+const page = await browser.getPage(PAGE_NAME);
+const start = Date.now();
+let lastResponseLength = null;
+while (Date.now() - start < POLL_TIMEOUT_MS) {{
+  const state = await page.evaluate((baselineCount) => {{
+    const errorEl = document.querySelector("[role='alert'], [data-testid*='error']");
+    const hasThinkingIndicator = !!document.querySelector(".result-thinking, [data-testid*='thinking']");
+    const assistantMessages = Array.from(document.querySelectorAll("[data-message-author-role='assistant']")).slice(baselineCount);
+    const response = assistantMessages.map((message) => message.innerText).join("\n---\n").trim();
     return {{
-        newAssistantCount: newAssistantMessages.length,
-        responseText
+      error: errorEl ? errorEl.innerText.slice(0, 200).trim() : null,
+      hasThinkingIndicator,
+      hasStopButton: !!document.querySelector("[data-testid='stop-button']"),
+      newAssistantCount: assistantMessages.length,
+      response,
     }};
-}}, ASSISTANT_COUNT_BEFORE_SEND);
-
-let status = pollError ? "error" : (completed ? "ok" : "timeout");
-let error = pollError || null;
-if (status === "timeout") {{
-    const diagnostics = await collectComposerDiagnostics(page);
-    error =
-        "ChatGPT response timed out after " + (Date.now() - pollStart) + "ms (" +
-        "last_state=" + JSON.stringify(lastPollState || {{}}) + ", " +
-        formatDiagnostics(diagnostics) + ")" +
-        warningSuffix();
-}} else if (status === "ok" && responseState.newAssistantCount === 0) {{
-    status = "error";
-    error = "ChatGPT did not produce a new assistant response" + warningSuffix();
-}} else if (status === "ok" && !ALLOW_EMPTY_RESPONSE && responseState.responseText.length === 0) {{
-    status = "error";
-    error = "ChatGPT returned an empty response" + warningSuffix();
+  }}, BASELINE);
+  if (state.error) {{
+    console.log(JSON.stringify({{ status: "error", error: state.error }}));
+    return;
+  }}
+  const completionCandidate =
+    !state.hasStopButton &&
+    !state.hasThinkingIndicator &&
+    state.newAssistantCount > 0 &&
+    (ALLOW_EMPTY_RESPONSE || state.response.length > 0);
+  if (completionCandidate) {{
+    if (lastResponseLength !== null && state.response.length === lastResponseLength) {{
+      console.log(JSON.stringify({{ status: "ok", response: state.response }}));
+      return;
+    }}
+    lastResponseLength = state.response.length;
+  }} else {{
+    lastResponseLength = null;
+  }}
+  await page.waitForTimeout(POLL_INTERVAL_MS);
 }}
+console.log(JSON.stringify({{
+  status: "timeout",
+  error: `ChatGPT response timed out after ${{POLL_TIMEOUT_MS}}ms`,
+}}));
+"#,
+        page_name_json = page_name_json,
+        assistant_count_before_send = assistant_count_before_send,
+        poll_timeout_ms = poll_settings.timeout_ms,
+        poll_interval_ms = poll_settings.interval_ms,
+        allow_empty_response = allow_empty_response,
+    )
+}
 
-const result = {{
-    status,
-    error,
-    elapsed_ms: Date.now() - pollStart,
-    response_length: responseState.responseText.length,
-    response: responseState.responseText,
-    warnings,
-    assistant_message_count_before_send: ASSISTANT_COUNT_BEFORE_SEND,
-    new_assistant_message_count: responseState.newAssistantCount,
-}};
-
-console.log(JSON.stringify(result));
-"##,
-        model_json = model_json,
-        prompt_json = prompt_json,
-        bundle_text_json = bundle_text_json,
-        staged_name_json = staged_name_json,
-        paste_mode = ctx.paste_mode,
-        disable_extended = ctx.disable_extended,
-        poll_timeout_ms = ctx.poll_settings.timeout_ms,
-        poll_interval_ms = ctx.poll_settings.interval_ms,
-        allow_empty_response = ctx.allow_empty_response,
+fn build_chatgpt_cleanup_script(page_name: &str) -> String {
+    let page_name_json = serde_json::to_string(page_name).unwrap();
+    format!(
+        r#"
+const PAGE_NAME = {page_name_json};
+const pages = await browser.listPages();
+if (pages.find((page) => page.name === PAGE_NAME)) {{
+    const page = await browser.getPage(PAGE_NAME);
+    await page.close().catch(() => {{}});
+}}
+"#,
+        page_name_json = page_name_json,
     )
 }
 
@@ -1066,13 +1262,11 @@ fn parse_chatgpt_recipe_result(
 
 /// Run the ChatGPT recipe via dev-browser.
 ///
-/// This replaces the YAML-based chatgpt.yaml recipe with a single Playwright
-/// script that handles navigation, model selection, file upload (via
-/// filechooser + keyboard.type), prompt entry, and response polling.
+/// The flow is intentionally split into micro-scripts because dev-browser runs
+/// QuickJS/WASM sandboxes, and large scripts with many closures are prone to a
+/// GC assertion on disposal. Rust owns the orchestration; each script only does
+/// one browser phase and returns JSON over stdout.
 pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<String> {
-    // Stage the bundle file if provided (for attachment mode).
-    // Use a unique prefix (PID + timestamp) to avoid collisions between
-    // concurrent recipe runs.
     let unique_prefix = format!(
         "{}_{}",
         std::process::id(),
@@ -1081,8 +1275,11 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<String> {
             .unwrap_or_default()
             .as_millis()
     );
+    let page_name = format!("yoetz-chatgpt-{unique_prefix}");
     let mut staged_file_guard = None;
-    let staged_name = if !ctx.paste_mode {
+    let mut staged_file_name = None;
+    let mut upload_file_name = None;
+    if !ctx.paste_mode {
         if let Some(bundle_path) = &ctx.bundle_path {
             let content = fs::read_to_string(bundle_path)
                 .with_context(|| format!("read bundle: {}", bundle_path.display()))?;
@@ -1092,34 +1289,109 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<String> {
                 .unwrap_or("bundle.txt");
             let name = format!("{unique_prefix}_{base_name}");
             let path = stage_file(&name, &content)?;
+            staged_file_name = Some(name);
+            upload_file_name = Some(base_name.to_string());
             staged_file_guard = Some(StagedFileGuard::new(path));
-            Some(name)
         } else if let Some(text) = &ctx.bundle_text {
             let name = format!("{unique_prefix}_bundle.md");
             let path = stage_file(&name, text)?;
+            staged_file_name = Some(name);
+            upload_file_name = Some("bundle.md".to_string());
             staged_file_guard = Some(StagedFileGuard::new(path));
-            Some(name)
-        } else {
-            None
         }
-    } else {
-        None
+    }
+
+    let cdp_endpoint = ctx.cdp_endpoint.as_deref();
+    let cleanup = |cdp_endpoint| -> Result<()> {
+        let cleanup_script = build_chatgpt_cleanup_script(&page_name);
+        match run_script_connect_with_endpoint(&cleanup_script, Some(15), cdp_endpoint) {
+            Ok(_) => Ok(()),
+            Err(err) => {
+                eprintln!("warn: failed to clean up dev-browser recipe page `{page_name}`: {err}");
+                Ok(())
+            }
+        }
     };
 
-    let script = build_chatgpt_recipe_script(ctx, staged_name.as_deref());
+    let result = (|| -> Result<(String, Vec<String>)> {
+        let mut warnings = Vec::new();
+        let delivery_text = if ctx.paste_mode {
+            format!(
+                "{}\n\n{}",
+                ctx.prompt,
+                ctx.bundle_text.as_deref().unwrap_or("")
+            )
+        } else {
+            ctx.prompt.clone()
+        };
 
-    let stdout = run_script_connect_with_endpoint(
-        &script,
-        Some(chatgpt_script_timeout_secs(ctx.poll_settings.timeout_ms)),
-        ctx.cdp_endpoint.as_deref(),
-    )?;
+        let prepare_script = build_chatgpt_prepare_script(&page_name, &ctx.model);
+        let prepare_stdout =
+            run_script_connect_with_endpoint(&prepare_script, Some(60), cdp_endpoint)?;
+        let prepare: ChatgptPrepareResult =
+            parse_script_json("parse chatgpt prepare result", &prepare_stdout)?;
+        match prepare.status.as_str() {
+            "ready" if prepare.logged_in && prepare.composer_ready => {}
+            "login_required" => {
+                return Err(anyhow!(
+                    "chatgpt login required in the attached Chrome session. Log in there and try again."
+                ));
+            }
+            "not_ready" => {
+                return Err(anyhow!(
+                    "ChatGPT did not finish loading the composer on {}. Restart Chrome with chrome://inspect/#remote-debugging enabled and try again.",
+                    prepare.url
+                ));
+            }
+            other => {
+                return Err(anyhow!(
+                    "unexpected ChatGPT prepare status `{other}` on {}",
+                    prepare.url
+                ));
+            }
+        }
+
+        let send_script = build_chatgpt_send_script(
+            &page_name,
+            &ctx.prompt,
+            &delivery_text,
+            staged_file_name.as_deref(),
+            upload_file_name.as_deref(),
+            ctx.disable_extended,
+        );
+        let send_stdout = run_script_connect_with_endpoint(&send_script, Some(90), cdp_endpoint)?;
+        let send: ChatgptSendResult = parse_script_json("parse chatgpt send result", &send_stdout)?;
+        if send.status != "sent" {
+            return Err(anyhow!("unexpected ChatGPT send status `{}`", send.status));
+        }
+        if let Some(warning) = send.warning {
+            warnings.push(warning);
+        }
+
+        let poll_script = build_chatgpt_poll_script(
+            &page_name,
+            send.assistant_count_before_send,
+            ctx.poll_settings,
+            ctx.allow_empty_response,
+        );
+        let poll_stdout = run_script_connect_with_endpoint(
+            &poll_script,
+            Some(chatgpt_script_timeout_secs(ctx.poll_settings.timeout_ms)),
+            cdp_endpoint,
+        )?;
+        let (response, mut poll_warnings) =
+            parse_chatgpt_recipe_result(&poll_stdout, ctx.poll_settings.timeout_ms)?;
+        warnings.append(&mut poll_warnings);
+        Ok((response, warnings))
+    })();
+
     drop(staged_file_guard);
+    cleanup(cdp_endpoint)?;
 
-    let (response, warnings) = parse_chatgpt_recipe_result(&stdout, ctx.poll_settings.timeout_ms)?;
+    let (response, warnings) = result?;
     for warning in warnings {
         eprintln!("warn: {warning}");
     }
-
     Ok(response)
 }
 
@@ -1344,133 +1616,154 @@ mod tests {
     }
 
     #[test]
-    fn build_chatgpt_recipe_script_uses_poll_settings_and_stable_idle_detection() {
-        let script = build_chatgpt_recipe_script(
-            &DevBrowserRecipeContext {
-                prompt: "test prompt".to_string(),
-                poll_settings: ChatgptPollSettings {
-                    timeout_ms: 900_000,
-                    interval_ms: 45_000,
-                },
-                ..Default::default()
-            },
-            None,
+    fn parse_devtools_active_port_returns_browser_ws_url() {
+        let entry =
+            parse_devtools_active_port("9222\n/devtools/browser/test-browser-id\n").unwrap();
+
+        assert_eq!(entry.port, 9222);
+        assert_eq!(
+            entry.ws_url,
+            "ws://127.0.0.1:9222/devtools/browser/test-browser-id"
+        );
+    }
+
+    #[test]
+    fn parse_devtools_active_port_rejects_malformed_payload() {
+        assert!(
+            parse_devtools_active_port("9222\n/devtools/page/not-a-browser-target\n").is_none()
+        );
+        assert!(parse_devtools_active_port("not-a-port\n/devtools/browser/test\n").is_none());
+    }
+
+    #[test]
+    fn json_version_url_normalizes_http_and_ws_endpoints() {
+        assert_eq!(
+            json_version_url("http://127.0.0.1:9222/devtools/browser/test")
+                .unwrap()
+                .as_str(),
+            "http://127.0.0.1:9222/json/version"
+        );
+        assert_eq!(
+            json_version_url("ws://127.0.0.1:9222/devtools/browser/test")
+                .unwrap()
+                .as_str(),
+            "http://127.0.0.1:9222/json/version"
+        );
+    }
+
+    #[test]
+    fn resolve_dev_browser_connect_endpoint_skips_probing_for_auto_connect() {
+        assert_eq!(resolve_dev_browser_connect_endpoint(None).unwrap(), None);
+    }
+
+    #[test]
+    fn probe_cdp_candidate_marks_local_404_as_poisoned() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request);
+            stream
+                .write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n")
+                .unwrap();
+        });
+
+        let candidate = CdpCandidate {
+            endpoint: format!("http://127.0.0.1:{}", addr.port()),
+            source: "test".to_string(),
+        };
+        let outcome = probe_cdp_candidate(&candidate);
+        server.join().unwrap();
+
+        match outcome {
+            CdpProbeOutcome::Poisoned(detail) => {
+                assert!(detail.contains("HTTP 404"));
+                assert!(detail.contains(CDP_HALF_STATE_MARKER));
+            }
+            other => panic!("expected poisoned outcome, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_chatgpt_prepare_script_uses_named_page_and_login_check() {
+        let script = build_chatgpt_prepare_script("yoetz-chatgpt-test", "gpt-5-4-pro");
+
+        assert!(script.contains("const PAGE_NAME = \"yoetz-chatgpt-test\";"));
+        assert!(script.contains("const MODEL = \"gpt-5-4-pro\";"));
+        assert!(script.contains("const page = await browser.getPage(PAGE_NAME);"));
+        assert!(script.contains("await page.goto(\"https://chatgpt.com/\");"));
+        assert!(script.contains("[data-testid='login-button']"));
+        assert!(script.contains(
+            "status: !loggedIn ? \"login_required\" : composerReady ? \"ready\" : \"not_ready\""
+        ));
+    }
+
+    #[test]
+    fn build_chatgpt_send_script_uses_file_path_and_press_sequentially() {
+        let script = build_chatgpt_send_script(
+            "yoetz-chatgpt-test",
+            "Review this file.",
+            "Review this file.",
+            Some("upload_123_bundle.md"),
+            Some("bundle.md"),
+            true,
         );
 
+        assert!(script.contains("const PAGE_NAME = \"yoetz-chatgpt-test\";"));
+        assert!(script.contains("const STAGED_FILE_NAME = \"upload_123_bundle.md\";"));
+        assert!(script.contains("const UPLOAD_FILE_NAME = \"bundle.md\";"));
+        assert!(script.contains("[data-testid='composer-plus-btn']"));
+        assert!(script.contains("[role='menuitem']"));
+        assert!(script.contains("hasText: /Add photos/i"));
+        assert!(script.contains("await uploadFile(page, STAGED_FILE_NAME"));
+        assert!(script.contains("selector: \"input[type='file']\""));
+        assert!(script.contains("mimeType: \"text/markdown\""));
+        assert!(script.contains("pressSequentially(DELIVERY_TEXT, { delay: 15 })"));
+        assert!(script.contains("status: \"sent\""));
+    }
+
+    #[test]
+    fn parse_script_json_reads_prepare_result() {
+        let result: ChatgptPrepareResult = parse_script_json(
+            "prepare",
+            r#"{"status":"ready","loggedIn":true,"composerReady":true,"url":"https://chatgpt.com/"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(result.status, "ready");
+        assert!(result.logged_in);
+        assert!(result.composer_ready);
+    }
+
+    #[test]
+    fn build_chatgpt_poll_script_waits_for_stable_non_thinking_idle() {
+        let script = build_chatgpt_poll_script(
+            "yoetz-chatgpt-test",
+            3,
+            ChatgptPollSettings {
+                timeout_ms: 900_000,
+                interval_ms: 45_000,
+            },
+            false,
+        );
+
+        assert!(script.contains("const PAGE_NAME = \"yoetz-chatgpt-test\";"));
+        assert!(script.contains("const BASELINE = 3;"));
         assert!(script.contains("const POLL_TIMEOUT_MS = 900000;"));
         assert!(script.contains("const POLL_INTERVAL_MS = 45000;"));
         assert!(script.contains("const ALLOW_EMPTY_RESPONSE = false;"));
-        assert!(script.contains("const warnings = [];"));
-        assert!(script.contains("const COMPOSER_READY_TIMEOUT_MS = 15000;"));
-        assert!(script.contains("const SEND_READY_TIMEOUT_MS = 30000;"));
-        assert!(script.contains("const SEND_READY_INTERVAL_MS = 1000;"));
-        assert!(script.contains("function warningSuffix()"));
-        assert!(script.contains("async function waitForComposerReady(page)"));
-        assert!(script.contains("async function ensureFreshConversation(page)"));
-        assert!(script.contains("async function waitForSendButtonReady(page)"));
-        assert!(script.contains("const ASSISTANT_COUNT_BEFORE_SEND = await page.evaluate"));
-        assert!(script.contains("let idleFingerprint = null;"));
-        assert!(script.contains("let lastPollState = null;"));
-        assert!(script.contains(
-            ".result-thinking, [class*=\"result-thinking\"], [data-testid*=\"thinking\"]"
-        ));
-        assert!(script.contains("idleFingerprint === fingerprint"));
-        assert!(!script.contains("await page.waitForTimeout(2000);\n        completed = true;"));
-        assert!(script.contains(
-            "\" after waiting for ChatGPT to finish processing the prompt/attachment (\""
-        ));
-        assert!(script.contains("newAssistantMessages = assistantMessages.slice(baselineCount)"));
-        assert!(script.contains("ChatGPT returned an empty response"));
-        assert!(script.contains("await ensureFreshConversation(page);"));
-        assert!(script.contains("const page = await browser.newPage();"));
-        assert!(script
-            .contains("await page.waitForURL('**/c/**', { timeout: 10000 }).catch(() => {});"));
-        // Error detection must be scoped to error UI elements, not full page body.
-        // Scanning document.body.innerText causes false positives when conversation
-        // text or page chrome contains error-like phrases.
-        assert!(
-            script.contains(r#"document.querySelector("#),
-            "error detection should use querySelector on specific error elements"
-        );
-        assert!(
-            script.contains("[role=\"alert\"]"),
-            "error detection should check role=alert elements"
-        );
-        assert!(
-            !script.contains("document.body.innerText.toLowerCase();\n        const errors"),
-            "error detection must NOT scan full page body text"
-        );
-        // File upload uses native filechooser + setFiles(FilePayload).
-        // Buffer must come from Uint8Array (not string — QuickJS base64).
-        assert!(
-            script.contains("waitForEvent('filechooser'")
-                || script.contains("waitForEvent(\"filechooser\""),
-            "file upload should use filechooser event"
-        );
-        assert!(
-            script.contains("setFiles"),
-            "file upload should use setFiles with FilePayload"
-        );
-        assert!(
-            script.contains(
-                "const addFilesMenuItem = page.getByRole('menuitem', { name: /add photos & files/i }).first();"
-            ),
-            "upload menu selection should resolve a role+name menu item"
-        );
-        assert!(
-            script.contains("await addFilesMenuItem.waitFor({ state: 'visible', timeout: 5000 });"),
-            "upload menu item should be awaited before click"
-        );
-        assert!(
-            script.contains("addFilesMenuItem.click()"),
-            "upload menu selection should click the awaited menu item"
-        );
-        assert!(
-            script.contains("Buffer.from(new Uint8Array("),
-            "Buffer must be constructed from Uint8Array, not string"
-        );
-        assert!(
-            script.contains("keyboard.type"),
-            "text input should use keyboard.type (not fill/execCommand)"
-        );
-        assert!(
-            script.contains("await waitForSendButtonReady(page);"),
-            "script should wait for ChatGPT to re-enable send after attachment processing"
-        );
-        assert!(
-            script.contains("await modelBtn.waitFor({ state: 'visible', timeout: 5000 });"),
-            "model selector button should use a 5s wait timeout"
-        );
-        assert!(
-            script.contains("await menuItem.waitFor({ state: 'visible', timeout: 5000 });"),
-            "menu item search should use a 5s wait timeout"
-        );
-        assert!(
-            !script.contains("warnings.push(\"model selection failed (\" + detail + \"), using current model\");"),
-            "explicit model selection should no longer degrade to a warning"
-        );
-        assert!(
-            script.contains("warnings,"),
-            "recipe result should include script warnings"
-        );
-        assert!(
-            !script.contains("console.error(\"warn: model selection failed"),
-            "model selection warnings should not be written to stderr and lost"
-        );
-        assert!(
-            !script.contains("bodyText.includes(\"pro thinking\")"),
-            "thinking detection should not rely on English body text"
-        );
-        assert!(
-            script.contains(
-                "sendState: !sendBtn ? \"missing\" : sendBtn.disabled ? \"disabled\" : \"enabled\""
-            ),
-            "poll state should expose explicit send state"
-        );
-        assert!(
-            script.contains("pollState.sendState === \"enabled\""),
-            "poll completion should key off the explicit send state"
-        );
+        assert!(script.contains("let lastResponseLength = null;"));
+        assert!(script.contains(".result-thinking, [data-testid*='thinking']"));
+        assert!(script.contains("[data-testid='stop-button']"));
+        assert!(script.contains("[data-message-author-role='assistant']"));
+        assert!(script.contains("!state.hasThinkingIndicator"));
+        assert!(script.contains("state.response.length === lastResponseLength"));
+        assert!(script.contains("status: \"ok\""));
+        assert!(script.contains("status: \"timeout\""));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -754,19 +754,6 @@ try {
         .ok_or_else(|| anyhow!("check_chatgpt_auth: missing 'authenticated' field in: {stdout}"))
 }
 
-/// Ensure the connected Chrome session can reach ChatGPT.
-/// Only checks dev-browser daemon connectivity — opening a separate page
-/// to verify auth causes interference with the recipe's named page.
-/// If not authenticated, the recipe will fail with a clear error.
-pub fn ensure_chatgpt_auth_with_endpoint(cdp_endpoint: Option<&str>) -> Result<()> {
-    check_connection_with_endpoint(cdp_endpoint).context(
-        "dev-browser cannot connect to Chrome. Enable remote debugging: chrome://inspect/#remote-debugging",
-    )?;
-    // Skip page-level auth check — it opens an anonymous page to chatgpt.com
-    // which interferes with the recipe's subsequent named page session.
-    Ok(())
-}
-
 /// Ensure the connected Chrome session can reach an authenticated ChatGPT page.
 /// Opens a temporary page — use only when not immediately followed by a recipe.
 pub fn ensure_chatgpt_auth_with_page_check_and_endpoint(cdp_endpoint: Option<&str>) -> Result<()> {

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -469,41 +469,42 @@ fn probe_cdp_candidate(candidate: &CdpCandidate) -> CdpProbeOutcome {
         Err(err) => return CdpProbeOutcome::Unavailable(err.to_string()),
     };
 
-    let agent = ureq::AgentBuilder::new()
+    let client = match reqwest::blocking::Client::builder()
         .timeout(CDP_HEALTH_TIMEOUT)
-        .build();
-    let response = match agent
+        .build()
+    {
+        Ok(client) => client,
+        Err(err) => return CdpProbeOutcome::Unavailable(err.to_string()),
+    };
+    let response = match client
         .get(probe_url.as_str())
-        .set("Accept", "application/json")
-        .call()
+        .header(reqwest::header::ACCEPT, "application/json")
+        .send()
     {
         Ok(response) => response,
-        Err(ureq::Error::Status(status, response)) => {
-            if status == 404 && is_localhost_url(&probe_url) {
-                return CdpProbeOutcome::Poisoned(build_half_state_diagnostic(
-                    candidate,
-                    probe_url.as_str(),
-                    "GET /json/version returned HTTP 404 from a localhost Chrome endpoint",
-                ));
-            }
-            response
-        }
-        Err(ureq::Error::Transport(err)) => {
-            return CdpProbeOutcome::Unavailable(err.to_string());
-        }
+        Err(err) => return CdpProbeOutcome::Unavailable(err.to_string()),
     };
+    let status = response.status();
 
     // Chrome 136+ can leave localhost CDP in a half-state where DevTools is
     // listening but HTTP discovery on the real profile returns 404.
-    if !(200..=299).contains(&response.status()) {
+    if status == reqwest::StatusCode::NOT_FOUND && is_localhost_url(&probe_url) {
+        return CdpProbeOutcome::Poisoned(build_half_state_diagnostic(
+            candidate,
+            probe_url.as_str(),
+            "GET /json/version returned HTTP 404 from a localhost Chrome endpoint",
+        ));
+    }
+
+    if !status.is_success() {
         return CdpProbeOutcome::Unavailable(format!(
             "HTTP {} from {}",
-            response.status(),
+            status,
             probe_url
         ));
     }
 
-    let body = match response.into_string() {
+    let body = match response.text() {
         Ok(body) => body,
         Err(err) => return CdpProbeOutcome::Unavailable(err.to_string()),
     };

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -25,6 +25,8 @@ use std::sync::OnceLock;
 use reqwest::Url;
 use yoetz_core::paths::home_dir;
 
+use crate::browser;
+
 /// Cached dev-browser resolution.
 static DEV_BROWSER: OnceLock<String> = OnceLock::new();
 
@@ -802,6 +804,8 @@ pub struct DevBrowserRecipeContext {
     pub allow_empty_response: bool,
     /// Optional explicit CDP endpoint for selecting a specific Chrome instance.
     pub cdp_endpoint: Option<String>,
+    /// Whether to print interactive Chrome-approval guidance to stderr.
+    pub show_approval_guidance: bool,
 }
 
 impl Default for DevBrowserRecipeContext {
@@ -816,6 +820,7 @@ impl Default for DevBrowserRecipeContext {
             poll_settings: ChatgptPollSettings::default(),
             allow_empty_response: false,
             cdp_endpoint: None,
+            show_approval_guidance: false,
         }
     }
 }
@@ -844,6 +849,16 @@ fn parse_positive_u64_var(vars: &BTreeMap<String, String>, key: &str) -> Result<
         return Err(anyhow!("recipe var `{key}` must be greater than 0"));
     }
     Ok(Some(value))
+}
+
+fn looks_like_dev_browser_connect_failure(err: &anyhow::Error) -> bool {
+    let message = format!("{err:#}").to_lowercase();
+    (message.contains("connectovercdp")
+        || message.contains("auto-connect")
+        || message.contains("auto connect")
+        || message.contains("could not connect to chrome")
+        || message.contains("browser.getversion"))
+        && (message.contains("timed out") || message.contains("timeout"))
 }
 
 fn chatgpt_script_timeout_secs(poll_timeout_ms: u64) -> u64 {
@@ -1244,7 +1259,28 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<String> {
         };
 
         let prepare_script = build_chatgpt_prepare_script(&page_name, &ctx.model);
-        let prepare_stdout = run_script(&prepare_script, Some(60))?;
+        let prepare_stdout = {
+            let approval_lock = browser::acquire_chrome_approval_lock()?;
+            if ctx.show_approval_guidance {
+                if approval_lock.waited() {
+                    eprintln!(
+                        "info: another yoetz process is already requesting Chrome approval; waiting for it to finish before trying the dev-browser transport"
+                    );
+                }
+                eprintln!(
+                    "info: connecting to Chrome — if prompted, click Allow in Chrome's remote debugging dialog"
+                );
+            }
+            run_script(&prepare_script, Some(60)).map_err(|err| {
+                if looks_like_dev_browser_connect_failure(&err) {
+                    err.context(
+                        "dev-browser could not connect to Chrome. Chrome may be showing an \"Allow remote debugging?\" dialog — click Allow in Chrome, then retry."
+                    )
+                } else {
+                    err
+                }
+            })?
+        };
         let prepare: ChatgptPrepareResult =
             parse_script_json("parse chatgpt prepare result", &prepare_stdout)?;
         match prepare.status.as_str() {
@@ -1373,6 +1409,17 @@ mod tests {
     #[test]
     fn chatgpt_script_timeout_secs_adds_grace_window() {
         assert_eq!(chatgpt_script_timeout_secs(1_800_000), 1_860);
+    }
+
+    #[test]
+    fn looks_like_dev_browser_connect_failure_matches_connect_timeout() {
+        let err = anyhow!(
+            "browser.newPage: Timeout 30000ms exceeded while waiting for connectOverCDP"
+        );
+        assert!(looks_like_dev_browser_connect_failure(&err));
+
+        let other = anyhow!("ChatGPT response timed out after 900000ms");
+        assert!(!looks_like_dev_browser_connect_failure(&other));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -887,6 +887,34 @@ fn format_recipe_transport_errors(errors: &[(browser::RecipeTransport, String)])
     format!("all browser recipe transports failed:\n- {joined}")
 }
 
+fn print_recipe_chrome_approval_message(transport: browser::RecipeTransport) {
+    eprintln!(
+        "info: connecting to Chrome via {} — if prompted, click Allow in Chrome's remote debugging dialog",
+        recipe_transport_name(transport)
+    );
+}
+
+fn print_recipe_chrome_approval_lock_wait_message(transport: browser::RecipeTransport) {
+    eprintln!(
+        "info: another yoetz process is already requesting Chrome approval; waiting for it to finish before trying the {} transport",
+        recipe_transport_name(transport)
+    );
+}
+
+fn recipe_has_remaining_manual_fallback(
+    transports: &[browser::RecipeTransport],
+    current_index: usize,
+) -> bool {
+    transports[current_index + 1..]
+        .iter()
+        .copied()
+        .any(|next| matches!(next, browser::RecipeTransport::Manual))
+}
+
+fn recipe_should_stop_live_transport_fallback(err: &anyhow::Error) -> bool {
+    browser::is_chrome_approval_wait_error(err)
+}
+
 fn run_recipe_via_dev_browser(
     recipe_args: &BrowserRecipeArgs,
     recipe_vars: &BTreeMap<String, String>,
@@ -940,6 +968,7 @@ fn run_recipe_via_dev_browser(
             .get("allow_empty_response")
             .is_some_and(|value| value == "true"),
         cdp_endpoint: cdp_endpoint.map(str::to_owned),
+        show_approval_guidance: matches!(format, OutputFormat::Text | OutputFormat::Markdown),
     };
 
     let response = dev_browser::run_chatgpt_recipe(&recipe_ctx)?;
@@ -980,6 +1009,15 @@ fn run_recipe_via_agent_browser(
     let needs_auth = is_chatgpt;
     let live_connection = if needs_auth {
         if let Some(endpoint) = cdp_endpoint.map(str::to_owned) {
+            let approval_lock = browser::acquire_chrome_approval_lock()?;
+            if matches!(format, OutputFormat::Text | OutputFormat::Markdown) {
+                if approval_lock.waited() {
+                    print_recipe_chrome_approval_lock_wait_message(
+                        browser::RecipeTransport::AgentBrowser,
+                    );
+                }
+                print_recipe_chrome_approval_message(browser::RecipeTransport::AgentBrowser);
+            }
             match browser::try_cdp_attach(&endpoint, browser::CHATGPT_URL) {
                 Ok(()) => Some(browser::BrowserConnection::Cdp { endpoint }),
                 Err(e) => {
@@ -996,6 +1034,18 @@ fn run_recipe_via_agent_browser(
                 }
             }
         } else {
+            let approval_lock = browser::acquire_chrome_approval_lock()?;
+            let should_warn_about_approval = !browser::is_daemon_healthy();
+            if matches!(format, OutputFormat::Text | OutputFormat::Markdown) {
+                if approval_lock.waited() {
+                    print_recipe_chrome_approval_lock_wait_message(
+                        browser::RecipeTransport::AgentBrowser,
+                    );
+                }
+                if should_warn_about_approval {
+                    print_recipe_chrome_approval_message(browser::RecipeTransport::AgentBrowser);
+                }
+            }
             match browser::try_auto_connect_lite() {
                 Ok(()) => Some(browser::BrowserConnection::AutoConnect),
                 Err(_) => {
@@ -1311,9 +1361,11 @@ fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputFormat) -> 
             let cdp_endpoint =
                 browser::resolve_cdp_endpoint(recipe_args.cdp.as_deref(), &ctx.config);
             let transports = browser::recipe_transports(&recipe, is_chatgpt);
+            let manual_fallback =
+                manual_browser_recipe_fallback(&recipe_path, recipe_args.bundle.as_deref());
             let mut transport_errors = Vec::new();
 
-            for transport in transports {
+            for (index, transport) in transports.iter().copied().enumerate() {
                 let result = match transport {
                     browser::RecipeTransport::DevBrowser => run_recipe_via_dev_browser(
                         &recipe_args,
@@ -1333,13 +1385,21 @@ fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputFormat) -> 
                     ),
                     browser::RecipeTransport::Manual => Err(anyhow!(
                         "{}",
-                        manual_browser_recipe_fallback(&recipe_path, recipe_args.bundle.as_deref())
+                        manual_fallback
                     )),
                 };
 
                 match result {
                     Ok(()) => return Ok(()),
                     Err(err) => {
+                        if recipe_should_stop_live_transport_fallback(&err) {
+                            transport_errors.push((transport, err.to_string()));
+                            if recipe_has_remaining_manual_fallback(&transports, index) {
+                                transport_errors
+                                    .push((browser::RecipeTransport::Manual, manual_fallback.clone()));
+                            }
+                            break;
+                        }
                         if !matches!(transport, browser::RecipeTransport::Manual) {
                             eprintln!(
                                 "info: {} transport failed ({err}), trying next transport",
@@ -1905,6 +1965,32 @@ mod tests {
         ] {
             assert!(PROTECTED_DOTENV_ENV_VARS.contains(&key), "{key} must stay protected");
         }
+    }
+
+    #[test]
+    fn recipe_should_stop_live_transport_fallback_on_approval_wait() {
+        let err = anyhow!(
+            "live browser attach timed out (30s). Chrome may be showing an \"Allow remote debugging?\" dialog — please click Allow in Chrome, then retry."
+        );
+        assert!(recipe_should_stop_live_transport_fallback(&err));
+    }
+
+    #[test]
+    fn recipe_should_not_stop_live_transport_fallback_on_non_approval_error() {
+        let err = anyhow!("chatgpt send button not found");
+        assert!(!recipe_should_stop_live_transport_fallback(&err));
+    }
+
+    #[test]
+    fn recipe_has_remaining_manual_fallback_detects_manual_transport() {
+        let transports = vec![
+            browser::RecipeTransport::DevBrowser,
+            browser::RecipeTransport::AgentBrowser,
+            browser::RecipeTransport::Manual,
+        ];
+        assert!(recipe_has_remaining_manual_fallback(&transports, 0));
+        assert!(recipe_has_remaining_manual_fallback(&transports, 1));
+        assert!(!recipe_has_remaining_manual_fallback(&transports, 2));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -673,6 +673,7 @@ async fn main() -> Result<()> {
     // CWD .env files must not override executable paths (supply-chain risk)
     // or redirect API keys to attacker-controlled endpoints.
     let pre_agent_bin = env::var("YOETZ_AGENT_BROWSER_BIN").ok();
+    let pre_dev_browser_bin = env::var("YOETZ_DEV_BROWSER_BIN").ok();
     let pre_scripts_dir = env::var("YOETZ_SCRIPTS_DIR").ok();
 
     // Capture API key env vars so CWD .env cannot silently replace them.
@@ -695,6 +696,9 @@ async fn main() -> Result<()> {
     // Prevent CWD .env from overriding executable paths (security)
     if pre_agent_bin.is_none() {
         env::remove_var("YOETZ_AGENT_BROWSER_BIN");
+    }
+    if pre_dev_browser_bin.is_none() {
+        env::remove_var("YOETZ_DEV_BROWSER_BIN");
     }
     if pre_scripts_dir.is_none() {
         env::remove_var("YOETZ_SCRIPTS_DIR");

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -641,6 +641,8 @@ struct CouncilResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     bundle: Option<yoetz_core::types::Bundle>,
     results: Vec<CouncilModelResult>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    errors: Vec<CouncilModelError>,
     pricing: CouncilPricing,
     usage: Usage,
     artifacts: ArtifactPaths,
@@ -653,6 +655,13 @@ struct CouncilModelResult {
     usage: Usage,
     pricing: PricingEstimate,
     response_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct CouncilModelError {
+    model: String,
+    provider: String,
+    error: String,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -907,7 +907,9 @@ fn run_recipe_via_dev_browser(
     }
 
     dev_browser::ensure_installed()?;
-    dev_browser::ensure_chatgpt_auth_with_endpoint(cdp_endpoint)?;
+    // The recipe prepare micro-script already verifies ChatGPT login state on the
+    // named page. Avoid a separate pre-flight attach here because it can trigger
+    // a fresh approval-gated CDP connection and block an otherwise working flow.
 
     let paste_mode = recipe_vars
         .get("paste")

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -1292,7 +1292,7 @@ fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputFormat) -> 
                 .with_context(|| format!("resolve recipe {:?}", recipe_args.recipe))?;
             let content = fs::read_to_string(&recipe_path)
                 .with_context(|| format!("read recipe {}", recipe_path.display()))?;
-            let recipe: browser::Recipe = serde_yaml::from_str(&content)?;
+            let recipe: browser::Recipe = serde_yml::from_str(&content)?;
             let recipe_vars =
                 browser::build_recipe_vars(recipe.defaults.as_ref(), &recipe_args.vars)?;
             let profile_dir =

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -676,54 +676,53 @@ struct ModelEstimate {
     estimate_usd: Option<f64>,
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Capture security-sensitive env vars before dotenv loading.
-    // CWD .env files must not override executable paths (supply-chain risk)
-    // or redirect API keys to attacker-controlled endpoints.
-    let pre_agent_bin = env::var("YOETZ_AGENT_BROWSER_BIN").ok();
-    let pre_dev_browser_bin = env::var("YOETZ_DEV_BROWSER_BIN").ok();
-    let pre_scripts_dir = env::var("YOETZ_SCRIPTS_DIR").ok();
+const PROTECTED_DOTENV_ENV_VARS: &[&str] = &[
+    "YOETZ_AGENT_BROWSER_BIN",
+    "YOETZ_DEV_BROWSER_BIN",
+    "YOETZ_SCRIPTS_DIR",
+    "YOETZ_CONFIG_PATH",
+    "YOETZ_REGISTRY_PATH",
+    "YOETZ_BROWSER_CDP",
+    "YOETZ_BROWSER_PROFILE",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "XAI_API_KEY",
+];
 
-    // Capture API key env vars so CWD .env cannot silently replace them.
-    const PROTECTED_API_KEYS: &[&str] = &[
-        "OPENAI_API_KEY",
-        "ANTHROPIC_API_KEY",
-        "GEMINI_API_KEY",
-        "OPENROUTER_API_KEY",
-        "XAI_API_KEY",
-    ];
-    let pre_api_keys: Vec<(&str, Option<String>)> = PROTECTED_API_KEYS
+fn snapshot_protected_dotenv_env() -> Vec<(&'static str, Option<String>)> {
+    PROTECTED_DOTENV_ENV_VARS
         .iter()
-        .map(|&k| (k, env::var(k).ok()))
-        .collect();
+        .map(|&key| (key, env::var(key).ok()))
+        .collect()
+}
 
-    // Load environment files (.env.local takes precedence over .env)
-    dotenvy::from_filename(".env.local").ok();
-    dotenvy::dotenv().ok();
-
-    // Prevent CWD .env from overriding executable paths (security)
-    if pre_agent_bin.is_none() {
-        env::remove_var("YOETZ_AGENT_BROWSER_BIN");
-    }
-    if pre_dev_browser_bin.is_none() {
-        env::remove_var("YOETZ_DEV_BROWSER_BIN");
-    }
-    if pre_scripts_dir.is_none() {
-        env::remove_var("YOETZ_SCRIPTS_DIR");
-    }
-
-    // Restore API key env vars if .env changed them (prevent credential hijack)
-    for (key, pre_value) in &pre_api_keys {
+fn restore_protected_dotenv_env(snapshot: &[(&str, Option<String>)]) {
+    for (key, pre_value) in snapshot {
         let post_value = env::var(key).ok();
         if post_value != *pre_value {
             match pre_value {
-                Some(v) => env::set_var(key, v),
+                Some(value) => env::set_var(key, value),
                 None => env::remove_var(key),
             }
             eprintln!("warning: CWD .env tried to override {key}, ignored");
         }
     }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Capture security-sensitive env vars before dotenv loading.
+    // CWD .env files must not override executable paths (supply-chain risk)
+    // or redirect config, registry, browser targets, or API keys.
+    let protected_env = snapshot_protected_dotenv_env();
+
+    // Load environment files (.env.local takes precedence over .env)
+    dotenvy::from_filename(".env.local").ok();
+    dotenvy::dotenv().ok();
+
+    restore_protected_dotenv_env(&protected_env);
 
     let cli = Cli::parse();
     let format = resolve_format(cli.format.as_deref())?;
@@ -1894,6 +1893,18 @@ mod tests {
             normalize_model_name_with_aliases("google/fast", &aliases),
             "google/gemini-3-flash-preview"
         );
+    }
+
+    #[test]
+    fn protected_dotenv_env_vars_cover_sensitive_paths_and_targets() {
+        for key in [
+            "YOETZ_CONFIG_PATH",
+            "YOETZ_REGISTRY_PATH",
+            "YOETZ_BROWSER_CDP",
+            "YOETZ_BROWSER_PROFILE",
+        ] {
+            assert!(PROTECTED_DOTENV_ENV_VARS.contains(&key), "{key} must stay protected");
+        }
     }
 
     #[test]

--- a/crates/yoetz-cli/src/providers/gemini.rs
+++ b/crates/yoetz-cli/src/providers/gemini.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Context, Result};
 use base64::{engine::general_purpose, Engine as _};
-use reqwest::Client;
+use reqwest::{Client, Url};
 use serde_json::Value;
 use std::path::Path;
 use tokio::time::{sleep, Duration};
@@ -12,6 +12,38 @@ use crate::http::send_json;
 use crate::providers::ProviderAuth;
 
 const INLINE_LIMIT_BYTES: u64 = 20 * 1024 * 1024;
+
+fn is_gemini_host(url: &str, base_url: &str) -> bool {
+    let parsed = match Url::parse(url) {
+        Ok(url) => url,
+        Err(_) => return false,
+    };
+    let candidate_host = match parsed.host_str() {
+        Some(host) => host,
+        None => return false,
+    };
+    let base_host = match Url::parse(base_url)
+        .ok()
+        .and_then(|url| url.host_str().map(str::to_owned))
+    {
+        Some(host) => host,
+        None => return false,
+    };
+    candidate_host == base_host
+}
+
+fn validate_gemini_url(url: &str, base_url: &str, purpose: &str) -> Result<()> {
+    if is_gemini_host(url, base_url) {
+        return Ok(());
+    }
+    Err(anyhow!(
+        "refusing to {purpose} from untrusted Gemini URL `{url}` (base host `{}`)",
+        Url::parse(base_url)
+            .ok()
+            .and_then(|parsed| parsed.host_str().map(str::to_owned))
+            .unwrap_or_else(|| "<invalid>".to_string())
+    ))
+}
 
 #[derive(Debug, Clone)]
 pub struct GeminiTextResult {
@@ -141,6 +173,7 @@ pub async fn generate_video_veo(
     } else {
         format!("{}/{}", auth.base_url.trim_end_matches('/'), op_name)
     };
+    validate_gemini_url(&op_url, &auth.base_url, "poll operation status")?;
 
     let mut attempts = 0u32;
     let response = loop {
@@ -162,6 +195,7 @@ pub async fn generate_video_veo(
 
     let uri =
         extract_video_uri(&response).ok_or_else(|| anyhow!("missing video uri in response"))?;
+    validate_gemini_url(&uri, &auth.base_url, "download generated video")?;
     if uri.starts_with("gs://") {
         return Err(anyhow!(
             "video is stored in GCS at {uri}; yoetz cannot download gs:// URIs without GCS credentials. Download with gsutil or gcloud and retry"
@@ -354,6 +388,7 @@ async fn upload_file(
         .and_then(|v| v.to_str().ok())
         .ok_or_else(|| anyhow!("missing upload url"))?
         .to_string();
+    validate_gemini_url(&upload_url, &auth.base_url, "upload file content")?;
 
     let (resp, _headers) = send_json::<Value>(
         client
@@ -486,6 +521,34 @@ mod tests {
             ]
         });
         assert_eq!(extract_text(&resp), "hi there");
+    }
+
+    #[test]
+    fn is_gemini_host_accepts_base_host() {
+        assert!(is_gemini_host(
+            "https://generativelanguage.googleapis.com/v1beta/files/abc",
+            "https://generativelanguage.googleapis.com/v1beta"
+        ));
+        assert!(is_gemini_host(
+            "https://generativelanguage.googleapis.com/upload/v1beta/files",
+            "https://generativelanguage.googleapis.com/v1beta"
+        ));
+    }
+
+    #[test]
+    fn is_gemini_host_rejects_spoofing_and_other_hosts() {
+        assert!(!is_gemini_host(
+            "https://generativelanguage.googleapis.com.evil.com/v1beta/files/abc",
+            "https://generativelanguage.googleapis.com/v1beta"
+        ));
+        assert!(!is_gemini_host(
+            "https://evil.example.com/download",
+            "https://generativelanguage.googleapis.com/v1beta"
+        ));
+        assert!(!is_gemini_host(
+            "not-a-url",
+            "https://generativelanguage.googleapis.com/v1beta"
+        ));
     }
 
     #[test]

--- a/crates/yoetz-core/src/config.rs
+++ b/crates/yoetz-core/src/config.rs
@@ -74,6 +74,11 @@ impl Config {
 
     fn merge(&mut self, other: ConfigFile, trusted: bool, source: &Path) {
         if let Some(defaults) = other.defaults {
+            let defaults = if trusted {
+                defaults
+            } else {
+                sanitize_untrusted_defaults(defaults, source)
+            };
             merge_defaults(&mut self.defaults, defaults);
         }
         if let Some(providers) = other.providers {
@@ -105,6 +110,22 @@ impl Config {
             self.aliases.extend(aliases);
         }
     }
+}
+
+fn sanitize_untrusted_defaults(mut defaults: Defaults, source: &Path) -> Defaults {
+    if defaults.browser_profile.take().is_some() {
+        eprintln!(
+            "warning: ignoring defaults.browser_profile from untrusted config {}",
+            source.display()
+        );
+    }
+    if defaults.browser_cdp.take().is_some() {
+        eprintln!(
+            "warning: ignoring defaults.browser_cdp from untrusted config {}",
+            source.display()
+        );
+    }
+    defaults
 }
 
 fn load_config_file(path: &Path) -> Result<ConfigFile> {
@@ -225,6 +246,8 @@ model = "gpt-5-4-pro"
         let file = ConfigFile {
             defaults: Some(Defaults {
                 model: Some("gpt-5-4-pro".to_string()),
+                browser_profile: Some("/tmp/evil-profile".to_string()),
+                browser_cdp: Some("http://evil.example.com:9222".to_string()),
                 ..Default::default()
             }),
             providers: Some(HashMap::from([(
@@ -247,6 +270,8 @@ model = "gpt-5-4-pro"
         config.merge(file, false, Path::new("./yoetz.toml"));
         // Safe fields applied
         assert_eq!(config.defaults.model.as_deref(), Some("gpt-5-4-pro"));
+        assert!(config.defaults.browser_profile.is_none());
+        assert!(config.defaults.browser_cdp.is_none());
         assert_eq!(
             config.aliases.get("fast").map(|s| s.as_str()),
             Some("gpt-5-4-pro")

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -14,7 +14,7 @@ This script:
 2. Creates release/vX.Y.Z
 3. Moves CHANGELOG.md's Unreleased section into a versioned release entry
 4. Bumps [workspace.package].version plus skill/plugin metadata
-5. Runs cargo check --workspace
+5. Runs cargo check/test/clippy/fmt release gates
 6. Commits the release bump as chore(release): vX.Y.Z
 7. Pushes the branch
 8. Creates a GitHub PR with gh and enables squash auto-merge
@@ -25,7 +25,7 @@ publishes artifacts, and uses CHANGELOG.md as the release notes source.
 Options:
   --date YYYY-MM-DD  Override release date (default: today in UTC)
   --allow-empty      Allow releasing with an empty Unreleased section
-  --skip-verify      Skip cargo check --workspace
+  --skip-verify      Skip cargo check/test/clippy/fmt release gates
   --no-auto-merge    Create the PR but do not enable auto-merge
 EOF
 }
@@ -198,8 +198,12 @@ if [[ -f "$SKILL_MD" ]]; then
     || sed -i "s/^version: .*/version: ${VERSION}/" "$SKILL_MD"
 fi
 
+<<<<<<< HEAD
 if [[ "$skip_verify" -eq 0 ]]; then
   cargo check --workspace
+  cargo test --workspace
+  cargo clippy --workspace -- -D warnings
+  cargo fmt --all -- --check
 fi
 ./scripts/check-release-version.sh "$VERSION"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,7 +13,7 @@ This script:
 1. Verifies you are on a clean, up-to-date main branch
 2. Creates release/vX.Y.Z
 3. Moves CHANGELOG.md's Unreleased section into a versioned release entry
-4. Bumps [workspace.package].version plus skill/plugin metadata
+4. Bumps [workspace.package].version plus skill/plugin metadata, including all versioned skills/*/SKILL.md frontmatter
 5. Runs cargo check/test/clippy/fmt release gates
 6. Commits the release bump as chore(release): vX.Y.Z
 7. Pushes the branch
@@ -192,13 +192,13 @@ for PLUGIN_JSON in .codex-plugin/plugin.json .claude-plugin/plugin.json; do
   fi
 done
 
-SKILL_MD="skills/yoetz/SKILL.md"
-if [[ -f "$SKILL_MD" ]]; then
-  sed -i '' "s/^version: .*/version: ${VERSION}/" "$SKILL_MD" 2>/dev/null \
-    || sed -i "s/^version: .*/version: ${VERSION}/" "$SKILL_MD"
-fi
+while IFS= read -r SKILL_MD; do
+  if grep -q '^version:' "$SKILL_MD"; then
+    sed -i '' "s/^version: .*/version: ${VERSION}/" "$SKILL_MD" 2>/dev/null \
+      || sed -i "s/^version: .*/version: ${VERSION}/" "$SKILL_MD"
+  fi
+done < <(find skills -mindepth 2 -maxdepth 2 -name SKILL.md | sort)
 
-<<<<<<< HEAD
 if [[ "$skip_verify" -eq 0 ]]; then
   cargo check --workspace
   cargo test --workspace
@@ -208,8 +208,11 @@ fi
 ./scripts/check-release-version.sh "$VERSION"
 
 git add CHANGELOG.md Cargo.toml Cargo.lock
-for f in .codex-plugin/plugin.json .claude-plugin/plugin.json skills/yoetz/SKILL.md; do
+for f in .codex-plugin/plugin.json .claude-plugin/plugin.json; do
   [[ -f "$f" ]] && git add "$f"
+done
+find skills -mindepth 2 -maxdepth 2 -name SKILL.md -print0 | while IFS= read -r -d '' f; do
+  git add "$f"
 done
 if git diff --cached --quiet; then
   echo "error: release prep produced no staged changes" >&2

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -108,9 +108,9 @@ yoetz council \
   --format json
 ```
 
-**Example council sets:**
-- Cross-provider: `openai/gpt-5.4,gemini/gemini-3.1-pro-preview,openrouter/xai/grok-4.20-multi-agent-beta`
-- Via OpenRouter only: `openrouter/openai/gpt-5.4,openrouter/anthropic/claude-sonnet-4.6,openrouter/google/gemini-3.1-pro-preview`
+**Example council sets (illustrative — always resolve live IDs via `yoetz models frontier`):**
+- Cross-provider: `openai/<FRONTIER>,gemini/<FRONTIER>,openrouter/xai/<FRONTIER>`
+- Via OpenRouter only: `openrouter/openai/<FRONTIER>,openrouter/anthropic/<FRONTIER>,openrouter/google/<FRONTIER>`
 
 ## Ask (Single Model)
 

--- a/skills/yoetz/references/commands.md
+++ b/skills/yoetz/references/commands.md
@@ -104,8 +104,7 @@ yoetz browser recipe --recipe <yaml> --bundle <path>
 ### `session` - Session management
 
 ```bash
-yoetz session list
-yoetz session show <id>
+yoetz session <id>
 ```
 
 ### `status` - Show configuration status
@@ -117,5 +116,5 @@ yoetz status
 ### `apply` - Apply code changes from review
 
 ```bash
-yoetz apply <session-id>
+yoetz apply --patch-file <path> [--check] [--reverse]
 ```


### PR DESCRIPTION
## Summary
- split the ChatGPT dev-browser recipe into smaller Rust-orchestrated micro-scripts
- use dev-browser host-level uploadFile with staged temp files instead of QuickJS-side file buffers
- keep explicit HTTP CDP endpoint probing while deferring auto-connect discovery to dev-browser
- document the dev-browser upload/runtime constraints in CLAUDE.md

## Verification
- cargo test -p yoetz
- cargo clippy -p yoetz --all-targets -- -D warnings