### PR TITLE
fix(browser): drop dead chrome-devtools-mcp gate + fail-fast on CDP-unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - `yoetz browser recipe --recipe chatgpt` now actually attempts the `chrome-devtools-mcp` transport instead of silently skipping it when `chrome-devtools-mcp` and `npx` are both absent from `PATH`. The availability gate was a leftover from v0.2.48 when the external binary was required for DOM snapshots; v0.2.49 removed that dependency, but the gate stayed. Each transport attempt now logs `info: attempting <name> transport` so skipped tiers are no longer invisible.
 - CDP-unreachable errors on the `chrome-devtools-mcp` transport now surface actionable guidance — enable `chrome://inspect/#remote-debugging`, pass `--cdp`, or use Chrome for Testing — instead of leaking the raw reqwest error. Chrome 136+ ignores `--remote-debugging-port` on the default profile, so this is the most common failure mode.
+- CDP-unreachable failures at tier 1 now stop the live-transport funnel and jump straight to manual, instead of cascading into dev-browser's `Target.setAutoAttach` hang (upstream Playwright bug). All live transports share the same CDP endpoint, so if tier 1 already determined Chrome is not listening, retrying the same endpoint via dev-browser or agent-browser cannot succeed.
 
 ### Clarified
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - `yoetz browser recipe --recipe chatgpt` now actually attempts the `chrome-devtools-mcp` transport instead of silently skipping it when `chrome-devtools-mcp` and `npx` are both absent from `PATH`. The availability gate was a leftover from v0.2.48 when the external binary was required for DOM snapshots; v0.2.49 removed that dependency, but the gate stayed. Each transport attempt now logs `info: attempting <name> transport` so skipped tiers are no longer invisible.
 - CDP-unreachable errors on the `chrome-devtools-mcp` transport now surface actionable guidance — enable `chrome://inspect/#remote-debugging`, pass `--cdp`, or use Chrome for Testing — instead of leaking the raw reqwest error. Chrome 136+ ignores `--remote-debugging-port` on the default profile, so this is the most common failure mode.
-- CDP-unreachable failures at tier 1 now stop the live-transport funnel and jump straight to manual, instead of cascading into dev-browser's `Target.setAutoAttach` hang (upstream Playwright bug). All live transports share the same CDP endpoint, so if tier 1 already determined Chrome is not listening, retrying the same endpoint via dev-browser or agent-browser cannot succeed.
+- CDP-unreachable failures at tier 1 now skip remaining pure live-CDP transports (chrome-devtools-mcp, dev-browser) instead of cascading into dev-browser's `Target.setAutoAttach` hang (upstream Playwright bug). `agent-browser` still runs — it transparently falls back from live-attach to a managed profile with stored cookies, so it works without CDP. `manual` remains the final fallback.
 
 ### Clarified
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- `yoetz browser recipe --recipe chatgpt` now actually attempts the `chrome-devtools-mcp` transport instead of silently skipping it when `chrome-devtools-mcp` and `npx` are both absent from `PATH`. The availability gate was a leftover from v0.2.48 when the external binary was required for DOM snapshots; v0.2.49 removed that dependency, but the gate stayed. Each transport attempt now logs `info: attempting <name> transport` so skipped tiers are no longer invisible.
+- CDP-unreachable errors on the `chrome-devtools-mcp` transport now surface actionable guidance — enable `chrome://inspect/#remote-debugging`, pass `--cdp`, or use Chrome for Testing — instead of leaking the raw reqwest error. Chrome 136+ ignores `--remote-debugging-port` on the default profile, so this is the most common failure mode.
+
+### Clarified
+
+- The `chrome-devtools-mcp` transport is a **direct CDP client** using vendored `headless_chrome` (`crates/yoetz-cli/src/chrome_devtools_mcp/client.rs`). It does NOT bridge to the chrome-devtools-mcp MCP server, despite the name. yoetz CLI runs as its own subprocess and cannot proxy MCP calls through a parent agent. Documentation updated in `recipes/chatgpt.yaml`.
 
 ## [0.2.50] - 2026-04-13
 ### Fixed

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -1,17 +1,18 @@
 use anyhow::{anyhow, Context, Result};
 use fs2::FileExt;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use std::env;
 use std::fs::{self, File, OpenOptions};
-use std::io::{self, IsTerminal, Read as _};
+use std::io::{self, IsTerminal, Read};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Command;
 use std::sync::OnceLock;
 use std::thread;
 use std::time::{Duration, Instant, SystemTime};
 
+use crate::chrome_devtools_mcp::client::{discover_running_chrome_targets, RunningChromeTarget};
 use yoetz_core::config::Config;
 use yoetz_core::output::{write_json, write_jsonl_event, OutputFormat};
 use yoetz_core::paths::home_dir;
@@ -46,6 +47,7 @@ const LIVE_ATTACH_COMMAND_TIMEOUT_MS: u64 = 30_000;
 const CDP_SESSION_NAME: &str = "yoetz-cdp";
 const CHROME_APPROVAL_LOCK_FILENAME: &str = "chrome-approval.lock";
 const CHATGPT_RECIPE_LOCK_FILENAME: &str = "chatgpt-recipe.lock";
+const BROWSER_TARGET_STATE_FILENAME: &str = "browser-target.json";
 pub const CHATGPT_URL: &str = "https://chatgpt.com/";
 const COOKIE_SYNC_NODE_MIN_VERSION: NodeVersion = NodeVersion {
     major: 24,
@@ -131,8 +133,40 @@ impl BrowserConnection {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ResolvedCdpTargetSource {
+    Flag,
+    Env,
+    Config,
+    Auto,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResolvedCdpTarget {
+    pub endpoint: String,
+    pub source: ResolvedCdpTargetSource,
+    pub description: String,
+    source_path: Option<PathBuf>,
+}
+
+impl ResolvedCdpTarget {
+    pub fn is_auto_discovered(&self) -> bool {
+        matches!(self.source, ResolvedCdpTargetSource::Auto)
+    }
+
+    pub fn is_authoritative(&self) -> bool {
+        !self.is_auto_discovered()
+    }
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct BrowserTargetState {
+    last_source_path: Option<PathBuf>,
+}
+
 /// Cached agent-browser resolution. Probed once per process, reused for all calls.
 static AGENT_BROWSER: OnceLock<Result<(String, Vec<String>), String>> = OnceLock::new();
+static BROWSER_TARGET_STATE_WARNING_EMITTED: OnceLock<()> = OnceLock::new();
 
 /// Returns true if dev-browser is the active browser backend.
 /// When dev-browser is available (installed or auto-installed), it is the
@@ -1322,9 +1356,24 @@ pub fn is_chrome_approval_wait_error(err: &anyhow::Error) -> bool {
 /// Stopping at tier 1 and jumping to manual gives the user an immediate,
 /// actionable error instead of a long wait.
 pub fn is_chrome_cdp_unreachable_error(err: &anyhow::Error) -> bool {
-    format!("{err:#}")
-        .to_lowercase()
-        .contains("chrome://inspect")
+    let message = format!("{err:#}").to_lowercase();
+    message.contains("chrome://inspect")
+        && (message.contains("could not reach chrome's cdp endpoint")
+            || message.contains("ignores --remote-debugging-port")
+            || (message.contains("requesting `http")
+                && message.contains("/json/version")
+                && (message.contains("failed") || message.contains("connection refused")))
+            || (message.contains("connectovercdp")
+                && (message.contains("econnrefused")
+                    || message.contains("connection refused")
+                    || message.contains("browser.getversion"))))
+}
+
+pub fn is_chatgpt_auth_issue_error(err: &anyhow::Error) -> bool {
+    let message = format!("{err:#}").to_lowercase();
+    message.contains("chatgpt login required")
+        || message.contains("cloudflare challenge detected")
+        || message.contains("captcha detected")
 }
 
 fn close_browser_daemon() -> Result<()> {
@@ -1795,6 +1844,207 @@ pub fn resolve_cdp_endpoint(cdp_override: Option<&str>, config: &Config) -> Opti
         .filter(|value| !value.is_empty())
 }
 
+pub fn resolve_cdp_target(
+    cdp_override: Option<&str>,
+    config: &Config,
+) -> Result<Option<ResolvedCdpTarget>> {
+    resolve_cdp_target_with_implicit(cdp_override, config, true)
+}
+
+pub fn resolve_cdp_target_with_implicit(
+    cdp_override: Option<&str>,
+    config: &Config,
+    allow_implicit: bool,
+) -> Result<Option<ResolvedCdpTarget>> {
+    if let Some(endpoint) = cdp_override
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+    {
+        return Ok(Some(ResolvedCdpTarget {
+            description: format!("using explicit --cdp target `{endpoint}`"),
+            endpoint,
+            source: ResolvedCdpTargetSource::Flag,
+            source_path: None,
+        }));
+    }
+
+    if !allow_implicit {
+        return Ok(None);
+    }
+
+    if let Some(endpoint) = env::var("YOETZ_BROWSER_CDP")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+    {
+        return Ok(Some(ResolvedCdpTarget {
+            description: format!("using YOETZ_BROWSER_CDP target `{endpoint}`"),
+            endpoint,
+            source: ResolvedCdpTargetSource::Env,
+            source_path: None,
+        }));
+    }
+
+    if let Some(endpoint) = config
+        .defaults
+        .browser_cdp
+        .clone()
+        .filter(|value| !value.is_empty())
+    {
+        return Ok(Some(ResolvedCdpTarget {
+            description: format!("using defaults.browser_cdp target `{endpoint}`"),
+            endpoint,
+            source: ResolvedCdpTargetSource::Config,
+            source_path: None,
+        }));
+    }
+
+    let mut targets = discover_running_chrome_targets();
+    let mut sticky_source = match load_browser_target_state() {
+        Ok(state) => state.last_source_path,
+        Err(err) => {
+            warn_invalid_browser_target_state(&err);
+            let _ = clear_browser_target_state();
+            None
+        }
+    };
+    if sticky_source
+        .as_ref()
+        .is_some_and(|path| !targets.iter().any(|target| target.source_path == *path))
+    {
+        let _ = clear_browser_target_state();
+        sticky_source = None;
+    }
+    let Some(target) =
+        select_preferred_running_chrome_target(&mut targets, sticky_source.as_deref())
+    else {
+        return Ok(None);
+    };
+    let description = if sticky_source
+        .as_deref()
+        .is_some_and(|sticky| sticky == target.source_path.as_path())
+    {
+        format!(
+            "reusing last successful Chrome target: {}",
+            target.summary()
+        )
+    } else {
+        format!("auto-selected running Chrome target: {}", target.summary())
+    };
+    Ok(Some(ResolvedCdpTarget {
+        endpoint: target.ws_endpoint.clone(),
+        source: ResolvedCdpTargetSource::Auto,
+        description,
+        source_path: Some(target.source_path.clone()),
+    }))
+}
+
+pub fn remember_cdp_target(target: &ResolvedCdpTarget) -> Result<()> {
+    let Some(source_path) = target.source_path.clone() else {
+        return Ok(());
+    };
+    save_browser_target_state(&BrowserTargetState {
+        last_source_path: Some(source_path),
+    })
+}
+
+pub fn forget_cdp_target(target: &ResolvedCdpTarget) -> Result<()> {
+    if target.source_path.is_none() {
+        return Ok(());
+    }
+    clear_browser_target_state()
+}
+
+fn browser_target_state_path() -> PathBuf {
+    if let Some(path) = env::var("YOETZ_BROWSER_TARGET_PATH")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+    {
+        return PathBuf::from(path);
+    }
+    if let Some(home) = home_dir() {
+        return home.join(".yoetz").join(BROWSER_TARGET_STATE_FILENAME);
+    }
+    PathBuf::from(".yoetz").join(BROWSER_TARGET_STATE_FILENAME)
+}
+
+fn load_browser_target_state() -> Result<BrowserTargetState> {
+    let path = browser_target_state_path();
+    if !path.exists() {
+        return Ok(BrowserTargetState::default());
+    }
+    let content = fs::read_to_string(&path)
+        .with_context(|| format!("read browser target {}", path.display()))?;
+    serde_json::from_str(&content)
+        .with_context(|| format!("parse browser target {}", path.display()))
+}
+
+fn save_browser_target_state(state: &BrowserTargetState) -> Result<()> {
+    let path = browser_target_state_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    let data = serde_json::to_string_pretty(state)?;
+    let tmp_path = path.with_extension(format!("tmp-{}", std::process::id()));
+    fs::write(&tmp_path, data).with_context(|| format!("write {}", tmp_path.display()))?;
+    fs::rename(&tmp_path, &path)
+        .with_context(|| format!("rename {} -> {}", tmp_path.display(), path.display()))
+}
+
+fn select_preferred_running_chrome_target(
+    targets: &mut [RunningChromeTarget],
+    sticky_source: Option<&Path>,
+) -> Option<RunningChromeTarget> {
+    targets.sort_by(|left, right| compare_running_chrome_targets(left, right, sticky_source));
+    targets.first().cloned()
+}
+
+fn compare_running_chrome_targets(
+    left: &RunningChromeTarget,
+    right: &RunningChromeTarget,
+    sticky_source: Option<&Path>,
+) -> std::cmp::Ordering {
+    let sticky_left = sticky_source.is_some_and(|path| path == left.source_path.as_path());
+    let sticky_right = sticky_source.is_some_and(|path| path == right.source_path.as_path());
+    right
+        .has_chatgpt_tab()
+        .cmp(&left.has_chatgpt_tab())
+        .then_with(|| right.chatgpt_tab_count.cmp(&left.chatgpt_tab_count))
+        .then_with(|| {
+            browser_family_priority(&right.browser_name)
+                .cmp(&browser_family_priority(&left.browser_name))
+        })
+        .then_with(|| {
+            modified_sort_key(right.modified_at).cmp(&modified_sort_key(left.modified_at))
+        })
+        .then_with(|| sticky_right.cmp(&sticky_left))
+        .then_with(|| left.source_path.cmp(&right.source_path))
+}
+
+fn browser_family_priority(browser_name: &str) -> u8 {
+    let name = browser_name.to_ascii_lowercase();
+    if name.contains("chrome beta") {
+        3
+    } else if name.contains("chrome canary") {
+        2
+    } else if name.contains("chrome") {
+        4
+    } else if name.contains("chromium") {
+        1
+    } else {
+        0
+    }
+}
+
+fn modified_sort_key(modified_at: Option<SystemTime>) -> u128 {
+    modified_at
+        .and_then(|time| time.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0)
+}
+
 fn resolve_browser_connection_fallback(
     profile_dir: &Path,
     headed: bool,
@@ -1832,13 +2082,23 @@ pub fn resolve_browser_connection(
     target_url: &str,
 ) -> Result<BrowserConnection> {
     if let Some(endpoint) = resolve_cdp_endpoint(cdp_override, config) {
-        if try_cdp_attach(&endpoint, target_url).is_ok() {
-            return Ok(BrowserConnection::Cdp { endpoint });
+        match try_cdp_attach(&endpoint, target_url) {
+            Ok(()) => return Ok(BrowserConnection::Cdp { endpoint }),
+            Err(err)
+                if is_chrome_approval_wait_error(&err) || is_chatgpt_auth_issue_error(&err) =>
+            {
+                return Err(err);
+            }
+            Err(_) => {}
         }
     }
 
-    if try_auto_connect(target_url).is_ok() {
-        return Ok(BrowserConnection::AutoConnect);
+    match try_auto_connect(target_url) {
+        Ok(()) => return Ok(BrowserConnection::AutoConnect),
+        Err(err) if is_chrome_approval_wait_error(&err) || is_chatgpt_auth_issue_error(&err) => {
+            return Err(err);
+        }
+        Err(_) => {}
     }
 
     resolve_browser_connection_fallback(profile_dir, /* headed */ false, target_url)
@@ -1917,23 +2177,47 @@ pub fn try_auto_connect(target_url: &str) -> Result<()> {
     verify_auth_cdp(target_url, &connection)
 }
 
+pub fn try_cdp_attach_lite(endpoint: &str) -> Result<()> {
+    let connection = BrowserConnection::Cdp {
+        endpoint: endpoint.to_string(),
+    };
+    probe_live_attach_connection(&connection).map_err(|e| {
+        if allow_dialog_error(&e) {
+            e
+        } else if is_localhost_endpoint(endpoint) {
+            e.context(chrome136_cdp_warning(endpoint))
+        } else {
+            e
+        }
+    })
+}
+
 /// Lightweight auto-connect check: verifies Chrome is reachable via
 /// auto-connect without opening new tabs. Used by the recipe path where
 /// the recipe itself handles navigation and auth detection.
 ///
 /// Returns immediately if an existing daemon is healthy. Otherwise spawns
-/// a bounded probe (15s timeout) so the CLI doesn't hang if Chrome shows
-/// a "Allow remote debugging?" dialog (Chrome 146+).
+/// a bounded probe so the CLI does not hang indefinitely on approval-gated
+/// CDP connections.
 pub fn try_auto_connect_lite() -> Result<()> {
     if is_daemon_healthy() {
         return Ok(());
     }
     let connection = BrowserConnection::AutoConnect;
+    probe_live_attach_connection(&connection)
+}
+
+fn probe_live_attach_connection(connection: &BrowserConnection) -> Result<()> {
+    if !connection.is_live_attach() {
+        return Err(anyhow!(
+            "probe_live_attach_connection requires a live browser connection"
+        ));
+    }
     let (bin, prefix_args) = resolve_agent_browser()?;
     let args = build_agent_browser_args(
         vec!["snapshot".to_string(), "-c".to_string()],
         OutputFormat::Text,
-        Some(&connection),
+        Some(connection),
         /* use_stealth */ false,
         /* headed */ false,
     );
@@ -1943,8 +2227,8 @@ pub fn try_auto_connect_lite() -> Result<()> {
     let mut child = Command::new(&bin)
         .args(&all_args)
         .env("AGENT_BROWSER_DEFAULT_TIMEOUT", "10000")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
         .spawn()
         .with_context(|| format!("failed to spawn agent-browser (via {bin})"))?;
 
@@ -1959,20 +2243,20 @@ pub fn try_auto_connect_lite() -> Result<()> {
                 let stderr = child
                     .stderr
                     .as_mut()
-                    .map(|s| {
+                    .map(|stream| {
                         let mut buf = String::new();
-                        let _ = s.read_to_string(&mut buf);
+                        let _ = stream.read_to_string(&mut buf);
                         buf
                     })
                     .unwrap_or_default();
-                return Err(anyhow!("auto-connect probe failed: {stderr}"));
+                return Err(anyhow!("live browser reachability probe failed: {stderr}"));
             }
             Ok(None) => {
                 if start.elapsed() > timeout {
                     let _ = child.kill();
                     let _ = child.wait();
                     return Err(anyhow!(
-                        "auto-connect probe timed out ({}s). \
+                        "live browser reachability probe timed out ({}s). \
                          Chrome may be showing an \"Allow remote debugging?\" dialog — \
                          please click Allow in Chrome to authorize the connection",
                         timeout.as_secs()
@@ -1980,9 +2264,26 @@ pub fn try_auto_connect_lite() -> Result<()> {
                 }
                 thread::sleep(Duration::from_millis(200));
             }
-            Err(e) => return Err(anyhow!("auto-connect probe error: {e}")),
+            Err(err) => return Err(anyhow!("live browser reachability probe error: {err}")),
         }
     }
+}
+
+fn clear_browser_target_state() -> Result<()> {
+    let path = browser_target_state_path();
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err).with_context(|| format!("remove {}", path.display())),
+    }
+}
+
+fn warn_invalid_browser_target_state(err: &anyhow::Error) {
+    BROWSER_TARGET_STATE_WARNING_EMITTED.get_or_init(|| {
+        eprintln!(
+            "warning: failed to load browser target state ({err}); clearing sticky target state"
+        );
+    });
 }
 
 pub fn verify_auth_cdp(target_url: &str, connection: &BrowserConnection) -> Result<()> {
@@ -2889,6 +3190,104 @@ mod tests {
     }
 
     #[test]
+    #[allow(unsafe_code)]
+    fn resolve_cdp_target_can_suppress_implicit_live_targets() {
+        let _guard = lock_env();
+        let _cdp_env = EnvVarGuard::set("YOETZ_BROWSER_CDP", "http://127.0.0.1:9000");
+        let mut config = Config::default();
+        config.defaults.browser_cdp = Some("http://127.0.0.1:9222".to_string());
+
+        let suppressed = resolve_cdp_target_with_implicit(None, &config, false).unwrap();
+        assert!(suppressed.is_none());
+
+        let explicit =
+            resolve_cdp_target_with_implicit(Some("http://127.0.0.1:9333"), &config, false)
+                .unwrap()
+                .unwrap();
+        assert_eq!(explicit.endpoint, "http://127.0.0.1:9333");
+        assert_eq!(explicit.source, ResolvedCdpTargetSource::Flag);
+    }
+
+    #[test]
+    fn select_preferred_running_chrome_target_prefers_chatgpt_before_sticky() {
+        let sticky_path = PathBuf::from("/tmp/chrome-sticky/DevToolsActivePort");
+        let older = SystemTime::UNIX_EPOCH + Duration::from_secs(10);
+        let newer = SystemTime::UNIX_EPOCH + Duration::from_secs(20);
+        let mut targets = vec![
+            RunningChromeTarget {
+                ws_endpoint: "ws://127.0.0.1:9333/devtools/browser/sticky".to_string(),
+                source_path: sticky_path.clone(),
+                browser_name: "Brave".to_string(),
+                chatgpt_tab_count: 0,
+                modified_at: Some(older),
+            },
+            RunningChromeTarget {
+                ws_endpoint: "ws://127.0.0.1:9222/devtools/browser/chatgpt".to_string(),
+                source_path: PathBuf::from("/tmp/chrome-default/DevToolsActivePort"),
+                browser_name: "Chrome".to_string(),
+                chatgpt_tab_count: 2,
+                modified_at: Some(newer),
+            },
+        ];
+
+        let sticky_choice =
+            select_preferred_running_chrome_target(&mut targets, Some(sticky_path.as_path()))
+                .unwrap();
+        assert_eq!(
+            sticky_choice.ws_endpoint,
+            "ws://127.0.0.1:9222/devtools/browser/chatgpt"
+        );
+
+        let chatgpt_choice = select_preferred_running_chrome_target(&mut targets, None).unwrap();
+        assert_eq!(
+            chatgpt_choice.ws_endpoint,
+            "ws://127.0.0.1:9222/devtools/browser/chatgpt"
+        );
+    }
+
+    #[test]
+    fn remember_cdp_target_persists_auto_selected_source_path() {
+        let _guard = lock_env();
+        let dir = unique_test_dir("browser_target_state");
+        let state_path = dir.join("browser-target.json");
+        let _state_env = EnvVarGuard::set("YOETZ_BROWSER_TARGET_PATH", &state_path);
+
+        let target = ResolvedCdpTarget {
+            endpoint: "ws://127.0.0.1:9222/devtools/browser/test".to_string(),
+            source: ResolvedCdpTargetSource::Auto,
+            description: "auto-selected running Chrome target".to_string(),
+            source_path: Some(PathBuf::from("/tmp/chrome-default/DevToolsActivePort")),
+        };
+
+        remember_cdp_target(&target).unwrap();
+        let loaded = load_browser_target_state().unwrap();
+        assert_eq!(
+            loaded.last_source_path,
+            Some(PathBuf::from("/tmp/chrome-default/DevToolsActivePort"))
+        );
+    }
+
+    #[test]
+    fn forget_cdp_target_clears_persisted_auto_selected_source_path() {
+        let _guard = lock_env();
+        let dir = unique_test_dir("browser_target_state_forget");
+        let state_path = dir.join("browser-target.json");
+        let _state_env = EnvVarGuard::set("YOETZ_BROWSER_TARGET_PATH", &state_path);
+
+        let target = ResolvedCdpTarget {
+            endpoint: "ws://127.0.0.1:9222/devtools/browser/test".to_string(),
+            source: ResolvedCdpTargetSource::Auto,
+            description: "auto-selected running Chrome target".to_string(),
+            source_path: Some(PathBuf::from("/tmp/chrome-default/DevToolsActivePort")),
+        };
+
+        remember_cdp_target(&target).unwrap();
+        forget_cdp_target(&target).unwrap();
+        let loaded = load_browser_target_state().unwrap();
+        assert_eq!(loaded.last_source_path, None);
+    }
+
+    #[test]
     fn interpolate_replaces_bundle_and_recipe_vars() {
         let ctx = recipe_context();
         let value = interpolate("open {{bundle_path}} {{model}}", &ctx, Some("ignored")).unwrap();
@@ -3404,6 +3803,31 @@ mod tests {
     fn is_chrome_cdp_unreachable_error_rejects_unrelated_errors() {
         let err = anyhow!("ChatGPT response timed out after 900000ms");
         assert!(!is_chrome_cdp_unreachable_error(&err));
+    }
+
+    #[test]
+    fn is_chrome_cdp_unreachable_error_requires_a_real_cdp_failure_shape() {
+        let err = anyhow!("read the docs at chrome://inspect/#remote-debugging before retrying");
+        assert!(!is_chrome_cdp_unreachable_error(&err));
+    }
+
+    #[test]
+    fn is_chatgpt_auth_issue_error_detects_login_and_challenge_errors() {
+        let login = anyhow!(
+            "chatgpt login required in the attached Chrome session. Log in there and try again."
+        );
+        let challenge = anyhow!(
+            "cloudflare challenge detected in the attached Chrome session. Solve it in your browser window and try again."
+        );
+        let captcha = anyhow!(
+            "captcha detected in the attached Chrome session, but stdin is not interactive."
+        );
+        let other = anyhow!("browserType.connectOverCDP: failed to list pages");
+
+        assert!(is_chatgpt_auth_issue_error(&login));
+        assert!(is_chatgpt_auth_issue_error(&challenge));
+        assert!(is_chatgpt_auth_issue_error(&captcha));
+        assert!(!is_chatgpt_auth_issue_error(&other));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -141,33 +141,6 @@ pub fn use_dev_browser() -> bool {
     crate::dev_browser::is_available()
 }
 
-/// Detect whether `chrome-devtools-mcp` is installed and callable.
-///
-/// Returns true when either (a) the globally installed
-/// `chrome-devtools-mcp` binary is on `PATH` (fast path, from
-/// `npm install -g chrome-devtools-mcp`), or (b) `npx` is on `PATH` as a
-/// transparent fallback — npx ships with Node.js and is the default
-/// recipe runner when no global install exists yet.
-///
-/// This detection is cheap (PATH walks + `is_file`) and synchronous, so
-/// it is safe to call from the transport funnel walker without
-/// triggering a subprocess spawn or a network fetch.
-pub fn is_chrome_devtools_mcp_available() -> bool {
-    let Some(path_env) = env::var_os("PATH") else {
-        return false;
-    };
-    let mut has_npx = false;
-    for dir in env::split_paths(&path_env) {
-        if dir.join("chrome-devtools-mcp").is_file() {
-            return true;
-        }
-        if !has_npx && dir.join("npx").is_file() {
-            has_npx = true;
-        }
-    }
-    has_npx
-}
-
 pub fn recipe_transports(recipe: &Recipe, is_chatgpt: bool) -> Vec<RecipeTransport> {
     recipe.transports.clone().unwrap_or_else(|| {
         if is_chatgpt {
@@ -3824,27 +3797,6 @@ steps:
             recipe_transports(&recipe, false),
             vec![RecipeTransport::AgentBrowser]
         );
-    }
-
-    #[test]
-    fn chrome_devtools_mcp_availability_matches_path() {
-        // The detector should return true when either `chrome-devtools-mcp`
-        // itself is on PATH (e.g. `npm install -g chrome-devtools-mcp`) OR
-        // when `npx` is on PATH as a transparent fallback. On any developer
-        // machine running this test suite, at least one of the two is
-        // expected to be present (yoetz's own CI installs Node).
-        //
-        // If the test environment does not have Node at all, the detector
-        // correctly returns false — that's a valid "transport unavailable"
-        // signal and the funnel walker skips the tier.
-        let expected = env::var_os("PATH")
-            .map(|path_env| {
-                env::split_paths(&path_env).any(|dir| {
-                    dir.join("chrome-devtools-mcp").is_file() || dir.join("npx").is_file()
-                })
-            })
-            .unwrap_or(false);
-        assert_eq!(is_chrome_devtools_mcp_available(), expected);
     }
 
     #[test]

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -1311,6 +1311,22 @@ pub fn is_chrome_approval_wait_error(err: &anyhow::Error) -> bool {
         .contains("allow remote debugging")
 }
 
+/// Detect the actionable "Chrome CDP unreachable" error produced by
+/// `chrome_devtools_mcp::chatgpt::cdp_attach_hint`.
+///
+/// When tier 1 (chrome-devtools-mcp) already determined that Chrome is not
+/// listening on CDP, the funnel should skip all remaining *live* transports
+/// — dev-browser and agent-browser are the same CDP endpoint behind
+/// different adapters, so they will fail for the same reason (dev-browser's
+/// Playwright `connectOverCDP` in particular hangs instead of failing fast).
+/// Stopping at tier 1 and jumping to manual gives the user an immediate,
+/// actionable error instead of a long wait.
+pub fn is_chrome_cdp_unreachable_error(err: &anyhow::Error) -> bool {
+    format!("{err:#}")
+        .to_lowercase()
+        .contains("chrome://inspect")
+}
+
 fn close_browser_daemon() -> Result<()> {
     let (bin, prefix_args) = resolve_agent_browser()?;
     let mut cmd = Command::new(bin);
@@ -3368,6 +3384,26 @@ mod tests {
     fn is_chrome_approval_wait_error_rejects_non_approval_timeouts() {
         let err = anyhow!("ChatGPT response timed out after 900000ms");
         assert!(!is_chrome_approval_wait_error(&err));
+    }
+
+    #[test]
+    fn is_chrome_cdp_unreachable_error_detects_wrapped_hint() {
+        let err =
+            anyhow!("requesting `http://127.0.0.1:9222/json/version` failed: connection refused")
+                .context(
+                    "chrome-devtools-mcp could not reach Chrome's CDP endpoint. \
+                 Chrome 136+ ignores --remote-debugging-port on the default profile — \
+                 either enable chrome://inspect/#remote-debugging (Chrome 144+) and retry, \
+                 or pass --cdp=ws://127.0.0.1:PORT after launching Chrome with a non-default \
+                 --user-data-dir, or use Chrome for Testing",
+                );
+        assert!(is_chrome_cdp_unreachable_error(&err));
+    }
+
+    #[test]
+    fn is_chrome_cdp_unreachable_error_rejects_unrelated_errors() {
+        let err = anyhow!("ChatGPT response timed out after 900000ms");
+        assert!(!is_chrome_cdp_unreachable_error(&err));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
@@ -72,7 +72,7 @@ pub async fn run(ctx: &DevtoolsMcpRecipeContext) -> Result<String> {
     }
     let client = CdpMcpClient::connect_to_running_chrome(ctx.cdp_endpoint.as_deref())
         .await
-        .context("chrome-devtools-mcp attach to running Chrome")?;
+        .map_err(cdp_attach_hint)?;
 
     // Step 1: open a fresh chatgpt.com page. Fresh page = zero conversation
     // history, no SPA reset dance needed.
@@ -197,6 +197,29 @@ async () => {
         .context("stable-idle polling for ChatGPT response")?;
 
     Ok(response_text)
+}
+
+/// Rewrite a CDP attach failure with actionable guidance.
+///
+/// Chrome 136+ ignores `--remote-debugging-port` on the default profile, so
+/// the most common failure mode is "port 9222 not listening" — which surfaces
+/// as a refused TCP connection or a non-2xx response on `/json/version`.
+/// Instead of leaking the raw reqwest error, point the user at the fix.
+fn cdp_attach_hint(err: anyhow::Error) -> anyhow::Error {
+    let raw = format!("{err:#}");
+    // Preserve approval-dialog errors verbatim so the outer fallback funnel can
+    // classify them as "stop, user needs to click Allow" rather than
+    // "transport broken, try the next one."
+    if raw.to_lowercase().contains("allow remote debugging") {
+        return err.context("chrome-devtools-mcp attach to running Chrome");
+    }
+    err.context(
+        "chrome-devtools-mcp could not reach Chrome's CDP endpoint. \
+         Chrome 136+ ignores --remote-debugging-port on the default profile — \
+         either enable chrome://inspect/#remote-debugging (Chrome 144+) and retry, \
+         or pass --cdp=ws://127.0.0.1:PORT after launching Chrome with a non-default \
+         --user-data-dir, or use Chrome for Testing",
+    )
 }
 
 /// Click the attach button, snapshot the mounted upload affordance, then call
@@ -679,4 +702,30 @@ mod tests {
         assert!(STABLE_IDLE_CONSECUTIVE_POLLS >= 2);
         assert!(!CHATGPT_URL.is_empty());
     };
+
+    #[test]
+    fn cdp_attach_hint_preserves_approval_dialog_errors() {
+        // Approval-wait errors must pass through so the outer transport funnel
+        // can classify them as "user needs to click Allow" (stop-fallback)
+        // rather than wrap them in generic Chrome-136+ guidance.
+        let err = anyhow!(
+            "live browser attach timed out (30s). Chrome may be showing an \"Allow remote debugging?\" dialog — click Allow, then retry."
+        );
+        let rewritten = cdp_attach_hint(err);
+        let msg = format!("{rewritten:#}");
+        assert!(msg.contains("Allow remote debugging"));
+        assert!(!msg.contains("chrome://inspect"));
+    }
+
+    #[test]
+    fn cdp_attach_hint_wraps_other_errors_with_actionable_guidance() {
+        let err =
+            anyhow!("requesting `http://127.0.0.1:9222/json/version` failed: connection refused");
+        let rewritten = cdp_attach_hint(err);
+        let msg = format!("{rewritten:#}");
+        assert!(msg.contains("chrome://inspect"));
+        assert!(msg.contains("Chrome 136+"));
+        // Original error chain is preserved.
+        assert!(msg.contains("connection refused"));
+    }
 }

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
@@ -47,9 +47,11 @@ const CHATGPT_URL: &str = "https://chatgpt.com/";
 const POLL_INTERVAL_MS: u64 = 5_000;
 /// Number of consecutive polls where (messageCount, textLength) must be
 /// unchanged before we declare the response complete. At 5s intervals, 4
-/// stable polls = 20s of genuinely idle generation, which is enough to
-/// distinguish "response finished" from "brief mid-stream pause."
-const STABLE_IDLE_CONSECUTIVE_POLLS: u32 = 4;
+/// stable polls = 60s of genuinely idle generation. ChatGPT Pro can pause
+/// for tens of seconds while still thinking, so keep the quiet window long
+/// enough that we do not return the early "I'm tracing the patch..." preamble
+/// as if it were the final review.
+const STABLE_IDLE_CONSECUTIVE_POLLS: u32 = 12;
 const UPLOAD_INPUT_WAIT_MS: u64 = 5_000;
 const ATTACHMENT_VERIFY_WAIT_MS: u64 = 15_000;
 
@@ -88,25 +90,90 @@ pub async fn run(ctx: &DevtoolsMcpRecipeContext) -> Result<String> {
     let wait_composer_js = r##"
 async () => {
   const deadline = Date.now() + 20000;
-  while (Date.now() < deadline) {
+  const clip = (value, max = 240) =>
+    String(value || "").replace(/\s+/g, " ").trim().slice(0, max);
+  const readState = () => {
     const composer = document.querySelector("#prompt-textarea, div[contenteditable='true'][role='textbox']");
+    const url = window.location.href || "";
+    const title = document.title || "";
+    const bodyText = clip(document.body?.innerText || "");
+    const haystack = `${title} ${bodyText}`.toLowerCase();
     if (composer) {
       composer.focus();
-      return true;
+      return { status: "ready", url, title, bodyText };
     }
-    await new Promise(r => setTimeout(r, 200));
+    if (/cloudflare|checking your browser|attention required|security check|just a moment|verify you are human|cf-chl/i.test(haystack)) {
+      return { status: "challenge", url, title, bodyText };
+    }
+    if (
+      /log in|login|sign in|sign up|create account|continue with google|continue with microsoft|continue with apple/i.test(haystack) ||
+      /auth\.openai\.com|\/auth\/|\/login/.test(url.toLowerCase())
+    ) {
+      return { status: "login", url, title, bodyText };
+    }
+    return { status: "pending", url, title, bodyText };
+  };
+
+  let state = readState();
+  if (state.status !== "pending") return state;
+
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    state = readState();
+    if (state.status !== "pending") return state;
   }
-  return false;
+
+  state.status = "timeout";
+  return state;
 }
 "##;
-    let composer_ready = client
+    let composer_state = client
         .evaluate_script(wait_composer_js, vec![])
         .await
         .context("evaluate_script wait-for-composer")?;
-    if composer_ready != serde_json::Value::Bool(true) {
-        return Err(anyhow!(
-            "ChatGPT composer did not mount within 20s — page may not have loaded correctly"
-        ));
+    match composer_state
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+    {
+        Some("ready") => {}
+        Some("challenge") => {
+            return Err(anyhow!(
+                "cloudflare challenge detected in the attached Chrome session. Solve it in your browser window and try again. {}",
+                format_page_probe_summary(&composer_state)
+            ));
+        }
+        Some("login") => {
+            return Err(anyhow!(
+                "chatgpt login required in the attached Chrome session. Log in there and try again. {}",
+                format_page_probe_summary(&composer_state)
+            ));
+        }
+        _ => {
+            let detail = match classify_live_chatgpt_page_issue(
+                composer_state
+                    .get("url")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default(),
+                composer_state
+                    .get("title")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default(),
+                composer_state
+                    .get("bodyText")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default(),
+            ) {
+                Some(issue) => issue.to_string(),
+                None => {
+                    "ChatGPT composer did not mount within 20s — page may not have loaded correctly"
+                        .to_string()
+                }
+            };
+            return Err(anyhow!(
+                "{detail}. {}",
+                format_page_probe_summary(&composer_state)
+            ));
+        }
     }
 
     // Step 3: upload the bundle if we have a path.
@@ -220,6 +287,89 @@ fn cdp_attach_hint(err: anyhow::Error) -> anyhow::Error {
          or pass --cdp=ws://127.0.0.1:PORT after launching Chrome with a non-default \
          --user-data-dir, or use Chrome for Testing",
     )
+}
+
+fn is_closed_cdp_transport_error(err: &anyhow::Error) -> bool {
+    let raw = format!("{err:#}").to_lowercase();
+    raw.contains("underlying connection is closed")
+        || raw.contains("connectionclosed")
+        || raw.contains("received shutdown message")
+}
+
+fn classify_live_chatgpt_page_issue(
+    url: &str,
+    title: &str,
+    body_text: &str,
+) -> Option<&'static str> {
+    let haystack = format!("{title} {body_text}").to_lowercase();
+    let url = url.to_lowercase();
+    if [
+        "cloudflare",
+        "checking your browser",
+        "attention required",
+        "security check",
+        "just a moment",
+        "verify you are human",
+        "cf-chl",
+    ]
+    .iter()
+    .any(|marker| haystack.contains(marker))
+    {
+        return Some(
+            "cloudflare challenge detected in the attached Chrome session. Solve it in your browser window and try again",
+        );
+    }
+
+    if [
+        "log in",
+        "login",
+        "sign in",
+        "sign up",
+        "create account",
+        "continue with google",
+        "continue with microsoft",
+        "continue with apple",
+    ]
+    .iter()
+    .any(|marker| haystack.contains(marker))
+        || url.contains("auth.openai.com")
+        || url.contains("/auth/")
+        || url.contains("/login")
+    {
+        return Some(
+            "chatgpt login required in the attached Chrome session. Log in there and try again",
+        );
+    }
+
+    None
+}
+
+fn format_page_probe_summary(state: &serde_json::Value) -> String {
+    let url = state
+        .get("url")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("unknown");
+    let title = state
+        .get("title")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("")
+        .trim();
+    let body_text = state
+        .get("bodyText")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("")
+        .trim();
+    let title_part = if title.is_empty() {
+        "title=<empty>".to_string()
+    } else {
+        format!("title={title:?}")
+    };
+    let body_part = if body_text.is_empty() {
+        "body=<empty>".to_string()
+    } else {
+        format!("body={body_text:?}")
+    };
+    format!("Current page: url={url}, {title_part}, {body_part}")
 }
 
 /// Click the attach button, snapshot the mounted upload affordance, then call
@@ -589,11 +739,33 @@ async fn poll_for_stable_response(
     let read_state_js = r##"
 () => {
   const nodes = Array.from(document.querySelectorAll("[data-message-author-role='assistant']"));
+  const stopSelectors = [
+    "[data-testid='stop-button']",
+    "[data-testid='fruitjuice-stop-button']",
+    "button[aria-label*='Stop']",
+    "button[aria-label*='stop']",
+  ];
+  const stopGenerating = stopSelectors.some((sel) => {
+    const el = document.querySelector(sel);
+    if (!el) return false;
+    const style = window.getComputedStyle(el);
+    return style.display !== "none" && style.visibility !== "hidden" && !el.disabled;
+  });
   if (nodes.length === 0) {
-    return { ready: false, count: 0, length: 0, text: null, streaming: false };
+    return {
+      ready: false,
+      count: 0,
+      length: 0,
+      text: null,
+      streaming: stopGenerating,
+      stopGenerating,
+    };
   }
   const last = nodes[nodes.length - 1];
-  const streaming = !!last.querySelector(".result-streaming") || last.classList.contains("result-streaming");
+  const streaming =
+    stopGenerating ||
+    !!last.querySelector(".result-streaming") ||
+    last.classList.contains("result-streaming");
   const text = last.innerText || "";
   return {
     ready: !streaming && text.length > 0,
@@ -601,6 +773,7 @@ async fn poll_for_stable_response(
     length: text.length,
     text,
     streaming,
+    stopGenerating,
   };
 }
 "##;
@@ -623,6 +796,11 @@ async fn poll_for_stable_response(
         let state = match client.evaluate_script(read_state_js, vec![]).await {
             Ok(state) => state,
             Err(err) => {
+                if is_closed_cdp_transport_error(&err) {
+                    return Err(err.context(
+                        "chrome-devtools-mcp lost the Chrome websocket while waiting for the ChatGPT response",
+                    ));
+                }
                 // Treat transient eval errors as non-fatal; keep polling.
                 eprintln!("warn: stable-idle poll eval failed ({err:#}), retrying");
                 continue;
@@ -727,5 +905,41 @@ mod tests {
         assert!(msg.contains("Chrome 136+"));
         // Original error chain is preserved.
         assert!(msg.contains("connection refused"));
+    }
+
+    #[test]
+    fn classify_live_chatgpt_page_issue_detects_login_and_challenge() {
+        assert_eq!(
+            classify_live_chatgpt_page_issue(
+                "https://chatgpt.com/auth/login",
+                "Log in - OpenAI",
+                "Continue with Google"
+            ),
+            Some(
+                "chatgpt login required in the attached Chrome session. Log in there and try again"
+            )
+        );
+        assert_eq!(
+            classify_live_chatgpt_page_issue(
+                "https://chatgpt.com/",
+                "Just a moment...",
+                "Verify you are human"
+            ),
+            Some(
+                "cloudflare challenge detected in the attached Chrome session. Solve it in your browser window and try again"
+            )
+        );
+        assert_eq!(
+            classify_live_chatgpt_page_issue("https://chatgpt.com/", "ChatGPT", "Send a message"),
+            None
+        );
+    }
+
+    #[test]
+    fn closed_cdp_transport_errors_are_classified() {
+        let err = anyhow!("Unable to make method calls because underlying connection is closed");
+        assert!(is_closed_cdp_transport_error(&err));
+        let other = anyhow!("timed out waiting for ChatGPT response");
+        assert!(!is_closed_cdp_transport_error(&other));
     }
 }

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
@@ -6,12 +6,25 @@ use headless_chrome::{
     browser::tab::element::Element, protocol::cdp::Target::CreateTarget, Browser, Tab,
 };
 use reqwest::Url;
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
 use serde_json::Value;
 use std::{
+    collections::BTreeSet,
+    io::{Read, Write},
+    net::TcpStream,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime},
 };
+
+const DEFAULT_LOCAL_CDP_ENDPOINT: &str = "http://127.0.0.1:9222";
+// `headless_chrome::Browser::connect_with_timeout` uses this as the transport's
+// idle lifetime, not just the initial dial budget. ChatGPT Pro reviews can sit
+// quiet for longer than 45s while the model thinks, so keep the attached CDP
+// session alive for long-running recipes.
+const CDP_SESSION_IDLE_TIMEOUT_SECS: u64 = 60 * 60;
+const DISCOVERY_HTTP_TIMEOUT_MS: u64 = 750;
 
 pub struct CdpMcpClient {
     browser: Browser,
@@ -97,16 +110,42 @@ pub struct WaitForResult {
     pub matched_text: String,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RunningChromeTarget {
+    pub ws_endpoint: String,
+    pub source_path: PathBuf,
+    pub browser_name: String,
+    pub chatgpt_tab_count: usize,
+    pub modified_at: Option<SystemTime>,
+}
+
+impl RunningChromeTarget {
+    pub fn has_chatgpt_tab(&self) -> bool {
+        self.chatgpt_tab_count > 0
+    }
+
+    pub fn summary(&self) -> String {
+        if self.chatgpt_tab_count > 0 {
+            format!(
+                "{} at {} (chatgpt tabs: {})",
+                self.browser_name,
+                self.source_path.display(),
+                self.chatgpt_tab_count
+            )
+        } else {
+            format!("{} at {}", self.browser_name, self.source_path.display())
+        }
+    }
+}
+
 impl CdpMcpClient {
     pub async fn connect_to_running_chrome(cdp_endpoint: Option<&str>) -> Result<Self> {
-        let endpoint = cdp_endpoint.unwrap_or("http://127.0.0.1:9222");
-        let parsed = Url::parse(endpoint)
-            .with_context(|| format!("invalid Chrome CDP endpoint `{endpoint}`"))?;
-        let ws_endpoint = resolve_browser_websocket(&parsed)?;
-        let browser = Browser::connect_with_timeout(ws_endpoint.clone(), Duration::from_secs(300))
-            .with_context(|| format!("connecting to Chrome websocket `{ws_endpoint}` failed"))?;
-
-        browser.register_missing_tabs();
+        let ws_endpoint = resolve_connect_ws_endpoint(cdp_endpoint)?;
+        let browser = Browser::connect_with_timeout(
+            ws_endpoint.clone(),
+            Duration::from_secs(CDP_SESSION_IDLE_TIMEOUT_SECS),
+        )
+        .with_context(|| format!("connecting to Chrome websocket `{ws_endpoint}` failed"))?;
 
         Ok(Self {
             browser,
@@ -269,6 +308,58 @@ impl CdpMcpClient {
     }
 }
 
+fn resolve_connect_ws_endpoint(cdp_endpoint: Option<&str>) -> Result<String> {
+    match cdp_endpoint {
+        Some(endpoint) => {
+            let parsed = Url::parse(endpoint)
+                .with_context(|| format!("invalid Chrome CDP endpoint `{endpoint}`"))?;
+            resolve_browser_websocket(&parsed)
+        }
+        None => {
+            if let Some(ws_endpoint) = resolve_any_devtools_active_port_ws() {
+                return Ok(ws_endpoint);
+            }
+            let parsed = Url::parse(DEFAULT_LOCAL_CDP_ENDPOINT)
+                .expect("DEFAULT_LOCAL_CDP_ENDPOINT must be a valid URL");
+            resolve_browser_websocket(&parsed)
+        }
+    }
+}
+
+pub fn discover_running_chrome_targets() -> Vec<RunningChromeTarget> {
+    let mut seen = BTreeSet::new();
+    let mut targets = Vec::new();
+
+    for source_path in devtools_active_port_candidates() {
+        let Ok(contents) = std::fs::read_to_string(&source_path) else {
+            continue;
+        };
+        let Some(ws_endpoint) = parse_devtools_active_port(&contents, None) else {
+            continue;
+        };
+        if !seen.insert(ws_endpoint.clone()) {
+            continue;
+        }
+
+        let modified_at = std::fs::metadata(&source_path)
+            .ok()
+            .and_then(|metadata| metadata.modified().ok());
+        let browser_name = fetch_browser_name(&ws_endpoint)
+            .unwrap_or_else(|| browser_name_from_source_path(&source_path));
+        let chatgpt_tab_count = fetch_chatgpt_tab_count(&ws_endpoint).unwrap_or(0);
+
+        targets.push(RunningChromeTarget {
+            ws_endpoint,
+            source_path,
+            browser_name,
+            chatgpt_tab_count,
+            modified_at,
+        });
+    }
+
+    targets
+}
+
 fn create_target(url: &str, background: bool) -> CreateTarget {
     CreateTarget {
         url: url.to_owned(),
@@ -375,8 +466,92 @@ fn resolve_devtools_active_port_ws(endpoint: &Url) -> Option<String> {
         .find_map(|path| {
             std::fs::read_to_string(path)
                 .ok()
-                .and_then(|contents| parse_devtools_active_port(&contents, expected_port))
+                .and_then(|contents| parse_devtools_active_port(&contents, Some(expected_port)))
         })
+}
+
+fn resolve_any_devtools_active_port_ws() -> Option<String> {
+    devtools_active_port_candidates()
+        .into_iter()
+        .find_map(|path| {
+            std::fs::read_to_string(path)
+                .ok()
+                .and_then(|contents| parse_devtools_active_port(&contents, None))
+        })
+}
+
+fn fetch_browser_name(ws_endpoint: &str) -> Option<String> {
+    let payload = local_http_json::<DevtoolsVersionPayload>(ws_endpoint, "/json/version")?;
+    payload.browser.map(|browser| {
+        browser
+            .split('/')
+            .next()
+            .unwrap_or(browser.as_str())
+            .to_string()
+    })
+}
+
+fn fetch_chatgpt_tab_count(ws_endpoint: &str) -> Option<usize> {
+    let entries = local_http_json::<Vec<DevtoolsTargetListEntry>>(ws_endpoint, "/json/list")?;
+    Some(
+        entries
+            .iter()
+            .filter(|entry| entry.target_type.as_deref() == Some("page"))
+            .filter(|entry| {
+                entry.url.as_deref().is_some_and(|url| {
+                    is_chatgpt_url(url) || is_chatgpt_title(entry.title.as_deref())
+                })
+            })
+            .count(),
+    )
+}
+
+fn local_http_json<T: DeserializeOwned>(ws_endpoint: &str, path: &str) -> Option<T> {
+    let url = browser_json_endpoint_from_ws(ws_endpoint, path)?;
+    if url.scheme() != "http" {
+        return None;
+    }
+    let host = url.host_str()?;
+    let port = url.port_or_known_default()?;
+    let request_path = match url.query() {
+        Some(query) => format!("{}?{query}", url.path()),
+        None => url.path().to_string(),
+    };
+    let mut stream = TcpStream::connect((host, port)).ok()?;
+    let timeout = Some(Duration::from_millis(DISCOVERY_HTTP_TIMEOUT_MS));
+    let _ = stream.set_read_timeout(timeout);
+    let _ = stream.set_write_timeout(timeout);
+    let request =
+        format!("GET {request_path} HTTP/1.1\r\nHost: {host}:{port}\r\nConnection: close\r\n\r\n");
+    stream.write_all(request.as_bytes()).ok()?;
+    let mut response = String::new();
+    stream.read_to_string(&mut response).ok()?;
+    parse_http_json_response(&response)
+}
+
+fn parse_http_json_response<T: DeserializeOwned>(response: &str) -> Option<T> {
+    if !response.starts_with("HTTP/1.1 200") && !response.starts_with("HTTP/1.0 200") {
+        return None;
+    }
+    let (_, body) = response.split_once("\r\n\r\n")?;
+    serde_json::from_str(body).ok()
+}
+
+fn browser_json_endpoint_from_ws(ws_endpoint: &str, path: &str) -> Option<Url> {
+    let mut url = Url::parse(ws_endpoint).ok()?;
+    match url.scheme() {
+        "ws" => {
+            let _ = url.set_scheme("http");
+        }
+        "wss" => {
+            let _ = url.set_scheme("https");
+        }
+        _ => return None,
+    }
+    url.set_path(path);
+    url.set_query(None);
+    url.set_fragment(None);
+    Some(url)
 }
 
 fn is_localhost_host(endpoint: &Url) -> bool {
@@ -449,7 +624,33 @@ fn home_dir_candidates() -> Vec<PathBuf> {
     dirs
 }
 
-fn parse_devtools_active_port(contents: &str, expected_port: u16) -> Option<String> {
+fn browser_name_from_source_path(source_path: &Path) -> String {
+    let path = source_path.to_string_lossy().to_lowercase();
+    if path.contains("chrome canary") || path.contains("google-chrome-unstable") {
+        "Chrome Canary".to_string()
+    } else if path.contains("chrome beta") || path.contains("google-chrome-beta") {
+        "Chrome Beta".to_string()
+    } else if path.contains("brave-browser") {
+        "Brave".to_string()
+    } else if path.contains("chromium") {
+        "Chromium".to_string()
+    } else {
+        "Chrome".to_string()
+    }
+}
+
+fn is_chatgpt_url(url: &str) -> bool {
+    let haystack = url.to_ascii_lowercase();
+    haystack.contains("chatgpt.com") || haystack.contains("chat.openai.com")
+}
+
+fn is_chatgpt_title(title: Option<&str>) -> bool {
+    title
+        .map(|value| value.to_ascii_lowercase().contains("chatgpt"))
+        .unwrap_or(false)
+}
+
+fn parse_devtools_active_port(contents: &str, expected_port: Option<u16>) -> Option<String> {
     let lines = contents
         .lines()
         .map(str::trim)
@@ -458,11 +659,29 @@ fn parse_devtools_active_port(contents: &str, expected_port: u16) -> Option<Stri
     let port = lines.first()?.parse::<u16>().ok()?;
     let web_socket_path = *lines.get(1)?;
 
-    if port != expected_port || !web_socket_path.starts_with("/devtools/browser/") {
+    if expected_port.is_some_and(|expected| port != expected)
+        || !web_socket_path.starts_with("/devtools/browser/")
+    {
         return None;
     }
 
     Some(format!("ws://127.0.0.1:{port}{web_socket_path}"))
+}
+
+#[derive(Debug, Deserialize)]
+struct DevtoolsVersionPayload {
+    #[serde(rename = "Browser")]
+    browser: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DevtoolsTargetListEntry {
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default, rename = "type")]
+    target_type: Option<String>,
 }
 
 fn find_snapshot_element<'a>(tab: &'a Arc<Tab>, uid: &str) -> Result<Element<'a>> {
@@ -836,7 +1055,8 @@ mod tests {
 
     #[test]
     fn parse_devtools_active_port_returns_browser_websocket() {
-        let parsed = parse_devtools_active_port("9222\n/devtools/browser/from-active-port\n", 9222);
+        let parsed =
+            parse_devtools_active_port("9222\n/devtools/browser/from-active-port\n", Some(9222));
         assert_eq!(
             parsed.as_deref(),
             Some("ws://127.0.0.1:9222/devtools/browser/from-active-port")
@@ -845,7 +1065,47 @@ mod tests {
 
     #[test]
     fn parse_devtools_active_port_rejects_mismatched_port_or_path() {
-        assert!(parse_devtools_active_port("9333\n/devtools/browser/x\n", 9222).is_none());
-        assert!(parse_devtools_active_port("9222\n/devtools/page/x\n", 9222).is_none());
+        assert!(parse_devtools_active_port("9333\n/devtools/browser/x\n", Some(9222)).is_none());
+        assert!(parse_devtools_active_port("9222\n/devtools/page/x\n", Some(9222)).is_none());
+    }
+
+    #[test]
+    fn parse_devtools_active_port_allows_auto_discovery_without_expected_port() {
+        let parsed = parse_devtools_active_port("9333\n/devtools/browser/from-active-port\n", None);
+        assert_eq!(
+            parsed.as_deref(),
+            Some("ws://127.0.0.1:9333/devtools/browser/from-active-port")
+        );
+    }
+
+    #[test]
+    fn browser_name_from_source_path_prefers_family_specific_labels() {
+        assert_eq!(
+            browser_name_from_source_path(Path::new(
+                "/Users/test/Library/Application Support/Google/Chrome Canary/DevToolsActivePort"
+            )),
+            "Chrome Canary"
+        );
+        assert_eq!(
+            browser_name_from_source_path(Path::new(
+                "/Users/test/Library/Application Support/BraveSoftware/Brave-Browser/DevToolsActivePort"
+            )),
+            "Brave"
+        );
+        assert_eq!(
+            browser_name_from_source_path(Path::new(
+                "/home/test/.config/chromium/DevToolsActivePort"
+            )),
+            "Chromium"
+        );
+    }
+
+    #[test]
+    fn chatgpt_matchers_cover_url_and_title() {
+        assert!(is_chatgpt_url("https://chatgpt.com/c/123"));
+        assert!(is_chatgpt_url("https://chat.openai.com/"));
+        assert!(!is_chatgpt_url("https://example.com/"));
+        assert!(is_chatgpt_title(Some("ChatGPT - New chat")));
+        assert!(!is_chatgpt_title(Some("Docs")));
     }
 }

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -20,9 +20,12 @@ use std::collections::BTreeMap;
 use std::env;
 #[cfg(test)]
 use std::fs;
+use std::io::{self, Read};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Output, Stdio};
 use std::sync::OnceLock;
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
 
 #[cfg(test)]
 use yoetz_core::paths::home_dir;
@@ -35,6 +38,8 @@ static DEV_BROWSER: OnceLock<String> = OnceLock::new();
 /// Default timeout for dev-browser scripts in seconds.
 const DEFAULT_SCRIPT_TIMEOUT_SECS: u64 = 30;
 const DEV_BROWSER_ATTACH_TO_OTHER_ENV: &str = "PW_CHROMIUM_ATTACH_TO_OTHER";
+const DEV_BROWSER_PARENT_TIMEOUT_GRACE_SECS: u64 = 20;
+const DEV_BROWSER_WAIT_POLL_MS: u64 = 100;
 
 /// Extended timeout for ChatGPT response polling (30 minutes by default).
 const CHATGPT_POLL_TIMEOUT_MS_DEFAULT: u64 = 1_800_000;
@@ -321,21 +326,25 @@ fn run_script_connect_with_browser_and_endpoint(
     let resolved_endpoint = resolve_dev_browser_connect_endpoint(cdp_endpoint)?;
     let args = connect_args(timeout, browser_name, resolved_endpoint.as_deref());
 
-    let output = dev_browser_command(&bin)
+    let mut child = dev_browser_command(&bin)
         .args(&args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .and_then(|mut child| {
-            use std::io::Write;
-            if let Some(ref mut stdin) = child.stdin {
-                stdin.write_all(script.as_bytes())?;
-            }
-            drop(child.stdin.take());
-            child.wait_with_output()
-        })
         .with_context(|| format!("failed to run dev-browser (via {bin})"))?;
+    {
+        use std::io::Write;
+        if let Some(ref mut stdin) = child.stdin {
+            stdin.write_all(script.as_bytes())?;
+        }
+    }
+    drop(child.stdin.take());
+    let output = wait_with_output_timeout(
+        child,
+        Duration::from_secs(timeout.saturating_add(DEV_BROWSER_PARENT_TIMEOUT_GRACE_SECS)),
+    )
+    .with_context(|| format!("failed to run dev-browser (via {bin})"))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -359,17 +368,93 @@ fn run_script_connect_with_browser_and_endpoint(
             return Ok(recovered.to_string());
         }
 
-        let detail = if !stderr.is_empty() {
-            stderr.to_string()
-        } else if !stdout.is_empty() {
-            stdout.to_string()
-        } else {
-            format!("exit code {:?}", output.status.code())
-        };
+        let detail = format_dev_browser_output_detail(&output);
         return Err(anyhow!("dev-browser script failed: {detail}"));
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn wait_with_output_timeout(mut child: Child, timeout: Duration) -> Result<Output> {
+    let stdout_reader = child.stdout.take().map(spawn_pipe_reader);
+    let stderr_reader = child.stderr.take().map(spawn_pipe_reader);
+    let deadline = Instant::now() + timeout;
+    let mut timed_out = false;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    timed_out = true;
+                    let _ = child.kill();
+                    break child
+                        .wait()
+                        .context("failed to stop timed out dev-browser child")?;
+                }
+                thread::sleep(Duration::from_millis(DEV_BROWSER_WAIT_POLL_MS));
+            }
+            Err(err) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = join_pipe_reader(stdout_reader, "stdout");
+                let _ = join_pipe_reader(stderr_reader, "stderr");
+                return Err(err).context("failed while waiting for dev-browser child");
+            }
+        }
+    };
+    let stdout = join_pipe_reader(stdout_reader, "stdout")?;
+    let stderr = join_pipe_reader(stderr_reader, "stderr")?;
+    let output = Output {
+        status,
+        stdout,
+        stderr,
+    };
+
+    if timed_out {
+        let detail = format_dev_browser_output_detail(&output);
+        Err(anyhow!(
+            "dev-browser timed out after {}s while waiting for script output: {detail}",
+            timeout.as_secs()
+        ))
+    } else {
+        Ok(output)
+    }
+}
+
+fn spawn_pipe_reader<R>(mut reader: R) -> JoinHandle<io::Result<Vec<u8>>>
+where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || {
+        let mut buf = Vec::new();
+        reader.read_to_end(&mut buf)?;
+        Ok(buf)
+    })
+}
+
+fn join_pipe_reader(
+    reader: Option<JoinHandle<io::Result<Vec<u8>>>>,
+    label: &str,
+) -> Result<Vec<u8>> {
+    match reader {
+        Some(reader) => reader
+            .join()
+            .map_err(|_| anyhow!("dev-browser {label} reader thread panicked"))?
+            .with_context(|| format!("failed to read dev-browser {label}")),
+        None => Ok(Vec::new()),
+    }
+}
+
+fn format_dev_browser_output_detail(output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if !stderr.trim().is_empty() {
+        stderr.to_string()
+    } else if !stdout.trim().is_empty() {
+        stdout.to_string()
+    } else {
+        format!("exit code {:?}", output.status.code())
+    }
 }
 
 fn dev_browser_command(bin: &str) -> Command {
@@ -481,10 +566,14 @@ try {
 /// Ensure the connected Chrome session can reach an authenticated ChatGPT page.
 /// Opens a temporary page — use only when not immediately followed by a recipe.
 pub fn ensure_chatgpt_auth_with_page_check_and_endpoint(cdp_endpoint: Option<&str>) -> Result<()> {
-    check_connection_with_endpoint(cdp_endpoint).context(
-        "dev-browser cannot connect to Chrome. Enable remote debugging: chrome://inspect/#remote-debugging",
-    )?;
+    eprintln!("info: probing Chrome reachability via dev-browser");
+    check_connection_with_endpoint(cdp_endpoint)
+        .map_err(maybe_add_dev_browser_connect_guidance)
+        .context(
+            "dev-browser cannot connect to Chrome. Enable remote debugging: chrome://inspect/#remote-debugging",
+        )?;
 
+    eprintln!("info: probing ChatGPT auth state via dev-browser");
     if check_chatgpt_auth_with_endpoint(cdp_endpoint)? {
         return Ok(());
     }

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -690,6 +690,7 @@ const PROTECTED_DOTENV_ENV_VARS: &[&str] = &[
     "YOETZ_CONFIG_PATH",
     "YOETZ_REGISTRY_PATH",
     "YOETZ_BROWSER_CDP",
+    "YOETZ_BROWSER_TARGET_PATH",
     "YOETZ_BROWSER_PROFILE",
     "OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",
@@ -923,8 +924,20 @@ fn recipe_has_remaining_manual_fallback(
         .any(|next| matches!(next, browser::RecipeTransport::Manual))
 }
 
-fn recipe_should_stop_live_transport_fallback(err: &anyhow::Error) -> bool {
-    browser::is_chrome_approval_wait_error(err)
+fn recipe_should_stop_live_transport_fallback(
+    err: &anyhow::Error,
+    selected_cdp_target: Option<&browser::ResolvedCdpTarget>,
+    transport: browser::RecipeTransport,
+) -> bool {
+    if browser::is_chrome_approval_wait_error(err) {
+        return true;
+    }
+
+    // Once the user or config has pinned a specific live Chrome target, do not
+    // fan out into more browser transports after the first failure. Auto-
+    // selected targets are only heuristics and remain advisory.
+    selected_cdp_target.is_some_and(browser::ResolvedCdpTarget::is_authoritative)
+        && !matches!(transport, browser::RecipeTransport::Manual)
 }
 
 /// A transport is "pure live-CDP" if its only way to drive the browser is
@@ -951,6 +964,21 @@ fn recipe_should_skip_remaining_live_cdp_transports(err: &anyhow::Error) -> bool
     browser::is_chrome_cdp_unreachable_error(err)
 }
 
+fn maybe_print_auto_selected_cdp_target(
+    target: Option<&browser::ResolvedCdpTarget>,
+    format: OutputFormat,
+) {
+    if !matches!(format, OutputFormat::Text | OutputFormat::Markdown) {
+        return;
+    }
+    let Some(target) = target else {
+        return;
+    };
+    if target.is_auto_discovered() {
+        eprintln!("info: {}", target.description);
+    }
+}
+
 fn explicit_cdp_attach_failure(err: anyhow::Error) -> anyhow::Error {
     if browser::is_chrome_approval_wait_error(&err) {
         anyhow!(
@@ -959,6 +987,69 @@ fn explicit_cdp_attach_failure(err: anyhow::Error) -> anyhow::Error {
         )
     } else {
         err.context("explicit --cdp failed; not falling back")
+    }
+}
+
+fn configured_cdp_attach_failure(err: anyhow::Error) -> anyhow::Error {
+    if browser::is_chrome_approval_wait_error(&err) {
+        anyhow!(
+            "Chrome may be showing an \"Allow remote debugging?\" dialog. \
+             Click Allow, then retry."
+        )
+    } else {
+        err.context("configured CDP target failed; not falling back")
+    }
+}
+
+fn resolved_cdp_attach_failure(
+    err: anyhow::Error,
+    target: &browser::ResolvedCdpTarget,
+) -> anyhow::Error {
+    match target.source {
+        browser::ResolvedCdpTargetSource::Flag => explicit_cdp_attach_failure(err),
+        browser::ResolvedCdpTargetSource::Env | browser::ResolvedCdpTargetSource::Config => {
+            configured_cdp_attach_failure(err)
+        }
+        browser::ResolvedCdpTargetSource::Auto => {
+            if browser::is_chrome_approval_wait_error(&err) {
+                anyhow!(
+                    "Chrome may be showing an \"Allow remote debugging?\" dialog. \
+                     Click Allow, then retry."
+                )
+            } else {
+                err.context("selected running Chrome target failed")
+            }
+        }
+    }
+}
+
+fn profile_forces_managed_browser(profile: Option<&Path>, cdp_override: Option<&str>) -> bool {
+    profile.is_some() && cdp_override.is_none()
+}
+
+fn maybe_demote_auto_selected_cdp_target(
+    target: &mut Option<browser::ResolvedCdpTarget>,
+    format: OutputFormat,
+    err: &anyhow::Error,
+) {
+    let Some(selected) = target.as_ref() else {
+        return;
+    };
+    if !selected.is_auto_discovered() {
+        return;
+    }
+    if browser::is_chrome_approval_wait_error(err) || browser::is_chatgpt_auth_issue_error(err) {
+        return;
+    }
+
+    let description = selected.description.clone();
+    if let Err(clear_err) = browser::forget_cdp_target(selected) {
+        eprintln!("warning: failed to clear auto-selected Chrome target after error: {clear_err}");
+    }
+    *target = None;
+
+    if matches!(format, OutputFormat::Text | OutputFormat::Markdown) {
+        eprintln!("info: {description} failed ({err}); continuing with fallback discovery");
     }
 }
 
@@ -1143,55 +1234,75 @@ fn run_recipe_via_agent_browser(
     profile_dir: PathBuf,
     format: OutputFormat,
     is_chatgpt: bool,
-    cdp_endpoint: Option<&str>,
+    selected_cdp_target: &mut Option<browser::ResolvedCdpTarget>,
 ) -> Result<()> {
     let needs_auth = is_chatgpt;
     let live_connection = if needs_auth {
-        if let Some(endpoint) = cdp_endpoint.map(str::to_owned) {
-            let approval_lock = browser::acquire_chrome_approval_lock()?;
-            if matches!(format, OutputFormat::Text | OutputFormat::Markdown) {
-                if approval_lock.waited() {
-                    print_recipe_chrome_approval_lock_wait_message(
-                        browser::RecipeTransport::AgentBrowser,
-                    );
-                }
-                print_recipe_chrome_approval_message(browser::RecipeTransport::AgentBrowser);
-            }
-            match browser::try_cdp_attach(&endpoint, browser::CHATGPT_URL) {
-                Ok(()) => Some(browser::BrowserConnection::Cdp { endpoint }),
-                Err(e) => {
-                    if browser::is_chrome_approval_wait_error(&e) {
-                        return Err(anyhow!(
-                            "Chrome may be showing an \"Allow remote debugging?\" dialog. Click Allow, then retry."
-                        ));
-                    }
-                    if recipe_args.cdp.is_some() {
-                        return Err(e.context("explicit --cdp failed; not falling back"));
-                    }
-                    None
-                }
-            }
+        if profile_forces_managed_browser(
+            recipe_args.profile.as_deref(),
+            recipe_args.cdp.as_deref(),
+        ) {
+            None
         } else {
-            let approval_lock = browser::acquire_chrome_approval_lock()?;
-            let should_warn_about_approval = !browser::is_daemon_healthy();
-            if matches!(format, OutputFormat::Text | OutputFormat::Markdown) {
-                if approval_lock.waited() {
-                    print_recipe_chrome_approval_lock_wait_message(
-                        browser::RecipeTransport::AgentBrowser,
-                    );
-                }
-                if should_warn_about_approval {
+            let mut selected_live_connection = None;
+            if let Some(target) = selected_cdp_target.as_ref().cloned() {
+                let endpoint = target.endpoint.clone();
+                let approval_lock = browser::acquire_chrome_approval_lock()?;
+                if matches!(format, OutputFormat::Text | OutputFormat::Markdown) {
+                    if approval_lock.waited() {
+                        print_recipe_chrome_approval_lock_wait_message(
+                            browser::RecipeTransport::AgentBrowser,
+                        );
+                    }
                     print_recipe_chrome_approval_message(browser::RecipeTransport::AgentBrowser);
                 }
-            }
-            match browser::try_auto_connect_lite() {
-                Ok(()) => Some(browser::BrowserConnection::AutoConnect),
-                Err(_) => {
-                    if let Some(err) = default_daemon_recovery_error(None) {
-                        return Err(err);
+                match browser::try_cdp_attach_lite(&endpoint) {
+                    Ok(()) => {
+                        selected_live_connection =
+                            Some(browser::BrowserConnection::Cdp { endpoint });
                     }
-                    eprintln!("info: auto-connect unavailable, falling back to profile");
-                    None
+                    Err(e) => {
+                        if browser::is_chrome_approval_wait_error(&e) {
+                            return Err(anyhow!(
+                                "Chrome may be showing an \"Allow remote debugging?\" dialog. Click Allow, then retry."
+                            ));
+                        } else if target.is_authoritative() {
+                            return Err(resolved_cdp_attach_failure(e, &target));
+                        }
+                        maybe_demote_auto_selected_cdp_target(selected_cdp_target, format, &e);
+                    }
+                }
+            }
+
+            if let Some(connection) = selected_live_connection {
+                Some(connection)
+            } else {
+                let approval_lock = browser::acquire_chrome_approval_lock()?;
+                let should_warn_about_approval = !browser::is_daemon_healthy();
+                if matches!(format, OutputFormat::Text | OutputFormat::Markdown) {
+                    if approval_lock.waited() {
+                        print_recipe_chrome_approval_lock_wait_message(
+                            browser::RecipeTransport::AgentBrowser,
+                        );
+                    }
+                    if should_warn_about_approval {
+                        print_recipe_chrome_approval_message(
+                            browser::RecipeTransport::AgentBrowser,
+                        );
+                    }
+                }
+                match browser::try_auto_connect_lite() {
+                    Ok(()) => Some(browser::BrowserConnection::AutoConnect),
+                    Err(err) => {
+                        if browser::is_chrome_approval_wait_error(&err) {
+                            return Err(err);
+                        } else if let Some(recovery) = default_daemon_recovery_error(Some(&err)) {
+                            return Err(recovery);
+                        } else {
+                            eprintln!("info: auto-connect unavailable, falling back to profile");
+                            None
+                        }
+                    }
                 }
             }
         }
@@ -1361,11 +1472,25 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             }
         }
         BrowserCommand::Check(check_args) => {
-            let dev_browser_cdp =
-                browser::resolve_cdp_endpoint(check_args.cdp.as_deref(), &ctx.config);
+            let managed_profile_only = profile_forces_managed_browser(
+                check_args.profile.as_deref(),
+                check_args.cdp.as_deref(),
+            );
+            let mut resolved_cdp_target = browser::resolve_cdp_target_with_implicit(
+                check_args.cdp.as_deref(),
+                &ctx.config,
+                !managed_profile_only,
+            )?;
+            maybe_print_auto_selected_cdp_target(resolved_cdp_target.as_ref(), format);
+            let dev_browser_cdp = resolved_cdp_target
+                .as_ref()
+                .map(|target| target.endpoint.clone());
             if let Some(ref cdp_url) = check_args.cdp {
                 browser::try_cdp_attach(cdp_url, "https://chatgpt.com/")
                     .map_err(explicit_cdp_attach_failure)?;
+                if let Some(target) = resolved_cdp_target.as_ref() {
+                    browser::remember_cdp_target(target)?;
+                }
                 let payload = json!({
                     "status": "ok",
                     "method": format!("cdp: {cdp_url}"),
@@ -1398,6 +1523,9 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                             "method": method,
                             "backend": "dev-browser",
                         });
+                        if let Some(target) = resolved_cdp_target.as_ref() {
+                            browser::remember_cdp_target(target)?;
+                        }
                         return match format {
                             OutputFormat::Json => write_json(&payload),
                             OutputFormat::Jsonl => write_jsonl("browser.check", &payload),
@@ -1408,6 +1536,30 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         };
                     }
                     Err(e) => {
+                        if browser::is_chrome_approval_wait_error(&e)
+                            || browser::is_chatgpt_auth_issue_error(&e)
+                        {
+                            return Err(e);
+                        }
+                        if resolved_cdp_target
+                            .as_ref()
+                            .is_some_and(browser::ResolvedCdpTarget::is_authoritative)
+                        {
+                            return Err(resolved_cdp_attach_failure(
+                                e.context("dev-browser auth check failed"),
+                                resolved_cdp_target.as_ref().expect("checked above"),
+                            ));
+                        }
+                        if resolved_cdp_target
+                            .as_ref()
+                            .is_some_and(browser::ResolvedCdpTarget::is_auto_discovered)
+                        {
+                            maybe_demote_auto_selected_cdp_target(
+                                &mut resolved_cdp_target,
+                                format,
+                                &e,
+                            );
+                        }
                         eprintln!("info: dev-browser auth check failed ({e}), trying legacy path");
                     }
                 }
@@ -1415,18 +1567,74 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
 
             let profile_dir =
                 browser::resolve_profile_dir(&ctx.config, check_args.profile.as_ref())?;
-            let connection = browser::resolve_browser_connection(
-                &ctx.config,
-                check_args.cdp.as_deref(),
-                &profile_dir,
-                "https://chatgpt.com/",
-            )
-            .map_err(|e| {
-                if let Some(recovery) = default_daemon_recovery_error(Some(&e)) {
-                    return recovery;
+            if managed_profile_only {
+                let connection = browser::resolve_auth(&profile_dir, /* headed */ false)?;
+                let method = match &connection {
+                    browser::BrowserConnection::CookieState { .. } => "cookie_state".to_string(),
+                    browser::BrowserConnection::Profile { .. } => "profile".to_string(),
+                    browser::BrowserConnection::Cdp { endpoint } => format!("cdp: {endpoint}"),
+                    browser::BrowserConnection::AutoConnect => "auto_connect".to_string(),
+                };
+                let payload = json!({
+                    "status": "ok",
+                    "profile": profile_dir.to_string_lossy(),
+                    "method": method,
+                });
+                return match format {
+                    OutputFormat::Json => write_json(&payload),
+                    OutputFormat::Jsonl => write_jsonl("browser.check", &payload),
+                    OutputFormat::Text | OutputFormat::Markdown => {
+                        println!("Browser authenticated via {method}");
+                        Ok(())
+                    }
+                };
+            }
+
+            let connection = if let Some(target) = resolved_cdp_target.as_ref() {
+                match browser::try_cdp_attach(&target.endpoint, "https://chatgpt.com/") {
+                    Ok(()) => browser::BrowserConnection::Cdp {
+                        endpoint: target.endpoint.clone(),
+                    },
+                    Err(err) if target.is_authoritative() => {
+                        return Err(resolved_cdp_attach_failure(err, target));
+                    }
+                    Err(err) => {
+                        maybe_demote_auto_selected_cdp_target(
+                            &mut resolved_cdp_target,
+                            format,
+                            &err,
+                        );
+                        browser::resolve_browser_connection(
+                            &ctx.config,
+                            None,
+                            &profile_dir,
+                            "https://chatgpt.com/",
+                        )
+                        .map_err(|e| {
+                            if let Some(recovery) = default_daemon_recovery_error(Some(&e)) {
+                                return recovery;
+                            }
+                            e
+                        })?
+                    }
                 }
-                e
-            })?;
+            } else {
+                let fallback_cdp = resolved_cdp_target
+                    .as_ref()
+                    .map(|target| target.endpoint.as_str());
+                browser::resolve_browser_connection(
+                    &ctx.config,
+                    fallback_cdp.or(check_args.cdp.as_deref()),
+                    &profile_dir,
+                    "https://chatgpt.com/",
+                )
+                .map_err(|e| {
+                    if let Some(recovery) = default_daemon_recovery_error(Some(&e)) {
+                        return recovery;
+                    }
+                    e
+                })?
+            };
             let method = match &connection {
                 browser::BrowserConnection::Cdp { endpoint } => format!("cdp: {endpoint}"),
                 browser::BrowserConnection::AutoConnect => "auto_connect".to_string(),
@@ -1438,6 +1646,11 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 "profile": profile_dir.to_string_lossy(),
                 "method": method,
             });
+            if matches!(connection, browser::BrowserConnection::Cdp { .. }) {
+                if let Some(target) = resolved_cdp_target.as_ref() {
+                    browser::remember_cdp_target(target)?;
+                }
+            }
             match format {
                 OutputFormat::Json => write_json(&payload),
                 OutputFormat::Jsonl => write_jsonl("browser.check", &payload),
@@ -1523,8 +1736,15 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             let profile_dir =
                 browser::resolve_profile_dir(&ctx.config, recipe_args.profile.as_ref())?;
             let is_chatgpt = is_chatgpt_recipe(&recipe, &recipe_path);
-            let cdp_endpoint =
-                browser::resolve_cdp_endpoint(recipe_args.cdp.as_deref(), &ctx.config);
+            let mut resolved_cdp_target = browser::resolve_cdp_target_with_implicit(
+                recipe_args.cdp.as_deref(),
+                &ctx.config,
+                !profile_forces_managed_browser(
+                    recipe_args.profile.as_deref(),
+                    recipe_args.cdp.as_deref(),
+                ),
+            )?;
+            maybe_print_auto_selected_cdp_target(resolved_cdp_target.as_ref(), format);
             let transports = browser::recipe_transports(&recipe, is_chatgpt);
             let manual_fallback =
                 manual_browser_recipe_fallback(&recipe_path, recipe_args.bundle.as_deref());
@@ -1532,6 +1752,9 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
 
             let mut skip_remaining_live_cdp = false;
             for (index, transport) in transports.iter().copied().enumerate() {
+                let cdp_endpoint = resolved_cdp_target
+                    .as_ref()
+                    .map(|target| target.endpoint.clone());
                 if skip_remaining_live_cdp && is_live_cdp_only_transport(transport) {
                     eprintln!(
                         "info: skipping {} transport — Chrome CDP was unreachable in an earlier tier",
@@ -1561,7 +1784,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         profile_dir.clone(),
                         format,
                         is_chatgpt,
-                        cdp_endpoint.as_deref(),
+                        &mut resolved_cdp_target,
                     ),
                     browser::RecipeTransport::ChromeDevtoolsMcp => {
                         run_recipe_via_chrome_devtools_mcp(
@@ -1577,9 +1800,35 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 };
 
                 match result {
-                    Ok(()) => return Ok(()),
+                    Ok(()) => {
+                        if matches!(
+                            transport,
+                            browser::RecipeTransport::ChromeDevtoolsMcp
+                                | browser::RecipeTransport::DevBrowser
+                                | browser::RecipeTransport::AgentBrowser
+                        ) {
+                            if let Some(target) = resolved_cdp_target.as_ref() {
+                                browser::remember_cdp_target(target)?;
+                            }
+                        }
+                        return Ok(());
+                    }
                     Err(err) => {
-                        if recipe_should_stop_live_transport_fallback(&err) {
+                        if resolved_cdp_target
+                            .as_ref()
+                            .is_some_and(browser::ResolvedCdpTarget::is_auto_discovered)
+                        {
+                            maybe_demote_auto_selected_cdp_target(
+                                &mut resolved_cdp_target,
+                                format,
+                                &err,
+                            );
+                        }
+                        if recipe_should_stop_live_transport_fallback(
+                            &err,
+                            resolved_cdp_target.as_ref(),
+                            transport,
+                        ) {
                             transport_errors.push((transport, recipe_transport_error_detail(&err)));
                             if recipe_has_remaining_manual_fallback(&transports, index) {
                                 transport_errors.push((
@@ -1607,15 +1856,26 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
         }
         BrowserCommand::Attach(attach_args) => {
             // Try explicit CDP first, then auto-connect. No cookie fallback for attach.
-            let cdp_endpoint =
-                browser::resolve_cdp_endpoint(attach_args.cdp.as_deref(), &ctx.config);
+            let mut resolved_cdp_target =
+                browser::resolve_cdp_target(attach_args.cdp.as_deref(), &ctx.config)?;
+            maybe_print_auto_selected_cdp_target(resolved_cdp_target.as_ref(), format);
+            let cdp_endpoint = resolved_cdp_target
+                .as_ref()
+                .map(|target| target.endpoint.as_str());
 
-            if let Some(ref endpoint) = cdp_endpoint {
+            if let Some(endpoint) = cdp_endpoint {
                 match browser::try_cdp_attach(endpoint, "https://chatgpt.com/") {
                     Ok(()) => {
+                        if let Some(target) = resolved_cdp_target.as_ref() {
+                            browser::remember_cdp_target(target)?;
+                        }
                         let payload = json!({
                             "status": "ok",
-                            "method": "cdp_explicit",
+                            "method": if attach_args.cdp.is_some() {
+                                "cdp_explicit"
+                            } else {
+                                "cdp_selected"
+                            },
                             "endpoint": endpoint,
                         });
                         return match format {
@@ -1629,6 +1889,21 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                     }
                     Err(e) if attach_args.cdp.is_some() => {
                         return Err(explicit_cdp_attach_failure(e));
+                    }
+                    Err(e)
+                        if resolved_cdp_target
+                            .as_ref()
+                            .is_some_and(browser::ResolvedCdpTarget::is_authoritative) =>
+                    {
+                        let target = resolved_cdp_target.as_ref().expect("checked above");
+                        return Err(resolved_cdp_attach_failure(e, target));
+                    }
+                    Err(e)
+                        if resolved_cdp_target
+                            .as_ref()
+                            .is_some_and(browser::ResolvedCdpTarget::is_auto_discovered) =>
+                    {
+                        maybe_demote_auto_selected_cdp_target(&mut resolved_cdp_target, format, &e);
                     }
                     Err(_) => {}
                 }
@@ -1649,8 +1924,13 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         }
                     };
                 }
-                Err(_) => {
-                    if let Some(recovery) = default_daemon_recovery_error(None) {
+                Err(err) => {
+                    if browser::is_chrome_approval_wait_error(&err)
+                        || browser::is_chatgpt_auth_issue_error(&err)
+                    {
+                        return Err(err);
+                    }
+                    if let Some(recovery) = default_daemon_recovery_error(Some(&err)) {
                         return Err(recovery);
                     }
                 }
@@ -2144,6 +2424,7 @@ mod tests {
             "YOETZ_CONFIG_PATH",
             "YOETZ_REGISTRY_PATH",
             "YOETZ_BROWSER_CDP",
+            "YOETZ_BROWSER_TARGET_PATH",
             "YOETZ_BROWSER_PROFILE",
         ] {
             assert!(
@@ -2158,13 +2439,37 @@ mod tests {
         let err = anyhow!(
             "live browser attach timed out (30s). Chrome may be showing an \"Allow remote debugging?\" dialog — please click Allow in Chrome, then retry."
         );
-        assert!(recipe_should_stop_live_transport_fallback(&err));
+        assert!(recipe_should_stop_live_transport_fallback(
+            &err,
+            None,
+            browser::RecipeTransport::ChromeDevtoolsMcp
+        ));
     }
 
     #[test]
     fn recipe_should_not_stop_live_transport_fallback_on_non_approval_error() {
         let err = anyhow!("chatgpt send button not found");
-        assert!(!recipe_should_stop_live_transport_fallback(&err));
+        assert!(!recipe_should_stop_live_transport_fallback(
+            &err,
+            None,
+            browser::RecipeTransport::ChromeDevtoolsMcp
+        ));
+    }
+
+    #[test]
+    fn recipe_should_stop_live_transport_fallback_when_target_is_selected() {
+        let err = anyhow!("chrome-devtools-mcp new_page on chatgpt.com");
+        let target = browser::resolve_cdp_target(
+            Some("ws://127.0.0.1:9222/devtools/browser/example"),
+            &Config::default(),
+        )
+        .unwrap()
+        .unwrap();
+        assert!(recipe_should_stop_live_transport_fallback(
+            &err,
+            Some(&target),
+            browser::RecipeTransport::ChromeDevtoolsMcp
+        ));
     }
 
     #[test]
@@ -2188,7 +2493,11 @@ mod tests {
         assert!(recipe_should_skip_remaining_live_cdp_transports(&err));
         // Crucial invariant: CDP-unreachable must NOT stop the whole
         // funnel — agent-browser still gets a chance via managed profile.
-        assert!(!recipe_should_stop_live_transport_fallback(&err));
+        assert!(!recipe_should_stop_live_transport_fallback(
+            &err,
+            None,
+            browser::RecipeTransport::ChromeDevtoolsMcp
+        ));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -924,7 +924,31 @@ fn recipe_has_remaining_manual_fallback(
 }
 
 fn recipe_should_stop_live_transport_fallback(err: &anyhow::Error) -> bool {
-    browser::is_chrome_approval_wait_error(err) || browser::is_chrome_cdp_unreachable_error(err)
+    browser::is_chrome_approval_wait_error(err)
+}
+
+/// A transport is "pure live-CDP" if its only way to drive the browser is
+/// attaching to a running Chrome over CDP. `chrome-devtools-mcp` (vendored
+/// headless_chrome) and `dev-browser` (Playwright `connectOverCDP`) are
+/// pure live-CDP. `agent-browser` is NOT — when live-attach fails, it
+/// transparently falls back to a managed profile with stored cookies, so
+/// it still works on Chrome 146+ default profiles where CDP is unreachable.
+/// `manual` never needs CDP.
+fn is_live_cdp_only_transport(transport: browser::RecipeTransport) -> bool {
+    matches!(
+        transport,
+        browser::RecipeTransport::ChromeDevtoolsMcp | browser::RecipeTransport::DevBrowser
+    )
+}
+
+/// When tier 1 (chrome-devtools-mcp) already determined Chrome is not
+/// listening on CDP, any other pure live-CDP transport will fail for the
+/// same reason — and dev-browser's Playwright `connectOverCDP` in
+/// particular hangs on `Target.setAutoAttach` instead of failing fast.
+/// Skip those tiers but still let agent-browser try (it can fall back to
+/// managed profile without CDP).
+fn recipe_should_skip_remaining_live_cdp_transports(err: &anyhow::Error) -> bool {
+    browser::is_chrome_cdp_unreachable_error(err)
 }
 
 fn explicit_cdp_attach_failure(err: anyhow::Error) -> anyhow::Error {
@@ -1506,7 +1530,15 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 manual_browser_recipe_fallback(&recipe_path, recipe_args.bundle.as_deref());
             let mut transport_errors = Vec::new();
 
+            let mut skip_remaining_live_cdp = false;
             for (index, transport) in transports.iter().copied().enumerate() {
+                if skip_remaining_live_cdp && is_live_cdp_only_transport(transport) {
+                    eprintln!(
+                        "info: skipping {} transport — Chrome CDP was unreachable in an earlier tier",
+                        recipe_transport_name(transport)
+                    );
+                    continue;
+                }
                 if !matches!(transport, browser::RecipeTransport::Manual) {
                     eprintln!(
                         "info: attempting {} transport",
@@ -1556,6 +1588,9 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                                 ));
                             }
                             break;
+                        }
+                        if recipe_should_skip_remaining_live_cdp_transports(&err) {
+                            skip_remaining_live_cdp = true;
                         }
                         if !matches!(transport, browser::RecipeTransport::Manual) {
                             eprintln!(
@@ -2133,12 +2168,14 @@ mod tests {
     }
 
     #[test]
-    fn recipe_should_stop_live_transport_fallback_on_cdp_unreachable() {
+    fn recipe_should_skip_remaining_live_cdp_transports_on_cdp_unreachable() {
         // When tier 1 (chrome-devtools-mcp) fails because Chrome is not
-        // listening on CDP at all, dev-browser and agent-browser will fail
-        // for the same reason. Stop the live fallback immediately and fall
-        // through to the manual path so the user gets an actionable error
-        // rather than waiting on dev-browser's `Target.setAutoAttach` hang.
+        // listening on CDP at all, dev-browser will fail for the same
+        // reason and Playwright's `connectOverCDP` hangs on
+        // `Target.setAutoAttach` instead of failing fast. Skip remaining
+        // pure live-CDP tiers — but NOT agent-browser, which transparently
+        // falls back from live-attach to a managed profile with stored
+        // cookies and still works without CDP.
         let err =
             anyhow!("requesting `http://127.0.0.1:9222/json/version` failed: connection refused")
                 .context(
@@ -2148,7 +2185,28 @@ mod tests {
              or pass --cdp=ws://127.0.0.1:PORT after launching Chrome with a non-default \
              --user-data-dir, or use Chrome for Testing",
                 );
-        assert!(recipe_should_stop_live_transport_fallback(&err));
+        assert!(recipe_should_skip_remaining_live_cdp_transports(&err));
+        // Crucial invariant: CDP-unreachable must NOT stop the whole
+        // funnel — agent-browser still gets a chance via managed profile.
+        assert!(!recipe_should_stop_live_transport_fallback(&err));
+    }
+
+    #[test]
+    fn is_live_cdp_only_transport_excludes_agent_browser_and_manual() {
+        assert!(is_live_cdp_only_transport(
+            browser::RecipeTransport::ChromeDevtoolsMcp
+        ));
+        assert!(is_live_cdp_only_transport(
+            browser::RecipeTransport::DevBrowser
+        ));
+        // agent-browser has a managed-profile fallback that does not need
+        // a live CDP endpoint, so CDP-unreachable must not skip it.
+        assert!(!is_live_cdp_only_transport(
+            browser::RecipeTransport::AgentBrowser
+        ));
+        assert!(!is_live_cdp_only_transport(
+            browser::RecipeTransport::Manual
+        ));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -1507,10 +1507,11 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             let mut transport_errors = Vec::new();
 
             for (index, transport) in transports.iter().copied().enumerate() {
-                if matches!(transport, browser::RecipeTransport::ChromeDevtoolsMcp)
-                    && !browser::is_chrome_devtools_mcp_available()
-                {
-                    continue;
+                if !matches!(transport, browser::RecipeTransport::Manual) {
+                    eprintln!(
+                        "info: attempting {} transport",
+                        recipe_transport_name(transport)
+                    );
                 }
 
                 let result = match transport {

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -924,7 +924,7 @@ fn recipe_has_remaining_manual_fallback(
 }
 
 fn recipe_should_stop_live_transport_fallback(err: &anyhow::Error) -> bool {
-    browser::is_chrome_approval_wait_error(err)
+    browser::is_chrome_approval_wait_error(err) || browser::is_chrome_cdp_unreachable_error(err)
 }
 
 fn explicit_cdp_attach_failure(err: anyhow::Error) -> anyhow::Error {
@@ -2130,6 +2130,25 @@ mod tests {
     fn recipe_should_not_stop_live_transport_fallback_on_non_approval_error() {
         let err = anyhow!("chatgpt send button not found");
         assert!(!recipe_should_stop_live_transport_fallback(&err));
+    }
+
+    #[test]
+    fn recipe_should_stop_live_transport_fallback_on_cdp_unreachable() {
+        // When tier 1 (chrome-devtools-mcp) fails because Chrome is not
+        // listening on CDP at all, dev-browser and agent-browser will fail
+        // for the same reason. Stop the live fallback immediately and fall
+        // through to the manual path so the user gets an actionable error
+        // rather than waiting on dev-browser's `Target.setAutoAttach` hang.
+        let err =
+            anyhow!("requesting `http://127.0.0.1:9222/json/version` failed: connection refused")
+                .context(
+                    "chrome-devtools-mcp could not reach Chrome's CDP endpoint. \
+             Chrome 136+ ignores --remote-debugging-port on the default profile — \
+             either enable chrome://inspect/#remote-debugging (Chrome 144+) and retry, \
+             or pass --cdp=ws://127.0.0.1:PORT after launching Chrome with a non-default \
+             --user-data-dir, or use Chrome for Testing",
+                );
+        assert!(recipe_should_stop_live_transport_fallback(&err));
     }
 
     #[test]

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -1,12 +1,16 @@
 name: chatgpt
 # Transport order:
-#   1. chrome-devtools-mcp (primary for Chrome 147+ live-attached Chrome)
+#   1. chrome-devtools-mcp — direct CDP client against running Chrome 147+
+#      (uses vendored `headless_chrome`; NOT a bridge to the chrome-devtools-mcp
+#      MCP server, despite the name — the module name is historical)
 #   2. dev-browser (fallback for Chrome <= 146 / Chrome for Testing)
 #   3. agent-browser (managed browser fallback)
 #   4. manual (last resort; upload the bundle yourself)
 #
 # Recommended: enable chrome://inspect/#remote-debugging (Chrome 144+) for auto-connect.
 # Note: Chrome 136+ ignores --remote-debugging-port on the default profile.
+# Note: yoetz CLI cannot proxy through a parent agent's MCP server; all
+# transports connect directly to Chrome via CDP.
 #
 # Variables:
 #   model    — model slug (e.g., "gpt-5-4-pro"). Omit to keep current.

--- a/vendor/headless_chrome/src/browser/mod.rs
+++ b/vendor/headless_chrome/src/browser/mod.rs
@@ -269,16 +269,47 @@ impl Browser {
 
         util::Wait::with_timeout(Duration::from_secs(20))
             .until(|| {
-                let tabs = self.inner.tabs.lock().unwrap();
-                tabs.iter().find_map(|tab| {
-                    if *tab.get_target_id() == target_id {
-                        Some(tab.clone())
-                    } else {
-                        None
-                    }
-                })
+                self.find_existing_tab(&target_id)
+                    .or_else(|| self.attach_tab_from_target_list(&target_id).ok().flatten())
             })
             .map_err(Into::into)
+    }
+
+    fn find_existing_tab(&self, target_id: &str) -> Option<Arc<Tab>> {
+        let tabs = self.inner.tabs.lock().unwrap();
+        tabs.iter()
+            .find(|tab| tab.get_target_id().as_str() == target_id)
+            .cloned()
+    }
+
+    fn attach_tab_from_target_list(&self, target_id: &str) -> Result<Option<Arc<Tab>>> {
+        let target = self
+            .call_method(GetTargets { filter: None })?
+            .target_infos
+            .into_iter()
+            .find(|target| {
+                target.Type == "page" && target.target_id.as_str() == target_id
+            });
+
+        let Some(target) = target else {
+            return Ok(None);
+        };
+
+        if let Some(existing) = self.find_existing_tab(target_id) {
+            return Ok(Some(existing));
+        }
+
+        let tab = Arc::new(Tab::new(target, self.inner.transport.clone())?);
+        let mut tabs = self.inner.tabs.lock().unwrap();
+        if let Some(existing) = tabs
+            .iter()
+            .find(|existing| existing.get_target_id() == tab.get_target_id())
+            .cloned()
+        {
+            return Ok(Some(existing));
+        }
+        tabs.push(tab.clone());
+        Ok(Some(tab))
     }
 
     /// Creates the equivalent of a new incognito window, AKA a browser context
@@ -393,9 +424,24 @@ impl Browser {
                                 // meaning the devtools has ben opened automatically..
                                 // for now ignoring devtools tabs to be in tabs..
                                 if target_info.Type == "page" {
+                                    if tabs
+                                        .lock()
+                                        .unwrap()
+                                        .iter()
+                                        .any(|tab| tab.get_target_id() == &target_info.target_id)
+                                    {
+                                        continue;
+                                    }
                                     match Tab::new(target_info, Arc::clone(&transport)) {
                                         Ok(new_tab) => {
-                                            tabs.lock().unwrap().push(Arc::new(new_tab));
+                                            let new_tab = Arc::new(new_tab);
+                                            let mut locked_tabs = tabs.lock().unwrap();
+                                            if locked_tabs.iter().any(|existing| {
+                                                existing.get_target_id() == new_tab.get_target_id()
+                                            }) {
+                                                continue;
+                                            }
+                                            locked_tabs.push(new_tab);
                                         }
                                         Err(_tab_creation_err) => {
                                             info!("Failed to create a handle to new tab");


### PR DESCRIPTION
## Summary

- `yoetz browser recipe --recipe chatgpt` silently skipped tier 1 (`chrome-devtools-mcp`) whenever `chrome-devtools-mcp` and `npx` were both absent from PATH, then cascaded into dev-browser's `Target.setAutoAttach` hang on Chrome 146+ default profile. The PATH gate was dead code left over from v0.2.48 when the external MCP server was required for DOM snapshots — v0.2.49 replaced that with vendored `headless_chrome`, making the gate a liability rather than a feature.
- Each transport attempt now logs `info: attempting <name> transport` (and `info: skipping <name> ...` when short-circuited) so the funnel is no longer invisible.
- CDP-unreachable errors at tier 1 now surface actionable Chrome 136+ guidance (enable `chrome://inspect/#remote-debugging`, pass `--cdp`, or use Chrome for Testing) and skip remaining pure live-CDP tiers (dev-browser). `agent-browser` still runs — it transparently falls back from live-attach to a managed profile with stored cookies and works without CDP. Manual remains the final fallback.
- CHANGELOG + `recipes/chatgpt.yaml` updated to make clear the transport is a direct CDP client (via vendored `headless_chrome`), NOT a bridge to the chrome-devtools-mcp MCP server.

Reported via AMQ from `sales-skills` project; both commits reviewed and approved by Codex on the same thread.

## Test plan

- [x] `cargo test --workspace` — 234 passed (4 new tests covering the classifiers and funnel semantics, including a guardrail test that asserts CDP-unreachable does NOT trip the whole-funnel stop)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [ ] Manual smoke test on Chrome 146+ default profile (CI cannot run a live Chrome attach; reporter will verify post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)