### PR TITLE
fix(browser): complete live Chrome follow-ups

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,10 +140,42 @@ jobs:
             echo "prerelease=${prerelease}"
           } >> "$GITHUB_OUTPUT"
 
-  build:
-    name: Build (${{ matrix.target }})
+  verify:
+    name: Verify Release Commit
     needs: prepare
     if: needs.prepare.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.prepare.outputs.release_ref }}
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          components: clippy, rustfmt
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Verify release metadata
+        run: ./scripts/check-release-version.sh "${{ needs.prepare.outputs.version }}"
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Run tests
+        run: cargo test --workspace
+
+  build:
+    name: Build (${{ matrix.target }})
+    needs: [prepare, verify]
+    if: needs.prepare.result == 'success' && needs.verify.result == 'success'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     permissions:
@@ -228,12 +260,14 @@ jobs:
 
   release:
     name: Create Release
-    needs: [prepare, build]
-    if: needs.prepare.result == 'success' && needs.build.result == 'success'
+    needs: [prepare, verify, build]
+    if: needs.prepare.result == 'success' && needs.verify.result == 'success' && needs.build.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: write
+      attestations: write
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -273,6 +307,27 @@ jobs:
         run: |
           cd artifacts
           sha256sum yoetz-* > SHA256SUMS.txt
+
+      - name: Collect attestation subjects
+        id: attestation_subjects
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t subjects < <(find artifacts -maxdepth 1 -type f | sort)
+          if ((${#subjects[@]} == 0)); then
+            echo "::error::No release artifacts found to attest."
+            exit 1
+          fi
+          {
+            echo "subjects<<EOF"
+            printf '%s\n' "${subjects[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate artifact attestation
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-path: ${{ steps.attestation_subjects.outputs.subjects }}
 
       - name: Extract release notes for this tag
         id: release_notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Browser target auto-discovery now rejects unhealthy `DevToolsActivePort` endpoints, keeps env/config auto-selection best-effort, restores managed-profile fallback on live auth/challenge failures, and stops leaking page body text in ChatGPT probe errors.
+- Remembered browser-target state is now best-effort and no longer able to turn a successful attach or recipe run into a post-success failure.
+
+### Changed
+
+- Release automation now re-verifies the merged release commit before tagging and publishes GitHub build provenance attestations for the shipped archives.
+
 ## [0.2.51] - 2026-04-13
 ### Fixed
 

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -155,7 +155,7 @@ impl ResolvedCdpTarget {
     }
 
     pub fn is_authoritative(&self) -> bool {
-        !self.is_auto_discovered()
+        matches!(self.source, ResolvedCdpTargetSource::Flag)
     }
 }
 
@@ -1360,13 +1360,7 @@ pub fn is_chrome_cdp_unreachable_error(err: &anyhow::Error) -> bool {
     message.contains("chrome://inspect")
         && (message.contains("could not reach chrome's cdp endpoint")
             || message.contains("ignores --remote-debugging-port")
-            || (message.contains("requesting `http")
-                && message.contains("/json/version")
-                && (message.contains("failed") || message.contains("connection refused")))
-            || (message.contains("connectovercdp")
-                && (message.contains("econnrefused")
-                    || message.contains("connection refused")
-                    || message.contains("browser.getversion"))))
+            || looks_like_cdp_transport_failure(err))
 }
 
 pub fn is_chatgpt_auth_issue_error(err: &anyhow::Error) -> bool {
@@ -2084,9 +2078,7 @@ pub fn resolve_browser_connection(
     if let Some(endpoint) = resolve_cdp_endpoint(cdp_override, config) {
         match try_cdp_attach(&endpoint, target_url) {
             Ok(()) => return Ok(BrowserConnection::Cdp { endpoint }),
-            Err(err)
-                if is_chrome_approval_wait_error(&err) || is_chatgpt_auth_issue_error(&err) =>
-            {
+            Err(err) if should_stop_live_attach_fallback(&err) => {
                 return Err(err);
             }
             Err(_) => {}
@@ -2095,7 +2087,7 @@ pub fn resolve_browser_connection(
 
     match try_auto_connect(target_url) {
         Ok(()) => return Ok(BrowserConnection::AutoConnect),
-        Err(err) if is_chrome_approval_wait_error(&err) || is_chatgpt_auth_issue_error(&err) => {
+        Err(err) if should_stop_live_attach_fallback(&err) => {
             return Err(err);
         }
         Err(_) => {}
@@ -2111,7 +2103,7 @@ pub fn try_cdp_attach(endpoint: &str, target_url: &str) -> Result<()> {
     verify_auth_cdp(target_url, &connection).map_err(|e| {
         if allow_dialog_error(&e) {
             e
-        } else if is_localhost_endpoint(endpoint) {
+        } else if should_attach_chrome136_warning(endpoint, &e) {
             e.context(chrome136_cdp_warning(endpoint))
         } else {
             e
@@ -2146,6 +2138,26 @@ fn is_localhost_endpoint(endpoint: &str) -> bool {
         host.to_lowercase().as_str(),
         "127.0.0.1" | "localhost" | "::1"
     )
+}
+
+fn should_attach_chrome136_warning(endpoint: &str, err: &anyhow::Error) -> bool {
+    is_localhost_endpoint(endpoint) && looks_like_cdp_transport_failure(err)
+}
+
+fn should_stop_live_attach_fallback(err: &anyhow::Error) -> bool {
+    is_chrome_approval_wait_error(err)
+}
+
+fn looks_like_cdp_transport_failure(err: &anyhow::Error) -> bool {
+    let message = format!("{err:#}").to_lowercase();
+    message.contains("could not reach chrome's cdp endpoint")
+        || (message.contains("requesting `http")
+            && message.contains("/json/version")
+            && (message.contains("failed") || message.contains("connection refused")))
+        || (message.contains("connectovercdp")
+            && (message.contains("econnrefused")
+                || message.contains("connection refused")
+                || message.contains("browser.getversion")))
 }
 
 /// Warning message explaining the Chrome 136+ breaking change for local CDP.
@@ -2184,7 +2196,7 @@ pub fn try_cdp_attach_lite(endpoint: &str) -> Result<()> {
     probe_live_attach_connection(&connection).map_err(|e| {
         if allow_dialog_error(&e) {
             e
-        } else if is_localhost_endpoint(endpoint) {
+        } else if should_attach_chrome136_warning(endpoint, &e) {
             e.context(chrome136_cdp_warning(endpoint))
         } else {
             e
@@ -3209,6 +3221,32 @@ mod tests {
     }
 
     #[test]
+    fn only_explicit_cdp_targets_are_authoritative() {
+        let explicit = ResolvedCdpTarget {
+            endpoint: "ws://127.0.0.1:9222/devtools/browser/flag".to_string(),
+            source: ResolvedCdpTargetSource::Flag,
+            description: "explicit".to_string(),
+            source_path: None,
+        };
+        let configured = ResolvedCdpTarget {
+            endpoint: "ws://127.0.0.1:9222/devtools/browser/config".to_string(),
+            source: ResolvedCdpTargetSource::Config,
+            description: "config".to_string(),
+            source_path: None,
+        };
+        let automatic = ResolvedCdpTarget {
+            endpoint: "ws://127.0.0.1:9222/devtools/browser/auto".to_string(),
+            source: ResolvedCdpTargetSource::Auto,
+            description: "auto".to_string(),
+            source_path: Some(PathBuf::from("/tmp/DevToolsActivePort")),
+        };
+
+        assert!(explicit.is_authoritative());
+        assert!(!configured.is_authoritative());
+        assert!(!automatic.is_authoritative());
+    }
+
+    #[test]
     fn select_preferred_running_chrome_target_prefers_chatgpt_before_sticky() {
         let sticky_path = PathBuf::from("/tmp/chrome-sticky/DevToolsActivePort");
         let older = SystemTime::UNIX_EPOCH + Duration::from_secs(10);
@@ -3780,6 +3818,24 @@ mod tests {
     }
 
     #[test]
+    fn should_attach_chrome136_warning_only_for_transport_failures() {
+        let auth_issue = anyhow!(
+            "chatgpt login required in the attached Chrome session. Log in there and try again."
+        );
+        let connect_failure =
+            anyhow!("requesting `http://127.0.0.1:9222/json/version` failed: connection refused");
+
+        assert!(!should_attach_chrome136_warning(
+            "http://127.0.0.1:9222",
+            &auth_issue
+        ));
+        assert!(should_attach_chrome136_warning(
+            "http://127.0.0.1:9222",
+            &connect_failure
+        ));
+    }
+
+    #[test]
     fn is_chrome_approval_wait_error_rejects_non_approval_timeouts() {
         let err = anyhow!("ChatGPT response timed out after 900000ms");
         assert!(!is_chrome_approval_wait_error(&err));
@@ -3828,6 +3884,19 @@ mod tests {
         assert!(is_chatgpt_auth_issue_error(&challenge));
         assert!(is_chatgpt_auth_issue_error(&captcha));
         assert!(!is_chatgpt_auth_issue_error(&other));
+    }
+
+    #[test]
+    fn should_stop_live_attach_fallback_only_on_approval_wait() {
+        let approval = anyhow!(
+            "live browser attach timed out (30s). Chrome may be showing an \"Allow remote debugging?\" dialog — please click Allow in Chrome, then retry."
+        );
+        let auth_issue = anyhow!(
+            "chatgpt login required in the attached Chrome session. Log in there and try again."
+        );
+
+        assert!(should_stop_live_attach_fallback(&approval));
+        assert!(!should_stop_live_attach_fallback(&auth_issue));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
@@ -354,22 +354,12 @@ fn format_page_probe_summary(state: &serde_json::Value) -> String {
         .and_then(serde_json::Value::as_str)
         .unwrap_or("")
         .trim();
-    let body_text = state
-        .get("bodyText")
-        .and_then(serde_json::Value::as_str)
-        .unwrap_or("")
-        .trim();
     let title_part = if title.is_empty() {
         "title=<empty>".to_string()
     } else {
         format!("title={title:?}")
     };
-    let body_part = if body_text.is_empty() {
-        "body=<empty>".to_string()
-    } else {
-        format!("body={body_text:?}")
-    };
-    format!("Current page: url={url}, {title_part}, {body_part}")
+    format!("Current page: url={url}, {title_part}")
 }
 
 /// Click the attach button, snapshot the mounted upload affordance, then call
@@ -933,6 +923,19 @@ mod tests {
             classify_live_chatgpt_page_issue("https://chatgpt.com/", "ChatGPT", "Send a message"),
             None
         );
+    }
+
+    #[test]
+    fn page_probe_summary_redacts_body_text() {
+        let summary = format_page_probe_summary(&serde_json::json!({
+            "url": "https://chatgpt.com/",
+            "title": "ChatGPT",
+            "bodyText": "secret review draft"
+        }));
+        assert!(summary.contains("url=https://chatgpt.com/"));
+        assert!(summary.contains("title=\"ChatGPT\""));
+        assert!(!summary.contains("secret review draft"));
+        assert!(!summary.contains("body="));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
@@ -344,17 +344,12 @@ pub fn discover_running_chrome_targets() -> Vec<RunningChromeTarget> {
         let modified_at = std::fs::metadata(&source_path)
             .ok()
             .and_then(|metadata| metadata.modified().ok());
-        let browser_name = fetch_browser_name(&ws_endpoint)
-            .unwrap_or_else(|| browser_name_from_source_path(&source_path));
-        let chatgpt_tab_count = fetch_chatgpt_tab_count(&ws_endpoint).unwrap_or(0);
+        let Some(target) = describe_running_chrome_target(&ws_endpoint, &source_path, modified_at)
+        else {
+            continue;
+        };
 
-        targets.push(RunningChromeTarget {
-            ws_endpoint,
-            source_path,
-            browser_name,
-            chatgpt_tab_count,
-            modified_at,
-        });
+        targets.push(target);
     }
 
     targets
@@ -474,20 +469,36 @@ fn resolve_any_devtools_active_port_ws() -> Option<String> {
     devtools_active_port_candidates()
         .into_iter()
         .find_map(|path| {
-            std::fs::read_to_string(path)
+            let contents = std::fs::read_to_string(&path).ok()?;
+            let ws_endpoint = parse_devtools_active_port(&contents, None)?;
+            let modified_at = std::fs::metadata(&path)
                 .ok()
-                .and_then(|contents| parse_devtools_active_port(&contents, None))
+                .and_then(|metadata| metadata.modified().ok());
+            describe_running_chrome_target(&ws_endpoint, &path, modified_at)
+                .map(|target| target.ws_endpoint)
         })
 }
 
-fn fetch_browser_name(ws_endpoint: &str) -> Option<String> {
-    let payload = local_http_json::<DevtoolsVersionPayload>(ws_endpoint, "/json/version")?;
-    payload.browser.map(|browser| {
-        browser
-            .split('/')
-            .next()
-            .unwrap_or(browser.as_str())
-            .to_string()
+fn describe_running_chrome_target(
+    ws_endpoint: &str,
+    source_path: &Path,
+    modified_at: Option<SystemTime>,
+) -> Option<RunningChromeTarget> {
+    let version = local_http_json::<DevtoolsVersionPayload>(ws_endpoint, "/json/version")?;
+    let browser_name = version
+        .browser
+        .as_deref()
+        .and_then(|browser| browser.split('/').next())
+        .filter(|browser| !browser.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| browser_name_from_source_path(source_path));
+    let chatgpt_tab_count = fetch_chatgpt_tab_count(ws_endpoint).unwrap_or(0);
+    Some(RunningChromeTarget {
+        ws_endpoint: ws_endpoint.to_string(),
+        source_path: source_path.to_path_buf(),
+        browser_name,
+        chatgpt_tab_count,
+        modified_at,
     })
 }
 
@@ -498,9 +509,8 @@ fn fetch_chatgpt_tab_count(ws_endpoint: &str) -> Option<usize> {
             .iter()
             .filter(|entry| entry.target_type.as_deref() == Some("page"))
             .filter(|entry| {
-                entry.url.as_deref().is_some_and(|url| {
-                    is_chatgpt_url(url) || is_chatgpt_title(entry.title.as_deref())
-                })
+                entry.url.as_deref().is_some_and(is_chatgpt_url)
+                    || (entry.url.as_deref().is_none() && is_chatgpt_title(entry.title.as_deref()))
             })
             .count(),
     )
@@ -646,7 +656,10 @@ fn is_chatgpt_url(url: &str) -> bool {
 
 fn is_chatgpt_title(title: Option<&str>) -> bool {
     title
-        .map(|value| value.to_ascii_lowercase().contains("chatgpt"))
+        .map(|value| value.trim().to_ascii_lowercase())
+        .map(|value| {
+            value == "chatgpt" || value.starts_with("chatgpt ") || value.starts_with("chatgpt -")
+        })
         .unwrap_or(false)
 }
 
@@ -943,6 +956,112 @@ fn node_contains_text(node: &serde_json::Map<String, Value>, wanted: &str) -> bo
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::{
+        fs,
+        io::{Read, Write},
+        net::TcpListener,
+        path::{Path, PathBuf},
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        thread,
+        time::Duration,
+    };
+    use tempfile::tempdir;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        #[allow(unsafe_code)]
+        fn set<K>(key: &'static str, value: K) -> Self
+        where
+            K: AsRef<std::ffi::OsStr>,
+        {
+            let original = std::env::var_os(key);
+            unsafe { std::env::set_var(key, value) };
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        #[allow(unsafe_code)]
+        fn drop(&mut self) {
+            match &self.original {
+                Some(value) => unsafe { std::env::set_var(self.key, value) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
+    fn devtools_active_port_test_paths(home: &Path) -> (PathBuf, PathBuf) {
+        match std::env::consts::OS {
+            "macos" => (
+                home.join("Library/Application Support/Google/Chrome/DevToolsActivePort"),
+                home.join("Library/Application Support/Google/Chrome Canary/DevToolsActivePort"),
+            ),
+            "windows" => (
+                home.join("AppData/Local/Google/Chrome/User Data/DevToolsActivePort"),
+                home.join("AppData/Local/Google/Chrome SxS/User Data/DevToolsActivePort"),
+            ),
+            _ => (
+                home.join(".config/google-chrome/DevToolsActivePort"),
+                home.join(".config/chromium/DevToolsActivePort"),
+            ),
+        }
+    }
+
+    fn write_devtools_active_port(path: &Path, port: u16, suffix: &str) {
+        fs::create_dir_all(path.parent().expect("candidate must have parent")).unwrap();
+        fs::write(path, format!("{port}\n/devtools/browser/{suffix}\n")).unwrap();
+    }
+
+    fn spawn_fake_devtools_server() -> (u16, Arc<AtomicBool>, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        listener
+            .set_nonblocking(true)
+            .expect("listener should accept nonblocking mode");
+        let port = listener.local_addr().unwrap().port();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_signal = shutdown.clone();
+        let handle = thread::spawn(move || {
+            while !shutdown_signal.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let mut request = [0_u8; 2048];
+                        let _ = stream.read(&mut request);
+                        let request = String::from_utf8_lossy(&request);
+                        let body = if request.starts_with("GET /json/version ") {
+                            r#"{"Browser":"Chrome/147.0.0.0"}"#
+                        } else if request.starts_with("GET /json/list ") {
+                            r#"[{"type":"page","url":"https://chatgpt.com/c/123","title":"ChatGPT - New chat"}]"#
+                        } else {
+                            ""
+                        };
+                        let response = if body.is_empty() {
+                            "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                                .to_string()
+                        } else {
+                            format!(
+                                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                                body.len(),
+                                body
+                            )
+                        };
+                        let _ = stream.write_all(response.as_bytes());
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+        (port, shutdown, handle)
+    }
 
     fn snapshot_fixture() -> Snapshot {
         Snapshot {
@@ -1101,11 +1220,36 @@ mod tests {
     }
 
     #[test]
-    fn chatgpt_matchers_cover_url_and_title() {
+    fn chatgpt_matchers_cover_url_and_title_fallback() {
         assert!(is_chatgpt_url("https://chatgpt.com/c/123"));
         assert!(is_chatgpt_url("https://chat.openai.com/"));
         assert!(!is_chatgpt_url("https://example.com/"));
         assert!(is_chatgpt_title(Some("ChatGPT - New chat")));
+        assert!(is_chatgpt_title(Some("ChatGPT Workspace")));
+        assert!(!is_chatgpt_title(Some("Notes about ChatGPT pricing")));
         assert!(!is_chatgpt_title(Some("Docs")));
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn discover_running_chrome_targets_skips_unhealthy_active_port_files() {
+        let home = tempdir().unwrap();
+        let (stale_path, healthy_path) = devtools_active_port_test_paths(home.path());
+        let (port, shutdown, handle) = spawn_fake_devtools_server();
+        write_devtools_active_port(&stale_path, port + 1, "stale");
+        write_devtools_active_port(&healthy_path, port, "healthy");
+
+        let _home = EnvVarGuard::set("HOME", home.path().as_os_str());
+        let _profile = EnvVarGuard::set("USERPROFILE", home.path().as_os_str());
+
+        let targets = discover_running_chrome_targets();
+
+        shutdown.store(true, Ordering::Relaxed);
+        let _ = handle.join();
+
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].source_path, healthy_path);
+        assert_eq!(targets[0].browser_name, "Chrome");
+        assert_eq!(targets[0].chatgpt_tab_count, 1);
     }
 }

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -933,9 +933,9 @@ fn recipe_should_stop_live_transport_fallback(
         return true;
     }
 
-    // Once the user or config has pinned a specific live Chrome target, do not
-    // fan out into more browser transports after the first failure. Auto-
-    // selected targets are only heuristics and remain advisory.
+    // Once the user has explicitly pinned a specific live Chrome target, do not
+    // fan out into more browser transports after the first failure. Env/config
+    // targets and auto-selected targets remain advisory.
     selected_cdp_target.is_some_and(browser::ResolvedCdpTarget::is_authoritative)
         && !matches!(transport, browser::RecipeTransport::Manual)
 }
@@ -1038,7 +1038,7 @@ fn maybe_demote_auto_selected_cdp_target(
     if !selected.is_auto_discovered() {
         return;
     }
-    if browser::is_chrome_approval_wait_error(err) || browser::is_chatgpt_auth_issue_error(err) {
+    if browser::is_chrome_approval_wait_error(err) {
         return;
     }
 
@@ -1050,6 +1050,17 @@ fn maybe_demote_auto_selected_cdp_target(
 
     if matches!(format, OutputFormat::Text | OutputFormat::Markdown) {
         eprintln!("info: {description} failed ({err}); continuing with fallback discovery");
+    }
+}
+
+fn maybe_remember_cdp_target(target: Option<&browser::ResolvedCdpTarget>, format: OutputFormat) {
+    let Some(target) = target else {
+        return;
+    };
+    if let Err(err) = browser::remember_cdp_target(target) {
+        if matches!(format, OutputFormat::Text | OutputFormat::Markdown) {
+            eprintln!("warning: failed to persist last successful Chrome target: {err}");
+        }
     }
 }
 
@@ -1488,9 +1499,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             if let Some(ref cdp_url) = check_args.cdp {
                 browser::try_cdp_attach(cdp_url, "https://chatgpt.com/")
                     .map_err(explicit_cdp_attach_failure)?;
-                if let Some(target) = resolved_cdp_target.as_ref() {
-                    browser::remember_cdp_target(target)?;
-                }
+                maybe_remember_cdp_target(resolved_cdp_target.as_ref(), format);
                 let payload = json!({
                     "status": "ok",
                     "method": format!("cdp: {cdp_url}"),
@@ -1523,9 +1532,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                             "method": method,
                             "backend": "dev-browser",
                         });
-                        if let Some(target) = resolved_cdp_target.as_ref() {
-                            browser::remember_cdp_target(target)?;
-                        }
+                        maybe_remember_cdp_target(resolved_cdp_target.as_ref(), format);
                         return match format {
                             OutputFormat::Json => write_json(&payload),
                             OutputFormat::Jsonl => write_jsonl("browser.check", &payload),
@@ -1536,9 +1543,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         };
                     }
                     Err(e) => {
-                        if browser::is_chrome_approval_wait_error(&e)
-                            || browser::is_chatgpt_auth_issue_error(&e)
-                        {
+                        if browser::is_chrome_approval_wait_error(&e) {
                             return Err(e);
                         }
                         if resolved_cdp_target
@@ -1647,9 +1652,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 "method": method,
             });
             if matches!(connection, browser::BrowserConnection::Cdp { .. }) {
-                if let Some(target) = resolved_cdp_target.as_ref() {
-                    browser::remember_cdp_target(target)?;
-                }
+                maybe_remember_cdp_target(resolved_cdp_target.as_ref(), format);
             }
             match format {
                 OutputFormat::Json => write_json(&payload),
@@ -1807,9 +1810,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                                 | browser::RecipeTransport::DevBrowser
                                 | browser::RecipeTransport::AgentBrowser
                         ) {
-                            if let Some(target) = resolved_cdp_target.as_ref() {
-                                browser::remember_cdp_target(target)?;
-                            }
+                            maybe_remember_cdp_target(resolved_cdp_target.as_ref(), format);
                         }
                         return Ok(());
                     }
@@ -1866,9 +1867,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             if let Some(endpoint) = cdp_endpoint {
                 match browser::try_cdp_attach(endpoint, "https://chatgpt.com/") {
                     Ok(()) => {
-                        if let Some(target) = resolved_cdp_target.as_ref() {
-                            browser::remember_cdp_target(target)?;
-                        }
+                        maybe_remember_cdp_target(resolved_cdp_target.as_ref(), format);
                         let payload = json!({
                             "status": "ok",
                             "method": if attach_args.cdp.is_some() {


### PR DESCRIPTION
## Summary
- complete the unreleased live-Chrome follow-up fixes from the review pass
- harden release automation by re-verifying the merged release commit before tagging
- emit GitHub build provenance attestations for shipped release archives

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- python3 -c "import yaml; yaml.safe_load(open(".github/workflows/release.yml"))"