### PR TITLE
chore(release): v0.2.53

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.2.52",
+  "version": "0.2.53",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.2.52",
+  "version": "0.2.53",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.53] - 2026-04-14
 ### Fixed
 
 - `yoetz browser recipe --recipe chatgpt` now honors `--var thread=reuse` in the primary `chrome-devtools-mcp` transport instead of always opening a fresh ChatGPT tab. Reuse now fails fast when the candidate tab is ambiguous or still streaming, instead of stealing an in-flight ChatGPT Pro run.
@@ -15,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `yoetz browser check` now uses the intended transport order again (`chrome-devtools-mcp` before `dev-browser`) and reports the chosen transport in its output.
 - The ChatGPT recipe now auto-selects the strongest available ChatGPT model by default, preferring GPT-5/Pro when present, and surfaces `model_used` in JSON output.
 - `yoetz bundle` now handles explicit ignored/untracked files reliably, rejects comma-separated `-f` values with a clear error, and allows prompt-only bundles without walking the repo.
+
 
 ## [0.2.52] - 2026-04-13
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3196,7 +3196,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoetz"
-version = "0.2.52"
+version = "0.2.53"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "yoetz-core"
-version = "0.2.52"
+version = "0.2.53"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/yoetz-core", "crates/yoetz-cli"]
 
 [workspace.package]
-version = "0.2.52"
+version = "0.2.53"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yoetz
-version: 0.2.52
+version: 0.2.53
 description: >
   Fast CLI-first LLM council, bundler, and multimodal gateway. Use ONLY when user
   explicitly mentions "yoetz", "yoetz ask", "yoetz council", "yoetz review",


### PR DESCRIPTION
## Release

- updates `CHANGELOG.md` for `v0.2.53`
- bumps workspace version to `0.2.53`
- aligns skill/plugin metadata to `0.2.53`
- merge triggers .github/workflows/release.yml, which creates the tag and
  publishes the release
- GitHub release notes come from the committed `CHANGELOG.md` entry