### PR TITLE
chore: fix clippy 1.95 (collapsible_match + useless_conversion)

### DIFF
--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -294,24 +294,25 @@ fn build_agent_browser_args(
             // For auto-connect, do NOT add --session. A managed session creates
             // an isolated context that can't see the real Chrome tabs/DOM.
             // Auto-connect should attach to the real browser directly.
-            if !args.iter().any(|a| a == "--auto-connect") {
+            let already_present = args.iter().any(|a| a == "--auto-connect");
+            if !already_present {
                 args.insert(0, "--auto-connect".to_string());
             }
         }
         Some(BrowserConnection::CookieState { state_file }) => {
-            if !args
+            let already_present = args
                 .iter()
-                .any(|a| a == "--state" || a.starts_with("--state="))
-            {
+                .any(|a| a == "--state" || a.starts_with("--state="));
+            if !already_present {
                 args.insert(0, state_file.to_string_lossy().to_string());
                 args.insert(0, "--state".to_string());
             }
         }
         Some(BrowserConnection::Profile { profile_dir }) => {
-            if !args
+            let already_present = args
                 .iter()
-                .any(|a| a == "--profile" || a.starts_with("--profile="))
-            {
+                .any(|a| a == "--profile" || a.starts_with("--profile="));
+            if !already_present {
                 args.insert(0, profile_dir.to_string_lossy().to_string());
                 args.insert(0, "--profile".to_string());
             }
@@ -1081,10 +1082,8 @@ fn parse_chatgpt_dom_state(raw: &str) -> Result<ChatgptDomState> {
             "lastlen" => {
                 assistant_last_len = value.parse().unwrap_or(0);
             }
-            "err" => {
-                if !value.is_empty() {
-                    error = value.to_string();
-                }
+            "err" if !value.is_empty() => {
+                error = value.to_string();
             }
             _ => {}
         }

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -2243,7 +2243,7 @@ fn parse_media_inputs(
     let kind_label = media_type_label(&kind);
     let overrides = normalize_mime_overrides(values.len(), mimes, kind_label)?;
     let mut out = Vec::with_capacity(values.len());
-    for (value, mime) in values.iter().zip(overrides.into_iter()) {
+    for (value, mime) in values.iter().zip(overrides) {
         out.push(parse_media_input(value, mime.as_deref(), kind.clone())?);
     }
     Ok(out)


### PR DESCRIPTION
## Summary
- Rust 1.95 / Clippy 1.95 tightened two lints that fire on existing code. `cargo clippy --workspace --all-targets -- -D warnings` fails under the newer toolchain (surfaced by #149's `cargo-deny-action` bump to 2.0.16).
- Fix them directly, no `#[allow(...)]` hiding.

### Fixes
- **`clippy::collapsible_match`** — `crates/yoetz-cli/src/browser.rs:297/302/311`: each `Some(BrowserConnection::...)` match arm had a single `if !present { insert }` body Clippy wants merged into a match guard. Match guards don't fit here (the non-insert case needs to fall through to sibling variants), so we break the single-expression arm by binding the presence check into `let already_present = ...` first.
- **`clippy::collapsible_match`** — `browser.rs:1085`: the `"err"` arm of a string match collapses cleanly into a match guard; the non-match case already falls through to the existing `_ => {}` arm.
- **`clippy::useless_conversion`** — `main.rs:2246`: drop the redundant `.into_iter()` in `values.iter().zip(overrides.into_iter())`.

## Test plan
- [x] `cargo +1.95.0 clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo +1.95.0 test --workspace` — all 267 tests pass (202 + 27 + 3 + 35)
- [x] `cargo +1.95.0 fmt --all -- --check` clean
- [ ] CI green (Clippy + Test + Format jobs)

## Follow-ups
- Separate PR: swap `serde_yml` → `serde_yaml_ng` to clear the `yaml-peg` unmaintained advisory surfaced by the same `cargo-deny-action` bump.
- After this PR + the `serde_yaml_ng` swap land, #149 (Dependabot actions bump) becomes rebase-ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)