### PR TITLE
chore(release): v0.2.50

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.2.49",
+  "version": "0.2.50",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.2.49",
+  "version": "0.2.50",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.50] - 2026-04-13
 ### Fixed
 
 - ChatGPT recipe no longer captures the streaming preamble ("I'm reviewing the bundle now...") as the final answer. The completion heuristic now requires either a copy button on the new assistant message (strong signal) or a real-time stable-idle window of `max(90s, 3 × wait_interval_ms)` with unchanged length. Removed the first-poll false-positive from the old `prev_dom=None => true` branch.
@@ -15,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - `--var thread=fresh|reuse` on `yoetz browser recipe --recipe chatgpt` (default `fresh`, byte-identical to prior behavior). `thread=reuse` keeps follow-up turns in the currently active ChatGPT conversation instead of opening a fresh tab on every call. Fail-fasts when the attached tab is not on chatgpt.com.
 - `completion_reason` (`copy_button` | `stable_idle_fallback`), `elapsed_ms`, `stable_for_ms`, and `stable_idle_threshold_ms` in the ChatGPT wait response JSON payload for observability.
+
 
 ## [0.2.49] - 2026-04-12
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3196,7 +3196,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoetz"
-version = "0.2.49"
+version = "0.2.50"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "yoetz-core"
-version = "0.2.49"
+version = "0.2.50"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/yoetz-core", "crates/yoetz-cli"]
 
 [workspace.package]
-version = "0.2.49"
+version = "0.2.50"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yoetz
-version: 0.2.49
+version: 0.2.50
 description: >
   Fast CLI-first LLM council, bundler, and multimodal gateway. Use ONLY when user
   explicitly mentions "yoetz", "yoetz ask", "yoetz council", "yoetz review",


### PR DESCRIPTION
## Release

- updates `CHANGELOG.md` for `v0.2.50`
- bumps workspace version to `0.2.50`
- aligns skill/plugin metadata to `0.2.50`
- merge triggers .github/workflows/release.yml, which creates the tag and
  publishes the release
- GitHub release notes come from the committed `CHANGELOG.md` entry