### PR TITLE
chore(release): v0.2.51

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.2.50",
+  "version": "0.2.51",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.2.50",
+  "version": "0.2.51",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+## [0.2.51] - 2026-04-13
 ### Fixed
 
 - `yoetz browser recipe --recipe chatgpt` now actually attempts the `chrome-devtools-mcp` transport instead of silently skipping it when `chrome-devtools-mcp` and `npx` are both absent from `PATH`. The availability gate was a leftover from v0.2.48 when the external binary was required for DOM snapshots; v0.2.49 removed that dependency, but the gate stayed. Each transport attempt now logs `info: attempting <name> transport` so skipped tiers are no longer invisible.
@@ -15,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Clarified
 
 - The `chrome-devtools-mcp` transport is a **direct CDP client** using vendored `headless_chrome` (`crates/yoetz-cli/src/chrome_devtools_mcp/client.rs`). It does NOT bridge to the chrome-devtools-mcp MCP server, despite the name. yoetz CLI runs as its own subprocess and cannot proxy MCP calls through a parent agent. Documentation updated in `recipes/chatgpt.yaml`.
+
 
 ## [0.2.50] - 2026-04-13
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3196,7 +3196,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoetz"
-version = "0.2.50"
+version = "0.2.51"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "yoetz-core"
-version = "0.2.50"
+version = "0.2.51"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/yoetz-core", "crates/yoetz-cli"]
 
 [workspace.package]
-version = "0.2.50"
+version = "0.2.51"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yoetz
-version: 0.2.50
+version: 0.2.51
 description: >
   Fast CLI-first LLM council, bundler, and multimodal gateway. Use ONLY when user
   explicitly mentions "yoetz", "yoetz ask", "yoetz council", "yoetz review",


### PR DESCRIPTION
## Release

- updates `CHANGELOG.md` for `v0.2.51`
- bumps workspace version to `0.2.51`
- aligns skill/plugin metadata to `0.2.51`
- merge triggers .github/workflows/release.yml, which creates the tag and
  publishes the release
- GitHub release notes come from the committed `CHANGELOG.md` entry