### PR TITLE
fix(browser): surface full error chain and stop lying about Chrome 147

### DIFF
--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -566,6 +566,16 @@ fn looks_like_dev_browser_connect_failure(err: &anyhow::Error) -> bool {
         && (message.contains("timed out") || message.contains("timeout"))
 }
 
+fn maybe_add_dev_browser_connect_guidance(err: anyhow::Error) -> anyhow::Error {
+    if looks_like_dev_browser_connect_failure(&err) {
+        err.context(
+            "dev-browser could not connect to Chrome. If Chrome is showing a remote debugging approval dialog, click Allow, then retry. Raw transport error follows.",
+        )
+    } else {
+        err
+    }
+}
+
 fn chatgpt_script_timeout_secs(poll_timeout_ms: u64) -> u64 {
     poll_timeout_ms.div_ceil(1000) + 60
 }
@@ -988,15 +998,7 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<String> {
                     "info: connecting to Chrome — if prompted, click Allow in Chrome's remote debugging dialog"
                 );
             }
-            run_script(&prepare_script, Some(60)).map_err(|err| {
-                if looks_like_dev_browser_connect_failure(&err) {
-                    err.context(
-                        "dev-browser could not connect to Chrome. Chrome may be showing an \"Allow remote debugging?\" dialog — click Allow in Chrome, then retry."
-                    )
-                } else {
-                    err
-                }
-            })?
+            run_script(&prepare_script, Some(60)).map_err(maybe_add_dev_browser_connect_guidance)?
         };
         let prepare: ChatgptPrepareResult =
             parse_script_json("parse chatgpt prepare result", &prepare_stdout)?;
@@ -1135,6 +1137,18 @@ mod tests {
 
         let other = anyhow!("ChatGPT response timed out after 900000ms");
         assert!(!looks_like_dev_browser_connect_failure(&other));
+    }
+
+    #[test]
+    fn maybe_add_dev_browser_connect_guidance_preserves_raw_cause_without_allow_marker() {
+        let err = anyhow!(
+            "browserType.connectOverCDP: Timeout 30000ms exceeded while waiting for connectOverCDP"
+        );
+        let err = maybe_add_dev_browser_connect_guidance(err);
+        let detail = format!("{err:#}");
+        assert!(detail.contains("dev-browser could not connect to Chrome"));
+        assert!(detail.contains("browserType.connectOverCDP: Timeout 30000ms exceeded"));
+        assert!(!detail.contains("Allow remote debugging"));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -894,6 +894,10 @@ fn format_recipe_transport_errors(errors: &[(browser::RecipeTransport, String)])
     format!("all browser recipe transports failed:\n- {joined}")
 }
 
+fn recipe_transport_error_detail(err: &anyhow::Error) -> String {
+    format!("{err:#}")
+}
+
 fn print_recipe_chrome_approval_message(transport: browser::RecipeTransport) {
     eprintln!(
         "info: connecting to Chrome via {} — if prompted, click Allow in Chrome's remote debugging dialog",
@@ -1445,7 +1449,7 @@ fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputFormat) -> 
                     Ok(()) => return Ok(()),
                     Err(err) => {
                         if recipe_should_stop_live_transport_fallback(&err) {
-                            transport_errors.push((transport, err.to_string()));
+                            transport_errors.push((transport, recipe_transport_error_detail(&err)));
                             if recipe_has_remaining_manual_fallback(&transports, index) {
                                 transport_errors.push((
                                     browser::RecipeTransport::Manual,
@@ -1460,7 +1464,7 @@ fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputFormat) -> 
                                 recipe_transport_name(transport)
                             );
                         }
-                        transport_errors.push((transport, err.to_string()));
+                        transport_errors.push((transport, recipe_transport_error_detail(&err)));
                     }
                 }
             }
@@ -2060,6 +2064,15 @@ mod tests {
         let err = run_recipe_via_chrome_devtools_mcp().unwrap_err();
         assert!(err.to_string().contains("not yet supported"));
         assert!(err.to_string().contains("chrome-devtools-mcp"));
+    }
+
+    #[test]
+    fn recipe_transport_error_detail_preserves_error_chain() {
+        let err = anyhow::anyhow!("browserType.connectOverCDP: Timeout 30000ms exceeded")
+            .context("dev-browser could not connect to Chrome");
+        let detail = recipe_transport_error_detail(&err);
+        assert!(detail.contains("dev-browser could not connect to Chrome"));
+        assert!(detail.contains("browserType.connectOverCDP: Timeout 30000ms exceeded"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve the full anyhow chain when browser recipe transports fail
- make the dev-browser Chrome approval hint conditional instead of masquerading as the root cause
- add regression tests for both the formatter and the new guidance behavior

## Why
On Chrome 147, the real failure mode is a Playwright `connectOverCDP` timeout, but yoetz was surfacing a lossy "click Allow in Chrome" wrapper and dropping the underlying cause entirely by aggregating `err.to_string()`. That led users to retry the wrong fix and hid the real transport error.

## Behavioral note
Chrome 147 connect timeouts now fall through to `agent-browser` before surfacing the manual fallback, so total error latency can be about 60s instead of 30s. This is deliberate: correctness wins here, because users now see that both live transports fail instead of assuming the second transport was never tried.

## Validation
- `cargo test -p yoetz`
- `cargo fmt --all --check`
- `cargo clippy -p yoetz --all-targets -- -D warnings`
