### PR TITLE
chore(release): v0.2.48

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.2.47",
+  "version": "0.2.48",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.2.47",
+  "version": "0.2.48",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+## [0.2.48] - 2026-04-11
 ### Fixed
 
 - Keep the ChatGPT dev-browser page stable across recipe runs so Chrome does not need a fresh remote-debugging approval for each new session request; the shared ChatGPT tab now persists between runs and yoetz serializes access to it
 - Stop re-probing explicit dev-browser CDP endpoints in yoetz; explicit `--cdp` values now pass through unchanged so dev-browser owns Chrome 146+ DevToolsActivePort fallback behavior
 - Stop silently recycling legacy live-attach daemons during normal browser flows; stale recovery is now explicit via `yoetz browser reset`
+
 
 ## [0.2.47] - 2026-04-05
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2994,7 +2994,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoetz"
-version = "0.2.47"
+version = "0.2.48"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3018,7 +3018,7 @@ dependencies = [
 
 [[package]]
 name = "yoetz-core"
-version = "0.2.47"
+version = "0.2.48"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/yoetz-core", "crates/yoetz-cli"]
 
 [workspace.package]
-version = "0.2.47"
+version = "0.2.48"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yoetz
-version: 0.2.47
+version: 0.2.48
 description: >
   Fast CLI-first LLM council, bundler, and multimodal gateway. Use ONLY when user
   explicitly mentions "yoetz", "yoetz ask", "yoetz council", "yoetz review",


### PR DESCRIPTION
## Release

- updates `CHANGELOG.md` for `v0.2.48`
- bumps workspace version to `0.2.48`
- aligns skill/plugin metadata to `0.2.48`
- merge triggers .github/workflows/release.yml, which creates the tag and
  publishes the release
- GitHub release notes come from the committed `CHANGELOG.md` entry