### PR TITLE
fix: stabilize ChatGPT browser tab flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `yoetz browser recipe --recipe chatgpt` now honors `--var thread=reuse` in the primary `chrome-devtools-mcp` transport instead of always opening a fresh ChatGPT tab. Reuse now fails fast when the candidate tab is ambiguous or still streaming, instead of stealing an in-flight ChatGPT Pro run.
+- `yoetz browser check` no longer opens extra ChatGPT probe tabs on repeated checks when a ChatGPT tab is already open. The auth probe reuses an existing ChatGPT tab read-only when possible and only falls back to a temporary background tab when nothing is open.
+- Reuse-related failures now stop browser-transport fallback immediately, preventing a second CDP attach attempt and the extra Chrome “Allow remote debugging?” popup that used to appear after an initial reuse failure.
+- `yoetz browser check` now uses the intended transport order again (`chrome-devtools-mcp` before `dev-browser`) and reports the chosen transport in its output.
+- The ChatGPT recipe now auto-selects the strongest available ChatGPT model by default, preferring GPT-5/Pro when present, and surfaces `model_used` in JSON output.
+- `yoetz bundle` now handles explicit ignored/untracked files reliably, rejects comma-separated `-f` values with a clear error, and allows prompt-only bundles without walking the repo.
+
 ## [0.2.52] - 2026-04-13
 ### Fixed
 

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
@@ -17,8 +17,9 @@
 //!
 //! - No Playwright `connectOverCDP` hang in the live-attach path
 //! - No QuickJS sandbox — `evaluate_script` runs plain JS in the page
-//! - No SPA reset dance — `new_page` creates a fresh page so the thread
-//!   starts empty
+//! - `thread=fresh` can still use `new_page` for a blank conversation, while
+//!   `thread=reuse` reattaches to an existing ChatGPT tab instead of opening
+//!   another one
 //! - First-class `upload_file` replaces the macOS clipboard-paste hack
 //!
 //! The one place we use `chrome-devtools-mcp`'s uid model is `upload_file`:
@@ -39,7 +40,7 @@ use anyhow::{anyhow, Context, Result};
 use std::time::Duration;
 
 use super::client::CdpMcpClient;
-use super::DevtoolsMcpRecipeContext;
+use super::{DevtoolsMcpRecipeContext, RecipeThreadMode};
 
 const CHATGPT_URL: &str = "https://chatgpt.com/";
 
@@ -54,41 +55,8 @@ const POLL_INTERVAL_MS: u64 = 5_000;
 const STABLE_IDLE_CONSECUTIVE_POLLS: u32 = 12;
 const UPLOAD_INPUT_WAIT_MS: u64 = 5_000;
 const ATTACHMENT_VERIFY_WAIT_MS: u64 = 15_000;
-
-/// The full ChatGPT Pro recipe. Returns the assistant's final response text.
-pub async fn run(ctx: &DevtoolsMcpRecipeContext) -> Result<String> {
-    if ctx.bundle_path.is_none() {
-        return Err(anyhow!(
-            "ChatGPT recipe requires `--bundle`; this transport uploads a file attachment and does not support paste mode"
-        ));
-    }
-
-    // Step 0: attach directly to the user's running Chrome session.
-    // The Chrome "Allow remote debugging" dialog fires here, once per Chrome
-    // session. Every subsequent yoetz invocation in the same Chrome session
-    // should be silent.
-    if ctx.show_approval_guidance {
-        eprintln!(
-            "info: connecting to Chrome via chrome-devtools-mcp — if prompted, click Allow in Chrome's remote debugging dialog (one-time per Chrome session)"
-        );
-    }
-    let client = CdpMcpClient::connect_to_running_chrome(ctx.cdp_endpoint.as_deref())
-        .await
-        .map_err(cdp_attach_hint)?;
-
-    // Step 1: open a fresh chatgpt.com page. Fresh page = zero conversation
-    // history, no SPA reset dance needed.
-    client
-        .new_page(CHATGPT_URL, /* background */ false, 30_000)
-        .await
-        .context("chrome-devtools-mcp new_page on chatgpt.com")?;
-
-    // Step 2: wait for the composer to mount, then focus it. We use
-    // `evaluate_script` rather than the snapshot-uid model because ChatGPT's
-    // composer role + accessible name are locale-dependent and unreliable.
-    // `#prompt-textarea` has been stable since 2023 (per Agent Y research).
-    let wait_composer_js = r##"
-async () => {
+const WAIT_FOR_COMPOSER_JS: &str = r##"
+async (focusComposer = true) => {
   const deadline = Date.now() + 20000;
   const clip = (value, max = 240) =>
     String(value || "").replace(/\s+/g, " ").trim().slice(0, max);
@@ -99,7 +67,7 @@ async () => {
     const bodyText = clip(document.body?.innerText || "");
     const haystack = `${title} ${bodyText}`.toLowerCase();
     if (composer) {
-      composer.focus();
+      if (focusComposer) composer.focus();
       return { status: "ready", url, title, bodyText };
     }
     if (/cloudflare|checking your browser|attention required|security check|just a moment|verify you are human|cf-chl/i.test(haystack)) {
@@ -127,54 +95,57 @@ async () => {
   return state;
 }
 "##;
-    let composer_state = client
-        .evaluate_script(wait_composer_js, vec![])
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ChatgptRunResult {
+    pub response: String,
+    pub model_used: Option<String>,
+}
+
+/// The full ChatGPT Pro recipe. Returns the assistant's final response text.
+pub async fn run(ctx: &DevtoolsMcpRecipeContext) -> Result<ChatgptRunResult> {
+    if ctx.bundle_path.is_none() {
+        return Err(anyhow!(
+            "ChatGPT recipe requires `--bundle`; this transport uploads a file attachment and does not support paste mode"
+        ));
+    }
+
+    // Step 0: attach directly to the user's running Chrome session.
+    // The Chrome "Allow remote debugging" dialog fires here, once per Chrome
+    // session. Every subsequent yoetz invocation in the same Chrome session
+    // should be silent.
+    if ctx.show_approval_guidance {
+        eprintln!(
+            "info: connecting to Chrome via chrome-devtools-mcp — if prompted, click Allow in Chrome's remote debugging dialog (one-time per Chrome session)"
+        );
+    }
+    let client = CdpMcpClient::connect_to_running_chrome(ctx.cdp_endpoint.as_deref())
         .await
-        .context("evaluate_script wait-for-composer")?;
-    match composer_state
-        .get("status")
-        .and_then(serde_json::Value::as_str)
-    {
-        Some("ready") => {}
-        Some("challenge") => {
-            return Err(anyhow!(
-                "cloudflare challenge detected in the attached Chrome session. Solve it in your browser window and try again. {}",
-                format_page_probe_summary(&composer_state)
-            ));
+        .map_err(cdp_attach_hint)?;
+
+    // Step 1: either start a fresh conversation or reuse the user's current
+    // ChatGPT tab, depending on the documented `thread` recipe variable.
+    match ctx.thread_mode {
+        RecipeThreadMode::Fresh => {
+            client
+                .new_page(CHATGPT_URL, /* background */ false, 30_000)
+                .await
+                .context("chrome-devtools-mcp new_page on chatgpt.com")?;
         }
-        Some("login") => {
-            return Err(anyhow!(
-                "chatgpt login required in the attached Chrome session. Log in there and try again. {}",
-                format_page_probe_summary(&composer_state)
-            ));
-        }
-        _ => {
-            let detail = match classify_live_chatgpt_page_issue(
-                composer_state
-                    .get("url")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or_default(),
-                composer_state
-                    .get("title")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or_default(),
-                composer_state
-                    .get("bodyText")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or_default(),
-            ) {
-                Some(issue) => issue.to_string(),
-                None => {
-                    "ChatGPT composer did not mount within 20s — page may not have loaded correctly"
-                        .to_string()
-                }
-            };
-            return Err(anyhow!(
-                "{detail}. {}",
-                format_page_probe_summary(&composer_state)
-            ));
+        RecipeThreadMode::Reuse => {
+            client
+                .reuse_chatgpt_page(30_000)
+                .await
+                .context("chrome-devtools-mcp select existing ChatGPT tab")?;
         }
     }
+
+    // Step 2: wait for the composer to mount, then select the best model the
+    // user can actually access. When `model` is `auto` or empty, prefer the
+    // strongest available Pro/GPT-5 option and fall back to the current model
+    // if the selector UI is unavailable.
+    wait_for_composer_ready(&client, /* focus_composer */ true).await?;
+    let model_used = maybe_select_model(&client, &ctx.model).await?;
 
     // Step 3: upload the bundle if we have a path.
     //
@@ -263,7 +234,270 @@ async () => {
         .await
         .context("stable-idle polling for ChatGPT response")?;
 
-    Ok(response_text)
+    Ok(ChatgptRunResult {
+        response: response_text,
+        model_used,
+    })
+}
+
+pub async fn check_auth(cdp_endpoint: Option<&str>) -> Result<()> {
+    let client = CdpMcpClient::connect_to_running_chrome(cdp_endpoint)
+        .await
+        .map_err(cdp_attach_hint)?;
+    let used_probe_page = client
+        .select_chatgpt_page_for_probe(30_000)
+        .await
+        .context("select existing ChatGPT page for auth probe")?
+        .is_none();
+    if used_probe_page {
+        client
+            .new_page(CHATGPT_URL, /* background */ true, 30_000)
+            .await
+            .context("chrome-devtools-mcp new_page on chatgpt.com")?;
+    }
+    let result = wait_for_composer_ready(&client, /* focus_composer */ false).await;
+    if used_probe_page {
+        let _ = client.close_selected_page(true);
+    }
+    result
+}
+
+async fn wait_for_composer_ready(client: &CdpMcpClient, focus_composer: bool) -> Result<()> {
+    let composer_state = client
+        .evaluate_script(
+            WAIT_FOR_COMPOSER_JS,
+            vec![serde_json::Value::Bool(focus_composer)],
+        )
+        .await
+        .context("evaluate_script wait-for-composer")?;
+    match composer_state
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+    {
+        Some("ready") => Ok(()),
+        Some("challenge") => Err(anyhow!(
+            "cloudflare challenge detected in the attached Chrome session. Solve it in your browser window and try again. {}",
+            format_page_probe_summary(&composer_state)
+        )),
+        Some("login") => Err(anyhow!(
+            "chatgpt login required in the attached Chrome session. Log in there and try again. {}",
+            format_page_probe_summary(&composer_state)
+        )),
+        _ => {
+            let detail = match classify_live_chatgpt_page_issue(
+                composer_state
+                    .get("url")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default(),
+                composer_state
+                    .get("title")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default(),
+                composer_state
+                    .get("bodyText")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default(),
+            ) {
+                Some(issue) => issue.to_string(),
+                None => {
+                    "ChatGPT composer did not mount within 20s — page may not have loaded correctly"
+                        .to_string()
+                }
+            };
+            Err(anyhow!(
+                "{detail}. {}",
+                format_page_probe_summary(&composer_state)
+            ))
+        }
+    }
+}
+
+async fn maybe_select_model(
+    client: &CdpMcpClient,
+    requested_model: &str,
+) -> Result<Option<String>> {
+    let script = build_model_selection_script(requested_model);
+    let selection = client
+        .evaluate_script(&script, vec![])
+        .await
+        .context("evaluate_script select model")?;
+    let status = selection
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("unknown");
+    let model_used = selection
+        .get("modelUsed")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    match status {
+        "selected" | "already-selected" | "kept-current" | "kept-current-no-selector" => {
+            Ok(model_used)
+        }
+        "missing-selector" => Err(anyhow!(
+            "ChatGPT model selector button not found. {}",
+            format_page_probe_summary(&selection)
+        )),
+        "not-found" => {
+            let requested = selection
+                .get("requested")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or(requested_model);
+            Err(anyhow!(
+                "requested ChatGPT model `{requested}` was not available in the current session. {}",
+                format_page_probe_summary(&selection)
+            ))
+        }
+        other => Err(anyhow!(
+            "unexpected ChatGPT model selection status `{other}`"
+        )),
+    }
+}
+
+fn build_model_selection_script(requested_model: &str) -> String {
+    let requested_model =
+        serde_json::to_string(requested_model).expect("serialize requested model");
+    format!(
+        r##"
+async () => {{
+  const requested = {requested_model};
+  const normalize = (value) => String(value || "").replace(/\s+/g, " ").trim();
+  const toHaystack = (value) => normalize(value).toLowerCase();
+  const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  const realClick = (el) => {{
+    el.dispatchEvent(new PointerEvent("pointerdown", {{ bubbles: true, cancelable: true, pointerId: 1 }}));
+    el.dispatchEvent(new MouseEvent("mousedown", {{ bubbles: true, cancelable: true }}));
+    el.dispatchEvent(new PointerEvent("pointerup", {{ bubbles: true, cancelable: true, pointerId: 1 }}));
+    el.dispatchEvent(new MouseEvent("mouseup", {{ bubbles: true, cancelable: true }}));
+    el.dispatchEvent(new MouseEvent("click", {{ bubbles: true, cancelable: true }}));
+  }};
+  const selectorButton = document.querySelector(
+    "[data-testid='model-switcher-dropdown-button'], button[aria-label='Model selector'], button[aria-label='Model selector menu']"
+  );
+  const currentLabel = normalize(
+    selectorButton?.querySelector?.("[data-testid='selected-model'], [data-testid='model-switcher-selected-model']")?.textContent ||
+    selectorButton?.innerText ||
+    selectorButton?.textContent ||
+    selectorButton?.getAttribute?.("aria-label") ||
+    ""
+  );
+  const responseBase = {{
+    requested,
+    currentLabel,
+    url: window.location.href || "",
+    title: document.title || "",
+    bodyText: normalize(document.body?.innerText || "").slice(0, 240),
+  }};
+  const requestedTrimmed = normalize(requested);
+  const requestedLower = requestedTrimmed.toLowerCase();
+  const autoMode = !requestedTrimmed || requestedLower === "auto";
+
+  if (!selectorButton) {{
+    return {{
+      ...responseBase,
+      status: autoMode ? "kept-current-no-selector" : "missing-selector",
+      modelUsed: currentLabel || null,
+    }};
+  }}
+
+  const readItems = () => Array.from(document.querySelectorAll("[role='menuitem'], [data-testid^='model-switcher-']"))
+    .map((el) => {{
+      const text = normalize(el.innerText || el.textContent || el.getAttribute?.("aria-label") || el.getAttribute?.("title") || "");
+      const testId = normalize(el.getAttribute?.("data-testid") || "");
+      const haystack = `${{testId}} ${{text}}`.toLowerCase();
+      return {{ el, text, testId, haystack }};
+    }})
+    .filter((item) => item.text || item.testId);
+
+  let items = readItems();
+  if (items.length === 0) {{
+    realClick(selectorButton);
+    await wait(350);
+    items = readItems();
+  }}
+
+  if (items.length === 0) {{
+    return {{
+      ...responseBase,
+      status: autoMode ? "kept-current" : "not-found",
+      modelUsed: currentLabel || null,
+    }};
+  }}
+
+  const requestedNeedles = (() => {{
+    if (autoMode) return [];
+    const needles = new Set([requestedLower]);
+    if (requestedLower.includes("gpt-5")) {{
+      needles.add("gpt-5");
+      needles.add("gpt 5");
+    }}
+    if (requestedLower.includes("pro")) needles.add("pro");
+    if (requestedLower.includes("thinking")) needles.add("thinking");
+    if (requestedLower.includes("instant") || requestedLower.includes("5-3")) {{
+      needles.add("instant");
+      needles.add("5-3");
+    }}
+    return Array.from(needles);
+  }})();
+
+  const score = (haystack) => {{
+    let total = 0;
+    if (/gpt[- ]?5/.test(haystack)) total += 100;
+    if (/\bpro\b/.test(haystack)) total += 90;
+    if (/thinking/.test(haystack)) total += 60;
+    if (/instant/.test(haystack) || /\b5[- ]?3\b/.test(haystack)) total += 30;
+    return total;
+  }};
+
+  let target = null;
+  if (autoMode) {{
+    target = items
+      .map((item) => ({{ ...item, score: score(item.haystack) }}))
+      .sort((left, right) => right.score - left.score || right.text.length - left.text.length)[0];
+    if (!target || target.score <= 0) {{
+      return {{
+        ...responseBase,
+        status: "kept-current",
+        modelUsed: currentLabel || null,
+      }};
+    }}
+  }} else {{
+    target =
+      items.find((item) => item.testId.toLowerCase() === `model-switcher-${{requestedLower}}`) ||
+      items.find((item) => requestedNeedles.some((needle) => item.haystack.includes(needle))) ||
+      null;
+    if (!target) {{
+      return {{
+        ...responseBase,
+        status: "not-found",
+        modelUsed: currentLabel || null,
+      }};
+    }}
+  }}
+
+  const targetNeedles = autoMode
+    ? [target.haystack]
+    : requestedNeedles;
+  const currentHaystack = toHaystack(currentLabel);
+  if (currentHaystack && targetNeedles.some((needle) => needle && currentHaystack.includes(needle))) {{
+    return {{
+      ...responseBase,
+      status: "already-selected",
+      modelUsed: target.text || currentLabel || requestedTrimmed || null,
+    }};
+  }}
+
+  realClick(target.el);
+  await wait(300);
+  return {{
+    ...responseBase,
+    status: "selected",
+    modelUsed: target.text || requestedTrimmed || currentLabel || null,
+  }};
+}}
+"##,
+    )
 }
 
 /// Rewrite a CDP attach failure with actionable guidance.
@@ -944,5 +1178,18 @@ mod tests {
         assert!(is_closed_cdp_transport_error(&err));
         let other = anyhow!("timed out waiting for ChatGPT response");
         assert!(!is_closed_cdp_transport_error(&other));
+    }
+
+    #[test]
+    fn model_selection_script_supports_auto_and_explicit_modes() {
+        let auto_script = build_model_selection_script("auto");
+        assert!(auto_script.contains(r#"const requested = "auto";"#));
+        assert!(auto_script.contains(r#"/gpt[- ]?5/"#));
+        assert!(auto_script.contains(r#""kept-current-no-selector""#));
+
+        let explicit_script = build_model_selection_script("gpt-5-4-pro");
+        assert!(explicit_script.contains(r#"const requested = "gpt-5-4-pro";"#));
+        assert!(explicit_script.contains("requestedNeedles"));
+        assert!(explicit_script.contains("model-switcher-${requestedLower}"));
     }
 }

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
@@ -37,6 +37,12 @@ pub struct NewPageResult {
 }
 
 #[derive(Debug, Clone)]
+pub struct ReusedPageResult {
+    pub page_id: String,
+    pub url: String,
+}
+
+#[derive(Debug, Clone)]
 pub struct NavigateResult {
     pub url: String,
 }
@@ -173,6 +179,39 @@ impl CdpMcpClient {
         })
     }
 
+    pub async fn reuse_chatgpt_page(&self, timeout_ms: u64) -> Result<ReusedPageResult> {
+        let candidates = self.chatgpt_tabs();
+        let tab = select_chatgpt_reuse_tab(candidates, timeout_ms)?;
+        configure_tab_timeout(&tab, timeout_ms);
+        let _ = tab.activate();
+        let _ = tab.bring_to_front();
+        self.set_selected_tab(tab.clone());
+
+        Ok(ReusedPageResult {
+            page_id: tab.get_target_id().to_string(),
+            url: tab.get_url(),
+        })
+    }
+
+    pub async fn select_chatgpt_page_for_probe(
+        &self,
+        timeout_ms: u64,
+    ) -> Result<Option<ReusedPageResult>> {
+        let candidates = self.chatgpt_tabs();
+        if candidates.is_empty() {
+            return Ok(None);
+        }
+
+        let tab = select_chatgpt_probe_tab(candidates, timeout_ms);
+        configure_tab_timeout(&tab, timeout_ms);
+        self.set_selected_tab(tab.clone());
+
+        Ok(Some(ReusedPageResult {
+            page_id: tab.get_target_id().to_string(),
+            url: tab.get_url(),
+        }))
+    }
+
     pub async fn navigate_page(&self, url: &str, timeout_ms: u64) -> Result<NavigateResult> {
         let tab = self.selected_tab()?;
         configure_tab_timeout(&tab, timeout_ms);
@@ -293,6 +332,13 @@ impl CdpMcpClient {
         Ok(response.get("value").cloned().unwrap_or(Value::Null))
     }
 
+    pub fn close_selected_page(&self, fire_unload: bool) -> Result<()> {
+        let tab = self.selected_tab()?;
+        tab.close(fire_unload)
+            .context("closing selected Chrome page failed")?;
+        Ok(())
+    }
+
     fn set_selected_tab(&self, tab: Arc<Tab>) {
         let mut guard = self.selected_tab.lock().unwrap();
         *guard = Some(tab);
@@ -305,6 +351,18 @@ impl CdpMcpClient {
             .as_ref()
             .cloned()
             .context("no Chrome page is currently selected; call `new_page` first")
+    }
+
+    fn chatgpt_tabs(&self) -> Vec<Arc<Tab>> {
+        self.browser.register_missing_tabs();
+        self.browser
+            .get_tabs()
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|tab| is_chatgpt_url(&tab.get_url()))
+            .cloned()
+            .collect::<Vec<_>>()
     }
 }
 
@@ -376,6 +434,180 @@ fn configure_tab_timeout(tab: &Arc<Tab>, timeout_ms: u64) {
     tab.set_default_timeout(Duration::from_millis(timeout_ms.max(1)));
 }
 
+fn select_chatgpt_reuse_tab(candidates: Vec<Arc<Tab>>, timeout_ms: u64) -> Result<Arc<Tab>> {
+    match candidates.len() {
+        0 => bail!("thread=reuse requires an existing ChatGPT tab, but none are currently open"),
+        1 => Ok(candidates.into_iter().next().expect("single candidate")),
+        _ => {
+            let probes = candidates
+                .iter()
+                .map(|tab| probe_chatgpt_tab(tab, timeout_ms))
+                .collect::<Vec<_>>();
+            let index = choose_chatgpt_reuse_probe(&probes)?;
+            Ok(candidates
+                .into_iter()
+                .nth(index)
+                .expect("chosen probe index should map to a candidate"))
+        }
+    }
+}
+
+fn select_chatgpt_probe_tab(candidates: Vec<Arc<Tab>>, timeout_ms: u64) -> Arc<Tab> {
+    if candidates.len() == 1 {
+        return candidates.into_iter().next().expect("single candidate");
+    }
+
+    let probes = candidates
+        .iter()
+        .map(|tab| probe_chatgpt_tab(tab, timeout_ms))
+        .collect::<Vec<_>>();
+    let index = choose_chatgpt_probe_index(&probes);
+    candidates
+        .into_iter()
+        .nth(index)
+        .expect("chosen probe index should map to a candidate")
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct ChatgptTabProbe {
+    url: String,
+    visible: bool,
+    has_focus: bool,
+    is_generating: bool,
+}
+
+fn choose_chatgpt_reuse_probe(probes: &[ChatgptTabProbe]) -> Result<usize> {
+    if probes.is_empty() {
+        bail!("no ChatGPT tabs were available for reuse");
+    }
+
+    let available = probes
+        .iter()
+        .enumerate()
+        .filter(|(_, probe)| !probe.is_generating)
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    if available.is_empty() {
+        bail!(
+            "thread=reuse found ChatGPT tabs, but all of them are still generating. \
+             Wait for the current run to finish or use `--var thread=fresh`."
+        );
+    }
+
+    let focused = probes
+        .iter()
+        .enumerate()
+        .filter(|(index, probe)| probe.has_focus && available.contains(index))
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    if focused.len() == 1 {
+        return Ok(focused[0]);
+    }
+
+    let visible = probes
+        .iter()
+        .enumerate()
+        .filter(|(index, probe)| probe.visible && available.contains(index))
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    if visible.len() == 1 {
+        return Ok(visible[0]);
+    }
+
+    if available.len() == 1 {
+        return Ok(available[0]);
+    }
+
+    let rendered = probes
+        .iter()
+        .enumerate()
+        .map(|(index, probe)| {
+            format!(
+                "#{index}: visible={}, focus={}, generating={}, url={}",
+                probe.visible, probe.has_focus, probe.is_generating, probe.url
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+    bail!(
+        "thread=reuse found multiple ChatGPT tabs but could not identify a unique active tab. \
+         Keep only one ChatGPT tab visible or use `--var thread=fresh`. Candidates: {rendered}"
+    );
+}
+
+fn choose_chatgpt_probe_index(probes: &[ChatgptTabProbe]) -> usize {
+    let focused = probes
+        .iter()
+        .enumerate()
+        .filter(|(_, probe)| probe.has_focus)
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    if focused.len() == 1 {
+        return focused[0];
+    }
+
+    let visible = probes
+        .iter()
+        .enumerate()
+        .filter(|(_, probe)| probe.visible)
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    if visible.len() == 1 {
+        return visible[0];
+    }
+
+    0
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct ChatgptTabProbePayload {
+    #[serde(default)]
+    url: String,
+    #[serde(default)]
+    visible: bool,
+    #[serde(default)]
+    has_focus: bool,
+    #[serde(default)]
+    is_generating: bool,
+}
+
+fn probe_chatgpt_tab(tab: &Arc<Tab>, timeout_ms: u64) -> ChatgptTabProbe {
+    configure_tab_timeout(tab, timeout_ms);
+    let fallback = ChatgptTabProbe {
+        url: tab.get_url(),
+        visible: false,
+        has_focus: false,
+        is_generating: false,
+    };
+    let payload = evaluate_json_payload(
+        tab,
+        r#"(() => JSON.stringify({
+  url: window.location.href || "",
+  visible: document.visibilityState === "visible",
+  has_focus: typeof document.hasFocus === "function" ? !!document.hasFocus() : false,
+  is_generating:
+    !!document.querySelector("[data-message-author-role='assistant'].result-streaming, .result-streaming") ||
+    !!document.querySelector("[data-testid='stop-button'], button[aria-label*='Stop']")
+}))()"#,
+        false,
+    )
+    .ok()
+    .and_then(|value| serde_json::from_value::<ChatgptTabProbePayload>(value).ok());
+
+    payload
+        .map(|payload| ChatgptTabProbe {
+            url: if payload.url.is_empty() {
+                fallback.url.clone()
+            } else {
+                payload.url
+            },
+            visible: payload.visible,
+            has_focus: payload.has_focus,
+            is_generating: payload.is_generating,
+        })
+        .unwrap_or(fallback)
+}
+
 fn inject_files_on_input(
     tab: &Arc<Tab>,
     input: &Element<'_>,
@@ -413,18 +645,23 @@ fn resolve_browser_websocket(parsed: &Url) -> Result<String> {
 
 fn resolve_browser_websocket_via_json_version(endpoint: &Url) -> Result<String> {
     let version_url = browser_version_url(endpoint)?;
-    let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(5))
-        .build()
-        .context("building /json/version HTTP client failed")?;
-    let payload = client
-        .get(version_url.clone())
-        .send()
-        .with_context(|| format!("requesting `{version_url}` failed"))?
-        .error_for_status()
-        .with_context(|| format!("Chrome rejected `{version_url}`"))?
-        .json::<Value>()
-        .with_context(|| format!("parsing `{version_url}` as JSON failed"))?;
+    let version_url_for_thread = version_url.clone();
+    let payload = std::thread::spawn(move || -> Result<Value> {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .context("building /json/version HTTP client failed")?;
+        client
+            .get(version_url_for_thread.clone())
+            .send()
+            .with_context(|| format!("requesting `{version_url_for_thread}` failed"))?
+            .error_for_status()
+            .with_context(|| format!("Chrome rejected `{version_url_for_thread}`"))?
+            .json::<Value>()
+            .with_context(|| format!("parsing `{version_url_for_thread}` as JSON failed"))
+    })
+    .join()
+    .map_err(|_| anyhow!("requesting `{version_url}` panicked"))??;
 
     browser_websocket_from_json_version_payload(&payload)
         .with_context(|| format!("`{version_url}` did not expose a valid browser websocket URL"))
@@ -1099,6 +1336,149 @@ mod tests {
                 ]
             }),
         }
+    }
+
+    #[test]
+    fn choose_chatgpt_reuse_probe_prefers_unique_focus() {
+        let probes = vec![
+            ChatgptTabProbe {
+                url: "https://chatgpt.com/c/old".to_string(),
+                visible: false,
+                has_focus: false,
+                is_generating: false,
+            },
+            ChatgptTabProbe {
+                url: "https://chatgpt.com/c/current".to_string(),
+                visible: true,
+                has_focus: true,
+                is_generating: false,
+            },
+        ];
+
+        assert_eq!(choose_chatgpt_reuse_probe(&probes).unwrap(), 1);
+    }
+
+    #[test]
+    fn choose_chatgpt_reuse_probe_prefers_unique_visible_when_focus_missing() {
+        let probes = vec![
+            ChatgptTabProbe {
+                url: "https://chatgpt.com/c/old".to_string(),
+                visible: false,
+                has_focus: false,
+                is_generating: false,
+            },
+            ChatgptTabProbe {
+                url: "https://chatgpt.com/c/current".to_string(),
+                visible: true,
+                has_focus: false,
+                is_generating: false,
+            },
+        ];
+
+        assert_eq!(choose_chatgpt_reuse_probe(&probes).unwrap(), 1);
+    }
+
+    #[test]
+    fn choose_chatgpt_reuse_probe_rejects_ambiguous_tabs() {
+        let probes = vec![
+            ChatgptTabProbe {
+                url: "https://chatgpt.com/c/1".to_string(),
+                visible: false,
+                has_focus: false,
+                is_generating: false,
+            },
+            ChatgptTabProbe {
+                url: "https://chatgpt.com/c/2".to_string(),
+                visible: false,
+                has_focus: false,
+                is_generating: false,
+            },
+        ];
+
+        let err = choose_chatgpt_reuse_probe(&probes).unwrap_err();
+        assert!(err.to_string().contains("multiple ChatGPT tabs"));
+        assert!(err.to_string().contains("thread=fresh"));
+    }
+
+    #[test]
+    fn choose_chatgpt_probe_index_prefers_unique_focus() {
+        let probes = vec![
+            ChatgptTabProbe {
+                url: "https://chatgpt.com/c/old".to_string(),
+                visible: false,
+                has_focus: false,
+                is_generating: false,
+            },
+            ChatgptTabProbe {
+                url: "https://chatgpt.com/c/current".to_string(),
+                visible: true,
+                has_focus: true,
+                is_generating: true,
+            },
+        ];
+
+        assert_eq!(choose_chatgpt_probe_index(&probes), 1);
+    }
+
+    #[test]
+    fn choose_chatgpt_probe_index_falls_back_to_first_candidate() {
+        let probes = vec![
+            ChatgptTabProbe {
+                url: "https://chatgpt.com/c/1".to_string(),
+                visible: false,
+                has_focus: false,
+                is_generating: false,
+            },
+            ChatgptTabProbe {
+                url: "https://chatgpt.com/c/2".to_string(),
+                visible: false,
+                has_focus: false,
+                is_generating: true,
+            },
+        ];
+
+        assert_eq!(choose_chatgpt_probe_index(&probes), 0);
+    }
+
+    #[test]
+    fn choose_chatgpt_reuse_probe_skips_busy_tab() {
+        let probes = vec![
+            ChatgptTabProbe {
+                url: "https://chatgpt.com/c/busy".to_string(),
+                visible: true,
+                has_focus: true,
+                is_generating: true,
+            },
+            ChatgptTabProbe {
+                url: "https://chatgpt.com/c/idle".to_string(),
+                visible: false,
+                has_focus: false,
+                is_generating: false,
+            },
+        ];
+
+        assert_eq!(choose_chatgpt_reuse_probe(&probes).unwrap(), 1);
+    }
+
+    #[test]
+    fn choose_chatgpt_reuse_probe_rejects_all_busy_tabs() {
+        let probes = vec![
+            ChatgptTabProbe {
+                url: "https://chatgpt.com/c/1".to_string(),
+                visible: true,
+                has_focus: true,
+                is_generating: true,
+            },
+            ChatgptTabProbe {
+                url: "https://chatgpt.com/c/2".to_string(),
+                visible: false,
+                has_focus: false,
+                is_generating: true,
+            },
+        ];
+
+        let err = choose_chatgpt_reuse_probe(&probes).unwrap_err();
+        assert!(err.to_string().contains("still generating"));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/mod.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/mod.rs
@@ -39,7 +39,27 @@ pub mod chatgpt;
 // shape (new_page → focus → upload → type → click → wait → extract) with
 // per-LLM selectors — trivial to add once the client plumbing is verified.
 
+use anyhow::{anyhow, Result};
 use std::path::PathBuf;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
+pub enum RecipeThreadMode {
+    #[default]
+    Fresh,
+    Reuse,
+}
+
+impl RecipeThreadMode {
+    pub fn parse(raw: Option<&str>) -> Result<Self> {
+        match raw.unwrap_or("fresh").trim().to_ascii_lowercase().as_str() {
+            "" | "fresh" => Ok(Self::Fresh),
+            "reuse" => Ok(Self::Reuse),
+            other => Err(anyhow!(
+                "unsupported `thread` value `{other}`; expected `fresh` or `reuse`"
+            )),
+        }
+    }
+}
 
 /// Context for any chrome-devtools-mcp recipe run. Threads the minimal config
 /// each recipe needs: CDP endpoint (attach-to-running-Chrome), bundle path for
@@ -71,6 +91,10 @@ pub struct DevtoolsMcpRecipeContext {
     /// User prompt to send alongside the bundle.
     pub prompt: String,
 
+    /// Whether the recipe should start a new conversation or reuse an
+    /// existing ChatGPT tab.
+    pub thread_mode: RecipeThreadMode,
+
     /// How long to wait for the full response before giving up, in ms.
     pub response_timeout_ms: u64,
 
@@ -86,6 +110,7 @@ impl Default for DevtoolsMcpRecipeContext {
             bundle_text: None,
             model: String::new(),
             prompt: String::new(),
+            thread_mode: RecipeThreadMode::Fresh,
             response_timeout_ms: 1_800_000, // 30 min default for ChatGPT Pro Extended
             show_approval_guidance: true,
         }

--- a/crates/yoetz-cli/src/commands/bundle.rs
+++ b/crates/yoetz-cli/src/commands/bundle.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 
 use crate::{maybe_write_output, render_bundle_md, resolve_prompt, AppContext, BundleArgs};
 use yoetz_core::bundle::{build_bundle, BundleOptions};
@@ -12,14 +12,12 @@ pub(crate) fn handle_bundle(
     format: OutputFormat,
 ) -> Result<()> {
     let prompt = resolve_prompt(args.prompt, args.prompt_file)?;
-    if args.files.is_empty() && !args.all {
-        return Err(anyhow!("--files is required unless --all is set"));
-    }
     let options = BundleOptions {
         include: args.files,
         exclude: args.exclude,
         max_file_bytes: args.max_file_bytes,
         max_total_bytes: args.max_total_bytes,
+        include_all: args.all,
         ..Default::default()
     };
 

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -73,14 +73,15 @@ fn dev_browser_tmp_dir() -> PathBuf {
 }
 
 fn command_is_available(bin: &str) -> bool {
-    // dev-browser doesn't support --version (exits 2). Use --help which
-    // exits 0 and is universally supported.
+    // Treat "process could be spawned at all" as availability. Some
+    // dev-browser builds print help and exit non-zero, and we do not want that
+    // to trigger a pointless npm reinstall over an existing binary.
     Command::new(bin)
         .arg("--help")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .status()
-        .is_ok_and(|s| s.success())
+        .output()
+        .is_ok()
 }
 
 fn configured_dev_browser_bin() -> Result<Option<String>> {
@@ -763,18 +764,62 @@ if (loggedIn && composerReady) {{
     composerReady = false;
   }}
 }}
-if (loggedIn && composerReady && MODEL) {{
+if (loggedIn && composerReady) {{
+  const requested = (MODEL || "").trim().toLowerCase();
+  const autoMode = !requested || requested === "auto";
   const modelBtn = page.locator("[data-testid='model-switcher-dropdown-button'], button[aria-label='Model selector']").first();
-  await modelBtn.waitFor({{ state: "visible", timeout: 5000 }});
-  await modelBtn.click({{ timeout: 5000 }});
-  const slug = MODEL.toLowerCase();
-  const byTestId = page.locator(`[data-testid="model-switcher-${{slug}}"]`).first();
-  if (await byTestId.count() > 0) {{
-    await byTestId.click({{ timeout: 5000 }});
-  }} else {{
-    const menuItem = page.locator("[role='menuitem']").filter({{ hasText: new RegExp(slug.includes("thinking") ? "thinking" : slug.includes("pro") ? "pro" : slug.includes("instant") || slug.includes("5-3") ? "instant" : slug, "i") }}).first();
-    await menuItem.waitFor({{ state: "visible", timeout: 5000 }});
-    await menuItem.click({{ timeout: 5000 }});
+  if (await modelBtn.count() > 0) {{
+    await modelBtn.waitFor({{ state: "visible", timeout: 5000 }});
+    await modelBtn.click({{ timeout: 5000 }});
+    await page.waitForTimeout(500);
+    const currentModel = String((await modelBtn.innerText().catch(() => "")) || "")
+      .replace(/\s+/g, " ")
+      .trim();
+    const items = await page.locator("[role='menuitem'], [data-testid^='model-switcher-']").evaluateAll((nodes) => nodes.map((node) => {{
+      const text = String(node.textContent || "").replace(/\s+/g, " ").trim();
+      const testId = node.getAttribute("data-testid") || "";
+      return {{ text, haystack: `${{testId}} ${{text}}`.toLowerCase() }};
+    }}));
+    if (items.length > 0) {{
+      if (autoMode) {{
+        const ranked = items
+          .map((item) => {{
+            let score = 0;
+            if (/gpt[- ]?5/.test(item.haystack)) score += 100;
+            if (/\bpro\b/.test(item.haystack)) score += 90;
+            if (/thinking/.test(item.haystack)) score += 60;
+            if (/instant/.test(item.haystack) || /\b5[- ]?3\b/.test(item.haystack)) score += 30;
+            return {{ ...item, score }};
+          }})
+          .sort((left, right) => right.score - left.score || right.text.length - left.text.length);
+        if (ranked[0] && ranked[0].score > 0 && !currentModel.toLowerCase().includes(ranked[0].text.toLowerCase())) {{
+          await page.locator("[role='menuitem'], [data-testid^='model-switcher-']").filter({{ hasText: new RegExp(ranked[0].text.replace(/[.*+?^${{}}()|[\]\\]/g, "\\$&"), "i") }}).first().click({{ timeout: 5000 }});
+        }}
+      }} else {{
+        const slug = requested;
+        const byTestId = page.locator(`[data-testid="model-switcher-${{slug}}"]`).first();
+        if (await byTestId.count() > 0) {{
+          await byTestId.click({{ timeout: 5000 }});
+        }} else {{
+          const matcher = slug.includes("thinking")
+            ? "thinking"
+            : slug.includes("pro")
+              ? "pro"
+              : slug.includes("instant") || slug.includes("5-3")
+                ? "instant"
+                : slug;
+          if (!currentModel.toLowerCase().includes(matcher)) {{
+            const menuItem = page.locator("[role='menuitem'], [data-testid^='model-switcher-']").filter({{ hasText: new RegExp(matcher, "i") }}).first();
+            await menuItem.waitFor({{ state: "visible", timeout: 5000 }});
+            await menuItem.click({{ timeout: 5000 }});
+          }}
+        }}
+      }}
+    }} else if (!autoMode) {{
+      throw new Error(`model '${{requested}}' not found`);
+    }}
+  }} else if (!autoMode) {{
+    throw new Error("model selector button not found");
   }}
   await page.waitForTimeout(500);
 }}
@@ -1546,5 +1591,30 @@ mod tests {
             "expected a native binary name for the current platform"
         );
         assert!(name.unwrap().starts_with("dev-browser-"));
+    }
+
+    #[test]
+    fn command_is_available_accepts_existing_binary_even_with_non_zero_help_exit() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = if cfg!(windows) {
+            dir.path().join("fake-dev-browser.cmd")
+        } else {
+            dir.path().join("fake-dev-browser")
+        };
+        let contents = if cfg!(windows) {
+            "@echo off\r\nexit /b 1\r\n"
+        } else {
+            "#!/bin/sh\nexit 1\n"
+        };
+        fs::write(&script, contents).unwrap();
+        #[cfg(not(windows))]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = fs::metadata(&script).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&script, permissions).unwrap();
+        }
+
+        assert!(command_is_available(script.to_str().unwrap()));
     }
 }

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -932,12 +932,22 @@ fn recipe_should_stop_live_transport_fallback(
     if browser::is_chrome_approval_wait_error(err) {
         return true;
     }
+    if is_thread_reuse_error(err) {
+        return true;
+    }
 
     // Once the user has explicitly pinned a specific live Chrome target, do not
     // fan out into more browser transports after the first failure. Env/config
     // targets and auto-selected targets remain advisory.
     selected_cdp_target.is_some_and(browser::ResolvedCdpTarget::is_authoritative)
         && !matches!(transport, browser::RecipeTransport::Manual)
+}
+
+fn is_thread_reuse_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        let message = cause.to_string();
+        message.contains("thread=reuse")
+    })
 }
 
 /// A transport is "pure live-CDP" if its only way to drive the browser is
@@ -962,6 +972,44 @@ fn is_live_cdp_only_transport(transport: browser::RecipeTransport) -> bool {
 /// managed profile without CDP).
 fn recipe_should_skip_remaining_live_cdp_transports(err: &anyhow::Error) -> bool {
     browser::is_chrome_cdp_unreachable_error(err)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BrowserCheckTransport {
+    ChromeDevtoolsMcp,
+    DevBrowser,
+    AgentBrowser,
+}
+
+fn browser_check_transports(
+    dev_browser_available: bool,
+    managed_profile_only: bool,
+) -> Vec<BrowserCheckTransport> {
+    if managed_profile_only {
+        return vec![BrowserCheckTransport::AgentBrowser];
+    }
+
+    let mut transports = vec![BrowserCheckTransport::ChromeDevtoolsMcp];
+    if dev_browser_available {
+        transports.push(BrowserCheckTransport::DevBrowser);
+    }
+    transports.push(BrowserCheckTransport::AgentBrowser);
+    transports
+}
+
+fn browser_check_transport_name(transport: BrowserCheckTransport) -> &'static str {
+    match transport {
+        BrowserCheckTransport::ChromeDevtoolsMcp => "chrome-devtools-mcp",
+        BrowserCheckTransport::DevBrowser => "dev-browser",
+        BrowserCheckTransport::AgentBrowser => "agent-browser",
+    }
+}
+
+fn browser_check_live_method(target: Option<&browser::ResolvedCdpTarget>) -> String {
+    match target {
+        Some(target) if !target.is_auto_discovered() => format!("cdp: {}", target.endpoint),
+        _ => "auto_connect".to_string(),
+    }
 }
 
 fn maybe_print_auto_selected_cdp_target(
@@ -1115,6 +1163,9 @@ async fn run_recipe_via_chrome_devtools_mcp(
     // Use the existing dev-browser poll settings resolver so the response
     // timeout env/recipe-var knobs stay symmetric with the dev-browser path.
     let poll_settings = dev_browser::resolve_chatgpt_poll_settings(recipe_vars)?;
+    let thread_mode = chrome_devtools_mcp::RecipeThreadMode::parse(
+        recipe_vars.get("thread").map(String::as_str),
+    )?;
 
     let ctx = chrome_devtools_mcp::DevtoolsMcpRecipeContext {
         cdp_endpoint: cdp_endpoint.map(str::to_owned),
@@ -1125,6 +1176,7 @@ async fn run_recipe_via_chrome_devtools_mcp(
             .get("prompt")
             .cloned()
             .unwrap_or_else(|| "Review the attached file and provide your analysis.".to_string()),
+        thread_mode,
         response_timeout_ms: poll_settings.timeout_ms,
         show_approval_guidance: matches!(format, OutputFormat::Text | OutputFormat::Markdown),
     };
@@ -1136,7 +1188,8 @@ async fn run_recipe_via_chrome_devtools_mcp(
             let payload = json!({
                 "status": "ok",
                 "backend": "chrome-devtools-mcp",
-                "response": response,
+                "response": response.response,
+                "model_used": response.model_used,
             });
             write_json(&payload)?;
         }
@@ -1144,12 +1197,13 @@ async fn run_recipe_via_chrome_devtools_mcp(
             let payload = json!({
                 "type": "recipe_complete",
                 "backend": "chrome-devtools-mcp",
-                "response": response,
+                "response": response.response,
+                "model_used": response.model_used,
             });
             write_jsonl("browser.recipe", &payload)?;
         }
         OutputFormat::Text | OutputFormat::Markdown => {
-            println!("{response}");
+            println!("{}", response.response);
         }
     }
 
@@ -1493,175 +1547,207 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 !managed_profile_only,
             )?;
             maybe_print_auto_selected_cdp_target(resolved_cdp_target.as_ref(), format);
-            let dev_browser_cdp = resolved_cdp_target
-                .as_ref()
-                .map(|target| target.endpoint.clone());
             if let Some(ref cdp_url) = check_args.cdp {
-                browser::try_cdp_attach(cdp_url, "https://chatgpt.com/")
+                chrome_devtools_mcp::chatgpt::check_auth(Some(cdp_url))
+                    .await
                     .map_err(explicit_cdp_attach_failure)?;
                 maybe_remember_cdp_target(resolved_cdp_target.as_ref(), format);
                 let payload = json!({
                     "status": "ok",
                     "method": format!("cdp: {cdp_url}"),
+                    "transport": "chrome-devtools-mcp",
                 });
                 return match format {
                     OutputFormat::Json => write_json(&payload),
                     OutputFormat::Jsonl => write_jsonl("browser.check", &payload),
                     OutputFormat::Text | OutputFormat::Markdown => {
-                        println!("Browser authenticated via cdp: {cdp_url}");
+                        println!("Browser authenticated via cdp: {cdp_url} (chrome-devtools-mcp)");
                         Ok(())
                     }
                 };
-            }
-
-            // Try dev-browser first for auth verification whenever we are
-            // targeting a live Chrome instance. `--profile` still routes to the
-            // legacy managed-profile path.
-            if browser::use_dev_browser() && check_args.profile.is_none() {
-                match dev_browser::ensure_chatgpt_auth_with_page_check_and_endpoint(
-                    dev_browser_cdp.as_deref(),
-                ) {
-                    Ok(()) => {
-                        let method = if dev_browser_cdp.is_some() {
-                            "dev-browser (cdp)"
-                        } else {
-                            "dev-browser (auto-connect)"
-                        };
-                        let payload = json!({
-                            "status": "ok",
-                            "method": method,
-                            "backend": "dev-browser",
-                        });
-                        maybe_remember_cdp_target(resolved_cdp_target.as_ref(), format);
-                        return match format {
-                            OutputFormat::Json => write_json(&payload),
-                            OutputFormat::Jsonl => write_jsonl("browser.check", &payload),
-                            OutputFormat::Text | OutputFormat::Markdown => {
-                                println!("Browser authenticated via {method}");
-                                Ok(())
-                            }
-                        };
-                    }
-                    Err(e) => {
-                        if browser::is_chrome_approval_wait_error(&e) {
-                            return Err(e);
-                        }
-                        if resolved_cdp_target
-                            .as_ref()
-                            .is_some_and(browser::ResolvedCdpTarget::is_authoritative)
-                        {
-                            return Err(resolved_cdp_attach_failure(
-                                e.context("dev-browser auth check failed"),
-                                resolved_cdp_target.as_ref().expect("checked above"),
-                            ));
-                        }
-                        if resolved_cdp_target
-                            .as_ref()
-                            .is_some_and(browser::ResolvedCdpTarget::is_auto_discovered)
-                        {
-                            maybe_demote_auto_selected_cdp_target(
-                                &mut resolved_cdp_target,
-                                format,
-                                &e,
-                            );
-                        }
-                        eprintln!("info: dev-browser auth check failed ({e}), trying legacy path");
-                    }
-                }
             }
 
             let profile_dir =
                 browser::resolve_profile_dir(&ctx.config, check_args.profile.as_ref())?;
-            if managed_profile_only {
-                let connection = browser::resolve_auth(&profile_dir, /* headed */ false)?;
-                let method = match &connection {
-                    browser::BrowserConnection::CookieState { .. } => "cookie_state".to_string(),
-                    browser::BrowserConnection::Profile { .. } => "profile".to_string(),
-                    browser::BrowserConnection::Cdp { endpoint } => format!("cdp: {endpoint}"),
-                    browser::BrowserConnection::AutoConnect => "auto_connect".to_string(),
-                };
-                let payload = json!({
-                    "status": "ok",
-                    "profile": profile_dir.to_string_lossy(),
-                    "method": method,
-                });
-                return match format {
-                    OutputFormat::Json => write_json(&payload),
-                    OutputFormat::Jsonl => write_jsonl("browser.check", &payload),
-                    OutputFormat::Text | OutputFormat::Markdown => {
-                        println!("Browser authenticated via {method}");
-                        Ok(())
+            let transports =
+                browser_check_transports(browser::use_dev_browser(), managed_profile_only);
+
+            for transport in transports {
+                match transport {
+                    BrowserCheckTransport::ChromeDevtoolsMcp => {
+                        let cdp_endpoint = resolved_cdp_target
+                            .as_ref()
+                            .map(|target| target.endpoint.as_str());
+                        match chrome_devtools_mcp::chatgpt::check_auth(cdp_endpoint).await {
+                            Ok(()) => {
+                                maybe_remember_cdp_target(resolved_cdp_target.as_ref(), format);
+                                let method =
+                                    browser_check_live_method(resolved_cdp_target.as_ref());
+                                let payload = json!({
+                                    "status": "ok",
+                                    "method": method,
+                                    "transport": browser_check_transport_name(transport),
+                                });
+                                return match format {
+                                    OutputFormat::Json => write_json(&payload),
+                                    OutputFormat::Jsonl => write_jsonl("browser.check", &payload),
+                                    OutputFormat::Text | OutputFormat::Markdown => {
+                                        println!(
+                                            "Browser authenticated via {} ({})",
+                                            payload["method"].as_str().unwrap_or("auto_connect"),
+                                            browser_check_transport_name(transport)
+                                        );
+                                        Ok(())
+                                    }
+                                };
+                            }
+                            Err(e) => {
+                                if browser::is_chrome_approval_wait_error(&e) {
+                                    return Err(e);
+                                }
+                                if resolved_cdp_target
+                                    .as_ref()
+                                    .is_some_and(browser::ResolvedCdpTarget::is_authoritative)
+                                {
+                                    return Err(resolved_cdp_attach_failure(
+                                        e,
+                                        resolved_cdp_target.as_ref().expect("checked above"),
+                                    ));
+                                }
+                                if resolved_cdp_target
+                                    .as_ref()
+                                    .is_some_and(browser::ResolvedCdpTarget::is_auto_discovered)
+                                {
+                                    maybe_demote_auto_selected_cdp_target(
+                                        &mut resolved_cdp_target,
+                                        format,
+                                        &e,
+                                    );
+                                }
+                                eprintln!(
+                                    "info: {} auth check failed ({e}), trying next transport",
+                                    browser_check_transport_name(transport)
+                                );
+                            }
+                        }
                     }
-                };
+                    BrowserCheckTransport::DevBrowser => {
+                        let cdp_endpoint = resolved_cdp_target
+                            .as_ref()
+                            .map(|target| target.endpoint.as_str());
+                        match dev_browser::ensure_chatgpt_auth_with_page_check_and_endpoint(
+                            cdp_endpoint,
+                        ) {
+                            Ok(()) => {
+                                let payload = json!({
+                                    "status": "ok",
+                                    "method": if cdp_endpoint.is_some() {
+                                        "cdp"
+                                    } else {
+                                        "auto_connect"
+                                    },
+                                    "transport": browser_check_transport_name(transport),
+                                });
+                                maybe_remember_cdp_target(resolved_cdp_target.as_ref(), format);
+                                return match format {
+                                    OutputFormat::Json => write_json(&payload),
+                                    OutputFormat::Jsonl => write_jsonl("browser.check", &payload),
+                                    OutputFormat::Text | OutputFormat::Markdown => {
+                                        println!(
+                                            "Browser authenticated via {} ({})",
+                                            payload["method"].as_str().unwrap_or("auto_connect"),
+                                            browser_check_transport_name(transport)
+                                        );
+                                        Ok(())
+                                    }
+                                };
+                            }
+                            Err(e) => {
+                                if browser::is_chrome_approval_wait_error(&e) {
+                                    return Err(e);
+                                }
+                                if resolved_cdp_target
+                                    .as_ref()
+                                    .is_some_and(browser::ResolvedCdpTarget::is_authoritative)
+                                {
+                                    return Err(resolved_cdp_attach_failure(
+                                        e.context("dev-browser auth check failed"),
+                                        resolved_cdp_target.as_ref().expect("checked above"),
+                                    ));
+                                }
+                                if resolved_cdp_target
+                                    .as_ref()
+                                    .is_some_and(browser::ResolvedCdpTarget::is_auto_discovered)
+                                {
+                                    maybe_demote_auto_selected_cdp_target(
+                                        &mut resolved_cdp_target,
+                                        format,
+                                        &e,
+                                    );
+                                }
+                                eprintln!(
+                                    "info: {} auth check failed ({e}), trying next transport",
+                                    browser_check_transport_name(transport)
+                                );
+                            }
+                        }
+                    }
+                    BrowserCheckTransport::AgentBrowser => {
+                        let connection = if managed_profile_only {
+                            browser::resolve_auth(&profile_dir, /* headed */ false)?
+                        } else {
+                            let fallback_cdp = resolved_cdp_target
+                                .as_ref()
+                                .map(|target| target.endpoint.as_str());
+                            browser::resolve_browser_connection(
+                                &ctx.config,
+                                fallback_cdp.or(check_args.cdp.as_deref()),
+                                &profile_dir,
+                                "https://chatgpt.com/",
+                            )
+                            .map_err(|e| {
+                                if let Some(recovery) = default_daemon_recovery_error(Some(&e)) {
+                                    return recovery;
+                                }
+                                e
+                            })?
+                        };
+                        let method = match &connection {
+                            browser::BrowserConnection::Cdp { endpoint } => {
+                                format!("cdp: {endpoint}")
+                            }
+                            browser::BrowserConnection::AutoConnect => "auto_connect".to_string(),
+                            browser::BrowserConnection::CookieState { .. } => {
+                                "cookie_state".to_string()
+                            }
+                            browser::BrowserConnection::Profile { .. } => "profile".to_string(),
+                        };
+                        let payload = json!({
+                            "status": "ok",
+                            "profile": profile_dir.to_string_lossy(),
+                            "method": method,
+                            "transport": browser_check_transport_name(transport),
+                        });
+                        if matches!(connection, browser::BrowserConnection::Cdp { .. }) {
+                            maybe_remember_cdp_target(resolved_cdp_target.as_ref(), format);
+                        }
+                        return match format {
+                            OutputFormat::Json => write_json(&payload),
+                            OutputFormat::Jsonl => write_jsonl("browser.check", &payload),
+                            OutputFormat::Text | OutputFormat::Markdown => {
+                                println!(
+                                    "Browser authenticated via {} ({})",
+                                    payload["method"].as_str().unwrap_or("auto_connect"),
+                                    browser_check_transport_name(transport)
+                                );
+                                Ok(())
+                            }
+                        };
+                    }
+                }
             }
 
-            let connection = if let Some(target) = resolved_cdp_target.as_ref() {
-                match browser::try_cdp_attach(&target.endpoint, "https://chatgpt.com/") {
-                    Ok(()) => browser::BrowserConnection::Cdp {
-                        endpoint: target.endpoint.clone(),
-                    },
-                    Err(err) if target.is_authoritative() => {
-                        return Err(resolved_cdp_attach_failure(err, target));
-                    }
-                    Err(err) => {
-                        maybe_demote_auto_selected_cdp_target(
-                            &mut resolved_cdp_target,
-                            format,
-                            &err,
-                        );
-                        browser::resolve_browser_connection(
-                            &ctx.config,
-                            None,
-                            &profile_dir,
-                            "https://chatgpt.com/",
-                        )
-                        .map_err(|e| {
-                            if let Some(recovery) = default_daemon_recovery_error(Some(&e)) {
-                                return recovery;
-                            }
-                            e
-                        })?
-                    }
-                }
-            } else {
-                let fallback_cdp = resolved_cdp_target
-                    .as_ref()
-                    .map(|target| target.endpoint.as_str());
-                browser::resolve_browser_connection(
-                    &ctx.config,
-                    fallback_cdp.or(check_args.cdp.as_deref()),
-                    &profile_dir,
-                    "https://chatgpt.com/",
-                )
-                .map_err(|e| {
-                    if let Some(recovery) = default_daemon_recovery_error(Some(&e)) {
-                        return recovery;
-                    }
-                    e
-                })?
-            };
-            let method = match &connection {
-                browser::BrowserConnection::Cdp { endpoint } => format!("cdp: {endpoint}"),
-                browser::BrowserConnection::AutoConnect => "auto_connect".to_string(),
-                browser::BrowserConnection::CookieState { .. } => "cookie_state".to_string(),
-                browser::BrowserConnection::Profile { .. } => "profile".to_string(),
-            };
-            let payload = json!({
-                "status": "ok",
-                "profile": profile_dir.to_string_lossy(),
-                "method": method,
-            });
-            if matches!(connection, browser::BrowserConnection::Cdp { .. }) {
-                maybe_remember_cdp_target(resolved_cdp_target.as_ref(), format);
-            }
-            match format {
-                OutputFormat::Json => write_json(&payload),
-                OutputFormat::Jsonl => write_jsonl("browser.check", &payload),
-                OutputFormat::Text | OutputFormat::Markdown => {
-                    println!("Browser authenticated via {method}");
-                    Ok(())
-                }
-            }
+            unreachable!("browser check transport list must include a fallback transport")
         }
         BrowserCommand::Reset(_) => {
             let dev_browser_stopped = if browser::use_dev_browser() {
@@ -2446,6 +2532,18 @@ mod tests {
     }
 
     #[test]
+    fn recipe_should_stop_live_transport_fallback_on_thread_reuse_errors() {
+        let err = anyhow!(
+            "thread=reuse found multiple ChatGPT tabs but could not identify a unique active tab"
+        );
+        assert!(recipe_should_stop_live_transport_fallback(
+            &err,
+            None,
+            browser::RecipeTransport::ChromeDevtoolsMcp
+        ));
+    }
+
+    #[test]
     fn recipe_should_not_stop_live_transport_fallback_on_non_approval_error() {
         let err = anyhow!("chatgpt send button not found");
         assert!(!recipe_should_stop_live_transport_fallback(
@@ -2558,6 +2656,44 @@ mod tests {
         );
     }
 
+    #[test]
+    fn browser_check_prefers_cdp_before_other_transports() {
+        assert_eq!(
+            browser_check_transports(false, false),
+            vec![
+                BrowserCheckTransport::ChromeDevtoolsMcp,
+                BrowserCheckTransport::AgentBrowser,
+            ]
+        );
+        assert_eq!(
+            browser_check_transports(true, false),
+            vec![
+                BrowserCheckTransport::ChromeDevtoolsMcp,
+                BrowserCheckTransport::DevBrowser,
+                BrowserCheckTransport::AgentBrowser,
+            ]
+        );
+        assert_eq!(
+            browser_check_transports(true, true),
+            vec![BrowserCheckTransport::AgentBrowser]
+        );
+    }
+
+    #[test]
+    fn browser_check_live_method_uses_auto_connect_for_implicit_targets() {
+        assert_eq!(browser_check_live_method(None), "auto_connect");
+
+        let mut config = Config::default();
+        config.defaults.browser_cdp = Some("ws://127.0.0.1:9222/devtools/browser/config".into());
+        let configured = browser::resolve_cdp_target(None, &config)
+            .unwrap()
+            .expect("configured target");
+        assert_eq!(
+            browser_check_live_method(Some(&configured)),
+            "cdp: ws://127.0.0.1:9222/devtools/browser/config"
+        );
+    }
+
     #[tokio::test]
     async fn run_recipe_via_chrome_devtools_mcp_rejects_non_chatgpt_recipes() {
         // Until the claude/gemini ports land, non-chatgpt recipes through the
@@ -2657,6 +2793,31 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("--bundle"));
         assert!(msg.contains("paste mode"));
+    }
+
+    #[tokio::test]
+    async fn run_recipe_via_chrome_devtools_mcp_rejects_invalid_thread_mode() {
+        let recipe_args = BrowserRecipeArgs {
+            recipe: PathBuf::from("recipes/chatgpt.yaml"),
+            bundle: Some(PathBuf::from("/tmp/bundle.md")),
+            profile: None,
+            cdp: None,
+            vars: vec![],
+        };
+        let recipe_vars = BTreeMap::from([("thread".to_string(), "sideways".to_string())]);
+        let err = run_recipe_via_chrome_devtools_mcp(
+            &recipe_args,
+            &recipe_vars,
+            None,
+            OutputFormat::Text,
+            /* is_chatgpt */ true,
+        )
+        .await
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("thread"));
+        assert!(msg.contains("fresh"));
+        assert!(msg.contains("reuse"));
     }
 
     #[test]

--- a/crates/yoetz-cli/tests/cli.rs
+++ b/crates/yoetz-cli/tests/cli.rs
@@ -319,11 +319,8 @@ fn browser_login_explicit_cdp_failure_does_not_fallback() {
 
 #[test]
 fn browser_check_explicit_cdp_failure_does_not_fallback() {
-    let (_dir, bin) = fake_agent_browser_failure_bin("connectOverCDP blew up");
-
     yoetz()
-        .args(["browser", "check", "--cdp", "http://127.0.0.1:9222"])
-        .env("YOETZ_AGENT_BROWSER_BIN", &bin)
+        .args(["browser", "check", "--cdp", "http://127.0.0.1:1"])
         .env("YOETZ_DEV_BROWSER_BIN", "/definitely/missing")
         .assert()
         .failure()
@@ -371,12 +368,32 @@ fn ask_em_dash_in_prompt_parses() {
 
 #[test]
 fn bundle_em_dash_in_prompt_parses() {
-    // Bundle with em-dash should parse without argument errors.
-    // --all is required to avoid "files required" error.
-    let result = yoetz()
-        .args(["bundle", "--prompt", "review \u{2014} all code", "--all"])
-        .assert();
-    result.stderr(predicate::str::contains("unexpected argument").not());
+    // Bundle with em-dash should parse without argument errors, even with a
+    // prompt-only bundle.
+    yoetz()
+        .args(["bundle", "--prompt", "review \u{2014} all code"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("unexpected argument").not());
+}
+
+#[test]
+fn bundle_prompt_file_without_files_succeeds() {
+    let dir = tempfile::tempdir().unwrap();
+    let prompt_file = dir.path().join("prompt.md");
+    fs::write(&prompt_file, "Review this dossier").unwrap();
+
+    yoetz()
+        .args([
+            "bundle",
+            "--prompt-file",
+            prompt_file.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"file_count\": 0"));
 }
 
 #[test]

--- a/crates/yoetz-core/src/bundle.rs
+++ b/crates/yoetz-core/src/bundle.rs
@@ -1,5 +1,5 @@
 use crate::types::{Bundle, BundleFile, BundleStats};
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use ignore::overrides::OverrideBuilder;
 use ignore::WalkBuilder;
 use sha2::{Digest, Sha256};
@@ -16,6 +16,7 @@ pub struct BundleOptions {
     pub exclude: Vec<String>,
     pub max_file_bytes: usize,
     pub max_total_bytes: usize,
+    pub include_all: bool,
     pub include_hidden: bool,
     pub include_binary: bool,
 }
@@ -28,6 +29,7 @@ impl Default for BundleOptions {
             exclude: Vec::new(),
             max_file_bytes: 200_000,
             max_total_bytes: 5_000_000,
+            include_all: false,
             include_hidden: false,
             include_binary: false,
         }
@@ -115,13 +117,36 @@ fn process_file(
 pub fn build_bundle(prompt: &str, options: BundleOptions) -> Result<Bundle> {
     // Partition include patterns: absolute literal paths are read directly;
     // everything else (relative paths, globs) goes through the directory walker.
-    let mut direct_files: Vec<PathBuf> = Vec::new();
+    let mut direct_files: Vec<(PathBuf, String)> = Vec::new();
     let mut glob_patterns: Vec<String> = Vec::new();
 
     for pattern in &options.include {
         let expanded = expand_tilde(pattern);
-        if Path::new(&expanded).is_absolute() && !has_glob_chars(&expanded) {
-            direct_files.push(PathBuf::from(expanded));
+        if !has_glob_chars(&expanded) {
+            let display_path = expanded.clone();
+            let resolved_path = if Path::new(&expanded).is_absolute() {
+                PathBuf::from(&expanded)
+            } else {
+                options.root.join(&expanded)
+            };
+            if resolved_path.is_file() {
+                direct_files.push((resolved_path, display_path));
+                continue;
+            }
+            if resolved_path.is_dir() {
+                let normalized = expanded.trim_end_matches('/');
+                glob_patterns.push(format!("{normalized}/**/*"));
+                continue;
+            }
+            if expanded.contains(',') {
+                return Err(anyhow!(
+                    "comma-separated file lists are not supported in `-f/--files`; repeat the flag instead (for example: `-f first -f second`)"
+                ));
+            }
+            return Err(anyhow!(
+                "-f path not found or not a file: {}",
+                Path::new(&display_path).display()
+            ));
         } else {
             glob_patterns.push(expanded);
         }
@@ -135,9 +160,9 @@ pub fn build_bundle(prompt: &str, options: BundleOptions) -> Result<Bundle> {
     let mut total_chars = 0usize;
 
     // 1. Read directly-specified absolute files.
-    for file_path in &direct_files {
+    for (file_path, display_path) in &direct_files {
         if !file_path.is_file() {
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "-f path not found or not a file: {}",
                 file_path.display()
             ));
@@ -147,10 +172,9 @@ pub fn build_bundle(prompt: &str, options: BundleOptions) -> Result<Bundle> {
         if !seen_files.insert(identity) {
             continue;
         }
-        let display_path = file_path.to_string_lossy().to_string();
         let (bf, consumed_bytes, consumed_chars) = process_file(
             file_path,
-            display_path,
+            display_path.clone(),
             options.max_file_bytes,
             options.max_total_bytes,
             total_bytes,
@@ -163,7 +187,7 @@ pub fn build_bundle(prompt: &str, options: BundleOptions) -> Result<Bundle> {
 
     // 2. Walk the directory tree for glob / relative patterns.
     //    Also walk when include was empty (the "walk everything" case, e.g. --all).
-    if !glob_patterns.is_empty() || options.include.is_empty() {
+    if !glob_patterns.is_empty() || options.include_all {
         let mut override_builder = OverrideBuilder::new(&options.root);
         for pattern in &glob_patterns {
             override_builder.add(pattern)?;
@@ -457,6 +481,7 @@ mod tests {
         let options = BundleOptions {
             root: root.clone(),
             include: vec![], // --all mode: no include patterns
+            include_all: true,
             ..BundleOptions::default()
         };
 
@@ -519,6 +544,89 @@ mod tests {
             bundle.stats.estimated_tokens,
             estimate_tokens("🙂".chars().count() + "a🙂b".chars().count())
         );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn bundle_includes_explicit_relative_ignored_file() {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("yoetz_ignored_literal_{nanos}"));
+        let tmp_dir = root.join("tmp");
+        fs::create_dir_all(&tmp_dir).unwrap();
+        fs::write(root.join(".gitignore"), "tmp/\n").unwrap();
+        fs::write(tmp_dir.join("dossier.md"), "generated review dossier").unwrap();
+
+        let bundle = build_bundle(
+            "prompt",
+            BundleOptions {
+                root: root.clone(),
+                include: vec!["tmp/dossier.md".to_string()],
+                ..BundleOptions::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(bundle.files.len(), 1);
+        assert_eq!(bundle.files[0].path, "tmp/dossier.md");
+        assert_eq!(
+            bundle.files[0].content.as_deref(),
+            Some("generated review dossier")
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn bundle_errors_on_comma_separated_file_list() {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("yoetz_comma_files_{nanos}"));
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("a.txt"), "a").unwrap();
+        fs::write(root.join("b.txt"), "b").unwrap();
+
+        let err = build_bundle(
+            "prompt",
+            BundleOptions {
+                root: root.clone(),
+                include: vec!["a.txt,b.txt".to_string()],
+                ..BundleOptions::default()
+            },
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("comma-separated file lists"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn bundle_allows_prompt_only_without_walking_repo() {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("yoetz_prompt_only_{nanos}"));
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("a.txt"), "aaa").unwrap();
+
+        let bundle = build_bundle(
+            "prompt only",
+            BundleOptions {
+                root: root.clone(),
+                ..BundleOptions::default()
+            },
+        )
+        .unwrap();
+
+        assert!(bundle.files.is_empty());
+        assert_eq!(bundle.stats.file_count, 0);
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -13,7 +13,8 @@ name: chatgpt
 # transports connect directly to Chrome via CDP.
 #
 # Variables:
-#   model    — model slug (e.g., "gpt-5-4-pro"). Omit to keep current.
+#   model    — model slug (e.g., "gpt-5-4-pro"). Default: "auto" selects the
+#              best available model, preferring GPT-5/Pro when the account has it.
 #   extended — set to "false" to disable Extended Pro. Default: leave as-is.
 #   prompt   — prompt text to send with the attachment.
 #   thread   — "fresh" (default) opens a new ChatGPT conversation each call.
@@ -31,7 +32,7 @@ transports:
 
 defaults:
   prompt: Review the attached file and provide your analysis.
-  model: ""
+  model: "auto"
   extended: ""
   thread: "fresh"
   wait_timeout_ms: "1800000"
@@ -87,28 +88,31 @@ steps:
     args:
       - |
         (() => {
-          const raw = "{{model}}";
-          if (!raw) return "skipped: no model specified";
+          const raw = "{{model}}".trim();
+          const autoMode = !raw || raw.toLowerCase() === "auto";
           const btn = document.querySelector(
             '[data-testid="model-switcher-dropdown-button"], ' +
             'button[aria-label="Model selector"]'
           );
-          if (!btn) throw new Error("model selector button not found — ChatGPT may have changed their UI. Inspect the model picker for data-testid or aria-label attributes.");
+          if (!btn) {
+            if (autoMode) return "kept current model: selector not found";
+            throw new Error("model selector button not found — ChatGPT may have changed their UI. Inspect the model picker for data-testid or aria-label attributes.");
+          }
           btn.dispatchEvent(new PointerEvent('pointerdown', {bubbles: true, cancelable: true, pointerId: 1}));
           btn.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, cancelable: true}));
           btn.dispatchEvent(new PointerEvent('pointerup', {bubbles: true, cancelable: true, pointerId: 1}));
           btn.dispatchEvent(new MouseEvent('mouseup', {bubbles: true, cancelable: true}));
           btn.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}));
-          return "opened model selector";
+          return autoMode ? "opened model selector for auto selection" : "opened model selector";
         })()
   - sleep_ms: 1200
   - action: eval
     args:
       - |
         (() => {
-          const raw = "{{model}}";
-          if (!raw) return "skipped: no model specified";
+          const raw = "{{model}}".trim();
           const slug = raw.toLowerCase();
+          const autoMode = !slug || slug === "auto";
           function realClick(el) {
             el.dispatchEvent(new PointerEvent('pointerdown', {bubbles: true, cancelable: true, pointerId: 1}));
             el.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, cancelable: true}));
@@ -116,13 +120,49 @@ steps:
             el.dispatchEvent(new MouseEvent('mouseup', {bubbles: true, cancelable: true}));
             el.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}));
           }
-          const byTestId = document.querySelector('[data-testid="model-switcher-' + slug + '"]');
-          if (byTestId) { realClick(byTestId); return "selected: " + slug; }
+          const items = Array.from(document.querySelectorAll('[role="menuitem"], [data-testid^="model-switcher-"]'))
+            .map((el) => {
+              const text = ((el.textContent || '').replace(/\s+/g, ' ').trim());
+              const testId = el.getAttribute('data-testid') || '';
+              return {el, text, haystack: (testId + ' ' + text).toLowerCase()};
+            })
+            .filter((item) => item.text || item.haystack);
+          if (items.length === 0) {
+            if (autoMode) return "kept current model: no menu items";
+            throw new Error("model selector opened but no model options were visible");
+          }
+          const currentLabel = (((document.querySelector('[data-testid="model-switcher-dropdown-button"], button[aria-label="Model selector"]') || {}).textContent) || '')
+            .replace(/\s+/g, ' ')
+            .trim()
+            .toLowerCase();
+          if (autoMode) {
+            const ranked = items
+              .map((item) => {
+                let score = 0;
+                if (/gpt[- ]?5/.test(item.haystack)) score += 100;
+                if (/\bpro\b/.test(item.haystack)) score += 90;
+                if (/thinking/.test(item.haystack)) score += 60;
+                if (/instant/.test(item.haystack) || /\b5[- ]?3\b/.test(item.haystack)) score += 30;
+                return {...item, score};
+              })
+              .sort((a, b) => b.score - a.score || b.text.length - a.text.length);
+            if (!ranked[0] || ranked[0].score <= 0) return "kept current model";
+            if (currentLabel && currentLabel.includes(ranked[0].text.toLowerCase())) {
+              return "kept current model: " + ranked[0].text;
+            }
+            realClick(ranked[0].el);
+            return "selected: " + ranked[0].text;
+          }
           const names = {"gpt-5-4-pro":"pro","gpt-5-4-thinking":"thinking","gpt-5-3":"instant","pro":"pro","thinking":"thinking","instant":"instant"};
           const target = names[slug] || slug;
-          const items = Array.from(document.querySelectorAll('[role="menuitem"]'));
-          const match = items.find(el => (el.textContent||"").trim().toLowerCase().includes(target));
-          if (match) { realClick(match); return "selected: " + target; }
+          const byTestId = document.querySelector('[data-testid="model-switcher-' + slug + '"]');
+          if (byTestId) { realClick(byTestId); return "selected: " + slug; }
+          const match = items.find(item => item.haystack.includes(target));
+          if (match) {
+            if (currentLabel && currentLabel.includes(target)) return "kept current model: " + match.text;
+            realClick(match.el);
+            return "selected: " + match.text;
+          }
           throw new Error("model '" + slug + "' not found");
         })()
   - sleep_ms: 500
@@ -191,7 +231,15 @@ steps:
         (() => {
           const btn = document.querySelector("button[data-testid='send-button']");
           if (!btn) throw new Error("send button not found");
-          if (btn.disabled) throw new Error("send button disabled — text may not have been injected");
+          if (btn.disabled) {
+            const composerEl = document.querySelector("#prompt-textarea, [role='textbox']");
+            const state = {
+              url: window.location.href,
+              attachmentPresent: !!document.querySelector("[class*='file-tile'], [data-testid*='attachment']"),
+              composerTextLength: ((composerEl?.innerText || composerEl?.textContent || "").trim()).length,
+            };
+            throw new Error("send button disabled — page is likely recoverable: " + JSON.stringify(state));
+          }
           btn.click();
           return "sent";
         })()

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -254,7 +254,8 @@ BUNDLE=$(yoetz bundle -p "Review this code" -f src/*.rs --format json | jq -r .a
 # Send to ChatGPT
 yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE"
 
-# Override the built-in model selection if needed
+# By default yoetz now auto-selects the strongest model the logged-in account
+# can access, preferring GPT-5/Pro when available. Override it only if needed.
 yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE" --var model=gpt-5-4-pro
 
 # Reuse the currently active ChatGPT tab/conversation for a follow-up turn


### PR DESCRIPTION
## Summary
- honor `--var thread=reuse` in the primary ChatGPT browser transport instead of always opening a fresh tab
- stop `browser check` from creating extra persistent ChatGPT probe tabs and stop reuse failures from cascading into more CDP attach attempts
- bundle the related browser/bundle/model-selection fixes and document them in `CHANGELOG.md`

## Verification
- cargo fmt
- cargo test
- cargo clippy --workspace -- -D warnings
- git diff --check

## Notes
- `thread=reuse` now refuses ambiguous or still-generating ChatGPT tabs instead of stealing an in-flight Pro run
- `browser check` reuses an existing ChatGPT tab read-only when possible and only falls back to a temporary background probe tab when nothing is open

Closes #144
Closes #145
Closes #146
