### PR TITLE
fix(browser): trust live daemons for CDP reuse

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -73,7 +73,17 @@ Daily spend is tracked in a local JSON file. The `--max-cost-usd` flag estimates
 
 ### Browser Mode
 
-For models without API access (e.g., ChatGPT Pro), yoetz bundles files into markdown, then connects to the user's running Chrome via CDP (Chrome DevTools Protocol) using agent-browser to submit the bundle through the web UI. Connection priority: explicit CDP endpoint > auto-connect > cookie state > profile fallback. Chrome 146+ requires a one-time "Allow remote debugging?" approval; the daemon keeps the connection alive across recipe steps.
+For models without API access (e.g., ChatGPT Pro), yoetz bundles files into markdown, then connects to the user's running Chrome via CDP (Chrome DevTools Protocol) and submits the bundle through the web UI.
+
+Browser integrations are extension-free by design. Yoetz prefers to act as a wrapper over the underlying transport rather than reimplementing transport logic itself:
+
+- `dev-browser` is the primary live-Chrome transport for ChatGPT recipes.
+- `agent-browser` remains the legacy fallback when `dev-browser` is unavailable or a non-ChatGPT path still depends on it.
+- Explicit CDP endpoints are forwarded to the transport unchanged; the transport owns `/json/version`, `DevToolsActivePort`, and related connection logic.
+
+Connection priority remains connect-first: explicit CDP endpoint > auto-connect > cookie state > profile fallback.
+
+Chrome 146+ may show a one-time "Allow remote debugging?" approval dialog for a new CDP session. The acceptance criterion is one approval per browser session, not per yoetz invocation, so yoetz avoids silently tearing down live-attach daemons in normal attach/check/recipe flows. Recovery is explicit via `yoetz browser reset`.
 
 ## Data Flow
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -79,6 +79,7 @@ Browser integrations are extension-free by design. Yoetz prefers to act as a wra
 
 - `dev-browser` is the primary live-Chrome transport for ChatGPT recipes.
 - `agent-browser` remains the legacy fallback when `dev-browser` is unavailable or a non-ChatGPT path still depends on it.
+- `chrome-devtools-mcp` is an extension-free fallback candidate, but it is not integrated yet.
 - Explicit CDP endpoints are forwarded to the transport unchanged; the transport owns `/json/version`, `DevToolsActivePort`, and related connection logic.
 
 Connection priority remains connect-first: explicit CDP endpoint > auto-connect > cookie state > profile fallback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- Keep the ChatGPT dev-browser page stable across recipe runs so Chrome does not need a fresh remote-debugging approval for each new session request; the shared ChatGPT tab now persists between runs and yoetz serializes access to it
+- Stop re-probing explicit dev-browser CDP endpoints in yoetz; explicit `--cdp` values now pass through unchanged so dev-browser owns Chrome 146+ DevToolsActivePort fallback behavior
+- Stop silently recycling legacy live-attach daemons during normal browser flows; stale recovery is now explicit via `yoetz browser reset`
 
 ## [0.2.47] - 2026-04-05
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,22 @@ recipe flows, treat `dev-browser` as a QuickJS/WASM runner, not Node.js:
 - The QuickJS GC crash recovery in `dev_browser.rs` can salvage stdout from a
   completed script, but recipe correctness must not depend on that recovery.
 
+## Browser Architecture
+
+Yoetz browser integrations are extension-free by design.
+
+- Treat yoetz as a thin wrapper over the underlying browser transport unless
+  yoetz must own behavior for correctness or UX.
+- Preferred transport order for live Chrome work is `dev-browser` first,
+  `agent-browser` second. `chrome-devtools-mcp` is an extension-free fallback
+  candidate, not an excuse to add an extension-based path.
+- Default mode is connect-first: attach to the user's already running Chrome
+  session (`--connect`, auto-connect, or explicit `--cdp`) before considering
+  cookie sync or managed-profile fallbacks.
+- The daemon is trusted by default. Do not silently recycle live-attach daemons
+  during normal attach/check/recipe flows. If recovery is needed, require an
+  explicit `yoetz browser reset`.
+
 ## Provider Configuration
 
 API keys via environment variables:

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -59,6 +59,7 @@ struct NodeVersion {
 pub enum RecipeTransport {
     DevBrowser,
     AgentBrowser,
+    ChromeDevtoolsMcp,
     Manual,
 }
 
@@ -132,10 +133,19 @@ pub fn use_dev_browser() -> bool {
     crate::dev_browser::is_available()
 }
 
+pub fn is_chrome_devtools_mcp_available() -> bool {
+    false
+}
+
 pub fn recipe_transports(recipe: &Recipe, is_chatgpt: bool) -> Vec<RecipeTransport> {
     recipe.transports.clone().unwrap_or_else(|| {
         if is_chatgpt {
-            vec![RecipeTransport::DevBrowser, RecipeTransport::AgentBrowser]
+            vec![
+                RecipeTransport::DevBrowser,
+                RecipeTransport::AgentBrowser,
+                RecipeTransport::ChromeDevtoolsMcp,
+                RecipeTransport::Manual,
+            ]
         } else {
             vec![RecipeTransport::AgentBrowser]
         }
@@ -3387,7 +3397,7 @@ steps:
         let recipe = serde_yml::from_str::<Recipe>(
             r#"
 name: chatgpt
-transports: [dev-browser, agent-browser, manual]
+transports: [dev-browser, agent-browser, chrome-devtools-mcp, manual]
 steps:
   - action: open
     args: ["https://chatgpt.com/"]
@@ -3400,13 +3410,14 @@ steps:
             Some(vec![
                 RecipeTransport::DevBrowser,
                 RecipeTransport::AgentBrowser,
+                RecipeTransport::ChromeDevtoolsMcp,
                 RecipeTransport::Manual,
             ])
         );
     }
 
     #[test]
-    fn recipe_transports_default_to_dev_browser_for_chatgpt() {
+    fn recipe_transports_default_to_chatgpt_funnel() {
         let recipe = serde_yml::from_str::<Recipe>(
             r#"
 name: chatgpt
@@ -3419,12 +3430,22 @@ steps:
 
         assert_eq!(
             recipe_transports(&recipe, true),
-            vec![RecipeTransport::DevBrowser, RecipeTransport::AgentBrowser]
+            vec![
+                RecipeTransport::DevBrowser,
+                RecipeTransport::AgentBrowser,
+                RecipeTransport::ChromeDevtoolsMcp,
+                RecipeTransport::Manual,
+            ]
         );
         assert_eq!(
             recipe_transports(&recipe, false),
             vec![RecipeTransport::AgentBrowser]
         );
+    }
+
+    #[test]
+    fn chrome_devtools_mcp_is_unavailable_by_default() {
+        assert!(!is_chrome_devtools_mcp_available());
     }
 
     #[test]

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -37,6 +37,7 @@ const DAEMON_APPROVAL_GRACE_WINDOW: Duration = Duration::from_secs(30);
 const LIVE_ATTACH_COMMAND_TIMEOUT_MS: u64 = 30_000;
 const CDP_SESSION_NAME: &str = "yoetz-cdp";
 const CHROME_APPROVAL_LOCK_FILENAME: &str = "chrome-approval.lock";
+const CHATGPT_RECIPE_LOCK_FILENAME: &str = "chatgpt-recipe.lock";
 pub const CHATGPT_URL: &str = "https://chatgpt.com/";
 const COOKIE_SYNC_NODE_MIN_VERSION: NodeVersion = NodeVersion {
     major: 24,
@@ -1061,20 +1062,24 @@ pub fn close_browser() -> Result<()> {
     close_browser_daemon()
 }
 
+pub fn close_live_attach_session() -> Result<()> {
+    let (bin, prefix_args) = resolve_agent_browser()?;
+    let mut cmd = Command::new(bin);
+    cmd.args(prefix_args);
+    match cmd.args(["--session", CDP_SESSION_NAME, "close"]).output() {
+        Ok(output) if !output.status.success() => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            eprintln!("warning: session close failed: {stderr}");
+        }
+        Err(e) => eprintln!("warning: session close error: {e}"),
+        _ => {}
+    }
+    Ok(())
+}
+
 pub fn close_browser_for_connection(connection: &BrowserConnection) -> Result<()> {
     if connection.is_live_attach() {
-        let (bin, prefix_args) = resolve_agent_browser()?;
-        let mut cmd = Command::new(bin);
-        cmd.args(prefix_args);
-        match cmd.args(["--session", CDP_SESSION_NAME, "close"]).output() {
-            Ok(output) if !output.status.success() => {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                eprintln!("warning: session close failed: {stderr}");
-            }
-            Err(e) => eprintln!("warning: session close error: {e}"),
-            _ => {}
-        }
-        return Ok(());
+        return close_live_attach_session();
     }
     close_browser_daemon()
 }
@@ -1085,6 +1090,14 @@ pub enum DaemonRecoveryAction {
     Healthy,
     AwaitingApproval,
     KilledStale,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DaemonState {
+    NoSocket,
+    Healthy,
+    AwaitingApproval,
+    Stale,
 }
 
 #[derive(Debug)]
@@ -1099,15 +1112,26 @@ impl ChromeApprovalLock {
     }
 }
 
-fn chrome_approval_lock_path() -> PathBuf {
-    if let Some(home) = home_dir() {
-        return home.join(".yoetz").join(CHROME_APPROVAL_LOCK_FILENAME);
-    }
-    PathBuf::from(".yoetz").join(CHROME_APPROVAL_LOCK_FILENAME)
+#[derive(Debug)]
+pub struct ChatgptRecipeLock {
+    _lock_file: File,
+    waited: bool,
 }
 
-pub fn acquire_chrome_approval_lock() -> Result<ChromeApprovalLock> {
-    let lock_path = chrome_approval_lock_path();
+impl ChatgptRecipeLock {
+    pub fn waited(&self) -> bool {
+        self.waited
+    }
+}
+
+fn yoetz_lock_path(filename: &str) -> PathBuf {
+    if let Some(home) = home_dir() {
+        return home.join(".yoetz").join(filename);
+    }
+    PathBuf::from(".yoetz").join(filename)
+}
+
+fn acquire_waitable_lock(lock_path: &Path, action: &str) -> Result<(File, bool)> {
     if let Some(parent) = lock_path.parent() {
         fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
     }
@@ -1116,23 +1140,39 @@ pub fn acquire_chrome_approval_lock() -> Result<ChromeApprovalLock> {
         .read(true)
         .write(true)
         .truncate(false)
-        .open(&lock_path)
-        .with_context(|| format!("open browser approval lock {}", lock_path.display()))?;
+        .open(lock_path)
+        .with_context(|| format!("open {action} {}", lock_path.display()))?;
 
     let waited = match file.try_lock_exclusive() {
         Ok(()) => false,
         Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
             file.lock_exclusive()
-                .with_context(|| format!("lock browser approval {}", lock_path.display()))?;
+                .with_context(|| format!("lock {action} {}", lock_path.display()))?;
             true
         }
         Err(err) => {
-            return Err(err)
-                .with_context(|| format!("lock browser approval {}", lock_path.display()));
+            return Err(err).with_context(|| format!("lock {action} {}", lock_path.display()));
         }
     };
 
+    Ok((file, waited))
+}
+
+pub fn acquire_chrome_approval_lock() -> Result<ChromeApprovalLock> {
+    let lock_path = yoetz_lock_path(CHROME_APPROVAL_LOCK_FILENAME);
+    let (file, waited) = acquire_waitable_lock(&lock_path, "browser approval lock")?;
+
     Ok(ChromeApprovalLock {
+        _lock_file: file,
+        waited,
+    })
+}
+
+pub fn acquire_chatgpt_recipe_lock() -> Result<ChatgptRecipeLock> {
+    let lock_path = yoetz_lock_path(CHATGPT_RECIPE_LOCK_FILENAME);
+    let (file, waited) = acquire_waitable_lock(&lock_path, "chatgpt recipe lock")?;
+
+    Ok(ChatgptRecipeLock {
         _lock_file: file,
         waited,
     })
@@ -1241,16 +1281,16 @@ fn socket_is_recent(sock_path: &Path, grace_window: Duration) -> bool {
     age <= grace_window
 }
 
-fn force_kill_stale_daemon_with_paths(
+fn inspect_daemon_with_paths(
     pid_path: &Path,
     sock_path: &Path,
     grace_window: Duration,
-) -> DaemonRecoveryAction {
+) -> DaemonState {
     if !sock_path.exists() {
-        return DaemonRecoveryAction::NoSocket;
+        return DaemonState::NoSocket;
     }
     if is_daemon_socket_healthy(sock_path) {
-        return DaemonRecoveryAction::Healthy;
+        return DaemonState::Healthy;
     }
 
     if let Some(pid) = read_daemon_pid(pid_path) {
@@ -1258,8 +1298,33 @@ fn force_kill_stale_daemon_with_paths(
             && process_looks_like_agent_browser(pid)
             && socket_is_recent(sock_path, grace_window)
         {
-            return DaemonRecoveryAction::AwaitingApproval;
+            return DaemonState::AwaitingApproval;
         }
+    }
+
+    DaemonState::Stale
+}
+
+pub fn inspect_default_daemon() -> DaemonState {
+    let Some((pid_path, sock_path)) = default_daemon_paths() else {
+        return DaemonState::NoSocket;
+    };
+    inspect_daemon_with_paths(&pid_path, &sock_path, DAEMON_APPROVAL_GRACE_WINDOW)
+}
+
+fn force_kill_stale_daemon_with_paths(
+    pid_path: &Path,
+    sock_path: &Path,
+    grace_window: Duration,
+) -> DaemonRecoveryAction {
+    match inspect_daemon_with_paths(pid_path, sock_path, grace_window) {
+        DaemonState::NoSocket => return DaemonRecoveryAction::NoSocket,
+        DaemonState::Healthy => return DaemonRecoveryAction::Healthy,
+        DaemonState::AwaitingApproval => return DaemonRecoveryAction::AwaitingApproval,
+        DaemonState::Stale => {}
+    }
+
+    if let Some(pid) = read_daemon_pid(pid_path) {
         if process_is_alive(pid) {
             if process_looks_like_agent_browser(pid) {
                 let _ = Command::new("kill").args(["-9", &pid.to_string()]).output();

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -14,15 +14,17 @@
 //! - Single script executes batch operations (fewer IPC round-trips)
 
 use anyhow::{anyhow, Context, Result};
+use reqwest::Url;
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::env;
+#[cfg(test)]
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::OnceLock;
 
-use reqwest::Url;
+#[cfg(test)]
 use yoetz_core::paths::home_dir;
 
 use crate::browser;
@@ -32,14 +34,12 @@ static DEV_BROWSER: OnceLock<String> = OnceLock::new();
 
 /// Default timeout for dev-browser scripts in seconds.
 const DEFAULT_SCRIPT_TIMEOUT_SECS: u64 = 30;
-const CDP_HEALTH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
-const CHROME_EXPLICIT_REMOTE_DEBUGGING_PORT: u16 = 9222;
-const CDP_HALF_STATE_MARKER: &str =
-    "Chrome CDP endpoint is reachable but not responding to protocol commands";
 
 /// Extended timeout for ChatGPT response polling (30 minutes by default).
 const CHATGPT_POLL_TIMEOUT_MS_DEFAULT: u64 = 1_800_000;
 const CHATGPT_POLL_INTERVAL_MS_DEFAULT: u64 = 30_000;
+const CHATGPT_BROWSER_NAME: &str = "yoetz-chatgpt";
+const CHATGPT_PAGE_NAME: &str = "yoetz-chatgpt-main";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ChatgptPollSettings {
@@ -54,30 +54,6 @@ impl Default for ChatgptPollSettings {
             interval_ms: CHATGPT_POLL_INTERVAL_MS_DEFAULT,
         }
     }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct CdpCandidate {
-    endpoint: String,
-    source: String,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct ResolvedCdpEndpoint {
-    ws_url: String,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct DevToolsActivePortEntry {
-    port: u16,
-    ws_url: String,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-enum CdpProbeOutcome {
-    Healthy(ResolvedCdpEndpoint),
-    Unavailable(String),
-    Poisoned(String),
 }
 
 /// dev-browser tmp directory for file staging.
@@ -264,358 +240,52 @@ pub fn ensure_installed() -> Result<()> {
     ))
 }
 
+/// Stop the dev-browser daemon explicitly. Returns true when a running daemon
+/// was asked to stop, false when no daemon was running.
+pub fn stop_daemon() -> Result<bool> {
+    let bin = resolve_dev_browser()?;
+    let output = Command::new(&bin)
+        .arg("stop")
+        .output()
+        .with_context(|| format!("failed to run dev-browser stop (via {bin})"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if !stderr.is_empty() {
+            stderr
+        } else if !stdout.is_empty() {
+            stdout
+        } else {
+            format!("exit code {:?}", output.status.code())
+        };
+        return Err(anyhow!("dev-browser stop failed: {detail}"));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(!stdout.to_lowercase().contains("not running"))
+}
+
 /// Run a dev-browser script against a live Chrome instance (auto-connect).
 /// Returns the script's stdout output.
 pub fn run_script_connect(script: &str, timeout_secs: Option<u64>) -> Result<String> {
     run_script_connect_with_endpoint(script, timeout_secs, None)
 }
 
-fn chrome_default_profile_cdp_guidance() -> String {
-    #[cfg(target_os = "macos")]
-    {
-        let profile_dir = home_dir()
-            .map(|home| {
-                home.join("Library")
-                    .join("Application Support")
-                    .join("Google")
-                    .join("Chrome")
-            })
-            .map(|path| path.display().to_string())
-            .unwrap_or_else(|| "~/Library/Application Support/Google/Chrome".to_string());
-        format!(
-            "This is a known Chrome 136+ limitation when using the default profile.\n\
-             For a reliable explicit CDP endpoint, relaunch Chrome with:\n\
-               --remote-debugging-port={CHROME_EXPLICIT_REMOTE_DEBUGGING_PORT} --user-data-dir={profile_dir}\n\
-             Or use Chrome for Testing."
-        )
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    {
-        format!(
-        "This is a known Chrome 136+ limitation when using the default profile.\n\
-         For a reliable explicit CDP endpoint, relaunch Chrome with:\n\
-           --remote-debugging-port={CHROME_EXPLICIT_REMOTE_DEBUGGING_PORT} --user-data-dir=~/.config/yoetz/chrome-profile\n\
-         Or use Chrome for Testing."
-        )
-    }
-}
-
-fn is_poisoned_cdp_error(err: &anyhow::Error) -> bool {
-    err.to_string().contains(CDP_HALF_STATE_MARKER)
-}
-
-fn is_localhost_url(url: &Url) -> bool {
-    matches!(url.host_str(), Some("127.0.0.1" | "localhost" | "::1"))
-}
-
-fn endpoint_port(endpoint: &str) -> Option<u16> {
-    let url = Url::parse(endpoint).ok()?;
-    url.port_or_known_default()
-}
-
-fn standard_devtools_active_port_candidates() -> Vec<PathBuf> {
-    let Some(home_dir) = home_dir() else {
-        return Vec::new();
-    };
-
-    #[cfg(target_os = "macos")]
-    {
-        return vec![
-            home_dir
-                .join("Library")
-                .join("Application Support")
-                .join("Google")
-                .join("Chrome")
-                .join("DevToolsActivePort"),
-            home_dir
-                .join("Library")
-                .join("Application Support")
-                .join("Google")
-                .join("Chrome Canary")
-                .join("DevToolsActivePort"),
-            home_dir
-                .join("Library")
-                .join("Application Support")
-                .join("Chromium")
-                .join("DevToolsActivePort"),
-            home_dir
-                .join("Library")
-                .join("Application Support")
-                .join("BraveSoftware")
-                .join("Brave-Browser")
-                .join("DevToolsActivePort"),
-        ];
-    }
-
-    #[cfg(target_os = "linux")]
-    {
-        return vec![
-            home_dir
-                .join(".config")
-                .join("google-chrome")
-                .join("DevToolsActivePort"),
-            home_dir
-                .join(".config")
-                .join("chromium")
-                .join("DevToolsActivePort"),
-            home_dir
-                .join(".config")
-                .join("google-chrome-beta")
-                .join("DevToolsActivePort"),
-            home_dir
-                .join(".config")
-                .join("google-chrome-unstable")
-                .join("DevToolsActivePort"),
-            home_dir
-                .join(".config")
-                .join("BraveSoftware")
-                .join("Brave-Browser")
-                .join("DevToolsActivePort"),
-        ];
-    }
-
-    #[cfg(target_os = "windows")]
-    {
-        return vec![
-            home_dir
-                .join("AppData")
-                .join("Local")
-                .join("Google")
-                .join("Chrome")
-                .join("User Data")
-                .join("DevToolsActivePort"),
-            home_dir
-                .join("AppData")
-                .join("Local")
-                .join("Google")
-                .join("Chrome Beta")
-                .join("User Data")
-                .join("DevToolsActivePort"),
-            home_dir
-                .join("AppData")
-                .join("Local")
-                .join("Google")
-                .join("Chrome SxS")
-                .join("User Data")
-                .join("DevToolsActivePort"),
-            home_dir
-                .join("AppData")
-                .join("Local")
-                .join("Chromium")
-                .join("User Data")
-                .join("DevToolsActivePort"),
-            home_dir
-                .join("AppData")
-                .join("Local")
-                .join("BraveSoftware")
-                .join("Brave-Browser")
-                .join("User Data")
-                .join("DevToolsActivePort"),
-        ];
-    }
-
-    #[allow(unreachable_code)]
-    Vec::new()
-}
-
-fn parse_devtools_active_port(contents: &str) -> Option<DevToolsActivePortEntry> {
-    let lines = contents
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .collect::<Vec<_>>();
-    let port = lines.first()?.parse::<u16>().ok()?;
-    let ws_path = *lines.get(1)?;
-    if port == 0 || !ws_path.starts_with("/devtools/browser/") {
-        return None;
-    }
-    Some(DevToolsActivePortEntry {
-        port,
-        ws_url: format!("ws://127.0.0.1:{port}{ws_path}"),
-    })
-}
-
-fn devtools_active_port_entries() -> Vec<(PathBuf, DevToolsActivePortEntry)> {
-    standard_devtools_active_port_candidates()
-        .into_iter()
-        .filter_map(|path| {
-            let contents = fs::read_to_string(&path).ok()?;
-            let entry = parse_devtools_active_port(&contents)?;
-            Some((path, entry))
-        })
-        .collect()
-}
-
-fn matching_devtools_active_port_candidate(port: u16) -> Option<CdpCandidate> {
-    devtools_active_port_entries()
-        .into_iter()
-        .find_map(|(path, entry)| {
-            (entry.port == port).then_some(CdpCandidate {
-                endpoint: entry.ws_url,
-                source: format!("DevToolsActivePort ({})", path.display()),
-            })
-        })
-}
-
-fn json_version_url(endpoint: &str) -> Result<Url> {
-    let mut url = Url::parse(endpoint)
-        .with_context(|| format!("invalid Chrome CDP endpoint `{endpoint}`"))?;
-    match url.scheme() {
-        "http" | "https" => {}
-        "ws" => {
-            url.set_scheme("http")
-                .map_err(|_| anyhow!("invalid CDP endpoint scheme for `{endpoint}`"))?;
-        }
-        "wss" => {
-            url.set_scheme("https")
-                .map_err(|_| anyhow!("invalid CDP endpoint scheme for `{endpoint}`"))?;
-        }
-        other => {
-            return Err(anyhow!(
-                "unsupported Chrome CDP endpoint scheme `{other}` in `{endpoint}`"
-            ));
-        }
-    }
-    url.set_path("/json/version");
-    url.set_query(None);
-    url.set_fragment(None);
-    Ok(url)
-}
-
-#[derive(serde::Deserialize)]
-struct JsonVersionResponse {
-    #[serde(rename = "webSocketDebuggerUrl")]
-    web_socket_debugger_url: Option<String>,
-}
-
-fn build_half_state_diagnostic(candidate: &CdpCandidate, probe_url: &str, detail: &str) -> String {
-    format!(
-        "{CDP_HALF_STATE_MARKER}.\n\
-         Endpoint: {}\n\
-         Probe: {probe_url}\n\
-         Source: {}\n\
-         Observed: {detail}\n\
-         {}\n\
-         Restart Chrome with chrome://inspect/#remote-debugging enabled, then retry auto-connect or pass the exact ws:// CDP endpoint.",
-        candidate.endpoint,
-        candidate.source,
-        chrome_default_profile_cdp_guidance(),
-    )
-}
-
-fn probe_cdp_candidate(candidate: &CdpCandidate) -> CdpProbeOutcome {
-    let probe_url = match json_version_url(&candidate.endpoint) {
-        Ok(url) => url,
-        Err(err) => return CdpProbeOutcome::Unavailable(err.to_string()),
-    };
-
-    let client = match reqwest::blocking::Client::builder()
-        .timeout(CDP_HEALTH_TIMEOUT)
-        .build()
-    {
-        Ok(client) => client,
-        Err(err) => return CdpProbeOutcome::Unavailable(err.to_string()),
-    };
-    let response = match client
-        .get(probe_url.as_str())
-        .header(reqwest::header::ACCEPT, "application/json")
-        .send()
-    {
-        Ok(response) => response,
-        Err(err) => return CdpProbeOutcome::Unavailable(err.to_string()),
-    };
-    let status = response.status();
-
-    // Chrome 136+ can leave localhost CDP in a half-state where DevTools is
-    // listening but HTTP discovery on the real profile returns 404.
-    if status == reqwest::StatusCode::NOT_FOUND && is_localhost_url(&probe_url) {
-        return CdpProbeOutcome::Poisoned(build_half_state_diagnostic(
-            candidate,
-            probe_url.as_str(),
-            "GET /json/version returned HTTP 404 from a localhost Chrome endpoint",
-        ));
-    }
-
-    if !status.is_success() {
-        return CdpProbeOutcome::Unavailable(format!("HTTP {} from {}", status, probe_url));
-    }
-
-    let body = match response.text() {
-        Ok(body) => body,
-        Err(err) => return CdpProbeOutcome::Unavailable(err.to_string()),
-    };
-    if body.trim().is_empty() {
-        return CdpProbeOutcome::Poisoned(build_half_state_diagnostic(
-            candidate,
-            probe_url.as_str(),
-            "GET /json/version returned an empty body",
-        ));
-    }
-
-    let payload: JsonVersionResponse = match serde_json::from_str(&body) {
-        Ok(payload) => payload,
-        Err(err) => {
-            return CdpProbeOutcome::Poisoned(build_half_state_diagnostic(
-                candidate,
-                probe_url.as_str(),
-                &format!("GET /json/version returned invalid JSON ({err})"),
-            ));
-        }
-    };
-
-    let Some(ws_url) = payload
-        .web_socket_debugger_url
-        .filter(|url| !url.trim().is_empty())
-    else {
-        return CdpProbeOutcome::Poisoned(build_half_state_diagnostic(
-            candidate,
-            probe_url.as_str(),
-            "GET /json/version did not include webSocketDebuggerUrl",
-        ));
-    };
-
-    CdpProbeOutcome::Healthy(ResolvedCdpEndpoint { ws_url })
-}
-
 fn resolve_dev_browser_connect_endpoint(cdp_endpoint: Option<&str>) -> Result<Option<String>> {
     let Some(endpoint) = cdp_endpoint else {
-        // Let dev-browser own auto-connect discovery. It already knows how to
-        // read DevToolsActivePort without relying on /json/version.
         return Ok(None);
     };
 
+    // dev-browser already owns HTTP probing, /json/version fallback, and
+    // DevToolsActivePort resolution. yoetz only validates that the caller
+    // passed a recognizable CDP URL shape, then forwards it unchanged.
     let url = Url::parse(endpoint)
         .with_context(|| format!("invalid Chrome CDP endpoint `{endpoint}`"))?;
     match url.scheme() {
-        "ws" | "wss" => return Ok(Some(endpoint.to_string())),
-        "http" | "https" => {}
-        other => {
-            return Err(anyhow!(
-                "unsupported Chrome CDP endpoint scheme `{other}` in `{endpoint}`"
-            ));
-        }
-    }
-
-    let candidate = CdpCandidate {
-        endpoint: endpoint.to_string(),
-        source: "explicit --cdp".to_string(),
-    };
-    match probe_cdp_candidate(&candidate) {
-        CdpProbeOutcome::Healthy(resolved) => Ok(Some(resolved.ws_url)),
-        CdpProbeOutcome::Poisoned(detail) => {
-            if let Some(port) = endpoint_port(endpoint) {
-                if let Some(ws_candidate) = matching_devtools_active_port_candidate(port) {
-                    match probe_cdp_candidate(&ws_candidate) {
-                        CdpProbeOutcome::Healthy(resolved) => return Ok(Some(resolved.ws_url)),
-                        CdpProbeOutcome::Poisoned(_) | CdpProbeOutcome::Unavailable(_) => {}
-                    }
-                }
-            }
-            Err(anyhow!(detail))
-        }
-        CdpProbeOutcome::Unavailable(detail) => Err(anyhow!(
-            "dev-browser could not resolve a healthy Chrome CDP endpoint from `{endpoint}`: {detail}"
+        "http" | "https" | "ws" | "wss" => Ok(Some(endpoint.to_string())),
+        other => Err(anyhow!(
+            "unsupported Chrome CDP endpoint scheme `{other}` in `{endpoint}`"
         )),
     }
 }
@@ -753,9 +423,6 @@ console.log("ok:" + pages.length);
         Ok(stdout) if stdout.trim().starts_with("ok:") => Ok(()),
         Ok(stdout) => Err(anyhow!("dev-browser connection check failed: {stdout}")),
         Err(first_err) => {
-            if is_poisoned_cdp_error(&first_err) {
-                return Err(first_err.context("dev-browser connection check failed"));
-            }
             let msg = format!("{first_err:#}");
             let is_timeout = msg.contains("Timeout") || msg.contains("timed out");
             if !is_timeout {
@@ -930,18 +597,62 @@ fn build_chatgpt_prepare_script(page_name: &str, model: &str) -> String {
     let page_name_json = serde_json::to_string(page_name).unwrap();
     let model_json = serde_json::to_string(model).unwrap();
     format!(
-        r#"
+        r##"
 const PAGE_NAME = {page_name_json};
 const MODEL = {model_json};
 const page = await browser.getPage(PAGE_NAME);
-await page.goto("https://chatgpt.com/");
-let composerReady = true;
-try {{
-  await page.locator("[role='textbox']").first().waitFor({{ state: "visible", timeout: 20000 }});
-}} catch (_) {{
-  composerReady = false;
-}}
+const CHATGPT_URL = "https://chatgpt.com/";
+const COMPOSER_SELECTOR = "#prompt-textarea, [role='textbox']";
+const ASSISTANT_SELECTOR = "[data-message-author-role='assistant']";
+const NEW_CHAT_SELECTOR = "[data-testid='new-chat-button']";
+await page.goto(CHATGPT_URL, {{ waitUntil: "domcontentloaded" }});
+await page.waitForTimeout(800);
 const loggedIn = (await page.locator("[data-testid='login-button']").first().count()) === 0;
+// QuickJS: keep this helper small and let Rust own the broader orchestration.
+// Playwright's page.evaluate accepts exactly one arg after the function, so
+// the selectors are passed as a single object.
+const readState = async () => await page.evaluate(({{ composerSelector, assistantSelector }}) => {{
+  const composer = document.querySelector(composerSelector);
+  const assistantCount = document.querySelectorAll(assistantSelector).length;
+  const pathname = window.location.pathname || "/";
+  return {{
+    url: window.location.href,
+    pathname,
+    onConversationPath: pathname.startsWith("/c/"),
+    assistantCount,
+    composerVisible: !!composer,
+  }};
+}}, {{ composerSelector: COMPOSER_SELECTOR, assistantSelector: ASSISTANT_SELECTOR }});
+let state = await readState();
+let composerReady =
+  loggedIn &&
+  state.composerVisible &&
+  state.assistantCount === 0 &&
+  !state.onConversationPath;
+if (loggedIn && !composerReady) {{
+  for (let attempt = 0; attempt < 2 && !composerReady; attempt += 1) {{
+    const canUseNewChat = attempt === 0;
+    const newChatButton = canUseNewChat ? page.locator(NEW_CHAT_SELECTOR).first() : null;
+    if (newChatButton && (await newChatButton.count() > 0)) {{
+      await newChatButton.click({{ timeout: 5000 }});
+    }} else {{
+      await page.reload({{ waitUntil: "domcontentloaded" }});
+    }}
+    await page.waitForTimeout(1000);
+    state = await readState();
+    composerReady =
+      state.composerVisible &&
+      state.assistantCount === 0 &&
+      !state.onConversationPath;
+  }}
+}}
+if (loggedIn && composerReady) {{
+  try {{
+    await page.locator(COMPOSER_SELECTOR).first().waitFor({{ state: "visible", timeout: 20000 }});
+  }} catch (_) {{
+    composerReady = false;
+  }}
+}}
 if (loggedIn && composerReady && MODEL) {{
   const modelBtn = page.locator("[data-testid='model-switcher-dropdown-button'], button[aria-label='Model selector']").first();
   await modelBtn.waitFor({{ state: "visible", timeout: 5000 }});
@@ -961,9 +672,9 @@ console.log(JSON.stringify({{
   status: !loggedIn ? "login_required" : composerReady ? "ready" : "not_ready",
   loggedIn,
   composerReady,
-  url: page.url(),
+  url: state.url,
 }}));
-"#,
+"##,
         page_name_json = page_name_json,
         model_json = model_json,
     )
@@ -1150,21 +861,6 @@ console.log(JSON.stringify({{
     )
 }
 
-fn build_chatgpt_cleanup_script(page_name: &str) -> String {
-    let page_name_json = serde_json::to_string(page_name).unwrap();
-    format!(
-        r#"
-const PAGE_NAME = {page_name_json};
-const pages = await browser.listPages();
-if (pages.find((page) => page.name === PAGE_NAME)) {{
-    const page = await browser.getPage(PAGE_NAME);
-    await page.close().catch(() => {{}});
-}}
-"#,
-        page_name_json = page_name_json,
-    )
-}
-
 fn parse_chatgpt_recipe_result(
     stdout: &str,
     poll_timeout_ms: u64,
@@ -1237,16 +933,9 @@ fn parse_chatgpt_recipe_result(
 /// GC assertion on disposal. Rust owns the orchestration; each script only does
 /// one browser phase and returns JSON over stdout.
 pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<String> {
-    let unique_prefix = format!(
-        "{}_{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis()
-    );
-    let browser_name = "yoetz-chatgpt".to_string();
-    let page_name = format!("yoetz-chatgpt-page-{unique_prefix}");
+    let recipe_lock = browser::acquire_chatgpt_recipe_lock()?;
+    let browser_name = CHATGPT_BROWSER_NAME.to_string();
+    let page_name = CHATGPT_PAGE_NAME.to_string();
     let cdp_endpoint = ctx.cdp_endpoint.as_deref();
     let run_script = |script: &str, timeout_secs: Option<u64>| {
         run_script_connect_with_browser_and_endpoint(
@@ -1256,21 +945,11 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<String> {
             cdp_endpoint,
         )
     };
-    let cleanup = |cdp_endpoint| -> Result<()> {
-        let cleanup_script = build_chatgpt_cleanup_script(&page_name);
-        match run_script_connect_with_browser_and_endpoint(
-            &cleanup_script,
-            Some(15),
-            Some(browser_name.as_str()),
-            cdp_endpoint,
-        ) {
-            Ok(_) => Ok(()),
-            Err(err) => {
-                eprintln!("warn: failed to clean up dev-browser recipe page `{page_name}`: {err}");
-                Ok(())
-            }
-        }
-    };
+    if ctx.show_approval_guidance && recipe_lock.waited() {
+        eprintln!(
+            "info: another yoetz process is already using the shared ChatGPT dev-browser page; waiting for it to finish before reusing the tab"
+        );
+    }
 
     let result = (|| -> Result<(String, Vec<String>)> {
         let mut warnings = Vec::new();
@@ -1373,7 +1052,6 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<String> {
         warnings.append(&mut poll_warnings);
         Ok((response, warnings))
     })();
-    cleanup(cdp_endpoint)?;
 
     let (response, warnings) = result?;
     for warning in warnings {
@@ -1487,76 +1165,23 @@ mod tests {
     }
 
     #[test]
-    fn parse_devtools_active_port_returns_browser_ws_url() {
-        let entry =
-            parse_devtools_active_port("9222\n/devtools/browser/test-browser-id\n").unwrap();
-
-        assert_eq!(entry.port, 9222);
-        assert_eq!(
-            entry.ws_url,
-            "ws://127.0.0.1:9222/devtools/browser/test-browser-id"
-        );
-    }
-
-    #[test]
-    fn parse_devtools_active_port_rejects_malformed_payload() {
-        assert!(
-            parse_devtools_active_port("9222\n/devtools/page/not-a-browser-target\n").is_none()
-        );
-        assert!(parse_devtools_active_port("not-a-port\n/devtools/browser/test\n").is_none());
-    }
-
-    #[test]
-    fn json_version_url_normalizes_http_and_ws_endpoints() {
-        assert_eq!(
-            json_version_url("http://127.0.0.1:9222/devtools/browser/test")
-                .unwrap()
-                .as_str(),
-            "http://127.0.0.1:9222/json/version"
-        );
-        assert_eq!(
-            json_version_url("ws://127.0.0.1:9222/devtools/browser/test")
-                .unwrap()
-                .as_str(),
-            "http://127.0.0.1:9222/json/version"
-        );
-    }
-
-    #[test]
     fn resolve_dev_browser_connect_endpoint_skips_probing_for_auto_connect() {
         assert_eq!(resolve_dev_browser_connect_endpoint(None).unwrap(), None);
     }
 
     #[test]
-    fn probe_cdp_candidate_marks_local_404_as_poisoned() {
-        use std::io::{Read, Write};
-        use std::net::TcpListener;
-
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let addr = listener.local_addr().unwrap();
-        let server = std::thread::spawn(move || {
-            let (mut stream, _) = listener.accept().unwrap();
-            let mut request = [0_u8; 1024];
-            let _ = stream.read(&mut request);
-            stream
-                .write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n")
-                .unwrap();
-        });
-
-        let candidate = CdpCandidate {
-            endpoint: format!("http://127.0.0.1:{}", addr.port()),
-            source: "test".to_string(),
-        };
-        let outcome = probe_cdp_candidate(&candidate);
-        server.join().unwrap();
-
-        match outcome {
-            CdpProbeOutcome::Poisoned(detail) => {
-                assert!(detail.contains("HTTP 404"));
-                assert!(detail.contains(CDP_HALF_STATE_MARKER));
-            }
-            other => panic!("expected poisoned outcome, got {other:?}"),
-        }
+    fn resolve_dev_browser_connect_endpoint_passes_explicit_endpoints_through() {
+        assert_eq!(
+            resolve_dev_browser_connect_endpoint(Some("http://127.0.0.1:9222")).unwrap(),
+            Some("http://127.0.0.1:9222".to_string())
+        );
+        assert_eq!(
+            resolve_dev_browser_connect_endpoint(Some(
+                "ws://127.0.0.1:9222/devtools/browser/test-browser-id"
+            ))
+            .unwrap(),
+            Some("ws://127.0.0.1:9222/devtools/browser/test-browser-id".to_string())
+        );
     }
 
     #[test]
@@ -1566,11 +1191,28 @@ mod tests {
         assert!(script.contains("const PAGE_NAME = \"yoetz-chatgpt-test\";"));
         assert!(script.contains("const MODEL = \"gpt-5-4-pro\";"));
         assert!(script.contains("const page = await browser.getPage(PAGE_NAME);"));
-        assert!(script.contains("await page.goto(\"https://chatgpt.com/\");"));
+        assert!(
+            script.contains("await page.goto(CHATGPT_URL, { waitUntil: \"domcontentloaded\" });")
+        );
         assert!(script.contains("[data-testid='login-button']"));
+        assert!(script.contains("const NEW_CHAT_SELECTOR = \"[data-testid='new-chat-button']\";"));
+        assert!(script.contains("const canUseNewChat = attempt === 0;"));
+        assert!(script.contains("await page.reload({ waitUntil: \"domcontentloaded\" });"));
+        assert!(script.contains("page.evaluate(({ composerSelector, assistantSelector })"));
+        assert!(!script.contains("page.evaluate((composerSelector, assistantSelector)"));
+        assert!(script.contains("state.assistantCount === 0"));
+        assert!(script.contains("pathname.startsWith(\"/c/\")"));
         assert!(script.contains(
             "status: !loggedIn ? \"login_required\" : composerReady ? \"ready\" : \"not_ready\""
         ));
+    }
+
+    #[test]
+    fn chatgpt_recipe_uses_stable_browser_and_page_names() {
+        assert_eq!(CHATGPT_BROWSER_NAME, "yoetz-chatgpt");
+        assert_eq!(CHATGPT_PAGE_NAME, "yoetz-chatgpt-main");
+        assert!(!CHATGPT_PAGE_NAME.contains("pid"));
+        assert!(!CHATGPT_PAGE_NAME.contains('_'));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -210,6 +210,9 @@ enum BrowserCommand {
     Recipe(BrowserRecipeArgs),
     Login(BrowserLoginArgs),
     Check(BrowserCheckArgs),
+    /// Explicitly reset browser automation daemons. Use this when recovery is
+    /// needed; yoetz does not silently recycle live-attach daemons for you.
+    Reset(BrowserResetArgs),
     /// Sync cookies from Chrome to agent-browser (bypasses Cloudflare)
     SyncCookies(BrowserSyncCookiesArgs),
     /// Attach to a running Chrome instance and verify authentication.
@@ -268,6 +271,9 @@ struct BrowserAttachArgs {
     #[arg(long)]
     cdp: Option<String>,
 }
+
+#[derive(Args)]
+struct BrowserResetArgs {}
 
 #[derive(Args)]
 struct BrowserSyncCookiesArgs {
@@ -915,6 +921,21 @@ fn recipe_should_stop_live_transport_fallback(err: &anyhow::Error) -> bool {
     browser::is_chrome_approval_wait_error(err)
 }
 
+fn default_daemon_recovery_error(original: Option<&anyhow::Error>) -> Option<anyhow::Error> {
+    let suffix = original
+        .map(|err| format!("\n\nOriginal error: {err}"))
+        .unwrap_or_default();
+    match browser::inspect_default_daemon() {
+        browser::DaemonState::AwaitingApproval => Some(anyhow!(
+            "Chrome may be showing an \"Allow remote debugging?\" dialog. Click Allow, then retry.{suffix}"
+        )),
+        browser::DaemonState::Stale => Some(anyhow!(
+            "The legacy agent-browser daemon looks stale. Run `yoetz browser reset` and retry.{suffix}"
+        )),
+        browser::DaemonState::NoSocket | browser::DaemonState::Healthy => None,
+    }
+}
+
 fn run_recipe_via_dev_browser(
     recipe_args: &BrowserRecipeArgs,
     recipe_vars: &BTreeMap<String, String>,
@@ -1021,13 +1042,12 @@ fn run_recipe_via_agent_browser(
             match browser::try_cdp_attach(&endpoint, browser::CHATGPT_URL) {
                 Ok(()) => Some(browser::BrowserConnection::Cdp { endpoint }),
                 Err(e) => {
-                    let recovery = browser::force_kill_stale_daemon();
+                    if browser::is_chrome_approval_wait_error(&e) {
+                        return Err(anyhow!(
+                            "Chrome may be showing an \"Allow remote debugging?\" dialog. Click Allow, then retry."
+                        ));
+                    }
                     if recipe_args.cdp.is_some() {
-                        if matches!(recovery, browser::DaemonRecoveryAction::AwaitingApproval) {
-                            return Err(anyhow!(
-                                "Chrome may be showing an \"Allow remote debugging?\" dialog. Click Allow, then retry."
-                            ));
-                        }
                         return Err(e.context("explicit --cdp failed; not falling back"));
                     }
                     None
@@ -1049,18 +1069,11 @@ fn run_recipe_via_agent_browser(
             match browser::try_auto_connect_lite() {
                 Ok(()) => Some(browser::BrowserConnection::AutoConnect),
                 Err(_) => {
-                    let recovery = browser::force_kill_stale_daemon();
-                    match recovery {
-                        browser::DaemonRecoveryAction::AwaitingApproval => {
-                            return Err(anyhow!(
-                                "Chrome may be showing an \"Allow remote debugging?\" dialog. Please click Allow in Chrome, then retry the recipe."
-                            ));
-                        }
-                        _ => {
-                            eprintln!("info: auto-connect unavailable, falling back to profile");
-                            None
-                        }
+                    if let Some(err) = default_daemon_recovery_error(None) {
+                        return Err(err);
                     }
+                    eprintln!("info: auto-connect unavailable, falling back to profile");
+                    None
                 }
             }
         }
@@ -1157,9 +1170,8 @@ fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputFormat) -> 
                             }
                         };
                     }
-                    Err(_) => {
-                        let recovery = browser::force_kill_stale_daemon();
-                        if matches!(recovery, browser::DaemonRecoveryAction::AwaitingApproval) {
+                    Err(e) => {
+                        if browser::is_chrome_approval_wait_error(&e) {
                             eprintln!(
                                 "hint: Chrome may be showing an \"Allow remote debugging?\" dialog. \
                                  Click Allow, then retry."
@@ -1284,12 +1296,8 @@ fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputFormat) -> 
                 "https://chatgpt.com/",
             )
             .map_err(|e| {
-                let recovery = browser::force_kill_stale_daemon();
-                if matches!(recovery, browser::DaemonRecoveryAction::AwaitingApproval) {
-                    return anyhow::anyhow!(
-                        "Chrome may be showing an \"Allow remote debugging?\" dialog. \
-                         Click Allow, then retry.\n\nOriginal error: {e}"
-                    );
+                if let Some(recovery) = default_daemon_recovery_error(Some(&e)) {
+                    return recovery;
                 }
                 e
             })?;
@@ -1309,6 +1317,37 @@ fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputFormat) -> 
                 OutputFormat::Jsonl => write_jsonl("browser.check", &payload),
                 OutputFormat::Text | OutputFormat::Markdown => {
                     println!("Browser authenticated via {method}");
+                    Ok(())
+                }
+            }
+        }
+        BrowserCommand::Reset(_) => {
+            let dev_browser_stopped = if browser::use_dev_browser() {
+                dev_browser::stop_daemon()?
+            } else {
+                false
+            };
+            browser::close_live_attach_session()?;
+            browser::close_browser()?;
+            let legacy_reset = browser::force_kill_stale_daemon();
+
+            let payload = json!({
+                "status": "ok",
+                "dev_browser_daemon_stopped": dev_browser_stopped,
+                "agent_browser_default": format!("{legacy_reset:?}"),
+                "agent_browser_cdp_session_closed": true,
+            });
+            match format {
+                OutputFormat::Json => write_json(&payload),
+                OutputFormat::Jsonl => write_jsonl("browser.reset", &payload),
+                OutputFormat::Text | OutputFormat::Markdown => {
+                    if dev_browser_stopped {
+                        println!("Stopped dev-browser daemon.");
+                    } else if browser::use_dev_browser() {
+                        println!("dev-browser daemon was not running.");
+                    }
+                    println!("Closed agent-browser live-attach session.");
+                    println!("Reset agent-browser default daemon state: {legacy_reset:?}.");
                     Ok(())
                 }
             }
@@ -1434,9 +1473,8 @@ fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputFormat) -> 
                             }
                         };
                     }
-                    Err(_) => {
-                        let recovery = browser::force_kill_stale_daemon();
-                        if matches!(recovery, browser::DaemonRecoveryAction::AwaitingApproval) {
+                    Err(e) => {
+                        if attach_args.cdp.is_some() && browser::is_chrome_approval_wait_error(&e) {
                             return Err(anyhow!(
                                 "Chrome may be showing an \"Allow remote debugging?\" dialog. \
                                  Click Allow, then retry."
@@ -1462,12 +1500,8 @@ fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputFormat) -> 
                     };
                 }
                 Err(_) => {
-                    let recovery = browser::force_kill_stale_daemon();
-                    if matches!(recovery, browser::DaemonRecoveryAction::AwaitingApproval) {
-                        return Err(anyhow!(
-                            "Chrome may be showing an \"Allow remote debugging?\" dialog. \
-                             Click Allow, then retry."
-                        ));
+                    if let Some(recovery) = default_daemon_recovery_error(None) {
+                        return Err(recovery);
                     }
                 }
             }

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -870,6 +870,7 @@ fn recipe_transport_name(transport: browser::RecipeTransport) -> &'static str {
     match transport {
         browser::RecipeTransport::DevBrowser => "dev-browser",
         browser::RecipeTransport::AgentBrowser => "agent-browser",
+        browser::RecipeTransport::ChromeDevtoolsMcp => "chrome-devtools-mcp",
         browser::RecipeTransport::Manual => "manual",
     }
 }
@@ -934,6 +935,12 @@ fn default_daemon_recovery_error(original: Option<&anyhow::Error>) -> Option<any
         )),
         browser::DaemonState::NoSocket | browser::DaemonState::Healthy => None,
     }
+}
+
+fn run_recipe_via_chrome_devtools_mcp() -> Result<()> {
+    Err(anyhow!(
+        "chrome-devtools-mcp transport not yet supported; install chrome-devtools-mcp and file an issue if you want it implemented"
+    ))
 }
 
 fn run_recipe_via_dev_browser(
@@ -1405,6 +1412,12 @@ fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputFormat) -> 
             let mut transport_errors = Vec::new();
 
             for (index, transport) in transports.iter().copied().enumerate() {
+                if matches!(transport, browser::RecipeTransport::ChromeDevtoolsMcp)
+                    && !browser::is_chrome_devtools_mcp_available()
+                {
+                    continue;
+                }
+
                 let result = match transport {
                     browser::RecipeTransport::DevBrowser => run_recipe_via_dev_browser(
                         &recipe_args,
@@ -1422,6 +1435,9 @@ fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputFormat) -> 
                         is_chatgpt,
                         cdp_endpoint.as_deref(),
                     ),
+                    browser::RecipeTransport::ChromeDevtoolsMcp => {
+                        run_recipe_via_chrome_devtools_mcp()
+                    }
                     browser::RecipeTransport::Manual => Err(anyhow!("{}", manual_fallback)),
                 };
 
@@ -2022,11 +2038,28 @@ mod tests {
         let transports = vec![
             browser::RecipeTransport::DevBrowser,
             browser::RecipeTransport::AgentBrowser,
+            browser::RecipeTransport::ChromeDevtoolsMcp,
             browser::RecipeTransport::Manual,
         ];
         assert!(recipe_has_remaining_manual_fallback(&transports, 0));
         assert!(recipe_has_remaining_manual_fallback(&transports, 1));
-        assert!(!recipe_has_remaining_manual_fallback(&transports, 2));
+        assert!(recipe_has_remaining_manual_fallback(&transports, 2));
+        assert!(!recipe_has_remaining_manual_fallback(&transports, 3));
+    }
+
+    #[test]
+    fn recipe_transport_name_covers_chrome_devtools_mcp() {
+        assert_eq!(
+            recipe_transport_name(browser::RecipeTransport::ChromeDevtoolsMcp),
+            "chrome-devtools-mcp"
+        );
+    }
+
+    #[test]
+    fn run_recipe_via_chrome_devtools_mcp_reports_not_supported() {
+        let err = run_recipe_via_chrome_devtools_mcp().unwrap_err();
+        assert!(err.to_string().contains("not yet supported"));
+        assert!(err.to_string().contains("chrome-devtools-mcp"));
     }
 
     #[test]

--- a/crates/yoetz-cli/tests/daemon_policy.rs
+++ b/crates/yoetz-cli/tests/daemon_policy.rs
@@ -1,0 +1,86 @@
+use std::fs;
+use std::path::PathBuf;
+
+fn source_file(path: &str) -> String {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    fs::read_to_string(manifest_dir.join(path)).expect("read source file")
+}
+
+fn occurrences(haystack: &str, needle: &str) -> usize {
+    haystack.match_indices(needle).count()
+}
+
+#[test]
+fn main_keeps_destructive_recovery_scoped_to_browser_reset() {
+    let main_rs = source_file("src/main.rs");
+
+    assert!(main_rs.contains("BrowserCommand::Reset(_) => {"));
+    assert_eq!(
+        occurrences(&main_rs, "browser::force_kill_stale_daemon();"),
+        1,
+        "force_kill_stale_daemon should only run in BrowserCommand::Reset"
+    );
+    assert_eq!(
+        occurrences(&main_rs, "dev_browser::stop_daemon()?"),
+        1,
+        "dev-browser stop_daemon should only run in BrowserCommand::Reset"
+    );
+    assert_eq!(
+        occurrences(&main_rs, "browser::close_browser()?;"),
+        1,
+        "legacy managed daemon close should only run in BrowserCommand::Reset"
+    );
+    assert_eq!(
+        occurrences(&main_rs, "browser::close_live_attach_session()?;"),
+        1,
+        "live-attach session close should only run in BrowserCommand::Reset"
+    );
+}
+
+#[test]
+fn browser_keeps_destructive_helpers_in_whitelisted_locations() {
+    let browser_rs = source_file("src/browser.rs");
+
+    assert_eq!(
+        occurrences(
+            &browser_rs,
+            "pub fn force_kill_stale_daemon() -> DaemonRecoveryAction {"
+        ),
+        1
+    );
+    assert_eq!(
+        occurrences(&browser_rs, "force_kill_stale_daemon("),
+        1,
+        "force_kill_stale_daemon should not be invoked from normal browser flow helpers"
+    );
+    assert_eq!(
+        occurrences(&browser_rs, "close_browser_daemon()"),
+        3,
+        "close_browser_daemon should only appear in close_browser, close_browser_for_connection, and its own definition"
+    );
+    assert!(
+        browser_rs.contains(
+            "pub fn close_browser_for_connection(connection: &BrowserConnection) -> Result<()> {\n    if connection.is_live_attach() {\n        return close_live_attach_session();\n    }\n    close_browser_daemon()\n}"
+        ),
+        "live-attach close path must stay non-destructive"
+    );
+    assert!(
+        browser_rs.contains("if !connection.is_live_attach() {\n        let _ = close_browser_for_connection(connection);\n    }"),
+        "normal auth checks must only close managed non-live daemons"
+    );
+}
+
+#[test]
+fn dev_browser_stop_daemon_stays_helper_only() {
+    let dev_browser_rs = source_file("src/dev_browser.rs");
+
+    assert_eq!(
+        occurrences(&dev_browser_rs, "pub fn stop_daemon() -> Result<bool> {"),
+        1
+    );
+    assert_eq!(
+        occurrences(&dev_browser_rs, "stop_daemon("),
+        1,
+        "dev-browser stop_daemon should remain a helper, not a normal-flow callsite"
+    );
+}

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -323,6 +323,7 @@ This keeps the default path aligned with the same browser transport users alread
 The browser module connects to your running Chrome via CDP (Chrome DevTools Protocol):
 - **dev-browser** (primary): Playwright-based transport that attaches to your logged-in Chrome session
 - **agent-browser** (fallback): legacy transport with cookie/profile fallback support
+- **chrome-devtools-mcp** (fallback 2, stub): Google's official CDP MCP server, not yet integrated
 - **Cookie sync** (legacy fallback): extracts cookies from Chrome's encrypted store, injects into agent-browser only after live attach paths are exhausted
 - Extension-free by design: no browser extension is required or desired
 - Daemon model: one persistent connection per session, reused across invocations until you explicitly run `yoetz browser reset`

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -216,10 +216,12 @@ yoetz browser attach
 
 ### Chrome 146+ notes
 
-Chrome 146 introduced a security dialog for external CDP connections. yoetz handles this automatically:
-- Detects the dialog and tells you to click Allow (instead of hanging)
-- Reuses healthy daemon connections (no repeated dialogs)
-- Cleans up stale daemons when the connection breaks
+Chrome 146 introduced a security dialog for external CDP connections. Yoetz is extension-free by design, so the only way to get "approve once, then run silently" behavior is to keep the daemon/CDP session alive and avoid tearing it down between invocations.
+
+Current policy:
+- Prefer live attach over cookie sync: `dev-browser` first, `agent-browser` second.
+- Trust an existing live-attach daemon by default; yoetz does not silently recycle it during normal attach/check/recipe flows.
+- If recovery is actually needed, use `yoetz browser reset` explicitly.
 
 If you see "Allow remote debugging?" in Chrome, click Allow and retry.
 
@@ -289,7 +291,7 @@ Built-in recipes: `chatgpt`, `claude`, `gemini`.
 | `Allow remote debugging?` dialog | Click **Allow** in Chrome, then retry. If the dialog is frozen, launch Chrome with `--remote-debugging-port=9222 --user-data-dir=/tmp/chrome-debug` and use `yoetz browser attach --cdp http://127.0.0.1:9222` instead. |
 | `auto-connect probe timed out` | Chrome dialog is probably showing. Click Allow. If Chrome will not accept the dialog, switch to the explicit `--cdp` flow above. Install `dev-browser` first; `agent-browser` remains a fallback. |
 | `chatgpt login required` | Chrome was reached but the wrong profile/tab was used. Open ChatGPT in the target Chrome profile first, or connect that profile explicitly with `--cdp`, then retry. |
-| `daemon already running` | Run `yoetz browser attach` to check connection, or kill stale daemon: `agent-browser close` |
+| `daemon already running` | Run `yoetz browser attach` to check connection. If the daemon is stale, use `yoetz browser reset`, not `agent-browser close` directly. |
 | `agent-browser failed` | Ensure `npx agent-browser --version` works, or `npm install -g agent-browser` |
 | `dev-browser failed` | Ensure `dev-browser --help` works, verify Chrome remote debugging is enabled, and retry with `--cdp` if you need a specific Chrome profile. |
 | Recipe not found | Use `--recipe chatgpt` (name) or full path. Check `brew --prefix`/share/yoetz/recipes/ |
@@ -321,9 +323,9 @@ This keeps the default path aligned with the same browser transport users alread
 The browser module connects to your running Chrome via CDP (Chrome DevTools Protocol):
 - **dev-browser** (primary): Playwright-based transport that attaches to your logged-in Chrome session
 - **agent-browser** (fallback): legacy transport with cookie/profile fallback support
-- **Cookie sync** (legacy fallback): extracts cookies from Chrome's encrypted store, injects into agent-browser
-- Uses stealth User-Agent headers and disables automation detection flags
-- Daemon model: one persistent connection per session, reused across recipe steps
+- **Cookie sync** (legacy fallback): extracts cookies from Chrome's encrypted store, injects into agent-browser only after live attach paths are exhausted
+- Extension-free by design: no browser extension is required or desired
+- Daemon model: one persistent connection per session, reused across invocations until you explicitly run `yoetz browser reset`
 
 ## Provider Configuration
 


### PR DESCRIPTION
## Summary
- keep ChatGPT browser automation extension-free and daemon-trusting across invocations
- pass explicit dev-browser CDP endpoints through unchanged and preserve the shared ChatGPT tab
- remove silent live-attach daemon recycling from normal browser flows and add explicit recovery via `yoetz browser reset`
- codify the browser transport and daemon lifecycle policy in repo docs and the yoetz skill

## Verification
- cargo test
- cargo test -p yoetz dev_browser
- cargo test -p yoetz browser::
- cargo fmt --check

## Review
- Claude LGTM on the final daemon trust + passthrough + docs diff
