### PR TITLE
ci: fix dependabot config for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,4 +20,3 @@ updates:
         patterns: ["*"]
     cooldown:
       default-days: 7
-      semver-major-days: 14


### PR DESCRIPTION
## Summary
- remove the unsupported semver-major cooldown override from the github-actions ecosystem
- keep Dependabot valid so workflow and release PRs do not get blocked by config parsing failures