### PR TITLE
refactor(browser): drop 'legacy' vocabulary from code + tests

### DIFF
--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -199,7 +199,7 @@ pub fn run_agent_browser(
     )
 }
 
-fn legacy_connection(
+fn managed_profile_connection(
     profile_dir: Option<&Path>,
     profile_mode: BrowserProfileMode,
     use_stealth: bool,
@@ -373,12 +373,12 @@ fn run_agent_browser_with_options(
     headed: bool,
     profile_mode: BrowserProfileMode,
 ) -> Result<String> {
-    let connection = legacy_connection(profile_dir, profile_mode, use_stealth);
+    let connection = managed_profile_connection(profile_dir, profile_mode, use_stealth);
     run_agent_browser_with_connection(args, format, connection.as_ref(), use_stealth, headed)
 }
 
 pub fn run_recipe(recipe: Recipe, ctx: RecipeContext, format: OutputFormat) -> Result<()> {
-    let connection = legacy_connection(
+    let connection = managed_profile_connection(
         ctx.profile_dir.as_deref(),
         ctx.profile_mode,
         ctx.use_stealth,
@@ -1480,7 +1480,7 @@ pub fn build_recipe_vars(
 /// Search for a yoetz data file (script or recipe) across standard locations.
 /// Order: YOETZ_SCRIPTS_DIR env, relative to exe, Homebrew share, XDG, ~/.local/share.
 fn find_data_file(subdir: &str, filename: &str) -> Result<PathBuf> {
-    // Check YOETZ_SCRIPTS_DIR env var (legacy, works for scripts)
+    // Check YOETZ_SCRIPTS_DIR env var (works for scripts)
     if subdir == "scripts" {
         if let Ok(dir) = env::var("YOETZ_SCRIPTS_DIR") {
             let path = PathBuf::from(dir).join(filename);
@@ -1876,7 +1876,7 @@ pub fn resolve_auth_mode(profile_dir: &Path, headed: bool) -> Result<BrowserProf
         BrowserConnection::CookieState { .. } => Ok(BrowserProfileMode::PreferState),
         BrowserConnection::Profile { .. } => Ok(BrowserProfileMode::ProfileOnly),
         BrowserConnection::Cdp { .. } | BrowserConnection::AutoConnect => Err(anyhow!(
-            "legacy auth mode cannot map a live browser connection"
+            "managed-profile auth mode cannot map a live browser connection"
         )),
     }
 }

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -199,7 +199,7 @@ pub fn run_agent_browser(
     )
 }
 
-fn managed_profile_connection(
+fn managed_connection(
     profile_dir: Option<&Path>,
     profile_mode: BrowserProfileMode,
     use_stealth: bool,
@@ -373,12 +373,12 @@ fn run_agent_browser_with_options(
     headed: bool,
     profile_mode: BrowserProfileMode,
 ) -> Result<String> {
-    let connection = managed_profile_connection(profile_dir, profile_mode, use_stealth);
+    let connection = managed_connection(profile_dir, profile_mode, use_stealth);
     run_agent_browser_with_connection(args, format, connection.as_ref(), use_stealth, headed)
 }
 
 pub fn run_recipe(recipe: Recipe, ctx: RecipeContext, format: OutputFormat) -> Result<()> {
-    let connection = managed_profile_connection(
+    let connection = managed_connection(
         ctx.profile_dir.as_deref(),
         ctx.profile_mode,
         ctx.use_stealth,

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -935,7 +935,7 @@ fn default_daemon_recovery_error(original: Option<&anyhow::Error>) -> Option<any
             "Chrome may be showing an \"Allow remote debugging?\" dialog. Click Allow, then retry.{suffix}"
         )),
         browser::DaemonState::Stale => Some(anyhow!(
-            "The legacy agent-browser daemon looks stale. Run `yoetz browser reset` and retry.{suffix}"
+            "The agent-browser default daemon looks stale. Run `yoetz browser reset` and retry.{suffix}"
         )),
         browser::DaemonState::NoSocket | browser::DaemonState::Healthy => None,
     }
@@ -1267,7 +1267,7 @@ fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputFormat) -> 
 
             // Try dev-browser first for auth verification whenever we are
             // targeting a live Chrome instance. `--profile` still routes to the
-            // legacy managed-profile path.
+            // managed-profile path.
             if browser::use_dev_browser() && check_args.profile.is_none() {
                 match dev_browser::ensure_chatgpt_auth_with_page_check_and_endpoint(
                     dev_browser_cdp.as_deref(),
@@ -1293,7 +1293,7 @@ fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputFormat) -> 
                         };
                     }
                     Err(e) => {
-                        eprintln!("info: dev-browser auth check failed ({e}), trying legacy path");
+                        eprintln!("info: dev-browser auth check failed ({e}), trying managed-profile path");
                     }
                 }
             }
@@ -1340,12 +1340,12 @@ fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputFormat) -> 
             };
             browser::close_live_attach_session()?;
             browser::close_browser()?;
-            let legacy_reset = browser::force_kill_stale_daemon();
+            let default_daemon_reset = browser::force_kill_stale_daemon();
 
             let payload = json!({
                 "status": "ok",
                 "dev_browser_daemon_stopped": dev_browser_stopped,
-                "agent_browser_default": format!("{legacy_reset:?}"),
+                "agent_browser_default": format!("{default_daemon_reset:?}"),
                 "agent_browser_cdp_session_closed": true,
             });
             match format {
@@ -1358,7 +1358,7 @@ fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputFormat) -> 
                         println!("dev-browser daemon was not running.");
                     }
                     println!("Closed agent-browser live-attach session.");
-                    println!("Reset agent-browser default daemon state: {legacy_reset:?}.");
+                    println!("Reset agent-browser default daemon state: {default_daemon_reset:?}.");
                     Ok(())
                 }
             }

--- a/crates/yoetz-cli/tests/daemon_policy.rs
+++ b/crates/yoetz-cli/tests/daemon_policy.rs
@@ -28,7 +28,7 @@ fn main_keeps_destructive_recovery_scoped_to_browser_reset() {
     assert_eq!(
         occurrences(&main_rs, "browser::close_browser()?;"),
         1,
-        "legacy managed daemon close should only run in BrowserCommand::Reset"
+        "managed-profile daemon close should only run in BrowserCommand::Reset"
     );
     assert_eq!(
         occurrences(&main_rs, "browser::close_live_attach_session()?;"),


### PR DESCRIPTION
## Summary

- The transport funnel is a waterfall. Every tier is valid; none is deprecated. Drop the \"legacy\" qualifier across yoetz's Rust code and replace with functional descriptions of what each path actually does.
- `browser.rs`: rename `legacy_connection` to `managed_profile_connection`, update the two call sites, drop `legacy,` from the YOETZ_SCRIPTS_DIR comment, rewrite the `resolve_auth_mode` error string as \"managed-profile auth mode cannot map a live browser connection\".
- `main.rs`: rewrite the Stale daemon guidance error as \"The agent-browser default daemon looks stale.\", drop \"legacy\" from the managed-profile path comment and the dev-browser fallback eprintln, rename the \`BrowserCommand::Reset\` local \`legacy_reset\` to \`default_daemon_reset\` (the \`agent_browser_default\` JSON field name is unchanged to keep the reset response schema stable).
- `tests/daemon_policy.rs`: update the \`close_browser()\` assertion message to \"managed-profile daemon close should only run in BrowserCommand::Reset\".

Docs (ARCHITECTURE.md, CHANGELOG.md, skills/yoetz/SKILL.md, recipes/chatgpt.yaml) will get the same treatment in the in-flight funnel reorder branch so the two changes land together without doc conflicts. \`.gitleaks.toml\` keeps its \"openai-api-key-legacy\" entry verbatim — that refers to OpenAI's deprecated sk- key format, not to transport tiers.

## Test plan

- [x] \`cargo test -p yoetz\` — 148 unit + 23 CLI + 3 daemon_policy pass
- [x] \`cargo fmt --check\` — clean
- [x] \`cargo clippy -p yoetz --all-targets -- -D warnings\` — clean
- [ ] CI on this PR
- [ ] Rebase of codex's in-flight funnel-reorder branch onto this