### PR TITLE
chore(release): v0.2.52

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.2.51",
+  "version": "0.2.52",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.2.51",
+  "version": "0.2.52",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.52] - 2026-04-13
 ### Fixed
 
 - Browser target auto-discovery now rejects unhealthy `DevToolsActivePort` endpoints, keeps env/config auto-selection best-effort, restores managed-profile fallback on live auth/challenge failures, and stops leaking page body text in ChatGPT probe errors.
@@ -15,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - Release automation now re-verifies the merged release commit before tagging and publishes GitHub build provenance attestations for the shipped archives.
+
 
 ## [0.2.51] - 2026-04-13
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3196,7 +3196,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoetz"
-version = "0.2.51"
+version = "0.2.52"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "yoetz-core"
-version = "0.2.51"
+version = "0.2.52"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/yoetz-core", "crates/yoetz-cli"]
 
 [workspace.package]
-version = "0.2.51"
+version = "0.2.52"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yoetz
-version: 0.2.51
+version: 0.2.52
 description: >
   Fast CLI-first LLM council, bundler, and multimodal gateway. Use ONLY when user
   explicitly mentions "yoetz", "yoetz ask", "yoetz council", "yoetz review",


### PR DESCRIPTION
## Release

- updates `CHANGELOG.md` for `v0.2.52`
- bumps workspace version to `0.2.52`
- aligns skill/plugin metadata to `0.2.52`
- merge triggers .github/workflows/release.yml, which creates the tag and
  publishes the release
- GitHub release notes come from the committed `CHANGELOG.md` entry