### PR TITLE
fix: harden ChatGPT browser transports and smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,3 +243,46 @@ jobs:
           name: yoetz-${{ matrix.os }}
           path: target/release/yoetz.exe
           retention-days: 3
+
+  browser-integration:
+    name: Real-Browser Smoke (Chrome for Testing)
+    needs: changes
+    if: needs.changes.outputs.release_only != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Install Chrome for Testing
+        id: install-chrome
+        uses: browser-actions/setup-chrome@c785b87e244131f27c9f19c1a33e2ead956ab7ce # v2
+        with:
+          chrome-version: stable
+      - name: Install host dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            jq \
+            libnss3 \
+            libatk-bridge2.0-0 \
+            libdrm2 \
+            libgbm1 \
+            libasound2t64 \
+            fonts-liberation \
+            libxcomposite1 \
+            libxdamage1 \
+            libxrandr2 \
+            libu2f-udev \
+            libvulkan1 \
+            xdg-utils
+      - name: Fake-ChatGPT fixture tests
+        env:
+          YOETZ_CHROME_BIN: ${{ steps.install-chrome.outputs.chrome-path }}
+        run: cargo test -p yoetz fake_chatgpt_fixture_ -- --ignored
+      - name: Build yoetz
+        run: cargo build --release --bin yoetz
+      - name: Real-browser smoke
+        env:
+          YOETZ_CHROME_BIN: ${{ steps.install-chrome.outputs.chrome-path }}
+        run: ./scripts/ci-real-browser-smoke.sh

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -69,7 +69,7 @@ This enables replay, debugging, and the `apply` command for code review suggesti
 
 ### Budget Tracking
 
-Daily spend is tracked in a local JSON file. The `--max-cost-usd` flag estimates cost before sending (using the pricing registry) and aborts if over budget. `--daily-budget-usd` accumulates across commands.
+Daily spend is tracked in a local JSON file. The `--max-cost-usd` flag estimates cost before sending (using the pricing registry) and aborts if over budget. `--daily-budget-usd` accumulates across `ask`, `council`, and `review`. Generation commands do not expose budget flags yet, and multimodal `ask` currently rejects strict preflight budget enforcement until media pricing can be estimated accurately.
 
 ### Browser Mode
 
@@ -77,9 +77,9 @@ For models without API access (e.g., ChatGPT Pro), yoetz bundles files into mark
 
 Browser integrations are extension-free by design. Yoetz prefers to act as a wrapper over the underlying transport rather than reimplementing transport logic itself:
 
-- `dev-browser` is the primary live-Chrome transport for ChatGPT recipes.
-- `agent-browser` remains the legacy fallback when `dev-browser` is unavailable or a non-ChatGPT path still depends on it.
-- `chrome-devtools-mcp` is an extension-free fallback candidate, but it is not integrated yet.
+- `chrome-devtools-mcp` is the primary live-Chrome transport for ChatGPT recipes.
+- `dev-browser` is the secondary live-Chrome transport.
+- `agent-browser` remains the tertiary / legacy fallback when the first two transports are unavailable or a non-ChatGPT path still depends on it.
 - Explicit CDP endpoints are forwarded to the transport unchanged; the transport owns `/json/version`, `DevToolsActivePort`, and related connection logic.
 
 Connection priority remains connect-first: explicit CDP endpoint > auto-connect > cookie state > profile fallback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `yoetz browser verify-cdp --cdp <url>` — a thin CI-friendly smoke command
+  that attaches to a given CDP endpoint and opens a throwaway tab, without
+  any ChatGPT auth probing. Backs the new real-browser CI lane that spins up
+  Chrome for Testing on every pull request.
+- Deterministic fake-ChatGPT fixture tests plus a gated
+  `scripts/chatgpt-browser-canary.sh` live canary so browser changes can be
+  exercised against both a scripted DOM and a real authenticated ChatGPT tab.
+
+### Changed
+
+- ChatGPT browser transports now share one typed request/output contract.
+  `chrome-devtools-mcp`, `dev-browser`, and the generic browser recipe all
+  return the same top-level JSON fields (`transport`, `backend`, `response`,
+  `model_used`, `warnings`, `fallback_used`, `delivery_mode`, and
+  `auto_paste_fallback`) instead of transport-specific shapes.
+- The generic `recipes/chatgpt.yaml` flow now delegates model selection,
+  attachment UI open, and send-button activation to shared Rust actions so the
+  transport-specific implementations stay aligned with the same DOM contract.
+
+### Removed
+
+- `--var thread=reuse` on `yoetz browser recipe --recipe chatgpt`. The reuse
+  mode introduced in 0.2.50 and updated in 0.2.53 had no safe path that
+  avoided hijacking an active ChatGPT Pro run. Every yoetz request now opens
+  a fresh, yoetz-owned ChatGPT tab marked with `?_yoetz=<run-id>`; passing
+  `thread=reuse` is rejected with a migration message pointing at this
+  behavior. Parallel yoetz runs continue to work because each run owns its
+  own tab.
+
+### Fixed
+
+- The vendored `headless_chrome` transport now uses flat CDP sessions and lazy
+  single-target attachment on modern Chrome, avoiding the `Page.enable`
+  `-32601` failures that showed up when a second client auto-attached existing
+  targets on Chrome 147.
+- `yoetz browser recipe --recipe chatgpt` now reconnects once and reattaches to
+  the same ChatGPT page target if Chrome drops the websocket during long
+  stable-idle response polling, instead of failing the run immediately.
+- `scripts/setup-chatgpt-profile.sh` now prefers the repo-built yoetz binary,
+  and the global config selector is `--config-profile`, avoiding collisions
+  with browser subcommands that already use `--profile`.
+
+### Security
+
+- Untrusted repo-local config can no longer set global defaults or model
+  aliases, and browser profile/CDP defaults remain restricted to trusted config
+  paths only.
+
 ## [0.2.53] - 2026-04-14
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3208,6 +3208,7 @@ dependencies = [
  "jsonschema",
  "litellm-rust",
  "predicates",
+ "rand",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -3216,6 +3217,7 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
+ "toml",
  "yoetz-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1929,9 +1929,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,16 +1256,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2094,18 +2084,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",
- "libyml",
- "memchr",
  "ryu",
  "serde",
- "version_check",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2552,6 +2540,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -3212,7 +3206,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_yaml_ng",
  "serial_test",
  "tempfile",
  "time",

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Most LLM CLI tools focus on a single provider or a single workflow. yoetz is dif
 
 - **Multi-model council** — get consensus from multiple LLMs in one command, not sequential copy-paste between tabs
 - **Multimodal native** — text, images, and video as first-class inputs across providers
-- **Agent-first design** — structured JSON output, budget tracking, and agent skill integration out of the box
+- **Agent-first design** — structured JSON output, local budget tracking for ask/council/review, and agent skill integration out of the box
 - **Zero lock-in** — one config, any provider (OpenRouter, OpenAI, Gemini, LiteLLM), switch with a flag
 - **Bundle-aware** — package your codebase with gitignore-awareness for maximum LLM context
 

--- a/crates/yoetz-cli/Cargo.toml
+++ b/crates/yoetz-cli/Cargo.toml
@@ -29,6 +29,8 @@ serde.workspace = true
 serde_json.workspace = true
 base64.workspace = true
 time.workspace = true
+rand.workspace = true
+toml.workspace = true
 
 clap = { version = "4.6", features = ["derive"] }
 reqwest = { version = "0.12", default-features = false, features = [

--- a/crates/yoetz-cli/Cargo.toml
+++ b/crates/yoetz-cli/Cargo.toml
@@ -40,7 +40,7 @@ reqwest = { version = "0.12", default-features = false, features = [
     "blocking",
 ] }
 tokio = { version = "1.51", features = ["rt-multi-thread", "macros", "time"] }
-serde_yml = "0.0.12"
+serde_yaml_ng = "0.10.0"
 tempfile = "3.27"
 jsonschema = "0.45"
 fs2 = "0.4"

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -6091,7 +6091,7 @@ browser_cdp = "http://evil.example.com:9222"
 
     #[test]
     fn recipe_yaml_rejects_unknown_keys() {
-        let top_level_err = serde_yml::from_str::<Recipe>(
+        let top_level_err = serde_yaml_ng::from_str::<Recipe>(
             r#"
 name: chatgpt
 oops: true
@@ -6103,7 +6103,7 @@ steps:
         .unwrap_err();
         assert!(top_level_err.to_string().contains("unknown field"));
 
-        let step_err = serde_yml::from_str::<Recipe>(
+        let step_err = serde_yaml_ng::from_str::<Recipe>(
             r#"
 name: chatgpt
 steps:
@@ -6118,7 +6118,7 @@ steps:
 
     #[test]
     fn recipe_yaml_parses_transport_order() {
-        let recipe = serde_yml::from_str::<Recipe>(
+        let recipe = serde_yaml_ng::from_str::<Recipe>(
             r#"
 name: chatgpt
 transports: [dev-browser, agent-browser, chrome-devtools-mcp, manual]
@@ -6142,7 +6142,7 @@ steps:
 
     #[test]
     fn recipe_transports_default_to_chatgpt_funnel() {
-        let recipe = serde_yml::from_str::<Recipe>(
+        let recipe = serde_yaml_ng::from_str::<Recipe>(
             r#"
 name: chatgpt
 steps:
@@ -6172,7 +6172,7 @@ steps:
 
     #[test]
     fn recipe_step_parses_timeout_ms() {
-        let recipe = serde_yml::from_str::<Recipe>(
+        let recipe = serde_yaml_ng::from_str::<Recipe>(
             r#"
 name: test
 steps:
@@ -6193,7 +6193,7 @@ steps:
         let bin = fake_agent_browser_bin();
         let _bin_env = EnvVarGuard::set("YOETZ_AGENT_BROWSER_BIN", &bin);
         let _log_env = EnvVarGuard::set("LOG_PATH", &log_path);
-        let recipe = serde_yml::from_str::<Recipe>(
+        let recipe = serde_yaml_ng::from_str::<Recipe>(
             r#"
 name: noop
 steps:
@@ -6236,7 +6236,7 @@ steps:
         let _guard = lock_env();
         let bin = fake_agent_browser_timeout_bin();
         let _bin_env = EnvVarGuard::set("YOETZ_AGENT_BROWSER_BIN", &bin);
-        let recipe = serde_yml::from_str::<Recipe>(
+        let recipe = serde_yaml_ng::from_str::<Recipe>(
             r#"
 name: fail-fast
 steps:

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -12,8 +12,13 @@ use std::sync::OnceLock;
 use std::thread;
 use std::time::{Duration, Instant, SystemTime};
 
-use crate::chrome_devtools_mcp::client::{discover_running_chrome_targets, RunningChromeTarget};
-use yoetz_core::config::Config;
+use crate::chatgpt_recipe;
+use crate::chatgpt_web;
+use crate::chrome_devtools_mcp::client::{
+    browser_id_from_ws_endpoint, discover_devtools_active_port_files,
+    discover_local_chromium_processes, discover_running_chrome_targets, infer_email_hints,
+    ChromiumProcessSummary, DevtoolsActivePortFile, RunningChromeTarget,
+};
 use yoetz_core::output::{write_json, write_jsonl_event, OutputFormat};
 use yoetz_core::paths::home_dir;
 
@@ -28,25 +33,19 @@ const LIVE_ATTACH_AUTH_CHECK_TIMEOUT_MS: u64 = 30_000;
 const AUTH_CHECK_POLL_MS: u64 = 500;
 const CHATGPT_WAIT_ACTION: &str = "chatgpt_wait_response";
 const CHATGPT_WAIT_UPLOAD_ACTION: &str = "chatgpt_wait_upload";
+const CHATGPT_SELECT_MODEL_ACTION: &str = "chatgpt_select_model";
+const CHATGPT_OPEN_ATTACHMENT_UI_ACTION: &str = "chatgpt_open_attachment_ui";
+const CHATGPT_SEND_ACTION: &str = "chatgpt_send";
 const CHATGPT_POLL_ATTEMPTS_DEFAULT: usize = 60;
 const CHATGPT_POLL_INTERVAL_MS_DEFAULT: u64 = 30_000;
 const CHATGPT_POLL_TOTAL_TIMEOUT_MS_DEFAULT: u64 = 1_800_000;
 const CHATGPT_POLL_COMMAND_TIMEOUT_MS_DEFAULT: u64 = 10_000;
-/// Minimum stable-idle window before falling back to "response done" without a
-/// copy button. Set to 90s so that with the default 30s poll interval, three
-/// consecutive identical idle polls are required — preventing preamble-pause
-/// false positives where ChatGPT briefly stops streaming during Pro deliberation.
-/// For shorter intervals we still require ≥90s real time; for longer intervals
-/// we require ≥3 × interval_ms so the policy degrades gracefully.
-const CHATGPT_STABLE_IDLE_FLOOR_MS: u64 = 90_000;
-const CHATGPT_STABLE_IDLE_INTERVAL_MULTIPLIER: u64 = 3;
 const CHATGPT_UPLOAD_POLL_ATTEMPTS_DEFAULT: usize = 30;
 const CHATGPT_UPLOAD_POLL_INTERVAL_MS_DEFAULT: u64 = 1_000;
 const DAEMON_APPROVAL_GRACE_WINDOW: Duration = Duration::from_secs(30);
 const LIVE_ATTACH_COMMAND_TIMEOUT_MS: u64 = 30_000;
 const CDP_SESSION_NAME: &str = "yoetz-cdp";
 const CHROME_APPROVAL_LOCK_FILENAME: &str = "chrome-approval.lock";
-const CHATGPT_RECIPE_LOCK_FILENAME: &str = "chatgpt-recipe.lock";
 const BROWSER_TARGET_STATE_FILENAME: &str = "browser-target.json";
 pub const CHATGPT_URL: &str = "https://chatgpt.com/";
 const COOKIE_SYNC_NODE_MIN_VERSION: NodeVersion = NodeVersion {
@@ -107,6 +106,23 @@ pub struct RecipeContext {
     pub target_url: String,
 }
 
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct BrowserDefaults {
+    pub profile: Option<String>,
+    pub cdp: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct BrowserConfigFile {
+    defaults: Option<BrowserConfigDefaults>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct BrowserConfigDefaults {
+    browser_profile: Option<String>,
+    browser_cdp: Option<String>,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum BrowserProfileMode {
     PreferState,
@@ -147,6 +163,7 @@ pub struct ResolvedCdpTarget {
     pub source: ResolvedCdpTargetSource,
     pub description: String,
     source_path: Option<PathBuf>,
+    selected_target: Option<RunningChromeTarget>,
 }
 
 impl ResolvedCdpTarget {
@@ -156,6 +173,10 @@ impl ResolvedCdpTarget {
 
     pub fn is_authoritative(&self) -> bool {
         matches!(self.source, ResolvedCdpTargetSource::Flag)
+    }
+
+    pub fn selected_running_target(&self) -> Option<&RunningChromeTarget> {
+        self.selected_target.as_ref()
     }
 }
 
@@ -167,10 +188,14 @@ struct BrowserTargetState {
 /// Cached agent-browser resolution. Probed once per process, reused for all calls.
 static AGENT_BROWSER: OnceLock<Result<(String, Vec<String>), String>> = OnceLock::new();
 static BROWSER_TARGET_STATE_WARNING_EMITTED: OnceLock<()> = OnceLock::new();
+const AGENT_BROWSER_INSTALL_GUIDANCE: &str = concat!(
+    "agent-browser not found in PATH. Install it explicitly using a pinned, vetted ",
+    "binary/package, or set YOETZ_AGENT_BROWSER_BIN to the exact executable to run."
+);
 
 /// Returns true if dev-browser is the active browser backend.
-/// When dev-browser is available (installed or auto-installed), it is the
-/// preferred backend for all browser operations.
+/// When dev-browser is available, it is the preferred backend for all browser
+/// operations.
 pub fn use_dev_browser() -> bool {
     crate::dev_browser::is_available()
 }
@@ -200,34 +225,30 @@ pub fn recipe_transports(recipe: &Recipe, is_chatgpt: bool) -> Vec<RecipeTranspo
 
 /// Returns (program, extra_prefix_args) for launching agent-browser.
 /// Checks YOETZ_AGENT_BROWSER_BIN on every call, then falls back to a cached
-/// PATH/npx probe for the lifetime of the process.
+/// PATH probe for the lifetime of the process.
 fn resolve_agent_browser() -> Result<(String, Vec<String>)> {
     if let Ok(bin) = env::var("YOETZ_AGENT_BROWSER_BIN") {
         return Ok((bin, vec![]));
     }
 
-    let cached = AGENT_BROWSER.get_or_init(|| {
-        // Check if agent-browser is in PATH
-        if Command::new("agent-browser")
-            .arg("--version")
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .is_ok_and(|s| s.success())
-        {
-            return Ok(("agent-browser".to_string(), vec![]));
-        }
-        // Fall back to npx — runs from cache or downloads on first use.
-        eprintln!("info: agent-browser not found in PATH, using npx");
-        Ok((
-            "npx".to_string(),
-            vec!["--yes".to_string(), "agent-browser".to_string()],
-        ))
-    });
+    let cached = AGENT_BROWSER.get_or_init(detect_agent_browser_in_path);
     match cached {
         Ok(v) => Ok(v.clone()),
         Err(msg) => Err(anyhow!("{msg}")),
     }
+}
+
+fn detect_agent_browser_in_path() -> Result<(String, Vec<String>), String> {
+    if Command::new("agent-browser")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+    {
+        return Ok(("agent-browser".to_string(), vec![]));
+    }
+    Err(AGENT_BROWSER_INSTALL_GUIDANCE.to_string())
 }
 
 pub fn run_agent_browser(
@@ -290,33 +311,29 @@ fn build_agent_browser_args(
                 args.insert(0, "--cdp".to_string());
             }
         }
-        Some(BrowserConnection::AutoConnect) => {
+        Some(BrowserConnection::AutoConnect) if !args.iter().any(|a| a == "--auto-connect") => {
             // For auto-connect, do NOT add --session. A managed session creates
             // an isolated context that can't see the real Chrome tabs/DOM.
             // Auto-connect should attach to the real browser directly.
-            if !args.iter().any(|a| a == "--auto-connect") {
-                args.insert(0, "--auto-connect".to_string());
-            }
+            args.insert(0, "--auto-connect".to_string());
         }
-        Some(BrowserConnection::CookieState { state_file }) => {
+        Some(BrowserConnection::CookieState { state_file })
             if !args
                 .iter()
-                .any(|a| a == "--state" || a.starts_with("--state="))
-            {
-                args.insert(0, state_file.to_string_lossy().to_string());
-                args.insert(0, "--state".to_string());
-            }
+                .any(|a| a == "--state" || a.starts_with("--state=")) =>
+        {
+            args.insert(0, state_file.to_string_lossy().to_string());
+            args.insert(0, "--state".to_string());
         }
-        Some(BrowserConnection::Profile { profile_dir }) => {
+        Some(BrowserConnection::Profile { profile_dir })
             if !args
                 .iter()
-                .any(|a| a == "--profile" || a.starts_with("--profile="))
-            {
-                args.insert(0, profile_dir.to_string_lossy().to_string());
-                args.insert(0, "--profile".to_string());
-            }
+                .any(|a| a == "--profile" || a.starts_with("--profile=")) =>
+        {
+            args.insert(0, profile_dir.to_string_lossy().to_string());
+            args.insert(0, "--profile".to_string());
         }
-        None => {}
+        _ => {}
     }
 
     if use_stealth && !live_attach {
@@ -423,7 +440,7 @@ fn run_agent_browser_with_options(
     run_agent_browser_with_connection(args, format, connection.as_ref(), use_stealth, headed)
 }
 
-pub fn run_recipe(recipe: Recipe, ctx: RecipeContext, format: OutputFormat) -> Result<()> {
+pub fn run_recipe(recipe: Recipe, ctx: RecipeContext, format: OutputFormat) -> Result<Value> {
     let connection = legacy_connection(
         ctx.profile_dir.as_deref(),
         ctx.profile_mode,
@@ -438,7 +455,7 @@ pub fn run_recipe_with_live_connection(
     ctx: RecipeContext,
     connection: &BrowserConnection,
     format: OutputFormat,
-) -> Result<()> {
+) -> Result<Value> {
     run_recipe_with_connection(recipe, ctx, Some(connection), format)
 }
 
@@ -447,7 +464,7 @@ fn run_recipe_with_connection(
     ctx: RecipeContext,
     connection: Option<&BrowserConnection>,
     format: OutputFormat,
-) -> Result<()> {
+) -> Result<Value> {
     // For live-attach (auto-connect / CDP), skip the pre-recipe close.
     // The close creates a managed session that opens a blank tab in Chrome,
     // and then the recipe's `open` (rewritten to `tab new`) opens a second tab.
@@ -463,8 +480,19 @@ fn run_recipe_with_connection(
 
     let wants_json = matches!(format, OutputFormat::Json);
     let wants_jsonl = matches!(format, OutputFormat::Jsonl);
+    let is_chatgpt_recipe = recipe
+        .name
+        .as_deref()
+        .is_some_and(|name| name.eq_ignore_ascii_case("chatgpt"));
+    let collect_step_events = wants_json || (wants_jsonl && is_chatgpt_recipe);
     let mut events: Vec<Value> = Vec::new();
     let mut headed = ctx.headed;
+
+    if let Some(connection) = connection {
+        if connection.is_live_attach() {
+            maybe_select_live_attach_profile_tab(connection, &ctx, headed)?;
+        }
+    }
 
     if wants_jsonl {
         if let Some(name) = recipe.name.as_deref() {
@@ -499,13 +527,14 @@ fn run_recipe_with_connection(
 
         if let Some(ms) = step.sleep_ms {
             thread::sleep(Duration::from_millis(ms));
-            continue;
         }
 
-        let action = step
-            .action
-            .as_ref()
-            .ok_or_else(|| anyhow!("recipe step {idx} missing action"))?;
+        let Some(action) = step.action.as_ref() else {
+            if step.sleep_ms.is_some() {
+                continue;
+            }
+            return Err(anyhow!("recipe step {idx} missing action"));
+        };
 
         if action == CHATGPT_WAIT_ACTION {
             // Interpolate recipe vars (e.g. {{wait_timeout_ms}}) in args before parsing.
@@ -540,7 +569,8 @@ fn run_recipe_with_connection(
                 });
                 if wants_jsonl {
                     write_jsonl_event(&event)?;
-                } else {
+                }
+                if collect_step_events {
                     events.push(event);
                 }
             } else {
@@ -549,10 +579,9 @@ fn run_recipe_with_connection(
             continue;
         }
 
-        if action == CHATGPT_WAIT_UPLOAD_ACTION {
-            let stdout =
-                run_chatgpt_wait_upload(step.args.as_deref(), connection, ctx.use_stealth, headed)
-                    .with_context(|| format!("recipe step {idx} ({action}) failed"))?;
+        if action == CHATGPT_SELECT_MODEL_ACTION {
+            let stdout = run_chatgpt_select_model(&ctx, connection, ctx.use_stealth, headed)
+                .with_context(|| format!("recipe step {idx} ({action}) failed"))?;
 
             if wants_json || wants_jsonl {
                 let stdout_value =
@@ -566,7 +595,92 @@ fn run_recipe_with_connection(
                 });
                 if wants_jsonl {
                     write_jsonl_event(&event)?;
-                } else {
+                }
+                if collect_step_events {
+                    events.push(event);
+                }
+            } else {
+                print!("{stdout}");
+            }
+            continue;
+        }
+
+        if action == CHATGPT_OPEN_ATTACHMENT_UI_ACTION {
+            let stdout = run_chatgpt_open_attachment_ui(connection, ctx.use_stealth, headed)
+                .with_context(|| format!("recipe step {idx} ({action}) failed"))?;
+
+            if wants_json || wants_jsonl {
+                let stdout_value =
+                    parse_stdout_json(&stdout).unwrap_or(Value::String(stdout.clone()));
+                let event = json!({
+                    "type": "browser_step",
+                    "index": idx,
+                    "action": action,
+                    "args": step.args,
+                    "stdout": stdout_value,
+                });
+                if wants_jsonl {
+                    write_jsonl_event(&event)?;
+                }
+                if collect_step_events {
+                    events.push(event);
+                }
+            } else {
+                print!("{stdout}");
+            }
+            continue;
+        }
+
+        if action == CHATGPT_SEND_ACTION {
+            let stdout = run_chatgpt_send(connection, ctx.use_stealth, headed)
+                .with_context(|| format!("recipe step {idx} ({action}) failed"))?;
+
+            if wants_json || wants_jsonl {
+                let stdout_value =
+                    parse_stdout_json(&stdout).unwrap_or(Value::String(stdout.clone()));
+                let event = json!({
+                    "type": "browser_step",
+                    "index": idx,
+                    "action": action,
+                    "args": step.args,
+                    "stdout": stdout_value,
+                });
+                if wants_jsonl {
+                    write_jsonl_event(&event)?;
+                }
+                if collect_step_events {
+                    events.push(event);
+                }
+            } else {
+                print!("{stdout}");
+            }
+            continue;
+        }
+
+        if action == CHATGPT_WAIT_UPLOAD_ACTION {
+            let stdout = run_chatgpt_wait_upload(
+                &ctx,
+                step.args.as_deref(),
+                connection,
+                ctx.use_stealth,
+                headed,
+            )
+            .with_context(|| format!("recipe step {idx} ({action}) failed"))?;
+
+            if wants_json || wants_jsonl {
+                let stdout_value =
+                    parse_stdout_json(&stdout).unwrap_or(Value::String(stdout.clone()));
+                let event = json!({
+                    "type": "browser_step",
+                    "index": idx,
+                    "action": action,
+                    "args": step.args,
+                    "stdout": stdout_value,
+                });
+                if wants_jsonl {
+                    write_jsonl_event(&event)?;
+                }
+                if collect_step_events {
                     events.push(event);
                 }
             } else {
@@ -634,7 +748,8 @@ fn run_recipe_with_connection(
                 });
                 if wants_jsonl {
                     write_jsonl_event(&event)?;
-                } else {
+                }
+                if collect_step_events {
                     events.push(event);
                 }
             } else {
@@ -643,15 +758,91 @@ fn run_recipe_with_connection(
         }
     }
 
-    if wants_json {
-        let payload = json!({
+    let payload = if is_chatgpt_recipe {
+        chatgpt_recipe_payload_from_steps(&events)
+    } else {
+        json!({
             "name": recipe.name,
             "steps": events,
-        });
+        })
+    };
+
+    if wants_json {
         write_json(&payload)?;
+        return Ok(payload);
     }
 
-    Ok(())
+    if wants_jsonl && is_chatgpt_recipe {
+        let event = json!({
+            "type": "recipe_complete",
+            "transport": "agent-browser",
+            "backend": "agent-browser",
+            "response": payload.get("response").cloned().unwrap_or(Value::Null),
+            "model_used": payload.get("model_used").cloned().unwrap_or(Value::Null),
+            "warnings": payload
+                .get("warnings")
+                .cloned()
+                .unwrap_or_else(|| Value::Array(Vec::new())),
+            "fallback_used": true,
+            "delivery_mode": payload.get("delivery_mode").cloned().unwrap_or(Value::Null),
+            "auto_paste_fallback": payload
+                .get("auto_paste_fallback")
+                .cloned()
+                .unwrap_or(Value::Bool(false)),
+        });
+        write_jsonl_event(&event)?;
+    }
+
+    Ok(payload)
+}
+
+fn chatgpt_recipe_payload_from_steps(steps: &[Value]) -> Value {
+    let mut response = Value::Null;
+    let mut model_used = Value::Null;
+    let mut warnings: Vec<String> = Vec::new();
+
+    for step in steps {
+        let action = step
+            .get("action")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let stdout = step.get("stdout").unwrap_or(&Value::Null);
+        if action == CHATGPT_SELECT_MODEL_ACTION {
+            if let Some(value) = stdout.get("model_used").cloned() {
+                model_used = value;
+            }
+        }
+        if action == CHATGPT_WAIT_ACTION {
+            if let Some(value) = stdout.get("response").cloned() {
+                response = value;
+            }
+            if let Some(items) = stdout.get("warnings").and_then(Value::as_array) {
+                warnings.extend(
+                    items
+                        .iter()
+                        .filter_map(Value::as_str)
+                        .filter(|value| !value.trim().is_empty())
+                        .map(str::to_owned),
+                );
+            }
+        }
+    }
+
+    let output = chatgpt_recipe::ChatgptRecipeOutput {
+        transport: "agent-browser".to_string(),
+        backend: "agent-browser".to_string(),
+        response: response.as_str().unwrap_or_default().to_string(),
+        model_used: model_used.as_str().map(str::to_owned),
+        warnings,
+        fallback_used: true,
+        delivery_mode: chatgpt_recipe::ChatgptDeliveryMode::FileUpload,
+        auto_paste_fallback: false,
+    };
+    let mut payload = output.to_value();
+    if let Some(object) = payload.as_object_mut() {
+        object.insert("steps".to_string(), json!(steps));
+    }
+    payload
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -714,6 +905,46 @@ struct AgentBrowserTabListData {
 struct AgentBrowserTabListEnvelope {
     #[serde(default)]
     data: AgentBrowserTabListData,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum AutoConnectDoctorStatus {
+    Reachable(Vec<AgentBrowserTab>),
+    Unavailable(String),
+    Skipped(String),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum BrowserHelperProcessKind {
+    DevBrowserDaemon,
+    ChromeDevtoolsMcp,
+    ChromeDevtoolsMcpWatchdog,
+}
+
+impl BrowserHelperProcessKind {
+    fn label(&self) -> &'static str {
+        match self {
+            Self::DevBrowserDaemon => "dev-browser daemon",
+            Self::ChromeDevtoolsMcp => "chrome-devtools-mcp",
+            Self::ChromeDevtoolsMcpWatchdog => "chrome-devtools-mcp watchdog",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct BrowserHelperProcessSummary {
+    pid: u32,
+    kind: BrowserHelperProcessKind,
+    command: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct BrowserDoctorHelpers {
+    agent_browser_default: DaemonState,
+    agent_browser_default_pid: Option<u32>,
+    dev_browser_processes: Vec<BrowserHelperProcessSummary>,
+    external_mcp_processes: Vec<BrowserHelperProcessSummary>,
+    recommended_actions: Vec<String>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -779,8 +1010,16 @@ fn run_chatgpt_wait_response(
         match classify_chatgpt_completion(&dom, &baseline_dom) {
             CompletionVerdict::CopyButton => {
                 let elapsed_ms = started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+                let response = read_latest_chatgpt_response(
+                    connection,
+                    use_stealth,
+                    headed,
+                    command_timeout_ms,
+                )?;
                 let payload = json!({
                     "status": "ok",
+                    "response": response,
+                    "warnings": Vec::<String>::new(),
                     "completion_reason": "copy_button",
                     "attempt": attempt,
                     "attempts": options.attempts,
@@ -815,8 +1054,16 @@ fn run_chatgpt_wait_response(
                 if stable_for_ms >= stable_idle_threshold_ms {
                     let elapsed_ms =
                         started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+                    let response = read_latest_chatgpt_response(
+                        connection,
+                        use_stealth,
+                        headed,
+                        command_timeout_ms,
+                    )?;
                     let payload = json!({
                         "status": "ok",
+                        "response": response,
+                        "warnings": Vec::<String>::new(),
                         "completion_reason": "stable_idle_fallback",
                         "attempt": attempt,
                         "attempts": options.attempts,
@@ -881,7 +1128,125 @@ fn parse_upload_poll_options(args: Option<&[String]>) -> Result<ChatgptPollOptio
     }
 }
 
+fn run_chatgpt_select_model(
+    ctx: &RecipeContext,
+    connection: Option<&BrowserConnection>,
+    use_stealth: bool,
+    headed: bool,
+) -> Result<String> {
+    let requested_model = ctx
+        .vars
+        .get("model")
+        .map(String::as_str)
+        .unwrap_or_default();
+    let function = chatgpt_web::build_model_selection_function(requested_model);
+    let expression = chatgpt_web::wrap_function_source_for_json_eval(&function)?;
+    let stdout = run_agent_browser_with_connection_timeout(
+        vec!["eval".to_string(), expression],
+        OutputFormat::Text,
+        connection,
+        use_stealth,
+        headed,
+        Some(CHATGPT_POLL_COMMAND_TIMEOUT_MS_DEFAULT),
+    )?;
+    let selection: Value = parse_stdout_json(&stdout)
+        .with_context(|| format!("parse ChatGPT model selection result: {stdout}"))?;
+    let status = selection
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let model_used = chatgpt_web::select_reported_chatgpt_model(&selection, requested_model);
+    match status {
+        "selected" | "already-selected" => {
+            Ok(json!({
+                "status": "ok",
+                "model_used": model_used,
+            })
+            .to_string())
+        }
+        "missing-selector" => Err(anyhow!(
+            "ChatGPT model selector button not found. url={:?}, title={:?}",
+            selection.get("url").and_then(Value::as_str).unwrap_or(""),
+            selection.get("title").and_then(Value::as_str).unwrap_or("")
+        )),
+        "not-found" => Err(anyhow!(
+            "requested ChatGPT model `{}` was not available in the current session. Available options: {}",
+            selection
+                .get("requested")
+                .and_then(Value::as_str)
+                .unwrap_or(requested_model),
+            selection
+                .get("availableItems")
+                .and_then(Value::as_array)
+                .map(|items| {
+                    items
+                        .iter()
+                        .filter_map(Value::as_str)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                })
+                .filter(|items| !items.is_empty())
+                .unwrap_or_else(|| "<unknown>".to_string())
+        )),
+        "selection-mismatch" => Err(anyhow!(
+            "requested ChatGPT model `{}` was not actually selected. selected_label={:?}; target_testid={:?}; available_after={}",
+            selection
+                .get("requested")
+                .and_then(Value::as_str)
+                .unwrap_or(requested_model),
+            selection.get("selectedLabel").and_then(Value::as_str),
+            selection.get("targetTestId").and_then(Value::as_str),
+            selection
+                .get("availableItemsAfter")
+                .and_then(Value::as_array)
+                .map(|items| {
+                    items
+                        .iter()
+                        .filter_map(Value::as_str)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                })
+                .unwrap_or_default()
+        )),
+        other => Err(anyhow!("unexpected ChatGPT model selection status `{other}`")),
+    }
+}
+
+fn run_chatgpt_open_attachment_ui(
+    connection: Option<&BrowserConnection>,
+    use_stealth: bool,
+    headed: bool,
+) -> Result<String> {
+    let expression = chatgpt_web::wrap_function_source_for_json_eval(
+        &chatgpt_web::build_open_attachment_ui_function(),
+    )?;
+    let stdout = run_agent_browser_with_connection_timeout(
+        vec!["eval".to_string(), expression],
+        OutputFormat::Text,
+        connection,
+        use_stealth,
+        headed,
+        Some(CHATGPT_POLL_COMMAND_TIMEOUT_MS_DEFAULT),
+    )?;
+    let result: Value = parse_stdout_json(&stdout)
+        .with_context(|| format!("parse ChatGPT attachment UI result: {stdout}"))?;
+    match result
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+    {
+        "opened" => Ok(json!({"status": "ok"}).to_string()),
+        "not-found" => Err(anyhow!(
+            "ChatGPT attachment button not found. url={:?}, title={:?}",
+            result.get("url").and_then(Value::as_str).unwrap_or(""),
+            result.get("title").and_then(Value::as_str).unwrap_or("")
+        )),
+        other => Err(anyhow!("unexpected ChatGPT attachment UI status `{other}`")),
+    }
+}
+
 fn run_chatgpt_wait_upload(
+    ctx: &RecipeContext,
     args: Option<&[String]>,
     connection: Option<&BrowserConnection>,
     use_stealth: bool,
@@ -890,15 +1255,16 @@ fn run_chatgpt_wait_upload(
     let options = parse_upload_poll_options(args)?;
     let started_at = Instant::now();
     let deadline = started_at + Duration::from_millis(options.timeout_ms);
-
-    let check_script = r#"(() => {
-        const tile = document.querySelector('[class*="file-tile"]');
-        if (!tile) return "no_tile";
-        const spinner = tile.querySelector('[class*="animate-spin"]');
-        if (!spinner) return "done";
-        const hidden = getComputedStyle(spinner.parentElement).display === 'none';
-        return hidden ? "done" : "uploading";
-    })()"#;
+    let bundle_path = ctx
+        .bundle_path
+        .as_deref()
+        .context("ChatGPT upload waiter requires `bundle_path` in the recipe context")?;
+    let file_name = Path::new(bundle_path)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .context("bundle path must end in a UTF-8 filename")?;
+    let function = chatgpt_web::build_attachment_probe_function(file_name)?;
+    let check_script = chatgpt_web::wrap_function_source_for_json_eval(&function)?;
 
     for attempt in 1..=options.attempts {
         if Instant::now() >= deadline {
@@ -911,32 +1277,76 @@ fn run_chatgpt_wait_upload(
         thread::sleep(Duration::from_millis(options.interval_ms.min(remaining_ms)));
 
         let stdout = run_agent_browser_with_connection_timeout(
-            vec!["eval".to_string(), check_script.to_string()],
+            vec!["eval".to_string(), check_script.clone()],
             OutputFormat::Text,
             connection,
             use_stealth,
             headed,
             Some(CHATGPT_POLL_COMMAND_TIMEOUT_MS_DEFAULT),
         )?;
-        let status = stdout.trim().trim_matches('"');
+        let probe: Value = parse_stdout_json(&stdout)
+            .with_context(|| format!("parse attachment upload probe: {stdout}"))?;
+        let status = probe
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
 
         match status {
             "done" => {
                 return Ok(json!({"status": "ok", "polls": attempt}).to_string());
             }
             "no_tile" if attempt > 5 => {
-                return Err(anyhow!("file tile never appeared after {attempt} polls"));
+                return Err(anyhow!(
+                    "attachment chip for `{file_name}` never appeared after {attempt} polls"
+                ));
             }
-            _ => {} // "uploading" or "no_tile" early — keep polling
+            "no_match" if attempt > 5 => {
+                return Err(anyhow!(
+                    "attachment chip for `{file_name}` was never detected in the composer after {attempt} polls"
+                ));
+            }
+            _ => {}
         }
     }
 
     let elapsed_ms = started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
     Err(anyhow!(
-        "upload still processing after ~{}s (deadline={}ms)",
+        "upload for `{file_name}` still processing after ~{}s (deadline={}ms)",
         elapsed_ms / 1000,
         options.timeout_ms,
     ))
+}
+
+fn run_chatgpt_send(
+    connection: Option<&BrowserConnection>,
+    use_stealth: bool,
+    headed: bool,
+) -> Result<String> {
+    let expression = chatgpt_web::wrap_function_source_for_json_eval(
+        &chatgpt_web::build_send_button_click_function(),
+    )?;
+    let stdout = run_agent_browser_with_connection_timeout(
+        vec!["eval".to_string(), expression],
+        OutputFormat::Text,
+        connection,
+        use_stealth,
+        headed,
+        Some(CHATGPT_POLL_COMMAND_TIMEOUT_MS_DEFAULT),
+    )?;
+    let result: Value = parse_stdout_json(&stdout)
+        .with_context(|| format!("parse ChatGPT send result: {stdout}"))?;
+    match result
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+    {
+        "sent" => Ok(json!({"status": "ok"}).to_string()),
+        "not-ready" => Err(anyhow!(
+            "ChatGPT send button never became enabled after typing. {}",
+            result.get("diagnostics").cloned().unwrap_or(Value::Null)
+        )),
+        other => Err(anyhow!("unexpected ChatGPT send status `{other}`")),
+    }
 }
 
 fn inspect_chatgpt_dom_state(
@@ -945,23 +1355,11 @@ fn inspect_chatgpt_dom_state(
     headed: bool,
     timeout_ms: u64,
 ) -> Result<ChatgptDomState> {
-    let script = r#"(() => {
-  const send = document.querySelector("button[data-testid='send-button']");
-  const stop = document.querySelector("button[data-testid='stop-button'], button[aria-label*='Stop']");
-  const thinking = document.querySelector(".result-thinking, [data-testid*='thinking'], [class*='thinking']");
-  const msgs = document.querySelectorAll('[data-message-author-role="assistant"]');
-  const lastMsg = msgs.length > 0 ? msgs[msgs.length - 1] : null;
-  const copyButtons = lastMsg ? lastMsg.querySelectorAll("button[aria-label*='Copy'], button[data-testid*='copy']").length : 0;
-  const lastLen = msgs.length > 0 ? msgs[msgs.length - 1].innerText.length : 0;
-  const sendState = !send ? "missing" : send.disabled ? "disabled" : "enabled";
-  const errEl = document.querySelector('[class*="error-toast"], [data-testid*="error"], [role="alert"]');
-  const errText = errEl ? errEl.innerText.substring(0, 100).toLowerCase() : "";
-  const markers = ["network error","something went wrong","error generating","attachment failed","upload failed","too many requests"];
-  const err = markers.find(m => errText.includes(m)) || "";
-  return `send=${sendState}|stop=${stop ? 1 : 0}|thinking=${thinking ? 1 : 0}|copy=${copyButtons}|msgs=${msgs.length}|lastlen=${lastLen}|err=${err}`;
-})()"#;
+    let script = chatgpt_web::wrap_function_source_for_json_eval(
+        &chatgpt_web::build_chatgpt_dom_probe_function(),
+    )?;
     let stdout = run_agent_browser_with_connection_timeout(
-        vec!["eval".to_string(), script.to_string()],
+        vec!["eval".to_string(), script],
         OutputFormat::Text,
         connection,
         use_stealth,
@@ -975,6 +1373,32 @@ fn inspect_chatgpt_dom_state(
         .and_then(|s| s.strip_suffix('"'))
         .unwrap_or(raw);
     parse_chatgpt_dom_state(raw)
+}
+
+fn read_latest_chatgpt_response(
+    connection: Option<&BrowserConnection>,
+    use_stealth: bool,
+    headed: bool,
+    timeout_ms: u64,
+) -> Result<String> {
+    let expression = chatgpt_web::wrap_function_source_for_json_eval(
+        &chatgpt_web::build_latest_response_probe_function(),
+    )?;
+    let stdout = run_agent_browser_with_connection_timeout(
+        vec!["eval".to_string(), expression],
+        OutputFormat::Text,
+        connection,
+        use_stealth,
+        headed,
+        Some(timeout_ms),
+    )?;
+    let payload: Value = parse_stdout_json(&stdout)
+        .with_context(|| format!("parse ChatGPT latest response result: {stdout}"))?;
+    Ok(payload
+        .get("response")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string())
 }
 
 fn parse_chatgpt_poll_args(args: Option<&[String]>) -> Result<ChatgptPollOptions> {
@@ -1081,11 +1505,10 @@ fn parse_chatgpt_dom_state(raw: &str) -> Result<ChatgptDomState> {
             "lastlen" => {
                 assistant_last_len = value.parse().unwrap_or(0);
             }
-            "err" => {
-                if !value.is_empty() {
-                    error = value.to_string();
-                }
+            "err" if !value.is_empty() => {
+                error = value.to_string();
             }
+            "err" => {}
             _ => {}
         }
     }
@@ -1145,9 +1568,7 @@ fn classify_chatgpt_completion(
 /// idle polls regardless of how `wait_interval_ms` is configured, and ≥90s of
 /// real time even when the interval is short.
 fn chatgpt_stable_idle_threshold_ms(interval_ms: u64) -> u64 {
-    interval_ms
-        .saturating_mul(CHATGPT_STABLE_IDLE_INTERVAL_MULTIPLIER)
-        .max(CHATGPT_STABLE_IDLE_FLOOR_MS)
+    chatgpt_web::stable_idle_threshold_ms(interval_ms)
 }
 
 fn chatgpt_send_state_str(state: ChatgptSendState) -> &'static str {
@@ -1158,14 +1579,108 @@ fn chatgpt_send_state_str(state: ChatgptSendState) -> &'static str {
     }
 }
 
-pub fn resolve_profile_dir(config: &Config, override_profile: Option<&PathBuf>) -> Result<PathBuf> {
+pub fn load_browser_defaults_with_profile(profile: Option<&str>) -> Result<BrowserDefaults> {
+    load_browser_defaults_from_paths(browser_config_paths(profile))
+}
+
+fn load_browser_defaults_from_paths(paths: Vec<(PathBuf, bool)>) -> Result<BrowserDefaults> {
+    let mut defaults = BrowserDefaults::default();
+    for (path, trusted) in paths {
+        if !path.exists() {
+            continue;
+        }
+        let file = load_browser_config_file(&path)?;
+        let Some(file_defaults) = file.defaults else {
+            continue;
+        };
+        if trusted {
+            merge_browser_defaults(&mut defaults, file_defaults);
+        } else {
+            if file_defaults.browser_profile.is_some() {
+                eprintln!(
+                    "warning: ignoring defaults.browser_profile from untrusted config {}",
+                    path.display()
+                );
+            }
+            if file_defaults.browser_cdp.is_some() {
+                eprintln!(
+                    "warning: ignoring defaults.browser_cdp from untrusted config {}",
+                    path.display()
+                );
+            }
+        }
+    }
+    Ok(defaults)
+}
+
+fn browser_config_paths(profile: Option<&str>) -> Vec<(PathBuf, bool)> {
+    let mut paths: Vec<(PathBuf, bool)> = Vec::new();
+
+    if let Some(home) = home_dir() {
+        paths.push((home.join(".yoetz/config.toml"), true));
+        paths.push((home.join(".config/yoetz/config.toml"), true));
+    }
+    if let Ok(xdg) = env::var("XDG_CONFIG_HOME") {
+        paths.push((PathBuf::from(xdg).join("yoetz/config.toml"), true));
+    }
+    paths.push((PathBuf::from("./yoetz.toml"), false));
+
+    if let Ok(custom) = env::var("YOETZ_CONFIG_PATH") {
+        paths.push((PathBuf::from(custom), true));
+    }
+
+    if let Some(name) = profile {
+        if let Some(home) = home_dir() {
+            paths.push((
+                home.join(".yoetz/profiles").join(format!("{name}.toml")),
+                true,
+            ));
+            paths.push((
+                home.join(".config/yoetz/profiles")
+                    .join(format!("{name}.toml")),
+                true,
+            ));
+        }
+        if let Ok(xdg) = env::var("XDG_CONFIG_HOME") {
+            paths.push((
+                PathBuf::from(xdg)
+                    .join("yoetz/profiles")
+                    .join(format!("{name}.toml")),
+                true,
+            ));
+        }
+        paths.push((PathBuf::from(format!("./yoetz.{name}.toml")), false));
+    }
+
+    paths
+}
+
+fn load_browser_config_file(path: &Path) -> Result<BrowserConfigFile> {
+    let content =
+        fs::read_to_string(path).with_context(|| format!("read config {}", path.display()))?;
+    toml::from_str(&content).with_context(|| format!("parse config {}", path.display()))
+}
+
+fn merge_browser_defaults(target: &mut BrowserDefaults, other: BrowserConfigDefaults) {
+    if other.browser_profile.is_some() {
+        target.profile = other.browser_profile;
+    }
+    if other.browser_cdp.is_some() {
+        target.cdp = other.browser_cdp;
+    }
+}
+
+pub fn resolve_profile_dir(
+    browser_defaults: &BrowserDefaults,
+    override_profile: Option<&PathBuf>,
+) -> Result<PathBuf> {
     if let Some(path) = override_profile {
         return expand_tilde(path);
     }
     if let Ok(path) = env::var("YOETZ_BROWSER_PROFILE") {
         return expand_tilde(Path::new(&path));
     }
-    if let Some(path) = config.defaults.browser_profile.as_deref() {
+    if let Some(path) = browser_defaults.profile.as_deref() {
         return expand_tilde(Path::new(path));
     }
     default_profile_dir()
@@ -1273,18 +1788,6 @@ impl ChromeApprovalLock {
     }
 }
 
-#[derive(Debug)]
-pub struct ChatgptRecipeLock {
-    _lock_file: File,
-    waited: bool,
-}
-
-impl ChatgptRecipeLock {
-    pub fn waited(&self) -> bool {
-        self.waited
-    }
-}
-
 fn yoetz_lock_path(filename: &str) -> PathBuf {
     if let Some(home) = home_dir() {
         return home.join(".yoetz").join(filename);
@@ -1329,16 +1832,6 @@ pub fn acquire_chrome_approval_lock() -> Result<ChromeApprovalLock> {
     })
 }
 
-pub fn acquire_chatgpt_recipe_lock() -> Result<ChatgptRecipeLock> {
-    let lock_path = yoetz_lock_path(CHATGPT_RECIPE_LOCK_FILENAME);
-    let (file, waited) = acquire_waitable_lock(&lock_path, "chatgpt recipe lock")?;
-
-    Ok(ChatgptRecipeLock {
-        _lock_file: file,
-        waited,
-    })
-}
-
 pub fn is_chrome_approval_wait_error(err: &anyhow::Error) -> bool {
     format!("{err:#}")
         .to_lowercase()
@@ -1363,11 +1856,52 @@ pub fn is_chrome_cdp_unreachable_error(err: &anyhow::Error) -> bool {
             || looks_like_cdp_transport_failure(err))
 }
 
+pub fn is_chrome_create_target_block_error(err: &anyhow::Error) -> bool {
+    crate::chrome_devtools_mcp::client::is_external_create_target_block_error(err)
+}
+
+const CHATGPT_ATTACHED_PAGE_ERROR_MARKER: &str = "chatgpt attached page failed after live attach";
+
+pub fn mark_chatgpt_attached_page_error(err: anyhow::Error) -> anyhow::Error {
+    err.context(CHATGPT_ATTACHED_PAGE_ERROR_MARKER)
+}
+
 pub fn is_chatgpt_auth_issue_error(err: &anyhow::Error) -> bool {
     let message = format!("{err:#}").to_lowercase();
     message.contains("chatgpt login required")
         || message.contains("cloudflare challenge detected")
         || message.contains("captcha detected")
+}
+
+pub fn is_chatgpt_attached_page_error(err: &anyhow::Error) -> bool {
+    if err
+        .chain()
+        .any(|cause| cause.to_string() == CHATGPT_ATTACHED_PAGE_ERROR_MARKER)
+    {
+        return true;
+    }
+
+    let message = format!("{err:#}").to_lowercase();
+    (message.contains("requested chatgpt model") && message.contains("not actually selected"))
+        || (message.contains("requested model") && message.contains("was not selected"))
+        || (message.contains("requested chatgpt model")
+            && message.contains("was not available in the current session"))
+        || message.contains("chatgpt composer did not mount")
+        || message.contains("did not finish loading the composer")
+        || message.contains("could not find an enabled chatgpt send button")
+        || message.contains("no attach/upload controls were detected")
+        || (message.contains("could not attach `") && message.contains("to chatgpt"))
+        || message.contains("attachment chip for `")
+        || message.contains("chatgpt send button never became enabled after typing")
+        || message.contains("chatgpt send click did not trigger a ui transition")
+        || message.contains("chatgpt response timed out after")
+}
+
+pub fn is_chatgpt_profile_selector_visibility_error(err: &anyhow::Error) -> bool {
+    let message = format!("{err:#}").to_lowercase();
+    message.contains("profile_email `")
+        && (message.contains("live chrome browser context")
+            || message.contains("live auto-connect tab list"))
 }
 
 fn close_browser_daemon() -> Result<()> {
@@ -1496,6 +2030,140 @@ pub fn inspect_default_daemon() -> DaemonState {
         return DaemonState::NoSocket;
     };
     inspect_daemon_with_paths(&pid_path, &sock_path, DAEMON_APPROVAL_GRACE_WINDOW)
+}
+
+fn default_daemon_pid() -> Option<u32> {
+    let (pid_path, _) = default_daemon_paths()?;
+    read_daemon_pid(&pid_path)
+}
+
+fn render_daemon_state(state: DaemonState) -> &'static str {
+    match state {
+        DaemonState::NoSocket => "not running",
+        DaemonState::Healthy => "healthy",
+        DaemonState::AwaitingApproval => "awaiting approval",
+        DaemonState::Stale => "stale",
+    }
+}
+
+fn inspect_browser_helpers() -> BrowserDoctorHelpers {
+    let helper_processes = discover_browser_helper_processes();
+    let dev_browser_processes = helper_processes
+        .iter()
+        .filter(|process| matches!(process.kind, BrowserHelperProcessKind::DevBrowserDaemon))
+        .cloned()
+        .collect::<Vec<_>>();
+    let external_mcp_processes = helper_processes
+        .iter()
+        .filter(|process| {
+            matches!(
+                process.kind,
+                BrowserHelperProcessKind::ChromeDevtoolsMcp
+                    | BrowserHelperProcessKind::ChromeDevtoolsMcpWatchdog
+            )
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let agent_browser_default = inspect_default_daemon();
+    let agent_browser_default_pid = default_daemon_pid();
+
+    BrowserDoctorHelpers {
+        agent_browser_default,
+        agent_browser_default_pid,
+        recommended_actions: browser_doctor_recommended_actions(
+            agent_browser_default,
+            &dev_browser_processes,
+            &external_mcp_processes,
+        ),
+        dev_browser_processes,
+        external_mcp_processes,
+    }
+}
+
+fn browser_doctor_recommended_actions(
+    agent_browser_default: DaemonState,
+    dev_browser_processes: &[BrowserHelperProcessSummary],
+    external_mcp_processes: &[BrowserHelperProcessSummary],
+) -> Vec<String> {
+    let mut actions = Vec::new();
+
+    if matches!(agent_browser_default, DaemonState::Stale) {
+        actions.push(
+            "Run `yoetz browser reset` before `yoetz browser attach`, `yoetz browser check`, or `yoetz browser recipe` to clear stale yoetz-owned helpers.".to_string(),
+        );
+    }
+    if matches!(agent_browser_default, DaemonState::AwaitingApproval) {
+        actions.push(
+            "Agent-browser may still be waiting for Chrome's \"Allow remote debugging?\" dialog. Approve it in Chrome if this attach was intentional; otherwise run `yoetz browser reset`.".to_string(),
+        );
+    }
+    if !dev_browser_processes.is_empty() {
+        actions.push(
+            "A dev-browser daemon is still running. If you want a clean yoetz-owned attach retry, run `yoetz browser reset` first.".to_string(),
+        );
+    }
+    if !external_mcp_processes.is_empty() {
+        let pids = external_mcp_processes
+            .iter()
+            .map(|process| process.pid.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        actions.push(format!(
+            "External chrome-devtools-mcp processes are still running (pid {}). If they are not actively in use, close the owning tool/process first; `yoetz browser reset` will not stop them.",
+            pids
+        ));
+    }
+    if actions.is_empty() {
+        actions.push("None required.".to_string());
+    }
+
+    actions
+}
+
+#[cfg(unix)]
+fn discover_browser_helper_processes() -> Vec<BrowserHelperProcessSummary> {
+    let Ok(output) = Command::new("ps")
+        .args(["axww", "-o", "pid=,command="])
+        .output()
+    else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(parse_browser_helper_process_line)
+        .collect()
+}
+
+#[cfg(not(unix))]
+fn discover_browser_helper_processes() -> Vec<BrowserHelperProcessSummary> {
+    Vec::new()
+}
+
+fn parse_browser_helper_process_line(line: &str) -> Option<BrowserHelperProcessSummary> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let first_whitespace = trimmed.find(char::is_whitespace)?;
+    let pid = trimmed[..first_whitespace].trim().parse::<u32>().ok()?;
+    let command = trimmed[first_whitespace..].trim().to_string();
+    let kind = if command.contains(".dev-browser/daemon.mjs") {
+        BrowserHelperProcessKind::DevBrowserDaemon
+    } else if command.contains("chrome-devtools-mcp")
+        && command.contains("telemetry/watchdog/main.js")
+    {
+        BrowserHelperProcessKind::ChromeDevtoolsMcpWatchdog
+    } else if command.contains("chrome-devtools-mcp") {
+        BrowserHelperProcessKind::ChromeDevtoolsMcp
+    } else {
+        return None;
+    };
+
+    Some(BrowserHelperProcessSummary { pid, kind, command })
 }
 
 fn force_kill_stale_daemon_with_paths(
@@ -1826,7 +2494,10 @@ pub fn resolve_recipe(path: &Path) -> Result<PathBuf> {
 }
 
 /// Resolve CDP endpoint from flag → env → config (first non-empty wins).
-pub fn resolve_cdp_endpoint(cdp_override: Option<&str>, config: &Config) -> Option<String> {
+pub fn resolve_cdp_endpoint(
+    cdp_override: Option<&str>,
+    browser_defaults: &BrowserDefaults,
+) -> Option<String> {
     cdp_override
         .map(str::trim)
         .filter(|value| !value.is_empty())
@@ -1834,22 +2505,41 @@ pub fn resolve_cdp_endpoint(cdp_override: Option<&str>, config: &Config) -> Opti
         .or_else(|| env::var("YOETZ_BROWSER_CDP").ok())
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
-        .or_else(|| config.defaults.browser_cdp.clone())
+        .or_else(|| browser_defaults.cdp.clone())
         .filter(|value| !value.is_empty())
 }
 
+#[allow(dead_code)]
 pub fn resolve_cdp_target(
     cdp_override: Option<&str>,
-    config: &Config,
+    browser_defaults: &BrowserDefaults,
 ) -> Result<Option<ResolvedCdpTarget>> {
-    resolve_cdp_target_with_implicit(cdp_override, config, true)
+    resolve_cdp_target_with_selector(cdp_override, None, browser_defaults, true)
 }
 
+#[allow(dead_code)]
 pub fn resolve_cdp_target_with_implicit(
     cdp_override: Option<&str>,
-    config: &Config,
+    browser_defaults: &BrowserDefaults,
     allow_implicit: bool,
 ) -> Result<Option<ResolvedCdpTarget>> {
+    resolve_cdp_target_with_selector(cdp_override, None, browser_defaults, allow_implicit)
+}
+
+pub fn resolve_cdp_target_with_selector(
+    cdp_override: Option<&str>,
+    browser_id: Option<&str>,
+    browser_defaults: &BrowserDefaults,
+    allow_implicit: bool,
+) -> Result<Option<ResolvedCdpTarget>> {
+    let browser_id = browser_id.map(str::trim).filter(|value| !value.is_empty());
+    if cdp_override
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty())
+        && browser_id.is_some()
+    {
+        bail!("pass either `--cdp` or `--browser-id`, not both");
+    }
     if let Some(endpoint) = cdp_override
         .map(str::trim)
         .filter(|value| !value.is_empty())
@@ -1860,7 +2550,12 @@ pub fn resolve_cdp_target_with_implicit(
             endpoint,
             source: ResolvedCdpTargetSource::Flag,
             source_path: None,
+            selected_target: None,
         }));
+    }
+
+    if let Some(browser_id) = browser_id {
+        return Ok(Some(resolve_explicit_browser_id_target(browser_id)?));
     }
 
     if !allow_implicit {
@@ -1877,12 +2572,12 @@ pub fn resolve_cdp_target_with_implicit(
             endpoint,
             source: ResolvedCdpTargetSource::Env,
             source_path: None,
+            selected_target: None,
         }));
     }
 
-    if let Some(endpoint) = config
-        .defaults
-        .browser_cdp
+    if let Some(endpoint) = browser_defaults
+        .cdp
         .clone()
         .filter(|value| !value.is_empty())
     {
@@ -1891,6 +2586,7 @@ pub fn resolve_cdp_target_with_implicit(
             endpoint,
             source: ResolvedCdpTargetSource::Config,
             source_path: None,
+            selected_target: None,
         }));
     }
 
@@ -1931,7 +2627,429 @@ pub fn resolve_cdp_target_with_implicit(
         source: ResolvedCdpTargetSource::Auto,
         description,
         source_path: Some(target.source_path.clone()),
+        selected_target: Some(target),
     }))
+}
+
+fn resolve_explicit_browser_id_target(browser_id: &str) -> Result<ResolvedCdpTarget> {
+    let discovered_targets = discover_running_chrome_targets();
+    if let Some(target) = discovered_targets.iter().find(|target| {
+        browser_id_from_ws_endpoint(&target.ws_endpoint).as_deref() == Some(browser_id)
+    }) {
+        return Ok(ResolvedCdpTarget {
+            endpoint: target.ws_endpoint.clone(),
+            source: ResolvedCdpTargetSource::Flag,
+            description: format!(
+                "using explicit --browser-id target `{browser_id}`: {}",
+                target.summary()
+            ),
+            source_path: Some(target.source_path.clone()),
+            selected_target: Some(target.clone()),
+        });
+    }
+
+    let active_port_files = discover_devtools_active_port_files();
+    if let Some(file) = find_active_port_file_by_browser_id(&active_port_files, browser_id) {
+        let endpoint = file
+            .ws_endpoint
+            .clone()
+            .context("active port file matched browser_id without websocket endpoint")?;
+        return Ok(ResolvedCdpTarget {
+            endpoint,
+            source: ResolvedCdpTargetSource::Flag,
+            description: format!(
+                "using explicit --browser-id target `{browser_id}` from {}",
+                file.path.display()
+            ),
+            source_path: Some(file.path.clone()),
+            selected_target: None,
+        });
+    }
+
+    if let Some(file) = find_stale_active_port_file_by_browser_id(&active_port_files, browser_id) {
+        bail!(
+            "browser_id `{browser_id}` matched {}, but that DevToolsActivePort file is stale/unreachable. Wait for a healthy Chrome DevTools target to appear in `yoetz browser doctor`, or use an explicit `--cdp` endpoint.",
+            file.path.display()
+        );
+    }
+
+    bail!(
+        "browser_id `{browser_id}` did not match any local Chrome DevTools browser endpoint. Run `yoetz browser doctor` to list available browser IDs."
+    )
+}
+
+fn find_active_port_file_by_browser_id<'a>(
+    files: &'a [DevtoolsActivePortFile],
+    browser_id: &str,
+) -> Option<&'a DevtoolsActivePortFile> {
+    files.iter().find(|file| {
+        file.healthy
+            && file
+                .ws_endpoint
+                .as_deref()
+                .and_then(browser_id_from_ws_endpoint)
+                .as_deref()
+                == Some(browser_id)
+    })
+}
+
+fn find_stale_active_port_file_by_browser_id<'a>(
+    files: &'a [DevtoolsActivePortFile],
+    browser_id: &str,
+) -> Option<&'a DevtoolsActivePortFile> {
+    files.iter().find(|file| {
+        !file.healthy
+            && file
+                .ws_endpoint
+                .as_deref()
+                .and_then(browser_id_from_ws_endpoint)
+                .as_deref()
+                == Some(browser_id)
+    })
+}
+
+pub fn auto_discovered_cdp_target_warning(target: &ResolvedCdpTarget) -> Option<String> {
+    let targets = discover_running_chrome_targets();
+    let processes = discover_local_chromium_processes();
+    auto_discovered_cdp_target_warning_with_discovery(target, &targets, &processes)
+}
+
+fn auto_discovered_cdp_target_warning_with_discovery(
+    target: &ResolvedCdpTarget,
+    discovered_targets: &[RunningChromeTarget],
+    local_processes: &[ChromiumProcessSummary],
+) -> Option<String> {
+    let selected = target.selected_running_target()?;
+    if selected.has_chatgpt_tab() {
+        return None;
+    }
+
+    let mut warning = if selected.page_samples.is_empty() {
+        "auto-selected browser has no open ChatGPT tabs. yoetz will open ChatGPT in this browser/profile, which may not be the account you expect.".to_string()
+    } else {
+        format!(
+            "auto-selected browser has no open ChatGPT tabs. Current sample tabs: {}. yoetz will open ChatGPT in this browser/profile, which may not be the account you expect.",
+            selected.page_samples.join(", ")
+        )
+    };
+
+    let alternative_targets = discovered_targets
+        .iter()
+        .filter(|candidate| {
+            candidate.has_chatgpt_tab()
+                && candidate.source_path != selected.source_path
+                && candidate.ws_endpoint != selected.ws_endpoint
+        })
+        .take(2)
+        .map(RunningChromeTarget::summary)
+        .collect::<Vec<_>>();
+    if !alternative_targets.is_empty() {
+        warning.push_str(&format!(
+            " Another discovered debug target already has ChatGPT tabs: {}.",
+            alternative_targets.join(" | ")
+        ));
+    }
+
+    let undebugged = local_processes
+        .iter()
+        .filter(|process| !process.has_remote_debugging)
+        .take(3)
+        .map(|process| format!("{} (pid {})", process.browser_name, process.pid))
+        .collect::<Vec<_>>();
+    if !undebugged.is_empty() {
+        warning.push_str(&format!(
+            " Other local Chromium processes without remote debugging: {}.",
+            undebugged.join(", ")
+        ));
+        warning.push_str(
+            " If the expected window is one of them, Chrome 136+ may be ignoring remote debugging on the default profile.",
+        );
+    }
+
+    warning.push_str(" Run `yoetz browser doctor` to compare local Chromium targets.");
+
+    Some(warning)
+}
+
+pub fn browser_doctor_report(live_probe: bool) -> String {
+    let targets = discover_running_chrome_targets();
+    let devtools_files = discover_devtools_active_port_files();
+    let processes = discover_local_chromium_processes();
+    let auto_connect = if live_probe {
+        probe_auto_connect_tabs_for_doctor()
+    } else {
+        AutoConnectDoctorStatus::Skipped(
+            "skipped by default; use `yoetz browser doctor --live` to probe the auto-connect helper"
+                .to_string(),
+        )
+    };
+    let helpers = inspect_browser_helpers();
+    browser_doctor_report_with_discovery(
+        &targets,
+        &devtools_files,
+        &processes,
+        &auto_connect,
+        &helpers,
+    )
+}
+
+fn browser_doctor_report_with_discovery(
+    targets: &[RunningChromeTarget],
+    devtools_files: &[crate::chrome_devtools_mcp::client::DevtoolsActivePortFile],
+    processes: &[ChromiumProcessSummary],
+    auto_connect: &AutoConnectDoctorStatus,
+    helpers: &BrowserDoctorHelpers,
+) -> String {
+    let mut lines = Vec::new();
+
+    lines.push("Agent-browser auto-connect view:".to_string());
+    match auto_connect {
+        AutoConnectDoctorStatus::Reachable(tabs) => {
+            let chatgpt_tabs = tabs
+                .iter()
+                .filter(|tab| {
+                    let url = tab.url.to_ascii_lowercase();
+                    url.contains("chatgpt.com") || url.contains("chat.openai.com")
+                })
+                .count();
+            lines.push(format!(
+                "  - reachable (tabs: {}, chatgpt tabs: {})",
+                tabs.len(),
+                chatgpt_tabs
+            ));
+            lines.push(
+                "    note: this is the tab set exposed by the auto-connect helper; it may differ from the frontmost Chrome window/profile."
+                    .to_string(),
+            );
+            if chatgpt_tabs == 0 {
+                lines.push(
+                    "    note: if a visible ChatGPT tab is missing here, auto-connect is attached to a different Chrome browsing context than the one you are looking at."
+                        .to_string(),
+                );
+            }
+            let inferred_emails = summarize_auto_connect_profile_emails(tabs);
+            if !inferred_emails.is_empty() {
+                lines.push("    inferred profile emails:".to_string());
+                for (email, sample_tabs) in &inferred_emails {
+                    let sample_suffix = if sample_tabs.is_empty() {
+                        String::new()
+                    } else {
+                        format!("; sample tabs: {}", sample_tabs.join(", "))
+                    };
+                    lines.push(format!("      - {email}{sample_suffix}"));
+                }
+                if inferred_emails.len() > 1 {
+                    lines.push(
+                        "    note: multiple profile emails are visible; use `--var profile_email=<email>` to pin the ChatGPT recipe to one Chrome browser context."
+                            .to_string(),
+                    );
+                }
+            }
+            for tab in tabs.iter().take(6) {
+                let marker = if tab.active { "*" } else { "-" };
+                let title = if tab.title.trim().is_empty() {
+                    "<untitled>"
+                } else {
+                    tab.title.trim()
+                };
+                lines.push(format!(
+                    "    {marker} tab {}: {} ({})",
+                    tab.index, title, tab.url
+                ));
+            }
+        }
+        AutoConnectDoctorStatus::Unavailable(err) => {
+            lines.push(format!("  - unavailable: {err}"));
+        }
+        AutoConnectDoctorStatus::Skipped(reason) => {
+            lines.push(format!("  - skipped: {reason}"));
+        }
+    }
+
+    lines.push("Running Chrome targets:".to_string());
+    if targets.is_empty() {
+        lines.push("  - none discovered".to_string());
+        if matches!(auto_connect, AutoConnectDoctorStatus::Reachable(_)) {
+            lines.push(
+                "    note: auto-connect is reachable even though no raw DevToolsActivePort target was discovered."
+                    .to_string(),
+            );
+        }
+    } else {
+        for target in targets {
+            lines.push(format!("  - {}", target.summary()));
+            if let Some(browser_id) = browser_id_from_ws_endpoint(&target.ws_endpoint) {
+                lines.push(format!(
+                    "    browser_id: {browser_id} (use `--browser-id {browser_id}`)"
+                ));
+            }
+            lines.push(format!("    ws: {}", target.ws_endpoint));
+        }
+    }
+
+    lines.push("DevToolsActivePort files:".to_string());
+    if devtools_files.is_empty() {
+        lines.push("  - none found".to_string());
+    } else {
+        for file in devtools_files {
+            let modified = file
+                .modified_at
+                .and_then(|timestamp| timestamp.duration_since(SystemTime::UNIX_EPOCH).ok())
+                .map(|duration| duration.as_secs().to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            let endpoint = file
+                .ws_endpoint
+                .clone()
+                .unwrap_or_else(|| "unparseable".to_string());
+            let health = if file.healthy {
+                "healthy"
+            } else {
+                "stale/unreachable"
+            };
+            lines.push(format!(
+                "  - {} [{health}] mtime-unix={modified} ws={endpoint}",
+                file.path.display()
+            ));
+            if let Some(browser_id) = browser_id_from_ws_endpoint(&endpoint) {
+                if file.healthy {
+                    lines.push(format!(
+                        "    browser_id: {browser_id} (use `--browser-id {browser_id}`)"
+                    ));
+                } else {
+                    lines.push(format!(
+                        "    browser_id: {browser_id} (stale/unusable until this DevTools target becomes healthy)"
+                    ));
+                }
+            }
+        }
+    }
+
+    lines.push("Local Chromium browser processes:".to_string());
+    if processes.is_empty() {
+        lines.push("  - none found".to_string());
+    } else {
+        for process in processes {
+            let debug = if process.has_remote_debugging {
+                "debuggable"
+            } else {
+                "no-remote-debugging"
+            };
+            let user_data_dir = process
+                .user_data_dir
+                .as_deref()
+                .map(|value| format!(" user-data-dir={value}"))
+                .unwrap_or_default();
+            lines.push(format!(
+                "  - {} pid={} [{debug}]{}",
+                process.browser_name, process.pid, user_data_dir
+            ));
+            lines.push(format!("    cmd: {}", process.command));
+        }
+    }
+
+    lines.push("Browser helpers:".to_string());
+    lines.push(format!(
+        "  - agent-browser default daemon: {}{}",
+        render_daemon_state(helpers.agent_browser_default),
+        helpers
+            .agent_browser_default_pid
+            .map(|pid| format!(" (pid {pid})"))
+            .unwrap_or_default()
+    ));
+    lines.push("    note: only the default agent-browser session is inspected.".to_string());
+
+    if helpers.dev_browser_processes.is_empty() {
+        lines.push("  - dev-browser daemon: not running".to_string());
+    } else {
+        lines.push(format!(
+            "  - dev-browser daemon: running ({} process{})",
+            helpers.dev_browser_processes.len(),
+            if helpers.dev_browser_processes.len() == 1 {
+                ""
+            } else {
+                "es"
+            }
+        ));
+        for process in helpers.dev_browser_processes.iter().take(3) {
+            lines.push(format!("    - pid {}: {}", process.pid, process.command));
+        }
+        if helpers.dev_browser_processes.len() > 3 {
+            lines.push(format!(
+                "    - … and {} more",
+                helpers.dev_browser_processes.len() - 3
+            ));
+        }
+    }
+
+    if helpers.external_mcp_processes.is_empty() {
+        lines.push("  - external cdp clients: none detected".to_string());
+    } else {
+        lines.push(format!(
+            "  - external cdp clients: {} detected",
+            helpers.external_mcp_processes.len()
+        ));
+        for process in &helpers.external_mcp_processes {
+            lines.push(format!(
+                "    - {} (pid {})",
+                process.kind.label(),
+                process.pid
+            ));
+        }
+    }
+
+    lines.push("Recommended actions:".to_string());
+    for action in &helpers.recommended_actions {
+        lines.push(format!("  - {action}"));
+    }
+
+    lines.join("\n")
+}
+
+fn probe_auto_connect_tabs_for_doctor() -> AutoConnectDoctorStatus {
+    let connection = BrowserConnection::AutoConnect;
+    let stdout = match run_agent_browser_with_connection_timeout(
+        vec!["tab".to_string(), "list".to_string(), "--json".to_string()],
+        OutputFormat::Json,
+        Some(&connection),
+        /* use_stealth */ false,
+        /* headed */ false,
+        Some(10_000),
+    ) {
+        Ok(stdout) => stdout,
+        Err(err) => return AutoConnectDoctorStatus::Unavailable(format!("{err:#}")),
+    };
+
+    let parsed: AgentBrowserTabListEnvelope = match serde_json::from_str(stdout.trim()) {
+        Ok(parsed) => parsed,
+        Err(err) => {
+            return AutoConnectDoctorStatus::Unavailable(format!(
+                "invalid auto-connect tab list JSON: {err}"
+            ));
+        }
+    };
+
+    AutoConnectDoctorStatus::Reachable(parsed.data.tabs)
+}
+
+fn summarize_auto_connect_profile_emails(tabs: &[AgentBrowserTab]) -> Vec<(String, Vec<String>)> {
+    let mut grouped = BTreeMap::<String, Vec<String>>::new();
+    for tab in tabs {
+        let sample = if tab.title.trim().is_empty() {
+            tab.url.trim().to_string()
+        } else {
+            tab.title.trim().to_string()
+        };
+        for email in infer_email_hints(&tab.title, &tab.url) {
+            let samples = grouped.entry(email).or_default();
+            if !sample.is_empty()
+                && samples.len() < 3
+                && !samples.iter().any(|existing| existing == &sample)
+            {
+                samples.push(sample.clone());
+            }
+        }
+    }
+    grouped.into_iter().collect()
 }
 
 pub fn remember_cdp_target(target: &ResolvedCdpTarget) -> Result<()> {
@@ -2002,9 +3120,9 @@ fn compare_running_chrome_targets(
 ) -> std::cmp::Ordering {
     let sticky_left = sticky_source.is_some_and(|path| path == left.source_path.as_path());
     let sticky_right = sticky_source.is_some_and(|path| path == right.source_path.as_path());
-    right
-        .has_chatgpt_tab()
-        .cmp(&left.has_chatgpt_tab())
+    sticky_right
+        .cmp(&sticky_left)
+        .then_with(|| right.has_chatgpt_tab().cmp(&left.has_chatgpt_tab()))
         .then_with(|| right.chatgpt_tab_count.cmp(&left.chatgpt_tab_count))
         .then_with(|| {
             browser_family_priority(&right.browser_name)
@@ -2013,7 +3131,6 @@ fn compare_running_chrome_targets(
         .then_with(|| {
             modified_sort_key(right.modified_at).cmp(&modified_sort_key(left.modified_at))
         })
-        .then_with(|| sticky_right.cmp(&sticky_left))
         .then_with(|| left.source_path.cmp(&right.source_path))
 }
 
@@ -2070,12 +3187,12 @@ fn resolve_browser_connection_fallback(
 }
 
 pub fn resolve_browser_connection(
-    config: &Config,
+    browser_defaults: &BrowserDefaults,
     cdp_override: Option<&str>,
     profile_dir: &Path,
     target_url: &str,
 ) -> Result<BrowserConnection> {
-    if let Some(endpoint) = resolve_cdp_endpoint(cdp_override, config) {
+    if let Some(endpoint) = resolve_cdp_endpoint(cdp_override, browser_defaults) {
         match try_cdp_attach(&endpoint, target_url) {
             Ok(()) => return Ok(BrowserConnection::Cdp { endpoint }),
             Err(err) if should_stop_live_attach_fallback(&err) => {
@@ -2145,7 +3262,7 @@ fn should_attach_chrome136_warning(endpoint: &str, err: &anyhow::Error) -> bool 
 }
 
 fn should_stop_live_attach_fallback(err: &anyhow::Error) -> bool {
-    is_chrome_approval_wait_error(err)
+    is_chrome_approval_wait_error(err) || is_chrome_create_target_block_error(err)
 }
 
 fn looks_like_cdp_transport_failure(err: &anyhow::Error) -> bool {
@@ -2354,7 +3471,7 @@ fn check_auth_with_connection_timeout(
     }
     let mut current_headed = headed;
     let use_stealth = !connection.is_live_attach();
-    let verification_tab_index = if connection.is_live_attach() {
+    let verification_tab = if connection.is_live_attach() {
         open_live_attach_verification_tab(
             connection,
             use_stealth,
@@ -2411,7 +3528,7 @@ fn check_auth_with_connection_timeout(
                 connection,
                 use_stealth,
                 current_headed,
-                verification_tab_index,
+                verification_tab.as_ref(),
                 command_timeout_ms,
             );
             return Ok(());
@@ -2427,7 +3544,7 @@ fn check_auth_with_connection_timeout(
         connection,
         use_stealth,
         current_headed,
-        verification_tab_index,
+        verification_tab.as_ref(),
         command_timeout_ms,
     );
 
@@ -2440,42 +3557,130 @@ fn check_auth_with_connection_timeout(
     ))
 }
 
+/// URL query parameter yoetz stamps onto auth-probe tabs so the cleanup path
+/// can identify the probe tab unambiguously without reading tab ordering.
+/// (Review finding #6: stop closing probe tabs by index.)
+pub const YOETZ_PROBE_MARKER_PARAM: &str = "_yoetz_probe";
+
+/// Opaque handle returned by [`open_live_attach_verification_tab`] so the
+/// cleanup path can verify it is closing the exact probe tab it opened.
+#[derive(Debug, Clone)]
+pub struct LiveAttachProbeHandle {
+    /// Marker value embedded in the probe tab URL as
+    /// `?_yoetz_probe=<marker>` or `&_yoetz_probe=<marker>`.
+    marker: String,
+    /// Index the probe tab occupied on creation — kept only as a hint for
+    /// logging; close still re-resolves by marker before touching Chrome.
+    last_known_index: Option<usize>,
+}
+
+fn generate_probe_marker() -> String {
+    format!(
+        "yoetz-probe-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    )
+}
+
+pub(crate) fn mark_probe_url(target_url: &str, marker: &str) -> String {
+    let trimmed = target_url.trim();
+    if trimmed.is_empty() {
+        return format!("about:blank?{YOETZ_PROBE_MARKER_PARAM}={marker}");
+    }
+    let separator = if trimmed.split('#').next().unwrap_or(trimmed).contains('?') {
+        '&'
+    } else {
+        '?'
+    };
+    format!("{trimmed}{separator}{YOETZ_PROBE_MARKER_PARAM}={marker}")
+}
+
+fn find_probe_tab(tabs: &[AgentBrowserTab], marker: &str) -> Option<usize> {
+    if marker.is_empty() {
+        return None;
+    }
+    let needle = format!("{YOETZ_PROBE_MARKER_PARAM}={marker}");
+    tabs.iter()
+        .find(|tab| tab.url.contains(&needle))
+        .map(|tab| tab.index)
+}
+
 fn open_live_attach_verification_tab(
     connection: &BrowserConnection,
     use_stealth: bool,
     headed: bool,
     target_url: &str,
     command_timeout_ms: Option<u64>,
-) -> Result<Option<usize>> {
-    let before_tabs =
-        list_live_attach_tabs(connection, use_stealth, headed, command_timeout_ms).ok();
+) -> Result<Option<LiveAttachProbeHandle>> {
+    let marker = generate_probe_marker();
+    let marked_url = mark_probe_url(target_url, &marker);
     let _ = run_agent_browser_with_connection_timeout(
-        vec!["tab".to_string(), "new".to_string(), target_url.to_string()],
+        vec!["tab".to_string(), "new".to_string(), marked_url.clone()],
         OutputFormat::Text,
         Some(connection),
         use_stealth,
         headed,
         command_timeout_ms,
     )?;
-    let after_tabs =
-        list_live_attach_tabs(connection, use_stealth, headed, command_timeout_ms).ok();
-    Ok(match (before_tabs.as_deref(), after_tabs.as_deref()) {
-        (Some(before), Some(after)) => identify_live_attach_probe_tab(before, after),
-        _ => None,
-    })
+    // Surface tab-list failures as warnings (don't swallow silently, but also
+    // don't fail the whole auth check — the close path will re-try the list
+    // and either resolve the probe by marker or warn again). This is the
+    // review-finding-#6 requirement: stop the silent `.ok()` pattern.
+    let last_known_index = match list_live_attach_tabs(
+        connection,
+        use_stealth,
+        headed,
+        command_timeout_ms,
+    ) {
+        Ok(tabs) => find_probe_tab(&tabs, &marker),
+        Err(err) => {
+            eprintln!(
+                    "warn: listing Chrome tabs after opening the yoetz auth probe failed ({err:#}); close will re-resolve by marker `{marker}`"
+                );
+            None
+        }
+    };
+    Ok(Some(LiveAttachProbeHandle {
+        marker,
+        last_known_index,
+    }))
 }
 
 fn close_live_attach_verification_tab(
     connection: &BrowserConnection,
     use_stealth: bool,
     headed: bool,
-    verification_tab_index: Option<usize>,
+    verification_tab: Option<&LiveAttachProbeHandle>,
     command_timeout_ms: Option<u64>,
 ) {
     if !connection.is_live_attach() {
         return;
     }
-    let Some(index) = verification_tab_index else {
+    let Some(handle) = verification_tab else {
+        return;
+    };
+    // Always re-resolve the probe tab by its marker before closing so tab
+    // churn between open and close cannot redirect the close to an unrelated
+    // user tab (review finding #6).
+    let tabs = match list_live_attach_tabs(connection, use_stealth, headed, command_timeout_ms) {
+        Ok(tabs) => tabs,
+        Err(err) => {
+            eprintln!(
+                "warn: could not re-list Chrome tabs before closing yoetz auth probe ({err:#}); leaving the probe tab open to avoid closing the wrong one"
+            );
+            return;
+        }
+    };
+    let Some(index) = find_probe_tab(&tabs, &handle.marker) else {
+        if let Some(hint) = handle.last_known_index {
+            eprintln!(
+                "warn: yoetz auth probe tab (marker `{}`, last known at index {hint}) was not found; it may have already been closed by the user",
+                handle.marker
+            );
+        }
         return;
     };
     if run_agent_browser_with_connection_timeout(
@@ -2524,41 +3729,77 @@ fn list_live_attach_tabs(
     Ok(parsed.data.tabs)
 }
 
-fn identify_live_attach_probe_tab(
-    before_tabs: &[AgentBrowserTab],
-    after_tabs: &[AgentBrowserTab],
-) -> Option<usize> {
-    let mut before_counts = BTreeMap::<String, usize>::new();
-    for tab in before_tabs {
-        *before_counts
-            .entry(live_attach_tab_signature(tab))
-            .or_insert(0) += 1;
+fn maybe_select_live_attach_profile_tab(
+    connection: &BrowserConnection,
+    ctx: &RecipeContext,
+    headed: bool,
+) -> Result<()> {
+    if ctx
+        .vars
+        .get("browser_context_id")
+        .is_some_and(|value| !value.trim().is_empty())
+    {
+        return Ok(());
     }
+    let Some(requested_email) = ctx
+        .vars
+        .get("profile_email")
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(());
+    };
 
-    let mut extras = Vec::new();
-    for tab in after_tabs {
-        let signature = live_attach_tab_signature(tab);
-        match before_counts.get_mut(&signature) {
-            Some(count) if *count > 0 => *count -= 1,
-            _ => extras.push(tab),
-        }
-    }
-
-    extras
-        .iter()
-        .find(|tab| tab.active)
-        .copied()
-        .or_else(|| {
-            after_tabs.iter().find(|tab| {
-                tab.active && !before_tabs.iter().any(|before| before.index == tab.index)
-            })
-        })
-        .or_else(|| extras.last().copied())
-        .map(|tab| tab.index)
+    let tabs = list_live_attach_tabs(
+        connection,
+        ctx.use_stealth,
+        headed,
+        Some(LIVE_ATTACH_COMMAND_TIMEOUT_MS),
+    )?;
+    let selected = select_live_attach_profile_tab(&tabs, &requested_email)?;
+    run_agent_browser_with_connection_timeout(
+        vec!["tab".to_string(), selected.index.to_string()],
+        OutputFormat::Text,
+        Some(connection),
+        ctx.use_stealth,
+        headed,
+        Some(LIVE_ATTACH_COMMAND_TIMEOUT_MS),
+    )?;
+    Ok(())
 }
 
-fn live_attach_tab_signature(tab: &AgentBrowserTab) -> String {
-    format!("{}\n{}", tab.title, tab.url)
+fn select_live_attach_profile_tab<'a>(
+    tabs: &'a [AgentBrowserTab],
+    requested_email: &str,
+) -> Result<&'a AgentBrowserTab> {
+    let matches = tabs
+        .iter()
+        .filter(|tab| {
+            infer_email_hints(&tab.title, &tab.url)
+                .into_iter()
+                .any(|email| email == requested_email)
+        })
+        .collect::<Vec<_>>();
+    if matches.is_empty() {
+        let visible = summarize_auto_connect_profile_emails(tabs)
+            .into_iter()
+            .map(|(email, _)| email)
+            .collect::<Vec<_>>();
+        if visible.is_empty() {
+            bail!(
+                "profile_email `{requested_email}` was not visible in the live auto-connect tab list"
+            );
+        }
+        bail!(
+            "profile_email `{requested_email}` was not visible in the live auto-connect tab list. Visible emails: {}",
+            visible.join(", ")
+        );
+    }
+
+    if let Some(active) = matches.iter().copied().find(|tab| tab.active) {
+        return Ok(active);
+    }
+    Ok(matches[0])
 }
 
 fn looks_like_timeout(err: &anyhow::Error) -> bool {
@@ -2592,17 +3833,7 @@ fn auth_check_timeout_ms(connection: &BrowserConnection) -> u64 {
 /// Requires auth-specific markers (composer, sidebar controls) rather than branding
 /// strings like "chatgpt" that also appear on logged-out pages.
 fn looks_authenticated(snapshot: &str) -> bool {
-    let haystack = snapshot.to_lowercase();
-    // Auth-specific: these only appear when logged in with a functional session.
-    let auth_markers = [
-        "send a message",
-        "message chatgpt",
-        "new chat",
-        "send-button",
-        "prompt-textarea",
-        "composer",
-    ];
-    contains_any(&haystack, &auth_markers)
+    chatgpt_web::looks_authenticated_text(snapshot)
 }
 
 fn maybe_pause_for_captcha_challenge(
@@ -2661,58 +3892,17 @@ fn maybe_pause_for_captcha_challenge(
 }
 
 fn is_challenge_page(snapshot: &str) -> bool {
-    let haystack = snapshot.to_lowercase();
-    let challenge_markers = [
-        "cloudflare",
-        "checking your browser",
-        "attention required",
-        "security check",
-        "just a moment",
-        "verify you are human",
-        "cf-chl",
-    ];
-    contains_any(&haystack, &challenge_markers)
+    chatgpt_web::is_challenge_text(snapshot)
 }
 
 fn detect_auth_issue_for_connection(
     snapshot: &str,
     connection: Option<&BrowserConnection>,
 ) -> Option<&'static str> {
-    let haystack = snapshot.to_lowercase();
-    let login_markers = [
-        "log in",
-        "login",
-        "sign in",
-        "sign up",
-        "create account",
-        "continue with google",
-        "continue with microsoft",
-        "continue with apple",
-    ];
-
-    if is_challenge_page(snapshot) {
-        if connection.is_some_and(BrowserConnection::is_live_attach) {
-            return Some(
-                "cloudflare challenge detected in the attached Chrome session. Solve it in your browser window and try again.",
-            );
-        }
-        return Some(
-            "cloudflare challenge detected. Run `yoetz browser sync-cookies` or `yoetz browser login` and try again.",
-        );
-    }
-    if contains_any(&haystack, &login_markers) {
-        if connection.is_some_and(BrowserConnection::is_live_attach) {
-            return Some(
-                "chatgpt login required in the attached Chrome session. Log in there and try again.",
-            );
-        }
-        return Some("chatgpt login required. Run `yoetz browser login` and try again.");
-    }
-    None
-}
-
-fn contains_any(haystack: &str, needles: &[&str]) -> bool {
-    needles.iter().any(|needle| haystack.contains(needle))
+    chatgpt_web::detect_auth_issue_text(
+        snapshot,
+        connection.is_some_and(BrowserConnection::is_live_attach),
+    )
 }
 
 fn parse_stdout_json(stdout: &str) -> Option<Value> {
@@ -2967,6 +4157,75 @@ mod tests {
         }
     }
 
+    #[test]
+    fn mark_probe_url_appends_param_without_existing_query() {
+        let marked = mark_probe_url("https://chatgpt.com/", "run-abc");
+        assert_eq!(marked, "https://chatgpt.com/?_yoetz_probe=run-abc");
+    }
+
+    #[test]
+    fn mark_probe_url_appends_param_with_existing_query() {
+        let marked = mark_probe_url("https://chatgpt.com/?foo=bar", "run-abc");
+        assert_eq!(marked, "https://chatgpt.com/?foo=bar&_yoetz_probe=run-abc");
+    }
+
+    #[test]
+    fn mark_probe_url_ignores_fragment_when_deciding_separator() {
+        let marked = mark_probe_url("https://chatgpt.com/#chat", "run-abc");
+        assert_eq!(marked, "https://chatgpt.com/#chat?_yoetz_probe=run-abc");
+    }
+
+    #[test]
+    fn find_probe_tab_identifies_marker_ignoring_index_order() {
+        let tabs = vec![
+            AgentBrowserTab {
+                index: 2,
+                active: true,
+                title: "Inbox".to_string(),
+                url: "https://mail.google.com/".to_string(),
+            },
+            AgentBrowserTab {
+                index: 7,
+                active: false,
+                title: "ChatGPT probe".to_string(),
+                url: "https://chatgpt.com/?_yoetz_probe=run-abc".to_string(),
+            },
+            AgentBrowserTab {
+                index: 0,
+                active: false,
+                title: "ChatGPT real".to_string(),
+                url: "https://chatgpt.com/c/old".to_string(),
+            },
+        ];
+        assert_eq!(find_probe_tab(&tabs, "run-abc"), Some(7));
+        // A different marker must never resolve to a user-owned ChatGPT tab
+        // (review finding #6: identity must be certain before closing).
+        assert_eq!(find_probe_tab(&tabs, "other-run"), None);
+        assert_eq!(find_probe_tab(&tabs, ""), None);
+    }
+
+    #[test]
+    fn find_probe_tab_survives_index_churn_between_open_and_close() {
+        // The probe tab's index changed from 3 at open to 1 at close; only
+        // the URL marker is stable, so closing by stored index would destroy
+        // an unrelated user tab.
+        let tabs_before_close = vec![
+            AgentBrowserTab {
+                index: 1,
+                active: false,
+                title: "ChatGPT probe".to_string(),
+                url: "https://chatgpt.com/?_yoetz_probe=run-xyz".to_string(),
+            },
+            AgentBrowserTab {
+                index: 3,
+                active: true,
+                title: "Important Doc".to_string(),
+                url: "https://docs.google.com/".to_string(),
+            },
+        ];
+        assert_eq!(find_probe_tab(&tabs_before_close, "run-xyz"), Some(1));
+    }
+
     fn recipe_context() -> RecipeContext {
         RecipeContext {
             bundle_path: Some("/tmp/bundle.md".to_string()),
@@ -3067,10 +4326,16 @@ mod tests {
         BIN.get_or_init(|| {
             let dir = unique_test_dir("fake_agent_browser_auth_tabs");
             let bin = command_path(&dir, "fake-agent-browser-auth-tabs");
+            // The fake captures the URL passed to `tab new` so the subsequent
+            // `tab list` response can echo it back — including the
+            // `?_yoetz_probe=` marker yoetz now stamps on probe tabs
+            // (review finding #6). Without this, the new probe tab's URL
+            // would be static and the marker-based cleanup would refuse to
+            // close it.
             write_executable_script(
                 &bin,
-                "#!/bin/sh\nprintf 'timeout=%s args=%s\\n' \"$AGENT_BROWSER_DEFAULT_TIMEOUT\" \"$*\" >> \"$LOG_PATH\"\ncase \"$*\" in\n  *\"tab list --json\"*)\n    count=0\n    if [ -f \"$TAB_STATE_PATH\" ]; then\n      count=$(cat \"$TAB_STATE_PATH\")\n    fi\n    if [ \"$count\" = \"0\" ]; then\n      printf '1' > \"$TAB_STATE_PATH\"\n      printf '{\"success\":true,\"data\":{\"tabs\":[{\"active\":false,\"index\":0,\"title\":\"Docs\",\"url\":\"https://docs.example.com/\"},{\"active\":true,\"index\":2,\"title\":\"Workspace\",\"url\":\"https://app.example.com/\"}]}}'\n    else\n      printf '{\"success\":true,\"data\":{\"tabs\":[{\"active\":false,\"index\":0,\"title\":\"Docs\",\"url\":\"https://docs.example.com/\"},{\"active\":false,\"index\":2,\"title\":\"Workspace\",\"url\":\"https://app.example.com/\"},{\"active\":true,\"index\":5,\"title\":\"ChatGPT\",\"url\":\"https://chatgpt.com/\"}]}}'\n    fi\n    ;;\n  *snapshot*) printf '{\"text\":\"ChatGPT - New chat\"}' ;;\nesac\n",
-                "@echo off\r\necho timeout=%AGENT_BROWSER_DEFAULT_TIMEOUT% args=%*>> \"%LOG_PATH%\"\r\necho %* | findstr /c:\"tab list --json\" >nul\r\nif %errorlevel%==0 (\r\n  if not exist \"%TAB_STATE_PATH%\" (\r\n    > \"%TAB_STATE_PATH%\" echo 1\r\n    echo {\"success\":true,\"data\":{\"tabs\":[{\"active\":false,\"index\":0,\"title\":\"Docs\",\"url\":\"https://docs.example.com/\"},{\"active\":true,\"index\":2,\"title\":\"Workspace\",\"url\":\"https://app.example.com/\"}]}}\r\n  ) else (\r\n    echo {\"success\":true,\"data\":{\"tabs\":[{\"active\":false,\"index\":0,\"title\":\"Docs\",\"url\":\"https://docs.example.com/\"},{\"active\":false,\"index\":2,\"title\":\"Workspace\",\"url\":\"https://app.example.com/\"},{\"active\":true,\"index\":5,\"title\":\"ChatGPT\",\"url\":\"https://chatgpt.com/\"}]}}\r\n  )\r\n)\r\necho %* | findstr /c:\"snapshot\" >nul\r\nif %errorlevel%==0 echo {\"text\":\"ChatGPT - New chat\"}\r\n",
+                "#!/bin/sh\nprintf 'timeout=%s args=%s\\n' \"$AGENT_BROWSER_DEFAULT_TIMEOUT\" \"$*\" >> \"$LOG_PATH\"\ncase \"$*\" in\n  *\"tab new \"*)\n    probe_url=$(printf '%s' \"$*\" | sed -e 's/.*tab new //' -e 's/ .*//')\n    if [ -n \"$probe_url\" ]; then\n      printf '%s' \"$probe_url\" > \"${TAB_STATE_PATH}.url\"\n    fi\n    ;;\n  *\"tab list --json\"*)\n    count=0\n    if [ -f \"$TAB_STATE_PATH\" ]; then\n      count=$(cat \"$TAB_STATE_PATH\")\n    fi\n    if [ \"$count\" = \"0\" ]; then\n      printf '1' > \"$TAB_STATE_PATH\"\n      printf '{\"success\":true,\"data\":{\"tabs\":[{\"active\":false,\"index\":0,\"title\":\"Docs\",\"url\":\"https://docs.example.com/\"},{\"active\":true,\"index\":2,\"title\":\"Workspace\",\"url\":\"https://app.example.com/\"}]}}'\n    else\n      probe_url=\"https://chatgpt.com/\"\n      if [ -f \"${TAB_STATE_PATH}.url\" ]; then\n        probe_url=$(cat \"${TAB_STATE_PATH}.url\")\n      fi\n      printf '{\"success\":true,\"data\":{\"tabs\":[{\"active\":false,\"index\":0,\"title\":\"Docs\",\"url\":\"https://docs.example.com/\"},{\"active\":false,\"index\":2,\"title\":\"Workspace\",\"url\":\"https://app.example.com/\"},{\"active\":true,\"index\":5,\"title\":\"ChatGPT\",\"url\":\"%s\"}]}}' \"$probe_url\"\n    fi\n    ;;\n  *snapshot*) printf '{\"text\":\"ChatGPT - New chat\"}' ;;\nesac\n",
+                "@echo off\r\necho timeout=%AGENT_BROWSER_DEFAULT_TIMEOUT% args=%*>> \"%LOG_PATH%\"\r\necho %* | findstr /c:\"tab new \" >nul\r\nif %errorlevel%==0 (\r\n  for /f \"tokens=* delims= \" %%A in (\"%*\") do set args=%%A\r\n  for /f \"tokens=3\" %%U in (\"%args%\") do (> \"%TAB_STATE_PATH%.url\" echo %%U)\r\n)\r\necho %* | findstr /c:\"tab list --json\" >nul\r\nif %errorlevel%==0 (\r\n  if not exist \"%TAB_STATE_PATH%\" (\r\n    > \"%TAB_STATE_PATH%\" echo 1\r\n    echo {\"success\":true,\"data\":{\"tabs\":[{\"active\":false,\"index\":0,\"title\":\"Docs\",\"url\":\"https://docs.example.com/\"},{\"active\":true,\"index\":2,\"title\":\"Workspace\",\"url\":\"https://app.example.com/\"}]}}\r\n  ) else (\r\n    set probe_url=https://chatgpt.com/\r\n    if exist \"%TAB_STATE_PATH%.url\" (\r\n      set /p probe_url=<\"%TAB_STATE_PATH%.url\"\r\n    )\r\n    echo {\"success\":true,\"data\":{\"tabs\":[{\"active\":false,\"index\":0,\"title\":\"Docs\",\"url\":\"https://docs.example.com/\"},{\"active\":false,\"index\":2,\"title\":\"Workspace\",\"url\":\"https://app.example.com/\"},{\"active\":true,\"index\":5,\"title\":\"ChatGPT\",\"url\":\"%probe_url%\"}]}}\r\n  )\r\n)\r\necho %* | findstr /c:\"snapshot\" >nul\r\nif %errorlevel%==0 echo {\"text\":\"ChatGPT - New chat\"}\r\n",
             );
             bin
         })
@@ -3090,6 +4355,33 @@ mod tests {
             bin
         })
         .clone()
+    }
+
+    #[test]
+    fn detect_agent_browser_in_path_does_not_fall_back_to_npx() {
+        let _guard = lock_env();
+        let original_path = env::var_os("PATH");
+        #[allow(unsafe_code)]
+        unsafe {
+            env::set_var(
+                "PATH",
+                std::env::temp_dir().join("yoetz-missing-agent-browser-path"),
+            );
+        }
+
+        let result = detect_agent_browser_in_path();
+
+        #[allow(unsafe_code)]
+        unsafe {
+            match original_path {
+                Some(value) => env::set_var("PATH", value),
+                None => env::remove_var("PATH"),
+            }
+        }
+
+        let err = result.unwrap_err();
+        assert!(err.contains("agent-browser not found in PATH"));
+        assert!(!err.contains("npx"));
     }
 
     #[test]
@@ -3185,20 +4477,56 @@ mod tests {
     fn resolve_cdp_endpoint_prefers_flag_then_env_then_config() {
         let _guard = lock_env();
         let _cdp_env = EnvVarGuard::set("YOETZ_BROWSER_CDP", "http://127.0.0.1:9000");
-        let mut config = Config::default();
-        config.defaults.browser_cdp = Some("http://127.0.0.1:9222".to_string());
+        let browser_defaults = BrowserDefaults {
+            cdp: Some("http://127.0.0.1:9222".to_string()),
+            ..Default::default()
+        };
 
-        let from_flag = resolve_cdp_endpoint(Some("http://127.0.0.1:9333"), &config);
+        let from_flag = resolve_cdp_endpoint(Some("http://127.0.0.1:9333"), &browser_defaults);
         assert_eq!(from_flag.as_deref(), Some("http://127.0.0.1:9333"));
 
-        let from_env = resolve_cdp_endpoint(None, &config);
+        let from_env = resolve_cdp_endpoint(None, &browser_defaults);
         assert_eq!(from_env.as_deref(), Some("http://127.0.0.1:9000"));
 
         unsafe {
             env::remove_var("YOETZ_BROWSER_CDP");
         }
-        let from_config = resolve_cdp_endpoint(None, &config);
+        let from_config = resolve_cdp_endpoint(None, &browser_defaults);
         assert_eq!(from_config.as_deref(), Some("http://127.0.0.1:9222"));
+    }
+
+    #[test]
+    fn load_browser_defaults_from_paths_uses_only_trusted_files() {
+        let trusted_dir = unique_test_dir("browser_defaults_trusted");
+        let trusted_path = trusted_dir.join("config.toml");
+        fs::write(
+            &trusted_path,
+            r#"
+[defaults]
+browser_profile = "/safe/profile"
+browser_cdp = "http://127.0.0.1:9222"
+"#,
+        )
+        .unwrap();
+
+        let untrusted_dir = unique_test_dir("browser_defaults_untrusted");
+        let untrusted_path = untrusted_dir.join("yoetz.toml");
+        fs::write(
+            &untrusted_path,
+            r#"
+[defaults]
+browser_profile = "/tmp/evil-profile"
+browser_cdp = "http://evil.example.com:9222"
+"#,
+        )
+        .unwrap();
+
+        let defaults =
+            load_browser_defaults_from_paths(vec![(untrusted_path, false), (trusted_path, true)])
+                .unwrap();
+
+        assert_eq!(defaults.profile.as_deref(), Some("/safe/profile"));
+        assert_eq!(defaults.cdp.as_deref(), Some("http://127.0.0.1:9222"));
     }
 
     #[test]
@@ -3206,16 +4534,21 @@ mod tests {
     fn resolve_cdp_target_can_suppress_implicit_live_targets() {
         let _guard = lock_env();
         let _cdp_env = EnvVarGuard::set("YOETZ_BROWSER_CDP", "http://127.0.0.1:9000");
-        let mut config = Config::default();
-        config.defaults.browser_cdp = Some("http://127.0.0.1:9222".to_string());
+        let browser_defaults = BrowserDefaults {
+            cdp: Some("http://127.0.0.1:9222".to_string()),
+            ..Default::default()
+        };
 
-        let suppressed = resolve_cdp_target_with_implicit(None, &config, false).unwrap();
+        let suppressed = resolve_cdp_target_with_implicit(None, &browser_defaults, false).unwrap();
         assert!(suppressed.is_none());
 
-        let explicit =
-            resolve_cdp_target_with_implicit(Some("http://127.0.0.1:9333"), &config, false)
-                .unwrap()
-                .unwrap();
+        let explicit = resolve_cdp_target_with_implicit(
+            Some("http://127.0.0.1:9333"),
+            &browser_defaults,
+            false,
+        )
+        .unwrap()
+        .unwrap();
         assert_eq!(explicit.endpoint, "http://127.0.0.1:9333");
         assert_eq!(explicit.source, ResolvedCdpTargetSource::Flag);
     }
@@ -3227,18 +4560,21 @@ mod tests {
             source: ResolvedCdpTargetSource::Flag,
             description: "explicit".to_string(),
             source_path: None,
+            selected_target: None,
         };
         let configured = ResolvedCdpTarget {
             endpoint: "ws://127.0.0.1:9222/devtools/browser/config".to_string(),
             source: ResolvedCdpTargetSource::Config,
             description: "config".to_string(),
             source_path: None,
+            selected_target: None,
         };
         let automatic = ResolvedCdpTarget {
             endpoint: "ws://127.0.0.1:9222/devtools/browser/auto".to_string(),
             source: ResolvedCdpTargetSource::Auto,
             description: "auto".to_string(),
             source_path: Some(PathBuf::from("/tmp/DevToolsActivePort")),
+            selected_target: None,
         };
 
         assert!(explicit.is_authoritative());
@@ -3247,7 +4583,7 @@ mod tests {
     }
 
     #[test]
-    fn select_preferred_running_chrome_target_prefers_chatgpt_before_sticky() {
+    fn select_preferred_running_chrome_target_prefers_sticky_before_chatgpt() {
         let sticky_path = PathBuf::from("/tmp/chrome-sticky/DevToolsActivePort");
         let older = SystemTime::UNIX_EPOCH + Duration::from_secs(10);
         let newer = SystemTime::UNIX_EPOCH + Duration::from_secs(20);
@@ -3257,6 +4593,8 @@ mod tests {
                 source_path: sticky_path.clone(),
                 browser_name: "Brave".to_string(),
                 chatgpt_tab_count: 0,
+                page_target_count: 2,
+                page_samples: vec!["Inbox".to_string(), "Calendar".to_string()],
                 modified_at: Some(older),
             },
             RunningChromeTarget {
@@ -3264,6 +4602,8 @@ mod tests {
                 source_path: PathBuf::from("/tmp/chrome-default/DevToolsActivePort"),
                 browser_name: "Chrome".to_string(),
                 chatgpt_tab_count: 2,
+                page_target_count: 3,
+                page_samples: vec!["ChatGPT - New chat".to_string()],
                 modified_at: Some(newer),
             },
         ];
@@ -3273,7 +4613,7 @@ mod tests {
                 .unwrap();
         assert_eq!(
             sticky_choice.ws_endpoint,
-            "ws://127.0.0.1:9222/devtools/browser/chatgpt"
+            "ws://127.0.0.1:9333/devtools/browser/sticky"
         );
 
         let chatgpt_choice = select_preferred_running_chrome_target(&mut targets, None).unwrap();
@@ -3295,6 +4635,7 @@ mod tests {
             source: ResolvedCdpTargetSource::Auto,
             description: "auto-selected running Chrome target".to_string(),
             source_path: Some(PathBuf::from("/tmp/chrome-default/DevToolsActivePort")),
+            selected_target: None,
         };
 
         remember_cdp_target(&target).unwrap();
@@ -3303,6 +4644,416 @@ mod tests {
             loaded.last_source_path,
             Some(PathBuf::from("/tmp/chrome-default/DevToolsActivePort"))
         );
+    }
+
+    #[test]
+    fn auto_discovered_cdp_target_warning_omits_healthy_chatgpt_target() {
+        let selected = RunningChromeTarget {
+            ws_endpoint: "ws://127.0.0.1:9222/devtools/browser/chatgpt".to_string(),
+            source_path: PathBuf::from("/tmp/chrome-default/DevToolsActivePort"),
+            browser_name: "Chrome".to_string(),
+            chatgpt_tab_count: 1,
+            page_target_count: 1,
+            page_samples: vec!["ChatGPT - New chat".to_string()],
+            modified_at: Some(SystemTime::UNIX_EPOCH),
+        };
+        let target = ResolvedCdpTarget {
+            endpoint: selected.ws_endpoint.clone(),
+            source: ResolvedCdpTargetSource::Auto,
+            description: "auto-selected".to_string(),
+            source_path: Some(selected.source_path.clone()),
+            selected_target: Some(selected.clone()),
+        };
+
+        let warning = auto_discovered_cdp_target_warning_with_discovery(&target, &[selected], &[]);
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn auto_discovered_cdp_target_warning_mentions_alternative_target_and_profile_hint() {
+        let selected = RunningChromeTarget {
+            ws_endpoint: "ws://127.0.0.1:9222/devtools/browser/work".to_string(),
+            source_path: PathBuf::from("/tmp/chrome-work/DevToolsActivePort"),
+            browser_name: "Chrome".to_string(),
+            chatgpt_tab_count: 0,
+            page_target_count: 2,
+            page_samples: vec!["Inbox".to_string(), "Calendar".to_string()],
+            modified_at: Some(SystemTime::UNIX_EPOCH),
+        };
+        let alternative = RunningChromeTarget {
+            ws_endpoint: "ws://127.0.0.1:9333/devtools/browser/personal".to_string(),
+            source_path: PathBuf::from("/tmp/chrome-personal/DevToolsActivePort"),
+            browser_name: "Chrome".to_string(),
+            chatgpt_tab_count: 2,
+            page_target_count: 3,
+            page_samples: vec!["ChatGPT - New chat".to_string()],
+            modified_at: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1)),
+        };
+        let target = ResolvedCdpTarget {
+            endpoint: selected.ws_endpoint.clone(),
+            source: ResolvedCdpTargetSource::Auto,
+            description: "auto-selected".to_string(),
+            source_path: Some(selected.source_path.clone()),
+            selected_target: Some(selected.clone()),
+        };
+        let processes = [ChromiumProcessSummary {
+            pid: 2706,
+            browser_name: "Chrome".to_string(),
+            command: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome".to_string(),
+            has_remote_debugging: false,
+            user_data_dir: None,
+        }];
+
+        let warning = auto_discovered_cdp_target_warning_with_discovery(
+            &target,
+            &[selected, alternative.clone()],
+            &processes,
+        )
+        .unwrap();
+        assert!(warning.contains("Current sample tabs: Inbox, Calendar"));
+        assert!(warning.contains("Another discovered debug target already has ChatGPT tabs"));
+        assert!(warning.contains(&alternative.summary()));
+        assert!(warning.contains("Chrome 136+ may be ignoring remote debugging"));
+        assert!(warning.contains("yoetz browser doctor"));
+    }
+
+    #[test]
+    fn browser_doctor_report_renders_empty_sections() {
+        let report = browser_doctor_report_with_discovery(
+            &[],
+            &[],
+            &[],
+            &AutoConnectDoctorStatus::Unavailable("probe failed".to_string()),
+            &BrowserDoctorHelpers {
+                agent_browser_default: DaemonState::NoSocket,
+                agent_browser_default_pid: None,
+                dev_browser_processes: vec![],
+                external_mcp_processes: vec![],
+                recommended_actions: vec!["None required.".to_string()],
+            },
+        );
+        assert!(report.contains("Agent-browser auto-connect view:"));
+        assert!(report.contains("probe failed"));
+        assert!(report.contains("Running Chrome targets:"));
+        assert!(report.contains("  - none discovered"));
+        assert!(report.contains("DevToolsActivePort files:"));
+        assert!(report.contains("  - none found"));
+        assert!(report.contains("Local Chromium browser processes:"));
+        assert!(report.contains("Browser helpers:"));
+        assert!(report.contains("agent-browser default daemon: not running"));
+        assert!(report.contains("dev-browser daemon: not running"));
+        assert!(report.contains("external cdp clients: none detected"));
+        assert!(report.contains("Recommended actions:"));
+        assert!(report.contains("None required."));
+    }
+
+    #[test]
+    fn browser_doctor_report_can_skip_live_auto_connect_probe() {
+        let report = browser_doctor_report_with_discovery(
+            &[],
+            &[],
+            &[],
+            &AutoConnectDoctorStatus::Skipped(
+                "skipped by default; use `yoetz browser doctor --live` to probe the auto-connect helper"
+                    .to_string(),
+            ),
+            &BrowserDoctorHelpers {
+                agent_browser_default: DaemonState::NoSocket,
+                agent_browser_default_pid: None,
+                dev_browser_processes: vec![],
+                external_mcp_processes: vec![],
+                recommended_actions: vec!["None required.".to_string()],
+            },
+        );
+        assert!(report.contains("Agent-browser auto-connect view:"));
+        assert!(report.contains("skipped by default"));
+        assert!(report.contains("yoetz browser doctor --live"));
+    }
+
+    #[test]
+    fn browser_doctor_report_includes_auto_connect_tabs() {
+        let report = browser_doctor_report_with_discovery(
+            &[],
+            &[],
+            &[],
+            &AutoConnectDoctorStatus::Reachable(vec![
+                AgentBrowserTab {
+                    index: 3,
+                    active: true,
+                    title: "ChatGPT".to_string(),
+                    url: "https://chatgpt.com/".to_string(),
+                },
+                AgentBrowserTab {
+                    index: 1,
+                    active: false,
+                    title: "Inbox".to_string(),
+                    url: "https://mail.google.com/".to_string(),
+                },
+            ]),
+            &BrowserDoctorHelpers {
+                agent_browser_default: DaemonState::NoSocket,
+                agent_browser_default_pid: None,
+                dev_browser_processes: vec![],
+                external_mcp_processes: vec![],
+                recommended_actions: vec!["None required.".to_string()],
+            },
+        );
+        assert!(report.contains("reachable (tabs: 2, chatgpt tabs: 1)"));
+        assert!(report.contains("tab set exposed by the auto-connect helper"));
+        assert!(report.contains("* tab 3: ChatGPT (https://chatgpt.com/)"));
+        assert!(report.contains("- tab 1: Inbox (https://mail.google.com/)"));
+    }
+
+    #[test]
+    fn browser_doctor_report_warns_when_auto_connect_and_raw_targets_disagree() {
+        let report = browser_doctor_report_with_discovery(
+            &[],
+            &[],
+            &[],
+            &AutoConnectDoctorStatus::Reachable(vec![AgentBrowserTab {
+                index: 9,
+                active: true,
+                title: "<untitled>".to_string(),
+                url: "about:blank".to_string(),
+            }]),
+            &BrowserDoctorHelpers {
+                agent_browser_default: DaemonState::NoSocket,
+                agent_browser_default_pid: None,
+                dev_browser_processes: vec![],
+                external_mcp_processes: vec![],
+                recommended_actions: vec!["None required.".to_string()],
+            },
+        );
+        assert!(report.contains("chatgpt tabs: 0"));
+        assert!(report.contains("different Chrome browsing context"));
+        assert!(report.contains("no raw DevToolsActivePort target was discovered"));
+    }
+
+    #[test]
+    fn browser_doctor_report_surfaces_inferred_profile_emails() {
+        let report = browser_doctor_report_with_discovery(
+            &[],
+            &[],
+            &[],
+            &AutoConnectDoctorStatus::Reachable(vec![
+                AgentBrowserTab {
+                    index: 0,
+                    active: false,
+                    title: "Inbox (43,617) - avivsinai@gmail.com - Gmail".to_string(),
+                    url: "https://mail.google.com/mail/u/0/#inbox".to_string(),
+                },
+                AgentBrowserTab {
+                    index: 1,
+                    active: false,
+                    title: "Inbox (6,096) - aviv.s@taboola.com - Taboola Mail".to_string(),
+                    url: "https://mail.google.com/mail/u/0/#inbox".to_string(),
+                },
+            ]),
+            &BrowserDoctorHelpers {
+                agent_browser_default: DaemonState::NoSocket,
+                agent_browser_default_pid: None,
+                dev_browser_processes: vec![],
+                external_mcp_processes: vec![],
+                recommended_actions: vec!["None required.".to_string()],
+            },
+        );
+        assert!(report.contains("inferred profile emails"));
+        assert!(report.contains("avivsinai@gmail.com"));
+        assert!(report.contains("aviv.s@taboola.com"));
+        assert!(report.contains("use `--var profile_email=<email>`"));
+    }
+
+    #[test]
+    fn browser_doctor_report_surfaces_browser_ids() {
+        let report = browser_doctor_report_with_discovery(
+            &[RunningChromeTarget {
+                ws_endpoint: "ws://127.0.0.1:9222/devtools/browser/browser-work".to_string(),
+                source_path: PathBuf::from("/tmp/chrome-work/DevToolsActivePort"),
+                browser_name: "Chrome".to_string(),
+                chatgpt_tab_count: 1,
+                page_target_count: 2,
+                page_samples: vec!["ChatGPT".to_string()],
+                modified_at: Some(SystemTime::UNIX_EPOCH),
+            }],
+            &[DevtoolsActivePortFile {
+                path: PathBuf::from("/tmp/chrome-work/DevToolsActivePort"),
+                ws_endpoint: Some("ws://127.0.0.1:9222/devtools/browser/browser-work".to_string()),
+                modified_at: Some(SystemTime::UNIX_EPOCH),
+                healthy: true,
+            }],
+            &[],
+            &AutoConnectDoctorStatus::Unavailable("probe failed".to_string()),
+            &BrowserDoctorHelpers {
+                agent_browser_default: DaemonState::NoSocket,
+                agent_browser_default_pid: None,
+                dev_browser_processes: vec![],
+                external_mcp_processes: vec![],
+                recommended_actions: vec!["None required.".to_string()],
+            },
+        );
+        assert!(report.contains("browser_id: browser-work"));
+        assert!(report.contains("--browser-id browser-work"));
+    }
+
+    #[test]
+    fn browser_doctor_report_marks_stale_browser_ids_unusable() {
+        let report = browser_doctor_report_with_discovery(
+            &[],
+            &[DevtoolsActivePortFile {
+                path: PathBuf::from("/tmp/chrome-stale/DevToolsActivePort"),
+                ws_endpoint: Some("ws://127.0.0.1:9222/devtools/browser/browser-stale".to_string()),
+                modified_at: Some(SystemTime::UNIX_EPOCH),
+                healthy: false,
+            }],
+            &[],
+            &AutoConnectDoctorStatus::Skipped("skip".to_string()),
+            &BrowserDoctorHelpers {
+                agent_browser_default: DaemonState::NoSocket,
+                agent_browser_default_pid: None,
+                dev_browser_processes: vec![],
+                external_mcp_processes: vec![],
+                recommended_actions: vec!["None required.".to_string()],
+            },
+        );
+        assert!(report.contains("browser_id: browser-stale"));
+        assert!(report.contains("stale/unusable"));
+        assert!(!report.contains("use `--browser-id browser-stale`"));
+    }
+
+    #[test]
+    fn browser_doctor_report_surfaces_helper_recommendations() {
+        let report = browser_doctor_report_with_discovery(
+            &[],
+            &[],
+            &[],
+            &AutoConnectDoctorStatus::Unavailable("probe failed".to_string()),
+            &BrowserDoctorHelpers {
+                agent_browser_default: DaemonState::Stale,
+                agent_browser_default_pid: Some(1234),
+                dev_browser_processes: vec![BrowserHelperProcessSummary {
+                    pid: 2222,
+                    kind: BrowserHelperProcessKind::DevBrowserDaemon,
+                    command: "node /Users/test/.dev-browser/daemon.mjs".to_string(),
+                }],
+                external_mcp_processes: vec![
+                    BrowserHelperProcessSummary {
+                        pid: 3333,
+                        kind: BrowserHelperProcessKind::ChromeDevtoolsMcp,
+                        command: "chrome-devtools-mcp".to_string(),
+                    },
+                    BrowserHelperProcessSummary {
+                        pid: 3334,
+                        kind: BrowserHelperProcessKind::ChromeDevtoolsMcpWatchdog,
+                        command: "node .../telemetry/watchdog/main.js".to_string(),
+                    },
+                ],
+                recommended_actions: vec![
+                    "Run `yoetz browser reset` before `yoetz browser attach`, `yoetz browser check`, or `yoetz browser recipe` to clear stale yoetz-owned helpers.".to_string(),
+                    "External chrome-devtools-mcp processes are still running (pid 3333, 3334). If they are not actively in use, close the owning tool/process first; `yoetz browser reset` will not stop them.".to_string(),
+                ],
+            },
+        );
+        assert!(report.contains("agent-browser default daemon: stale (pid 1234)"));
+        assert!(report.contains("dev-browser daemon: running (1 process)"));
+        assert!(report.contains("external cdp clients: 2 detected"));
+        assert!(report.contains("chrome-devtools-mcp (pid 3333)"));
+        assert!(report.contains("chrome-devtools-mcp watchdog (pid 3334)"));
+        assert!(report.contains("Run `yoetz browser reset`"));
+        assert!(report.contains("will not stop them"));
+    }
+
+    #[test]
+    fn parse_browser_helper_process_line_classifies_helpers() {
+        let dev =
+            parse_browser_helper_process_line("10060 node /Users/test/.dev-browser/daemon.mjs")
+                .expect("dev-browser helper");
+        assert_eq!(dev.pid, 10060);
+        assert_eq!(dev.kind, BrowserHelperProcessKind::DevBrowserDaemon);
+
+        let mcp = parse_browser_helper_process_line(
+            "19608 npm exec chrome-devtools-mcp@latest --autoConnect --slim",
+        )
+        .expect("mcp helper");
+        assert_eq!(mcp.kind, BrowserHelperProcessKind::ChromeDevtoolsMcp);
+
+        let watchdog = parse_browser_helper_process_line(
+            "19863 node /path/node_modules/chrome-devtools-mcp/build/src/telemetry/watchdog/main.js --parent-pid=19841",
+        )
+        .expect("watchdog helper");
+        assert_eq!(
+            watchdog.kind,
+            BrowserHelperProcessKind::ChromeDevtoolsMcpWatchdog
+        );
+
+        assert!(parse_browser_helper_process_line(
+            "65418 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn find_active_port_file_by_browser_id_ignores_stale_entries() {
+        let files = vec![
+            DevtoolsActivePortFile {
+                path: PathBuf::from("/tmp/stale"),
+                ws_endpoint: Some("ws://127.0.0.1:9222/devtools/browser/browser-work".to_string()),
+                modified_at: None,
+                healthy: false,
+            },
+            DevtoolsActivePortFile {
+                path: PathBuf::from("/tmp/healthy"),
+                ws_endpoint: Some("ws://127.0.0.1:9223/devtools/browser/browser-work".to_string()),
+                modified_at: None,
+                healthy: true,
+            },
+        ];
+
+        assert_eq!(
+            find_active_port_file_by_browser_id(&files, "browser-work")
+                .map(|file| file.path.as_path()),
+            Some(Path::new("/tmp/healthy"))
+        );
+        assert_eq!(
+            find_stale_active_port_file_by_browser_id(&files, "browser-work")
+                .map(|file| file.path.as_path()),
+            Some(Path::new("/tmp/stale"))
+        );
+    }
+
+    #[test]
+    fn select_live_attach_profile_tab_prefers_active_matching_tab_for_fresh() {
+        let tabs = vec![
+            AgentBrowserTab {
+                index: 1,
+                active: true,
+                title: "Inbox (43,617) - avivsinai@gmail.com - Gmail".to_string(),
+                url: "https://mail.google.com/mail/u/0/#inbox".to_string(),
+            },
+            AgentBrowserTab {
+                index: 4,
+                active: false,
+                title: "Personal Pro OK".to_string(),
+                url: "https://chatgpt.com/c/abc".to_string(),
+            },
+        ];
+
+        let selected = select_live_attach_profile_tab(&tabs, "avivsinai@gmail.com").unwrap();
+        assert_eq!(selected.index, 1);
+    }
+
+    #[test]
+    fn select_live_attach_profile_tab_errors_when_email_not_visible() {
+        let tabs = vec![AgentBrowserTab {
+            index: 2,
+            active: true,
+            title: "Inbox (6,096) - aviv.s@taboola.com - Taboola Mail".to_string(),
+            url: "https://mail.google.com/mail/u/0/#inbox".to_string(),
+        }];
+
+        let err = select_live_attach_profile_tab(&tabs, "avivsinai@gmail.com").unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("profile_email `avivsinai@gmail.com` was not visible"));
     }
 
     #[test]
@@ -3317,6 +5068,7 @@ mod tests {
             source: ResolvedCdpTargetSource::Auto,
             description: "auto-selected running Chrome target".to_string(),
             source_path: Some(PathBuf::from("/tmp/chrome-default/DevToolsActivePort")),
+            selected_target: None,
         };
 
         remember_cdp_target(&target).unwrap();
@@ -3476,6 +5228,12 @@ mod tests {
         assert!(looks_authenticated(
             r#"{"ref": "prompt-textarea", "text": ""}"#
         ));
+        assert!(looks_authenticated(
+            r#"{"ref": "model-switcher-dropdown-button", "text": "ChatGPT"}"#
+        ));
+        assert!(looks_authenticated(
+            r#"{"ref": "composer-plus-btn", "text": ""}"#
+        ));
         // Branding-only strings should NOT match (logged-out page can have these).
         assert!(!looks_authenticated(r#"{"text": "ChatGPT"}"#));
         assert!(!looks_authenticated(r#"{"text": "Loading..."}"#));
@@ -3515,6 +5273,16 @@ mod tests {
             r#"{"text": "Cloudflare security check"}"#
         ));
         assert!(!is_challenge_page(r#"{"text": "ChatGPT - New chat"}"#));
+    }
+
+    #[test]
+    fn is_challenge_page_ignores_review_content_inside_authenticated_chat() {
+        let snapshot = r#"{
+            "url":"https://chatgpt.com/",
+            "text":"The review inspects Cloudflare security check handling and the phrase verify you are human.",
+            "ref":"prompt-textarea"
+        }"#;
+        assert!(!is_challenge_page(snapshot));
     }
 
     #[test]
@@ -3573,6 +5341,18 @@ mod tests {
             Some(&BrowserConnection::AutoConnect),
         );
         assert_eq!(authenticated, None);
+    }
+
+    #[test]
+    fn detect_auth_issue_ignores_challenge_phrases_in_authenticated_thread() {
+        let snapshot = r#"{
+            "url":"https://chatgpt.com/",
+            "text":"I am reviewing code that literally contains verify you are human and security check markers.",
+            "ref":"prompt-textarea"
+        }"#;
+        let issue =
+            detect_auth_issue_for_connection(snapshot, Some(&BrowserConnection::AutoConnect));
+        assert_eq!(issue, None);
     }
 
     #[test]
@@ -3887,15 +5667,43 @@ mod tests {
     }
 
     #[test]
-    fn should_stop_live_attach_fallback_only_on_approval_wait() {
+    fn is_chatgpt_attached_page_error_detects_marker_and_model_mismatch() {
+        let tagged = mark_chatgpt_attached_page_error(anyhow!("composer interaction failed"));
+        let mismatch = anyhow!(
+            "requested ChatGPT model `pro` was not actually selected. Current page: url=https://chatgpt.com/, title=\"ChatGPT\""
+        );
+        let other = anyhow!("browserType.connectOverCDP: failed to list pages");
+
+        assert!(is_chatgpt_attached_page_error(&tagged));
+        assert!(is_chatgpt_attached_page_error(&mismatch));
+        assert!(!is_chatgpt_attached_page_error(&other));
+    }
+
+    #[test]
+    fn is_chatgpt_profile_selector_visibility_error_detects_context_mismatch() {
+        let err = anyhow!(
+            "profile_email `aviv.s@taboola.com` was not visible in the live auto-connect tab list. Visible emails: avivsinai@gmail.com"
+        );
+        let other = anyhow!("requested ChatGPT model `pro` was not actually selected");
+
+        assert!(is_chatgpt_profile_selector_visibility_error(&err));
+        assert!(!is_chatgpt_profile_selector_visibility_error(&other));
+    }
+
+    #[test]
+    fn should_stop_live_attach_fallback_on_approval_wait_and_create_target_block() {
         let approval = anyhow!(
             "live browser attach timed out (30s). Chrome may be showing an \"Allow remote debugging?\" dialog — please click Allow in Chrome, then retry."
+        );
+        let create_target_block = anyhow!(
+            "creating a new Chrome page for `about:blank` failed: Chrome's default-profile CDP endpoint likely rejected external `Target.createTarget` while opening `about:blank`. Chrome 146+/147 can allow attach/read operations but close the session on new-tab creation for untrusted clients. First, open chrome://inspect/#remote-debugging, refresh Discover network targets (or Open dedicated DevTools for Node), and retry. If Chrome still closes the session, launch Chrome with `--remote-debugging-port=9222 --user-data-dir=/tmp/chrome-debug` and pass `--cdp`, or use Chrome for Testing. Unable to make method calls because underlying connection is closed"
         );
         let auth_issue = anyhow!(
             "chatgpt login required in the attached Chrome session. Log in there and try again."
         );
 
         assert!(should_stop_live_attach_fallback(&approval));
+        assert!(should_stop_live_attach_fallback(&create_target_block));
         assert!(!should_stop_live_attach_fallback(&auth_issue));
     }
 
@@ -4010,6 +5818,40 @@ mod tests {
         let args = vec!["--timeout-ms".to_string(), "0".to_string()];
         let err = parse_chatgpt_poll_args(Some(&args)).unwrap_err();
         assert!(err.to_string().contains("--timeout-ms"));
+    }
+
+    #[test]
+    fn chatgpt_recipe_payload_extracts_response_model_and_warnings() {
+        let steps = vec![
+            json!({
+                "type": "browser_step",
+                "action": CHATGPT_SELECT_MODEL_ACTION,
+                "stdout": {
+                    "status": "ok",
+                    "model_used": "gpt-5-4-pro"
+                }
+            }),
+            json!({
+                "type": "browser_step",
+                "action": CHATGPT_WAIT_ACTION,
+                "stdout": {
+                    "status": "ok",
+                    "response": "final answer",
+                    "warnings": ["used paste fallback"]
+                }
+            }),
+        ];
+
+        let payload = chatgpt_recipe_payload_from_steps(&steps);
+        assert_eq!(payload["transport"], "agent-browser");
+        assert_eq!(payload["backend"], "agent-browser");
+        assert_eq!(payload["response"], "final answer");
+        assert_eq!(payload["model_used"], "gpt-5-4-pro");
+        assert_eq!(payload["fallback_used"], true);
+        assert_eq!(payload["warnings"], json!(["used paste fallback"]));
+        assert_eq!(payload["delivery_mode"], "file_upload");
+        assert_eq!(payload["auto_paste_fallback"], false);
+        assert_eq!(payload["steps"], json!(steps));
     }
 
     fn dom(send: ChatgptSendState, stop: bool, thinking: bool, copy: usize) -> ChatgptDomState {
@@ -4344,7 +6186,13 @@ steps:
     }
 
     #[test]
-    fn recipe_step_with_sleep_and_action_prefers_sleep() {
+    fn recipe_step_with_sleep_and_action_runs_after_sleep() {
+        let _guard = lock_env();
+        let log_dir = unique_test_dir("sleep_then_action");
+        let log_path = log_dir.join("agent-browser.log");
+        let bin = fake_agent_browser_bin();
+        let _bin_env = EnvVarGuard::set("YOETZ_AGENT_BROWSER_BIN", &bin);
+        let _log_env = EnvVarGuard::set("LOG_PATH", &log_path);
         let recipe = serde_yml::from_str::<Recipe>(
             r#"
 name: noop
@@ -4355,14 +6203,58 @@ steps:
 "#,
         )
         .unwrap();
-        let connection = BrowserConnection::AutoConnect;
         run_recipe_with_connection(
+            recipe,
+            recipe_context(),
+            Some(&BrowserConnection::AutoConnect),
+            OutputFormat::Text,
+        )
+        .unwrap();
+
+        let logged = fs::read_to_string(&log_path).unwrap_or_default();
+        assert!(
+            logged.contains("open https://chatgpt.com/"),
+            "expected the action to run after sleep, got `{logged}`"
+        );
+    }
+
+    #[test]
+    fn chatgpt_recipe_uses_built_in_model_selection_action() {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../recipes/chatgpt.yaml");
+        let content = fs::read_to_string(&path).expect("read recipes/chatgpt.yaml");
+
+        assert!(content.contains("- action: chatgpt_select_model"));
+        assert!(content.contains("- action: chatgpt_open_attachment_ui"));
+        assert!(content.contains("- action: chatgpt_send"));
+        assert!(!content.contains("const fallbackLabels = ['instant', 'thinking', 'pro'"));
+        assert!(!content.contains("send button disabled — page is likely recoverable"));
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn recipe_step_errors_fail_the_recipe() {
+        let _guard = lock_env();
+        let bin = fake_agent_browser_timeout_bin();
+        let _bin_env = EnvVarGuard::set("YOETZ_AGENT_BROWSER_BIN", &bin);
+        let recipe = serde_yml::from_str::<Recipe>(
+            r#"
+name: fail-fast
+steps:
+  - action: eval
+    args: ["(() => { throw new Error('boom'); })()"]
+"#,
+        )
+        .unwrap();
+        let connection = BrowserConnection::AutoConnect;
+        let err = run_recipe_with_connection(
             recipe,
             recipe_context(),
             Some(&connection),
             OutputFormat::Text,
         )
-        .unwrap();
+        .unwrap_err();
+
+        assert!(err.to_string().contains("recipe step 0 (eval) failed"));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -193,9 +193,7 @@ const AGENT_BROWSER_INSTALL_GUIDANCE: &str = concat!(
     "binary/package, or set YOETZ_AGENT_BROWSER_BIN to the exact executable to run."
 );
 
-/// Returns true if dev-browser is the active browser backend.
-/// When dev-browser is available, it is the preferred backend for all browser
-/// operations.
+/// Returns true when the dev-browser backend is available locally.
 pub fn use_dev_browser() -> bool {
     crate::dev_browser::is_available()
 }

--- a/crates/yoetz-cli/src/chatgpt_recipe.rs
+++ b/crates/yoetz-cli/src/chatgpt_recipe.rs
@@ -1,0 +1,102 @@
+use serde_json::{json, Value};
+use std::path::PathBuf;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ChatgptDeliveryMode {
+    FileUpload,
+    Paste,
+}
+
+impl ChatgptDeliveryMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::FileUpload => "file_upload",
+            Self::Paste => "paste",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChatgptRecipeSpec {
+    pub bundle_path: Option<PathBuf>,
+    pub model: String,
+    pub prompt: String,
+    pub browser_context_id: Option<String>,
+    pub profile_email: Option<String>,
+    pub run_id: String,
+    pub wait_timeout_ms: u64,
+    pub wait_interval_ms: u64,
+    pub disable_extended: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChatgptRecipeOutput {
+    pub transport: String,
+    pub backend: String,
+    pub response: String,
+    pub model_used: Option<String>,
+    pub warnings: Vec<String>,
+    pub fallback_used: bool,
+    pub delivery_mode: ChatgptDeliveryMode,
+    pub auto_paste_fallback: bool,
+}
+
+impl ChatgptRecipeOutput {
+    pub fn to_value(&self) -> Value {
+        json!({
+            "status": "ok",
+            "transport": self.transport,
+            "backend": self.backend,
+            "response": self.response,
+            "model_used": self.model_used,
+            "warnings": self.warnings,
+            "fallback_used": self.fallback_used,
+            "delivery_mode": self.delivery_mode.as_str(),
+            "auto_paste_fallback": self.auto_paste_fallback,
+        })
+    }
+
+    pub fn to_recipe_complete_event(&self) -> Value {
+        json!({
+            "type": "recipe_complete",
+            "transport": self.transport,
+            "backend": self.backend,
+            "response": self.response,
+            "model_used": self.model_used,
+            "warnings": self.warnings,
+            "fallback_used": self.fallback_used,
+            "delivery_mode": self.delivery_mode.as_str(),
+            "auto_paste_fallback": self.auto_paste_fallback,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chatgpt_recipe_output_serializes_standard_contract() {
+        let output = ChatgptRecipeOutput {
+            transport: "dev-browser".to_string(),
+            backend: "dev-browser".to_string(),
+            response: "ok".to_string(),
+            model_used: Some("gpt-5-4-pro".to_string()),
+            warnings: vec!["fallback".to_string()],
+            fallback_used: true,
+            delivery_mode: ChatgptDeliveryMode::Paste,
+            auto_paste_fallback: true,
+        };
+
+        let payload = output.to_value();
+        assert_eq!(payload["status"], "ok");
+        assert_eq!(payload["transport"], "dev-browser");
+        assert_eq!(payload["backend"], "dev-browser");
+        assert_eq!(payload["response"], "ok");
+        assert_eq!(payload["model_used"], "gpt-5-4-pro");
+        assert_eq!(payload["warnings"], json!(["fallback"]));
+        assert_eq!(payload["fallback_used"], true);
+        assert_eq!(payload["delivery_mode"], "paste");
+        assert_eq!(payload["auto_paste_fallback"], true);
+    }
+}

--- a/crates/yoetz-cli/src/chatgpt_web.rs
+++ b/crates/yoetz-cli/src/chatgpt_web.rs
@@ -1330,10 +1330,22 @@ mod tests {
         Ok(listener.local_addr()?.port())
     }
 
+    fn should_disable_fixture_sandbox(is_linux: bool, is_ci: bool) -> bool {
+        is_linux && is_ci
+    }
+
     fn launch_fake_chatgpt_fixture() -> anyhow::Result<(Browser, Arc<Tab>)> {
         let mut builder = LaunchOptionsBuilder::default();
         builder.headless(true);
         builder.port(Some(reserve_loopback_debug_port()?));
+        if should_disable_fixture_sandbox(
+            cfg!(target_os = "linux"),
+            std::env::var_os("CI").is_some() || std::env::var_os("GITHUB_ACTIONS").is_some(),
+        ) {
+            // Chrome for Testing on hosted Linux runners can fail before
+            // exposing its DevTools websocket unless the sandbox is disabled.
+            builder.sandbox(false);
+        }
         if let Some(path) = std::env::var_os("YOETZ_CHROME_BIN") {
             builder.path(Some(PathBuf::from(path)));
         }
@@ -1430,5 +1442,13 @@ mod tests {
         let response = eval_fixture_function(&tab, &build_latest_response_probe_function())?;
         assert_eq!(response["response"], "Fixture assistant response");
         Ok(())
+    }
+
+    #[test]
+    fn fixture_sandbox_policy_only_disables_on_linux_ci() {
+        assert!(should_disable_fixture_sandbox(true, true));
+        assert!(!should_disable_fixture_sandbox(true, false));
+        assert!(!should_disable_fixture_sandbox(false, true));
+        assert!(!should_disable_fixture_sandbox(false, false));
     }
 }

--- a/crates/yoetz-cli/src/chatgpt_web.rs
+++ b/crates/yoetz-cli/src/chatgpt_web.rs
@@ -1008,6 +1008,7 @@ mod tests {
     use headless_chrome::{Browser, LaunchOptionsBuilder, Tab};
     use serde_json::Value;
     use serial_test::serial;
+    use std::net::TcpListener;
     use std::path::PathBuf;
     use std::sync::Arc;
     use std::thread;
@@ -1323,9 +1324,15 @@ mod tests {
 "#
     }
 
+    fn reserve_loopback_debug_port() -> anyhow::Result<u16> {
+        let listener = TcpListener::bind(("127.0.0.1", 0))?;
+        Ok(listener.local_addr()?.port())
+    }
+
     fn launch_fake_chatgpt_fixture() -> anyhow::Result<(Browser, Arc<Tab>)> {
         let mut builder = LaunchOptionsBuilder::default();
         builder.headless(true);
+        builder.port(Some(reserve_loopback_debug_port()?));
         if let Some(path) = std::env::var_os("YOETZ_CHROME_BIN") {
             builder.path(Some(PathBuf::from(path)));
         }

--- a/crates/yoetz-cli/src/chatgpt_web.rs
+++ b/crates/yoetz-cli/src/chatgpt_web.rs
@@ -1,0 +1,1426 @@
+use anyhow::{anyhow, Result};
+use rand::random;
+use std::collections::BTreeMap;
+use std::path::Path;
+use time::{format_description::FormatItem, macros::format_description, OffsetDateTime};
+
+pub const CHATGPT_URL: &str = "https://chatgpt.com/";
+pub const COMPOSER_SELECTOR: &str =
+    "#prompt-textarea, div[contenteditable='true'][role='textbox'], [role='textbox']";
+pub const MODEL_SELECTOR_BUTTON_SELECTOR: &str = "[data-testid='model-switcher-dropdown-button'], button[aria-label='Model selector'], button[aria-label='Model selector menu'], button:has([data-testid='selected-model']), button:has([data-testid='model-switcher-selected-model'])";
+pub const MODEL_ITEM_SELECTOR: &str = "[role='menuitem'], [role='menuitemradio'], [data-testid^='model-switcher-']:not([data-testid='model-switcher-selected-model'])";
+pub const ATTACHMENT_TILE_SELECTOR: &str = "[class*='file-tile'], [data-testid*='attachment']";
+pub const ATTACHMENT_TRIGGER_SELECTOR: &str = "button[data-testid='composer-plus-btn'], button[aria-label*='Attach'], button[aria-label*='attach'], button[data-testid*='attach']";
+pub const SEND_BUTTON_SELECTOR: &str =
+    "[data-testid='send-button'], [data-testid='fruitjuice-send-button'], form button[type='submit']:last-of-type";
+pub const STOP_BUTTON_SELECTOR: &str = "[data-testid='stop-button'], button[aria-label*='Stop']";
+pub const UPLOAD_MENU_TEXT_PATTERN: &str =
+    "upload from computer|from computer|upload files|choose files|browse";
+pub const STABLE_IDLE_FLOOR_MS: u64 = 90_000;
+pub const STABLE_IDLE_INTERVAL_MULTIPLIER: u64 = 3;
+static RUN_ID_TS_FORMAT: &[FormatItem<'static>] =
+    format_description!("[year][month][day]T[hour][minute][second]Z");
+const AUTH_MARKERS: &[&str] = &[
+    "send a message",
+    "message chatgpt",
+    "new chat",
+    "send-button",
+    "prompt-textarea",
+    "composer",
+    "model-switcher-dropdown-button",
+    "model-switcher-selected-model",
+    "create-new-chat-button",
+    "composer-plus-btn",
+];
+const CHALLENGE_MARKERS: &[&str] = &[
+    "cloudflare",
+    "checking your browser",
+    "attention required",
+    "security check",
+    "just a moment",
+    "verify you are human",
+    "cf-chl",
+];
+const LOGIN_MARKERS: &[&str] = &[
+    "log in",
+    "login",
+    "sign in",
+    "sign up",
+    "create account",
+    "continue with google",
+    "continue with microsoft",
+    "continue with apple",
+];
+
+pub fn stable_idle_threshold_ms(interval_ms: u64) -> u64 {
+    interval_ms
+        .saturating_mul(STABLE_IDLE_INTERVAL_MULTIPLIER)
+        .max(STABLE_IDLE_FLOOR_MS)
+}
+
+pub fn generate_run_id() -> String {
+    let ts = OffsetDateTime::now_utc()
+        .format(RUN_ID_TS_FORMAT)
+        .unwrap_or_else(|_| "unknown".to_string());
+    let suffix = format!("{:06x}", random::<u32>() & 0x00ff_ffff);
+    format!("{ts}_{suffix}")
+}
+
+pub fn validate_thread_mode(raw: Option<&str>) -> Result<()> {
+    match raw.unwrap_or("fresh").trim().to_ascii_lowercase().as_str() {
+        "" | "fresh" => Ok(()),
+        "reuse" => Err(anyhow!(
+            "thread=reuse is no longer supported. yoetz always opens a fresh ChatGPT tab for each request and never reuses user tabs — this lets you chat in ChatGPT normally without yoetz interfering. Omit `--var thread=reuse`."
+        )),
+        other => Err(anyhow!(
+            "unsupported `thread` value `{other}`; expected `fresh`"
+        )),
+    }
+}
+
+pub fn mark_chatgpt_url(run_id: &str) -> String {
+    format!("{CHATGPT_URL}?_yoetz={run_id}")
+}
+
+pub fn build_set_window_name_js(run_id: &str) -> String {
+    let window_name =
+        serde_json::to_string(&format!("yoetz:{run_id}")).expect("serialize window.name value");
+    format!(
+        r#"() => {{
+  window.name = {window_name};
+  return window.name;
+}}"#
+    )
+}
+
+pub fn model_testid_alias_map() -> BTreeMap<&'static str, &'static str> {
+    BTreeMap::from([
+        ("pro", "gpt-5-4-pro"),
+        ("gpt-5-pro", "gpt-5-4-pro"),
+        ("thinking", "gpt-5-4-thinking"),
+        ("gpt-5-thinking", "gpt-5-4-thinking"),
+        ("instant", "gpt-5-3"),
+    ])
+}
+
+pub fn model_testid_candidate_map() -> BTreeMap<&'static str, Vec<&'static str>> {
+    BTreeMap::from([
+        ("pro", vec!["gpt-5-4-pro"]),
+        ("gpt-5-pro", vec!["gpt-5-4-pro"]),
+        ("gpt-5-4-pro", vec!["gpt-5-4-pro"]),
+        ("thinking", vec!["gpt-5-4-thinking"]),
+        ("gpt-5-thinking", vec!["gpt-5-4-thinking"]),
+        ("gpt-5-4-thinking", vec!["gpt-5-4-thinking"]),
+        ("instant", vec!["gpt-5-3"]),
+        ("gpt-5-3", vec!["gpt-5-3"]),
+    ])
+}
+
+fn normalize_chatgpt_model_key(value: &str) -> Option<String> {
+    let mut normalized = String::new();
+    let mut last_was_separator = false;
+    for ch in value.trim().chars() {
+        if ch.is_ascii_alphanumeric() {
+            normalized.push(ch.to_ascii_lowercase());
+            last_was_separator = false;
+        } else if !normalized.is_empty() && !last_was_separator {
+            normalized.push('-');
+            last_was_separator = true;
+        }
+    }
+    let normalized = normalized.trim_matches('-').to_string();
+    if normalized.is_empty() {
+        None
+    } else {
+        Some(normalized)
+    }
+}
+
+fn is_low_signal_chatgpt_model_key(key: &str) -> bool {
+    matches!(
+        key,
+        "chatgpt"
+            | "chat-gpt"
+            | "openai"
+            | "configure"
+            | "model-selector"
+            | "selected-model"
+            | "dropdown-button"
+    )
+}
+
+pub fn canonical_chatgpt_model_slug(value: &str) -> Option<String> {
+    let normalized = normalize_chatgpt_model_key(value)?;
+    if let Some(stripped) = normalized.strip_prefix("model-switcher-") {
+        return canonical_chatgpt_model_slug(stripped);
+    }
+    if let Some(candidates) = model_testid_candidate_map().get(normalized.as_str()) {
+        return candidates.first().map(|value| (*value).to_string());
+    }
+    if let Some(alias) = model_testid_alias_map().get(normalized.as_str()) {
+        return Some((*alias).to_string());
+    }
+    if is_low_signal_chatgpt_model_key(&normalized) {
+        return None;
+    }
+    Some(normalized)
+}
+
+pub fn select_reported_chatgpt_model(
+    selection: &serde_json::Value,
+    requested_model: &str,
+) -> Option<String> {
+    for field in ["targetTestId", "modelUsed", "selectedLabel", "currentLabel"] {
+        if let Some(model) = selection
+            .get(field)
+            .and_then(serde_json::Value::as_str)
+            .and_then(canonical_chatgpt_model_slug)
+        {
+            return Some(model);
+        }
+    }
+
+    let requested_model = requested_model.trim();
+    if requested_model.is_empty() || requested_model.eq_ignore_ascii_case("auto") {
+        None
+    } else {
+        canonical_chatgpt_model_slug(requested_model)
+    }
+}
+
+pub fn model_selector_button_selector_json() -> String {
+    serde_json::to_string(MODEL_SELECTOR_BUTTON_SELECTOR)
+        .expect("serialize model selector selector")
+}
+
+pub fn composer_selector_json() -> String {
+    serde_json::to_string(COMPOSER_SELECTOR).expect("serialize composer selector")
+}
+
+pub fn model_item_selector_json() -> String {
+    serde_json::to_string(MODEL_ITEM_SELECTOR).expect("serialize model item selector")
+}
+
+pub fn attachment_tile_selector_json() -> String {
+    serde_json::to_string(ATTACHMENT_TILE_SELECTOR).expect("serialize attachment tile selector")
+}
+
+pub fn attachment_trigger_selector_json() -> String {
+    serde_json::to_string(ATTACHMENT_TRIGGER_SELECTOR)
+        .expect("serialize attachment trigger selector")
+}
+
+pub fn send_button_selector_json() -> String {
+    serde_json::to_string(SEND_BUTTON_SELECTOR).expect("serialize send button selector")
+}
+
+pub fn stop_button_selector_json() -> String {
+    serde_json::to_string(STOP_BUTTON_SELECTOR).expect("serialize stop button selector")
+}
+
+pub fn upload_menu_text_pattern_json() -> String {
+    serde_json::to_string(UPLOAD_MENU_TEXT_PATTERN).expect("serialize upload menu text pattern")
+}
+
+pub fn model_testid_aliases_json() -> String {
+    serde_json::to_string(&model_testid_alias_map()).expect("serialize model alias map")
+}
+
+pub fn model_testid_candidates_json() -> String {
+    serde_json::to_string(&model_testid_candidate_map()).expect("serialize model candidate map")
+}
+
+pub fn build_model_selection_function(requested_model: &str) -> String {
+    let requested_model =
+        serde_json::to_string(requested_model).expect("serialize requested model");
+    let model_button_selector = model_selector_button_selector_json();
+    let model_item_selector = model_item_selector_json();
+    let model_testid_aliases = model_testid_aliases_json();
+    let model_testid_candidates = model_testid_candidates_json();
+    format!(
+        r##"
+async () => {{
+  const requested = {requested_model};
+  const MODEL_BUTTON_SELECTOR = {model_button_selector};
+  const MODEL_ITEM_SELECTOR = {model_item_selector};
+  const MODEL_TESTID_ALIASES = {model_testid_aliases};
+  const MODEL_TESTID_CANDIDATES = {model_testid_candidates};
+  const normalize = (value) => String(value || "").replace(/\s+/g, " ").trim();
+  const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  const isCheckedState = (ariaChecked, dataState) => ariaChecked === "true" || dataState === "checked";
+  const isVisible = (el) => {{
+    if (!el) return false;
+    const rect = el.getBoundingClientRect();
+    const style = window.getComputedStyle(el);
+    return rect.width > 0 &&
+      rect.height > 0 &&
+      style.visibility !== "hidden" &&
+      style.display !== "none";
+  }};
+  const realClick = (el) => {{
+    el.dispatchEvent(new PointerEvent("pointerdown", {{ bubbles: true, cancelable: true, pointerId: 1 }}));
+    el.dispatchEvent(new MouseEvent("mousedown", {{ bubbles: true, cancelable: true }}));
+    el.dispatchEvent(new PointerEvent("pointerup", {{ bubbles: true, cancelable: true, pointerId: 1 }}));
+    el.dispatchEvent(new MouseEvent("mouseup", {{ bubbles: true, cancelable: true }}));
+    el.dispatchEvent(new MouseEvent("click", {{ bubbles: true, cancelable: true }}));
+  }};
+  const keyPress = (el, key, code) => {{
+    el.dispatchEvent(new KeyboardEvent("keydown", {{ key, code, bubbles: true, cancelable: true }}));
+    el.dispatchEvent(new KeyboardEvent("keyup", {{ key, code, bubbles: true, cancelable: true }}));
+  }};
+  const isVersionedModelTestId = (value) => /^model-switcher-gpt-\d/.test(normalize(value).toLowerCase());
+  const findPreferredTestIdItem = (entries, orderedTestIds) => {{
+    for (const testId of orderedTestIds) {{
+      const match = entries.find((item) => item.testId.toLowerCase() === testId);
+      if (match) return match;
+    }}
+    return null;
+  }};
+  const findGenericNeedleItem = (entries, needles) =>
+    entries.find((item) =>
+      !isVersionedModelTestId(item.testId) &&
+      needles.some((needle) => item.haystack.includes(needle))
+    ) || null;
+  const deriveRequestedTier = (value) => {{
+    if (!value) return null;
+    if (/\bthinking\b/.test(value)) return "thinking";
+    if (/\binstant\b/.test(value)) return "instant";
+    if (/\bpro\b/.test(value) && !/\b5[- .]?3\b/.test(value)) return "pro";
+    return null;
+  }};
+  const hasTrustedUserFacingTierLabel = (item, slug) => {{
+    const haystack = item?.haystack || "";
+    if (slug === "pro") return /research-grade intelligence/.test(haystack);
+    if (slug === "thinking") return /for complex questions/.test(haystack);
+    if (slug === "instant") return /for everyday chats/.test(haystack);
+    return false;
+  }};
+  const classifyTier = (item) => {{
+    const haystack = item?.haystack || "";
+    if (hasTrustedUserFacingTierLabel(item, "pro") || /\bpro\b/.test(haystack)) return "pro";
+    if (hasTrustedUserFacingTierLabel(item, "thinking") || /thinking/.test(haystack)) return "thinking";
+    if (hasTrustedUserFacingTierLabel(item, "instant") || /instant/.test(haystack)) return "instant";
+    return null;
+  }};
+  const parseVersionParts = (item) => {{
+    const haystack = item?.haystack || "";
+    const match = haystack.match(/gpt[- ]?(\d+)(?:[- .]?(\d+))?/i);
+    return match ? [Number.parseInt(match[1], 10) || 0, Number.parseInt(match[2] || "0", 10) || 0] : [0, 0];
+  }};
+  const compareVersionParts = (left, right) => (left[0] - right[0]) || (left[1] - right[1]);
+  const maxVersionPartsForTier = (entries, tier) =>
+    entries
+      .filter((item) => classifyTier(item) === tier)
+      .map((item) => parseVersionParts(item))
+      .reduce((best, current) => compareVersionParts(current, best) > 0 ? current : best, [0, 0]);
+  const effectiveVersionParts = (item, tier, tierMaxVersions) => {{
+    const parsed = parseVersionParts(item);
+    if (!tier) return parsed;
+    if (hasTrustedUserFacingTierLabel(item, tier) && compareVersionParts(parsed, tierMaxVersions[tier] || [0, 0]) < 0) {{
+      return tierMaxVersions[tier] || parsed;
+    }}
+    return parsed;
+  }};
+  const hasConflictingTierHint = (item, slug) => {{
+    const haystack = item?.haystack || "";
+    if (hasTrustedUserFacingTierLabel(item, slug)) return false;
+    if (slug === "pro") {{
+      return /\b5[- .]?3\b|gpt-5[- .]?3-pro/.test(haystack);
+    }}
+    if (slug === "thinking") {{
+      return /\b5[- .]?3\b|instant/.test(haystack);
+    }}
+    if (slug === "instant") {{
+      return /\bthinking\b|\bpro\b|gpt-5[- .]?4/.test(haystack);
+    }}
+    return false;
+  }};
+  const findSingleGenericTierItem = (entries, slug) => {{
+    if (!(slug === "pro" || slug === "thinking" || slug === "instant")) return null;
+    const matches = entries.filter((item) =>
+      item.haystack.includes(slug) && !hasConflictingTierHint(item, slug)
+    );
+    return matches.length === 1 ? matches[0] : null;
+  }};
+  const buildTierRankings = (entries) => {{
+    const tierMaxVersions = {{
+      pro: maxVersionPartsForTier(entries, "pro"),
+      thinking: maxVersionPartsForTier(entries, "thinking"),
+      instant: maxVersionPartsForTier(entries, "instant"),
+    }};
+    const tierScore = (tier) => tier === "pro" ? 300 : tier === "thinking" ? 200 : tier === "instant" ? 100 : 0;
+    const candidateScore = (item) => {{
+      const tier = classifyTier(item);
+      const version = effectiveVersionParts(item, tier, tierMaxVersions);
+      const trusted = tier && hasTrustedUserFacingTierLabel(item, tier);
+      return {{
+        tier,
+        version,
+        trusted,
+        score: tierScore(tier) * 1_000_000 + version[0] * 1_000 + version[1] + (trusted ? 1 : 0),
+      }};
+    }};
+    return {{ tierMaxVersions, candidateScore }};
+  }};
+  const selectBestTierItem = (entries, slug, rankings) =>
+    entries
+      .map((item) => ({{ item, meta: rankings.candidateScore(item) }}))
+      .filter(({{ item, meta }}) => meta.tier === slug && !hasConflictingTierHint(item, slug))
+      .sort((left, right) =>
+        right.meta.score - left.meta.score ||
+        right.item.text.length - left.item.text.length
+      )
+      .map(({{ item }}) => item)[0] || null;
+  const findSelectorButton = () => document.querySelector(MODEL_BUTTON_SELECTOR);
+  const selectorButton = findSelectorButton();
+  const currentLabel = normalize(
+    selectorButton?.querySelector?.("[data-testid='selected-model'], [data-testid='model-switcher-selected-model']")?.textContent ||
+    selectorButton?.innerText ||
+    selectorButton?.textContent ||
+    selectorButton?.getAttribute?.("aria-label") ||
+    ""
+  );
+  const responseBase = {{
+    requested,
+    currentLabel,
+    url: window.location.href || "",
+    title: document.title || "",
+    bodyText: normalize(document.body?.innerText || "").slice(0, 240),
+  }};
+  const requestedTrimmed = normalize(requested);
+  const requestedLower = requestedTrimmed.toLowerCase();
+  const autoMode = !requestedTrimmed || requestedLower === "auto";
+  const requestedGenericTier = deriveRequestedTier(requestedLower);
+
+  if (!selectorButton) {{
+    return {{
+      ...responseBase,
+      status: "missing-selector",
+      modelUsed: currentLabel || null,
+    }};
+  }}
+
+  const popupRoots = () => {{
+    const selectorButton = findSelectorButton();
+    const roots = [];
+    const add = (el) => {{
+      if (el && !roots.includes(el) && isVisible(el)) roots.push(el);
+    }};
+    const controlledId = selectorButton.getAttribute("aria-controls") || selectorButton.getAttribute("aria-owns");
+    if (controlledId) {{
+      add(document.getElementById(controlledId));
+    }}
+    Array.from(document.querySelectorAll("[role='menu'], [role='listbox'], [data-radix-popper-content-wrapper], [data-state='open']"))
+      .filter((el) => isVisible(el))
+      .forEach((el) => {{
+        if (el.querySelector(MODEL_ITEM_SELECTOR)) add(el);
+      }});
+    return roots;
+  }};
+
+  const readItems = () => {{
+    const selectorButton = findSelectorButton();
+    const roots = popupRoots();
+    let nodes = roots.flatMap((root) => Array.from(root.querySelectorAll(MODEL_ITEM_SELECTOR)));
+    if (nodes.length === 0) {{
+      nodes = Array.from(document.querySelectorAll(MODEL_ITEM_SELECTOR))
+        .filter((el) => !(selectorButton && selectorButton.contains(el)) && isVisible(el));
+    }}
+    const seen = new Set();
+    return nodes
+      .filter((el) => isVisible(el))
+      .map((el) => {{
+        const text = normalize(el.innerText || el.textContent || el.getAttribute?.("aria-label") || el.getAttribute?.("title") || "");
+        const testId = normalize(el.getAttribute?.("data-testid") || "");
+        const haystack = `${{testId}} ${{text}}`.toLowerCase();
+        const key = `${{testId}}|${{text}}`;
+        if (seen.has(key)) return null;
+        seen.add(key);
+        return {{
+          text,
+          testId,
+          haystack,
+          ariaChecked: normalize(el.getAttribute?.("aria-checked") || "").toLowerCase(),
+          dataState: normalize(el.getAttribute?.("data-state") || "").toLowerCase(),
+        }};
+      }})
+      .filter((item) => item && (item.text || item.testId));
+  }};
+
+  const openSelectorMenu = async () => {{
+    const button = findSelectorButton();
+    if (!button) return readItems();
+    const attempts = [
+      () => realClick(button),
+      () => button.click?.(),
+      () => {{
+        button.focus?.();
+        keyPress(button, "Enter", "Enter");
+      }},
+      () => {{
+        button.focus?.();
+        keyPress(button, " ", "Space");
+      }},
+    ];
+    let openedItems = readItems();
+    for (const attempt of attempts) {{
+      if (openedItems.length > 0) break;
+      attempt();
+      await wait(250);
+      openedItems = readItems();
+    }}
+    return openedItems;
+  }};
+
+  let items = readItems();
+  if (items.length === 0) {{
+    items = await openSelectorMenu();
+    for (let attempt = 0; attempt < 20 && items.length === 0; attempt += 1) {{
+      await wait(250);
+      items = readItems();
+    }}
+  }}
+
+  if (items.length === 0) {{
+    return {{
+      ...responseBase,
+      status: "not-found",
+      availableItems: [],
+      selectorExpanded: normalize(findSelectorButton()?.getAttribute?.("aria-expanded") || "").toLowerCase(),
+      itemCount: 0,
+      modelUsed: currentLabel || null,
+    }};
+  }}
+
+  const rankings = buildTierRankings(items);
+
+  let target = null;
+  let selectionNeedles = [];
+  if (autoMode) {{
+    target = items
+      .map((item) => ({{ item, meta: rankings.candidateScore(item) }}))
+      .filter(({{ item, meta }}) => !meta.tier || !hasConflictingTierHint(item, meta.tier))
+      .sort((left, right) => right.meta.score - left.meta.score || right.item.text.length - left.item.text.length)
+      .map(({{ item }}) => item)[0] || null;
+    if (!target || rankings.candidateScore(target).score <= 0) {{
+      return {{
+        ...responseBase,
+        status: "not-found",
+        availableItems: items.map((item) => item.text || item.testId).filter(Boolean).slice(0, 12),
+        itemCount: items.length,
+        modelUsed: currentLabel || null,
+      }};
+    }}
+    selectionNeedles.push(target.testId.toLowerCase(), target.text.toLowerCase());
+  }} else {{
+    const requestedTestIds = Array.from(new Set(
+      (MODEL_TESTID_CANDIDATES[requestedLower] || [MODEL_TESTID_ALIASES[requestedLower] || requestedLower])
+        .map((value) => normalize(value).toLowerCase())
+        .filter(Boolean)
+    ));
+    const exactTestIds = requestedTestIds.map((value) => `model-switcher-${{value}}`.toLowerCase());
+    const fallbackNeedles = Array.from(new Set([
+      requestedLower,
+      requestedLower.replace(/-/g, " "),
+      ...requestedTestIds,
+      ...requestedTestIds.map((value) => value.replace(/-/g, " ")),
+      ...exactTestIds,
+    ])).filter(Boolean);
+    target = requestedGenericTier
+      ? selectBestTierItem(items, requestedGenericTier, rankings) || findSingleGenericTierItem(items, requestedGenericTier) || null
+      : findPreferredTestIdItem(items, exactTestIds) ||
+        findGenericNeedleItem(items, fallbackNeedles) ||
+        null;
+    if (!target) {{
+      return {{
+        ...responseBase,
+        status: "not-found",
+        availableItems: items.map((item) => item.text || item.testId).filter(Boolean).slice(0, 12),
+        selectorExpanded: normalize(findSelectorButton()?.getAttribute?.("aria-expanded") || "").toLowerCase(),
+        itemCount: items.length,
+        modelUsed: currentLabel || null,
+      }};
+    }}
+    selectionNeedles.push(...fallbackNeedles, ...exactTestIds);
+  }}
+
+  const targetTestId = target.testId || null;
+  if (target.ariaChecked === "true" || target.dataState === "checked") {{
+    return {{
+      ...responseBase,
+      status: "already-selected",
+      modelUsed: target.text || currentLabel || requestedTrimmed || null,
+      targetTestId,
+    }};
+  }}
+
+  let selectionConfirmed = false;
+  let selectedLabel = "";
+  let targetChecked = false;
+  let menuReopenAttempts = 0;
+  const targetTierSlug = autoMode ? classifyTier(target) : (requestedGenericTier || classifyTier(target));
+  for (let attempt = 0; attempt < 20; attempt += 1) {{
+    realClick(findSelectorButton());
+    await wait(250);
+    const currentItems = readItems();
+    let currentTarget = targetTierSlug
+      ? selectBestTierItem(currentItems, targetTierSlug, buildTierRankings(currentItems)) ||
+        findSingleGenericTierItem(currentItems, targetTierSlug) ||
+        null
+      : targetTestId
+        ? findPreferredTestIdItem(currentItems, [targetTestId.toLowerCase()]) || null
+        : findGenericNeedleItem(currentItems, selectionNeedles) || null;
+    if (!currentTarget && currentItems.length === 0 && menuReopenAttempts < 3) {{
+      await openSelectorMenu();
+      menuReopenAttempts += 1;
+      continue;
+    }}
+    const selectorButton = findSelectorButton();
+    if (currentTarget) {{
+      realClick(document.querySelector(`[data-testid="${{currentTarget.testId}}"]`) || Array.from(document.querySelectorAll(MODEL_ITEM_SELECTOR)).find((el) => {{
+        const text = normalize(el.innerText || el.textContent || "");
+        const testId = normalize(el.getAttribute?.("data-testid") || "");
+        return testId === currentTarget.testId || text === currentTarget.text;
+      }}) || selectorButton);
+    }}
+    // Verify polling: after clicking the menu item, the menu usually closes,
+    // Radix propagates aria-checked, and ChatGPT's selector button label
+    // updates on its own schedule (sometimes >1s after the click). Poll up to
+    // ~3s on this attempt before re-opening/re-clicking on the next outer
+    // iteration.
+    let verifyConfirmed = false;
+    let updatedItems = [];
+    let updatedTarget = null;
+    for (let verify = 0; verify < 12 && !verifyConfirmed; verify += 1) {{
+      await wait(250);
+      updatedItems = readItems();
+      const updatedRankings = buildTierRankings(updatedItems);
+      updatedTarget = targetTierSlug
+        ? selectBestTierItem(updatedItems, targetTierSlug, updatedRankings) ||
+          findSingleGenericTierItem(updatedItems, targetTierSlug) ||
+          null
+        : targetTestId
+          ? findPreferredTestIdItem(updatedItems, [targetTestId.toLowerCase()]) || null
+          : findGenericNeedleItem(updatedItems, selectionNeedles) || null;
+      const targetNode = targetTestId
+        ? document.querySelector(`[data-testid="${{targetTestId}}"]`)
+        : null;
+      targetChecked = isCheckedState(
+        normalize(targetNode?.getAttribute?.("aria-checked") || "").toLowerCase(),
+        normalize(targetNode?.getAttribute?.("data-state") || "").toLowerCase(),
+      ) || isCheckedState(updatedTarget?.ariaChecked || "", updatedTarget?.dataState || "");
+      const liveSelectorButton = findSelectorButton();
+      selectedLabel = normalize(
+        liveSelectorButton?.querySelector?.("[data-testid='selected-model'], [data-testid='model-switcher-selected-model']")?.textContent ||
+        liveSelectorButton?.innerText ||
+        liveSelectorButton?.textContent ||
+        ""
+      ).toLowerCase();
+      const effectiveTierSlug = targetTierSlug || classifyTier(updatedTarget || target);
+      const trustedTierSelected = effectiveTierSlug && (
+        hasTrustedUserFacingTierLabel(updatedTarget || target, effectiveTierSlug) ||
+        updatedItems.some((item) => hasTrustedUserFacingTierLabel(item, effectiveTierSlug))
+      );
+      if (targetChecked || selectionNeedles.filter(Boolean).some((needle) => needle && selectedLabel.includes(needle)) || trustedTierSelected) {{
+        verifyConfirmed = true;
+      }}
+    }}
+    if (verifyConfirmed) {{
+      selectionConfirmed = true;
+      return {{
+        ...responseBase,
+        status: "selected",
+        modelUsed: targetChecked
+          ? (updatedTarget?.text || target.text || requestedTrimmed || currentLabel || null)
+          : (selectedLabel || updatedTarget?.text || target.text || requestedTrimmed || currentLabel || null),
+        selectedLabel: selectedLabel || null,
+        targetTestId,
+        targetChecked,
+        menuReopenAttempts,
+        selectorExpanded: normalize(findSelectorButton()?.getAttribute?.("aria-expanded") || "").toLowerCase(),
+        availableItemsAfter: updatedItems.map((item) => item.text || item.testId).filter(Boolean).slice(0, 12),
+      }};
+    }}
+  }}
+
+  return {{
+    ...responseBase,
+    status: selectionConfirmed ? "selected" : "selection-mismatch",
+    modelUsed: selectedLabel || target.text || null,
+    selectedLabel: selectedLabel || null,
+    targetTestId,
+    targetChecked,
+    menuReopenAttempts,
+    selectorExpanded: normalize(findSelectorButton()?.getAttribute?.("aria-expanded") || "").toLowerCase(),
+    itemCount: items.length,
+    availableItems: items.map((item) => item.text || item.testId).filter(Boolean).slice(0, 12),
+  }};
+}}
+"##,
+        model_button_selector = model_button_selector,
+        model_item_selector = model_item_selector,
+        model_testid_aliases = model_testid_aliases,
+        model_testid_candidates = model_testid_candidates,
+    )
+}
+
+pub fn build_attachment_probe_function(file_name: &str) -> Result<String> {
+    let file_name_json = serde_json::to_string(file_name)?;
+    let file_stem = Path::new(file_name)
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or(file_name);
+    let file_stem_json = serde_json::to_string(file_stem)?;
+    let attachment_tile_selector_json = attachment_tile_selector_json();
+    Ok(format!(
+        r##"
+() => {{
+  const fileName = {file_name_json};
+  const fileStem = {file_stem_json};
+  const ATTACHMENT_TILE_SELECTOR = {attachment_tile_selector_json};
+  const clip = (value, max = 120) => String(value || "").replace(/\s+/g, " ").trim().slice(0, max);
+  const composer = document.querySelector({composer_selector_json});
+  const composerForm = composer?.closest("form");
+  const root = composerForm || document;
+  const isBusy = (tile) => {{
+    const busyNode = tile.matches?.("[aria-busy='true'], [data-state='uploading'], [role='progressbar']")
+      ? tile
+      : tile.querySelector("[class*='animate-spin'], [role='progressbar'], [aria-busy='true'], [data-state='uploading']");
+    if (!busyNode) {{
+      const busyText = clip(tile.innerText || tile.textContent || "").toLowerCase();
+      return /\buploading\b|\bprocessing\b|\bscanning\b/.test(busyText);
+    }}
+    const visibilityTarget = busyNode.closest?.("[aria-busy='true'], [data-state='uploading'], [role='progressbar']") || busyNode.parentElement || busyNode;
+    return getComputedStyle(visibilityTarget).display !== "none";
+  }};
+  const describeTile = (tile) => {{
+    const text = clip(tile.innerText || tile.textContent || "");
+    const ariaLabel = clip(tile.getAttribute?.("aria-label") || "");
+    const title = clip(tile.getAttribute?.("title") || "");
+    const busy = isBusy(tile);
+    return {{
+      text,
+      ariaLabel,
+      title,
+      ready: !busy,
+    }};
+  }};
+  const visibleEvidence = Array.from(root.querySelectorAll(ATTACHMENT_TILE_SELECTOR))
+    .map((tile) => describeTile(tile))
+    .filter((entry) => {{
+      const combined = `${{entry.text}} ${{entry.ariaLabel}} ${{entry.title}}`;
+      return combined.includes(fileName) || (fileStem && combined.includes(fileStem));
+    }})
+    .slice(0, 6);
+  const inputs = Array.from(document.querySelectorAll("input[type='file']")).map((input) => ({{
+    fileNames: Array.from(input.files || []).map((file) => file.name),
+    multiple: !!input.multiple,
+  }}));
+  const inputMatched = inputs.some((input) => input.fileNames.some((name) => name === fileName));
+  if (visibleEvidence.some((entry) => entry.ready)) {{
+    return {{
+      ok: true,
+      status: "done",
+      visibleEvidence,
+      inputMatched,
+      composerScoped: !!composerForm,
+    }};
+  }}
+  return {{
+    ok: false,
+    status: visibleEvidence.length > 0 || inputMatched ? "uploading" : "no_match",
+    visibleEvidence,
+    inputMatched,
+    inputs,
+    composerScoped: !!composerForm,
+  }};
+}}
+"##,
+        attachment_tile_selector_json = attachment_tile_selector_json,
+        composer_selector_json = composer_selector_json(),
+    ))
+}
+
+pub fn build_open_attachment_ui_function() -> String {
+    let attachment_trigger_selector_json = attachment_trigger_selector_json();
+    format!(
+        r##"
+() => {{
+  const ATTACHMENT_TRIGGER_SELECTOR = {attachment_trigger_selector_json};
+  const clip = (value, max = 120) => String(value || "").replace(/\s+/g, " ").trim().slice(0, max);
+  const isVisible = (el) => {{
+    if (!el) return false;
+    const rect = el.getBoundingClientRect();
+    const style = window.getComputedStyle(el);
+    return rect.width > 0 &&
+      rect.height > 0 &&
+      style.visibility !== "hidden" &&
+      style.display !== "none" &&
+      style.pointerEvents !== "none";
+  }};
+  const button = Array.from(document.querySelectorAll(ATTACHMENT_TRIGGER_SELECTOR)).find((el) => isVisible(el))
+    || document.querySelector(ATTACHMENT_TRIGGER_SELECTOR);
+  if (!button) {{
+    return {{
+      status: "not-found",
+      url: window.location.href || "",
+      title: document.title || "",
+    }};
+  }}
+  button.click();
+  return {{
+    status: "opened",
+    label: clip(button.getAttribute?.("aria-label") || button.getAttribute?.("title") || button.innerText || button.textContent || ""),
+    testId: clip(button.getAttribute?.("data-testid") || "", 80),
+  }};
+}}
+"##,
+        attachment_trigger_selector_json = attachment_trigger_selector_json,
+    )
+}
+
+pub fn build_upload_menu_item_click_function() -> String {
+    let upload_menu_text_pattern_json = upload_menu_text_pattern_json();
+    format!(
+        r##"
+() => {{
+  const TEXT_PATTERN = new RegExp({upload_menu_text_pattern_json}, "i");
+  const clip = (value, max = 120) => String(value || "").replace(/\s+/g, " ").trim().slice(0, max);
+  const isVisible = (el) => {{
+    if (!el) return false;
+    const rect = el.getBoundingClientRect();
+    const style = window.getComputedStyle(el);
+    return rect.width > 0 &&
+      rect.height > 0 &&
+      style.visibility !== "hidden" &&
+      style.display !== "none" &&
+      style.pointerEvents !== "none";
+  }};
+  const selectors = ["[role='menuitem']", "button", "[role='button']", "label", "li"];
+  const nodes = Array.from(document.querySelectorAll(selectors.join(",")));
+  const target = nodes.find((el) => {{
+    const text = `${{el.innerText || ""}} ${{el.getAttribute?.("aria-label") || ""}} ${{el.getAttribute?.("title") || ""}}`
+      .replace(/\s+/g, " ")
+      .trim();
+    return isVisible(el) && TEXT_PATTERN.test(text);
+  }});
+  if (!target) {{
+    return {{ status: "not-found" }};
+  }}
+  target.click();
+  return {{
+    status: "clicked",
+    label: clip(target.getAttribute?.("aria-label") || target.getAttribute?.("title") || target.innerText || target.textContent || ""),
+  }};
+}}
+"##,
+        upload_menu_text_pattern_json = upload_menu_text_pattern_json,
+    )
+}
+
+/// Marker value written to `title` on the composer-scoped file input so the
+/// snapshot walker (and `upload_file`'s fallback) can identify the correct
+/// target. Using the composer form's own file input — never a page-wide
+/// first-match — keeps the bundle from landing on unrelated hidden inputs.
+pub const COMPOSER_FILE_INPUT_MARKER: &str = "yoetz-upload-target";
+
+pub fn build_scope_composer_file_input_function() -> String {
+    let composer_selector_json = composer_selector_json();
+    let marker_json = serde_json::to_string(COMPOSER_FILE_INPUT_MARKER)
+        .expect("serialize composer-file-input marker");
+    format!(
+        r##"
+() => {{
+  const COMPOSER_SELECTOR = {composer_selector_json};
+  const MARKER = {marker_json};
+  const composer = document.querySelector(COMPOSER_SELECTOR);
+  if (!composer) return {{ status: "no-composer" }};
+  const form = composer.closest("form");
+  if (!form) return {{ status: "no-form" }};
+  const input = form.querySelector("input[type='file']");
+  if (!input) return {{ status: "no-input" }};
+  // Clean up any stale marker from prior runs so we always mark the current
+  // composer input.
+  document
+    .querySelectorAll(`input[type='file'][title='${{MARKER}}']`)
+    .forEach((el) => {{ if (el !== input) el.removeAttribute("title"); }});
+  input.setAttribute("title", MARKER);
+  return {{ status: "marked" }};
+}}
+"##,
+    )
+}
+
+pub fn build_send_button_click_function() -> String {
+    let send_button_selector_json = send_button_selector_json();
+    let composer_selector_json = composer_selector_json();
+    let attachment_tile_selector_json = attachment_tile_selector_json();
+    format!(
+        r##"
+() => {{
+  const SEND_BUTTON_SELECTOR = {send_button_selector_json};
+  const COMPOSER_SELECTOR = {composer_selector_json};
+  const ATTACHMENT_TILE_SELECTOR = {attachment_tile_selector_json};
+  const clip = (value, max = 120) => String(value || "").replace(/\s+/g, " ").trim().slice(0, max);
+  const isVisible = (el) => {{
+    if (!el) return false;
+    const rect = el.getBoundingClientRect();
+    const style = window.getComputedStyle(el);
+    return rect.width > 0 &&
+      rect.height > 0 &&
+      style.visibility !== "hidden" &&
+      style.display !== "none" &&
+      style.pointerEvents !== "none";
+  }};
+  const buttons = Array.from(document.querySelectorAll(SEND_BUTTON_SELECTOR)).filter((el) => isVisible(el));
+  const enabledButton = buttons.find((button) => !button.disabled) || null;
+  const assistantMessages = Array.from(document.querySelectorAll("[data-message-author-role='assistant']"));
+  const lastAssistant = assistantMessages.length > 0 ? assistantMessages[assistantMessages.length - 1] : null;
+  const composerEl = document.querySelector(COMPOSER_SELECTOR);
+  const diagnostics = {{
+    url: window.location.href || "",
+    title: document.title || "",
+    attachmentPresent: !!document.querySelector(ATTACHMENT_TILE_SELECTOR),
+    composerTextLength: ((composerEl?.innerText || composerEl?.textContent || "").trim()).length,
+    buttonCount: buttons.length,
+    buttons: buttons.slice(0, 4).map((button) => ({{
+      text: clip(button.innerText || button.textContent || ""),
+      testId: clip(button.getAttribute?.("data-testid") || "", 80),
+      disabled: !!button.disabled,
+      ariaLabel: clip(button.getAttribute?.("aria-label") || ""),
+    }})),
+  }};
+  if (!enabledButton) {{
+    return {{
+      status: "not-ready",
+      diagnostics,
+    }};
+  }}
+  enabledButton.click();
+  return {{
+    status: "sent",
+    selectorLabel: clip(enabledButton.getAttribute?.("data-testid") || enabledButton.getAttribute?.("aria-label") || enabledButton.innerText || enabledButton.textContent || "", 80),
+    assistantCountBeforeSend: assistantMessages.length,
+    assistantLastLenBeforeSend: (lastAssistant?.innerText || "").length,
+  }};
+}}
+"##,
+        send_button_selector_json = send_button_selector_json,
+        composer_selector_json = composer_selector_json,
+        attachment_tile_selector_json = attachment_tile_selector_json,
+    )
+}
+
+pub fn build_chatgpt_dom_probe_function() -> String {
+    let send_button_selector_json = send_button_selector_json();
+    let stop_button_selector_json = stop_button_selector_json();
+    format!(
+        r##"
+() => {{
+  const send = Array.from(document.querySelectorAll({send_button_selector_json})).find((button) => {{
+    const rect = button.getBoundingClientRect();
+    const style = window.getComputedStyle(button);
+    return rect.width > 0 &&
+      rect.height > 0 &&
+      style.visibility !== "hidden" &&
+      style.display !== "none";
+  }}) || null;
+  const stop = document.querySelector({stop_button_selector_json});
+  const thinking = document.querySelector(".result-thinking, [data-testid*='thinking'], [class*='thinking']");
+  const msgs = document.querySelectorAll("[data-message-author-role='assistant']");
+  const lastMsg = msgs.length > 0 ? msgs[msgs.length - 1] : null;
+  const copyButtons = lastMsg ? lastMsg.querySelectorAll("button[aria-label*='Copy'], button[data-testid*='copy']").length : 0;
+  const lastLen = msgs.length > 0 ? msgs[msgs.length - 1].innerText.length : 0;
+  const sendState = !send ? "missing" : send.disabled ? "disabled" : "enabled";
+  const errEl = document.querySelector("[class*='error-toast'], [data-testid*='error'], [role='alert']");
+  const errText = errEl ? errEl.innerText.substring(0, 100).toLowerCase() : "";
+  const markers = ["network error","something went wrong","error generating","attachment failed","upload failed","too many requests"];
+  const err = markers.find((marker) => errText.includes(marker)) || "";
+  return `send=${{sendState}}|stop=${{stop ? 1 : 0}}|thinking=${{thinking ? 1 : 0}}|copy=${{copyButtons}}|msgs=${{msgs.length}}|lastlen=${{lastLen}}|err=${{err}}`;
+}}
+"##,
+        send_button_selector_json = send_button_selector_json,
+        stop_button_selector_json = stop_button_selector_json,
+    )
+}
+
+pub fn build_latest_response_probe_function() -> String {
+    r#"
+() => {
+  const msgs = Array.from(document.querySelectorAll("[data-message-author-role='assistant']"));
+  const lastMsg = msgs.length > 0 ? msgs[msgs.length - 1] : null;
+  return {
+    response: String(lastMsg?.innerText || "").trim(),
+  };
+}
+"#
+    .to_string()
+}
+
+pub fn wrap_function_source_for_json_eval(function_source: &str) -> Result<String> {
+    let function_json = serde_json::to_string(function_source)?;
+    Ok(format!(
+        r#"(async () => {{
+  const fn = eval("(" + {function_json} + ")");
+  return JSON.stringify(await fn());
+}})()"#
+    ))
+}
+
+pub fn looks_authenticated_text(haystack: &str) -> bool {
+    contains_any(&haystack.to_lowercase(), AUTH_MARKERS)
+}
+
+pub fn is_challenge_text(haystack: &str) -> bool {
+    if looks_authenticated_text(haystack) {
+        return false;
+    }
+    contains_any(&haystack.to_lowercase(), CHALLENGE_MARKERS)
+}
+
+pub fn detect_auth_issue_text(haystack: &str, live_attach: bool) -> Option<&'static str> {
+    let haystack = haystack.to_lowercase();
+    if is_challenge_text(&haystack) {
+        return Some(if live_attach {
+            "cloudflare challenge detected in the attached Chrome session. Solve it in your browser window and try again."
+        } else {
+            "cloudflare challenge detected. Run `yoetz browser sync-cookies` or `yoetz browser login` and try again."
+        });
+    }
+    if contains_any(&haystack, LOGIN_MARKERS) {
+        return Some(if live_attach {
+            "chatgpt login required in the attached Chrome session. Log in there and try again."
+        } else {
+            "chatgpt login required. Run `yoetz browser login` and try again."
+        });
+    }
+    None
+}
+
+fn contains_any(haystack: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| haystack.contains(needle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+    use headless_chrome::{Browser, LaunchOptionsBuilder, Tab};
+    use serde_json::Value;
+    use serial_test::serial;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn stable_idle_threshold_floors_and_scales() {
+        assert_eq!(stable_idle_threshold_ms(1_000), 90_000);
+        assert_eq!(stable_idle_threshold_ms(10_000), 90_000);
+        assert_eq!(stable_idle_threshold_ms(30_000), 90_000);
+        assert_eq!(stable_idle_threshold_ms(60_000), 180_000);
+        assert_eq!(stable_idle_threshold_ms(120_000), 360_000);
+    }
+
+    #[test]
+    fn model_aliases_cover_shortcuts() {
+        let aliases = model_testid_alias_map();
+        assert_eq!(aliases.get("pro"), Some(&"gpt-5-4-pro"));
+        assert_eq!(aliases.get("gpt-5-thinking"), Some(&"gpt-5-4-thinking"));
+        assert_eq!(aliases.get("instant"), Some(&"gpt-5-3"));
+        let candidates = model_testid_candidate_map();
+        assert_eq!(candidates.get("pro"), Some(&vec!["gpt-5-4-pro"]));
+        assert_eq!(candidates.get("gpt-5-3-pro"), None);
+    }
+
+    #[test]
+    fn canonical_chatgpt_model_slug_rejects_generic_labels() {
+        assert_eq!(canonical_chatgpt_model_slug("ChatGPT"), None);
+        assert_eq!(canonical_chatgpt_model_slug("Configure..."), None);
+        assert_eq!(
+            canonical_chatgpt_model_slug("Pro"),
+            Some("gpt-5-4-pro".to_string())
+        );
+        assert_eq!(
+            canonical_chatgpt_model_slug("model-switcher-gpt-5-4-thinking"),
+            Some("gpt-5-4-thinking".to_string())
+        );
+    }
+
+    #[test]
+    fn reported_chatgpt_model_prefers_target_test_id_over_generic_button_label() {
+        let selection = serde_json::json!({
+            "status": "selected",
+            "modelUsed": "chatgpt",
+            "selectedLabel": "chatgpt",
+            "currentLabel": "chatgpt",
+            "targetTestId": "model-switcher-gpt-5-4-pro"
+        });
+        assert_eq!(
+            select_reported_chatgpt_model(&selection, "pro"),
+            Some("gpt-5-4-pro".to_string())
+        );
+    }
+
+    #[test]
+    fn reported_chatgpt_model_falls_back_to_requested_alias_when_ui_label_is_generic() {
+        let selection = serde_json::json!({
+            "status": "selected",
+            "modelUsed": "chatgpt",
+            "selectedLabel": "chatgpt",
+            "currentLabel": "chatgpt"
+        });
+        assert_eq!(
+            select_reported_chatgpt_model(&selection, "pro"),
+            Some("gpt-5-4-pro".to_string())
+        );
+    }
+
+    #[test]
+    fn auth_detection_prefers_authenticated_markers_over_challenge_words() {
+        let review_text =
+            r#"{"ref":"prompt-textarea","text":"verify you are human and security check"}"#;
+        assert!(looks_authenticated_text(review_text));
+        assert!(!is_challenge_text(review_text));
+        assert_eq!(detect_auth_issue_text(review_text, true), None);
+    }
+
+    #[test]
+    fn auth_detection_distinguishes_challenge_and_login() {
+        assert_eq!(
+            detect_auth_issue_text("Verify you are human", true),
+            Some(
+                "cloudflare challenge detected in the attached Chrome session. Solve it in your browser window and try again."
+            )
+        );
+        assert_eq!(
+            detect_auth_issue_text("Please sign in", false),
+            Some("chatgpt login required. Run `yoetz browser login` and try again.")
+        );
+    }
+
+    #[test]
+    fn model_selection_auto_mode_filters_conflicting_tier_items() {
+        // Regression guard: auto mode must honor hasConflictingTierHint so
+        // items like `model-switcher-gpt-5-3-pro` are never auto-selected over
+        // the real current Pro. The explicit-model path already did this;
+        // the auto branch was missing the filter and would pick 5-3-pro when
+        // 5-4-pro wasn't visibly tagged.
+        let script = build_model_selection_function("auto");
+        assert!(
+            script
+                .contains(".filter(({ item, meta }) => !meta.tier || !hasConflictingTierHint(item, meta.tier))"),
+            "auto-mode ranking missing hasConflictingTierHint filter"
+        );
+    }
+
+    #[test]
+    fn scope_composer_file_input_function_targets_composer_form_only() {
+        // The upload scoping helper must bind to the composer's own form and
+        // write the shared marker — otherwise yoetz can tag a page-wide hidden
+        // file input and inject the bundle there (review finding #10).
+        let script = build_scope_composer_file_input_function();
+        assert!(
+            script.contains("composer.closest(\"form\")"),
+            "scope helper must walk to the composer's form ancestor"
+        );
+        assert!(
+            script.contains("form.querySelector(\"input[type='file']\")"),
+            "scope helper must restrict search to the composer form"
+        );
+        assert!(
+            script.contains(&format!("\"{}\"", COMPOSER_FILE_INPUT_MARKER)),
+            "scope helper must write the shared marker value"
+        );
+        assert!(
+            script.contains("status: \"marked\""),
+            "scope helper must report a `marked` status on success"
+        );
+    }
+
+    #[test]
+    fn model_selection_function_polls_verification_beyond_initial_click() {
+        // The verify loop must poll up to ~3s per outer attempt to let Radix
+        // propagate aria-checked and ChatGPT update the selector button label.
+        // A single 250ms wait is not enough on the live Pro UI.
+        let script = build_model_selection_function("auto");
+        assert!(
+            script.contains("verify < 12 && !verifyConfirmed"),
+            "verify loop missing or sized wrong; saw: {script}"
+        );
+        assert!(
+            script.contains("let verifyConfirmed = false;"),
+            "verify confirmation flag missing"
+        );
+    }
+
+    #[test]
+    fn model_selection_function_supports_auto_and_explicit_modes() {
+        let auto_script = build_model_selection_function("auto");
+        assert!(auto_script.contains(r#"const requested = "auto";"#));
+        assert!(!auto_script.contains(r#""kept-current-no-selector""#));
+        assert!(auto_script.contains("const deriveRequestedTier = (value) =>"));
+        assert!(auto_script.contains("const classifyTier = (item) =>"));
+        assert!(auto_script.contains("const buildTierRankings = (entries) =>"));
+
+        let explicit_script = build_model_selection_function("gpt-5-4-pro");
+        assert!(explicit_script.contains(r#"const requested = "gpt-5-4-pro";"#));
+        assert!(explicit_script.contains("\"gpt-5-pro\":\"gpt-5-4-pro\""));
+        assert!(!explicit_script.contains("\"gpt-5-3-pro\""));
+    }
+
+    #[test]
+    fn attachment_probe_function_scopes_by_filename() {
+        let script = build_attachment_probe_function("bundle.txt").unwrap();
+        assert!(script.contains(r#"const fileName = "bundle.txt";"#));
+        assert!(script.contains(r#"const fileStem = "bundle";"#));
+        assert!(script.contains(
+            r#"status: visibleEvidence.length > 0 || inputMatched ? "uploading" : "no_match""#
+        ));
+    }
+
+    #[test]
+    fn shared_dom_helper_functions_cover_attachment_and_send_controls() {
+        let attachment_ui = build_open_attachment_ui_function();
+        assert!(attachment_ui.contains("ATTACHMENT_TRIGGER_SELECTOR"));
+        assert!(attachment_ui.contains("status: \"opened\""));
+
+        let upload_menu = build_upload_menu_item_click_function();
+        assert!(upload_menu.contains("TEXT_PATTERN"));
+        assert!(upload_menu.contains("status: \"clicked\""));
+
+        let send_click = build_send_button_click_function();
+        assert!(send_click.contains("SEND_BUTTON_SELECTOR"));
+        assert!(send_click.contains("status: \"sent\""));
+        assert!(send_click.contains("status: \"not-ready\""));
+
+        let dom_probe = build_chatgpt_dom_probe_function();
+        assert!(dom_probe.contains("send="));
+        assert!(dom_probe.contains("copyButtons"));
+
+        let latest_response = build_latest_response_probe_function();
+        assert!(latest_response.contains("data-message-author-role"));
+        assert!(latest_response.contains("response: String"));
+    }
+
+    #[test]
+    fn validate_thread_mode_accepts_fresh_and_empty() {
+        validate_thread_mode(None).unwrap();
+        validate_thread_mode(Some("")).unwrap();
+        validate_thread_mode(Some("fresh")).unwrap();
+    }
+
+    #[test]
+    fn validate_thread_mode_rejects_reuse_with_migration_message() {
+        let err = validate_thread_mode(Some("reuse")).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("thread=reuse is no longer supported"));
+        assert!(msg.contains("fresh ChatGPT tab"));
+    }
+
+    #[test]
+    fn validate_thread_mode_rejects_unknown_values() {
+        let err = validate_thread_mode(Some("sideways")).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("unsupported `thread` value `sideways`"));
+        assert!(msg.contains("fresh"));
+    }
+
+    #[test]
+    fn generate_run_id_is_timestamped_with_hex_suffix() {
+        let run_id = generate_run_id();
+        let (timestamp, suffix) = run_id.split_once('_').unwrap();
+        assert_eq!(timestamp.len(), 16);
+        assert!(timestamp.ends_with('Z'));
+        assert_eq!(suffix.len(), 6);
+        assert!(suffix.chars().all(|ch| ch.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn mark_chatgpt_url_and_window_name_use_run_id() {
+        assert_eq!(
+            mark_chatgpt_url("20260417T071228Z_ab12cd"),
+            "https://chatgpt.com/?_yoetz=20260417T071228Z_ab12cd"
+        );
+        let script = build_set_window_name_js("20260417T071228Z_ab12cd");
+        assert!(script.contains(r#"window.name = "yoetz:20260417T071228Z_ab12cd""#));
+    }
+
+    fn fake_chatgpt_fixture_html() -> &'static str {
+        r#"<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Fake ChatGPT Fixture</title>
+    <style>
+      body { font-family: sans-serif; }
+      .file-tile { border: 1px solid #ccc; padding: 8px; margin-top: 8px; }
+      .hidden-copy { display: none; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <form id="chat-form">
+        <div id="prompt-textarea" role="textbox" contenteditable="true">Review this bundle.</div>
+        <button type="button" data-testid="send-button" aria-label="Send prompt">Send</button>
+        <button type="button" data-testid="composer-plus-btn" aria-label="Attach files">Attach</button>
+        <input id="fixture-upload" type="file" multiple />
+        <div class="file-tile" data-testid="attachment-item" aria-busy="true">
+          <span class="name">fixture-bundle.txt</span>
+          <span class="status">Uploading</span>
+          <div role="progressbar">Uploading…</div>
+        </div>
+      </form>
+      <section id="transcript"></section>
+    </main>
+    <script>
+      const transcript = document.getElementById("transcript");
+      const sendButton = document.querySelector("[data-testid='send-button']");
+      const appendAssistantMessage = () => {
+        const message = document.createElement("div");
+        message.setAttribute("data-message-author-role", "assistant");
+        message.textContent = "Fixture assistant response";
+        const copy = document.createElement("button");
+        copy.setAttribute("aria-label", "Copy");
+        copy.className = "hidden-copy";
+        copy.textContent = "Copy";
+        message.appendChild(copy);
+        transcript.appendChild(message);
+      };
+      sendButton.addEventListener("click", () => {
+        sendButton.disabled = true;
+        const stop = document.createElement("button");
+        stop.type = "button";
+        stop.setAttribute("data-testid", "stop-button");
+        stop.setAttribute("aria-label", "Stop generating");
+        stop.textContent = "Stop";
+        stop.id = "fixture-stop-button";
+        document.body.appendChild(stop);
+
+        const thinking = document.createElement("div");
+        thinking.className = "result-thinking";
+        thinking.id = "fixture-thinking";
+        thinking.textContent = "Thinking…";
+        document.body.appendChild(thinking);
+
+        setTimeout(() => {
+          appendAssistantMessage();
+          document.getElementById("fixture-stop-button")?.remove();
+          document.getElementById("fixture-thinking")?.remove();
+          sendButton.disabled = false;
+        }, 150);
+      });
+
+      window.fixtureMarkUploadDone = () => {
+        const tile = document.querySelector(".file-tile");
+        tile.removeAttribute("aria-busy");
+        tile.querySelector("[role='progressbar']").style.display = "none";
+        tile.querySelector(".status").textContent = "Ready";
+      };
+    </script>
+  </body>
+</html>
+"#
+    }
+
+    fn launch_fake_chatgpt_fixture() -> anyhow::Result<(Browser, Arc<Tab>)> {
+        let mut builder = LaunchOptionsBuilder::default();
+        builder.headless(true);
+        if let Some(path) = std::env::var_os("YOETZ_CHROME_BIN") {
+            builder.path(Some(PathBuf::from(path)));
+        }
+        let browser = Browser::new(builder.build()?)?;
+        let tab = browser.new_tab()?;
+        let html = fake_chatgpt_fixture_html();
+        let encoded = base64::engine::general_purpose::STANDARD.encode(html);
+        tab.navigate_to(&format!("data:text/html;base64,{encoded}"))?;
+        tab.wait_until_navigated()?;
+        tab.wait_for_element("#prompt-textarea")?;
+        Ok((browser, tab))
+    }
+
+    fn eval_fixture_function(tab: &Arc<Tab>, function_source: &str) -> anyhow::Result<Value> {
+        let expression = wrap_function_source_for_json_eval(function_source)?;
+        let result = tab.evaluate(&expression, true)?;
+        let json = result
+            .value
+            .and_then(|value| value.as_str().map(str::to_owned))
+            .ok_or_else(|| anyhow!("fixture eval did not return a JSON string"))?;
+        Ok(serde_json::from_str(&json)?)
+    }
+
+    fn set_fixture_input_file(tab: &Arc<Tab>, file_name: &str) -> anyhow::Result<()> {
+        let function_source = format!(
+            r##"() => {{
+  const input = document.querySelector("#fixture-upload");
+  const dt = new DataTransfer();
+  dt.items.add(new File(["fixture"], {file_name:?}, {{ type: "text/plain" }}));
+  input.files = dt.files;
+  return Array.from(input.files || []).map((file) => file.name);
+}}"##
+        );
+        let names = eval_fixture_function(tab, &function_source)?;
+        assert_eq!(names, serde_json::json!([file_name]));
+        Ok(())
+    }
+
+    #[test]
+    #[ignore = "requires Chrome"]
+    #[serial]
+    fn fake_chatgpt_fixture_upload_probe_tracks_uploading_then_ready() -> anyhow::Result<()> {
+        let (_browser, tab) = launch_fake_chatgpt_fixture()?;
+        set_fixture_input_file(&tab, "fixture-bundle.txt")?;
+
+        let uploading = eval_fixture_function(
+            &tab,
+            &build_attachment_probe_function("fixture-bundle.txt")?,
+        )?;
+        assert_eq!(uploading["status"], "uploading");
+        assert_eq!(uploading["ok"], false);
+        assert_eq!(uploading["inputMatched"], true);
+        assert_eq!(uploading["composerScoped"], true);
+
+        tab.evaluate("window.fixtureMarkUploadDone()", true)?;
+
+        let ready = eval_fixture_function(
+            &tab,
+            &build_attachment_probe_function("fixture-bundle.txt")?,
+        )?;
+        assert_eq!(ready["status"], "done");
+        assert_eq!(ready["ok"], true);
+        assert_eq!(ready["inputMatched"], true);
+        assert_eq!(ready["composerScoped"], true);
+        Ok(())
+    }
+
+    #[test]
+    #[ignore = "requires Chrome"]
+    #[serial]
+    fn fake_chatgpt_fixture_send_and_poll_probes_follow_scripted_dom() -> anyhow::Result<()> {
+        let (_browser, tab) = launch_fake_chatgpt_fixture()?;
+
+        let sent = eval_fixture_function(&tab, &build_send_button_click_function())?;
+        assert_eq!(sent["status"], "sent");
+        assert_eq!(sent["assistantCountBeforeSend"], 0);
+
+        thread::sleep(Duration::from_millis(60));
+        let during = eval_fixture_function(&tab, &build_chatgpt_dom_probe_function())?;
+        let during_raw = during.as_str().expect("dom probe string");
+        assert!(during_raw.contains("send=disabled"));
+        assert!(during_raw.contains("stop=1"));
+        assert!(during_raw.contains("thinking=1"));
+
+        thread::sleep(Duration::from_millis(180));
+        let finished = eval_fixture_function(&tab, &build_chatgpt_dom_probe_function())?;
+        let finished_raw = finished.as_str().expect("dom probe string");
+        assert!(finished_raw.contains("send=enabled"));
+        assert!(finished_raw.contains("stop=0"));
+        assert!(finished_raw.contains("thinking=0"));
+        assert!(finished_raw.contains("copy=1"));
+        assert!(finished_raw.contains("msgs=1"));
+
+        let response = eval_fixture_function(&tab, &build_latest_response_probe_function())?;
+        assert_eq!(response["response"], "Fixture assistant response");
+        Ok(())
+    }
+}

--- a/crates/yoetz-cli/src/chatgpt_web.rs
+++ b/crates/yoetz-cli/src/chatgpt_web.rs
@@ -1325,6 +1325,7 @@ mod tests {
     }
 
     fn reserve_loopback_debug_port() -> anyhow::Result<u16> {
+        // Intentionally drop the listener immediately so Chrome can rebind it.
         let listener = TcpListener::bind(("127.0.0.1", 0))?;
         Ok(listener.local_addr()?.port())
     }

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
@@ -17,9 +17,8 @@
 //!
 //! - No Playwright `connectOverCDP` hang in the live-attach path
 //! - No QuickJS sandbox — `evaluate_script` runs plain JS in the page
-//! - `thread=fresh` can still use `new_page` for a blank conversation, while
-//!   `thread=reuse` reattaches to an existing ChatGPT tab instead of opening
-//!   another one
+//! - Every yoetz request opens a fresh yoetz-owned ChatGPT tab marked with a
+//!   run-specific `?_yoetz=` query param and matching `window.name`
 //! - First-class `upload_file` replaces the macOS clipboard-paste hack
 //!
 //! The one place we use `chrome-devtools-mcp`'s uid model is `upload_file`:
@@ -37,26 +36,20 @@
 //! auto-poll already uses.
 
 use anyhow::{anyhow, Context, Result};
+use std::io::IsTerminal;
 use std::time::Duration;
 
-use super::client::CdpMcpClient;
-use super::{DevtoolsMcpRecipeContext, RecipeThreadMode};
-
-const CHATGPT_URL: &str = "https://chatgpt.com/";
+use super::client::{is_external_create_target_block_error, CdpMcpClient};
+use super::DevtoolsMcpRecipeContext;
+use crate::chatgpt_web;
 
 /// Stable-idle polling parameters.
-const POLL_INTERVAL_MS: u64 = 5_000;
-/// Number of consecutive polls where (messageCount, textLength) must be
-/// unchanged before we declare the response complete. At 5s intervals, 4
-/// stable polls = 60s of genuinely idle generation. ChatGPT Pro can pause
-/// for tens of seconds while still thinking, so keep the quiet window long
-/// enough that we do not return the early "I'm tracing the patch..." preamble
-/// as if it were the final review.
 const STABLE_IDLE_CONSECUTIVE_POLLS: u32 = 12;
 const UPLOAD_INPUT_WAIT_MS: u64 = 5_000;
 const ATTACHMENT_VERIFY_WAIT_MS: u64 = 15_000;
-const WAIT_FOR_COMPOSER_JS: &str = r##"
-async (focusComposer = true) => {
+const WAIT_FOR_COMPOSER_JS_TEMPLATE: &str = r##"
+async () => {
+  const focusComposer = __YOETZ_FOCUS_COMPOSER__;
   const deadline = Date.now() + 20000;
   const clip = (value, max = 240) =>
     String(value || "").replace(/\s+/g, " ").trim().slice(0, max);
@@ -96,10 +89,73 @@ async (focusComposer = true) => {
 }
 "##;
 
+fn build_wait_for_composer_script(focus_composer: bool) -> String {
+    WAIT_FOR_COMPOSER_JS_TEMPLATE.replace(
+        "__YOETZ_FOCUS_COMPOSER__",
+        if focus_composer { "true" } else { "false" },
+    )
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ChatgptRunResult {
     pub response: String,
     pub model_used: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+struct ResponseBaseline {
+    assistant_count: i64,
+    assistant_last_len: i64,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct ResponsePollState {
+    assistant_count: i64,
+    assistant_last_len: i64,
+    text: String,
+    streaming: bool,
+    send_state: ResponseSendState,
+    has_stop_button: bool,
+    has_thinking_indicator: bool,
+    copy_button_count: usize,
+    error: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum ResponseCompletionVerdict {
+    Generating,
+    CopyButton,
+    Idle,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum ResponseSendState {
+    Enabled,
+    Disabled,
+    Missing,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum InitialPageOpenMode {
+    CreateTarget,
+    RecoverViaExistingAnchor,
+}
+
+impl InitialPageOpenMode {
+    fn debug_strategy(self) -> &'static str {
+        match self {
+            Self::CreateTarget => "create_target",
+            Self::RecoverViaExistingAnchor => "recover_via_existing_anchor",
+        }
+    }
+}
+
+fn retry_initial_page_open_mode() -> InitialPageOpenMode {
+    InitialPageOpenMode::RecoverViaExistingAnchor
+}
+
+fn should_recover_initial_page_open_after_reconnect(err: &anyhow::Error) -> bool {
+    should_retry_initial_new_page_after_reconnect(err) || is_external_create_target_block_error(err)
 }
 
 /// The full ChatGPT Pro recipe. Returns the assistant's final response text.
@@ -110,35 +166,87 @@ pub async fn run(ctx: &DevtoolsMcpRecipeContext) -> Result<ChatgptRunResult> {
         ));
     }
 
-    // Step 0: attach directly to the user's running Chrome session.
-    // The Chrome "Allow remote debugging" dialog fires here, once per Chrome
-    // session. Every subsequent yoetz invocation in the same Chrome session
-    // should be silent.
-    if ctx.show_approval_guidance {
-        eprintln!(
-            "info: connecting to Chrome via chrome-devtools-mcp — if prompted, click Allow in Chrome's remote debugging dialog (one-time per Chrome session)"
-        );
-    }
-    let client = CdpMcpClient::connect_to_running_chrome(ctx.cdp_endpoint.as_deref())
+    run_attached_recipe_with_reconnect(ctx)
         .await
-        .map_err(cdp_attach_hint)?;
+        .map_err(crate::browser::mark_chatgpt_attached_page_error)
+}
 
-    // Step 1: either start a fresh conversation or reuse the user's current
-    // ChatGPT tab, depending on the documented `thread` recipe variable.
-    match ctx.thread_mode {
-        RecipeThreadMode::Fresh => {
-            client
-                .new_page(CHATGPT_URL, /* background */ false, 30_000)
+async fn run_attached_recipe_with_reconnect(
+    ctx: &DevtoolsMcpRecipeContext,
+) -> Result<ChatgptRunResult> {
+    let client = connect_client(ctx).await?;
+    match run_attached_recipe(client, ctx, InitialPageOpenMode::CreateTarget).await {
+        Ok(result) => Ok(result),
+        Err(err) if should_recover_initial_page_open_after_reconnect(&err) => {
+            emit_transport_retry_notice(ctx);
+            debug_phase(
+                "new_page transport failed during initial CreateTarget; reconnecting once and falling back to existing-anchor recovery",
+            );
+            let retry_client = connect_client(ctx).await?;
+            run_attached_recipe(retry_client, ctx, retry_initial_page_open_mode())
                 .await
-                .context("chrome-devtools-mcp new_page on chatgpt.com")?;
+                .context("retrying ChatGPT page open after reconnect")
+                .context(err)
         }
-        RecipeThreadMode::Reuse => {
-            client
-                .reuse_chatgpt_page(30_000)
-                .await
-                .context("chrome-devtools-mcp select existing ChatGPT tab")?;
-        }
+        Err(err) => Err(err),
     }
+}
+
+async fn connect_client(ctx: &DevtoolsMcpRecipeContext) -> Result<CdpMcpClient> {
+    // Step 0: attach directly to the user's running Chrome session.
+    // Chrome may show an "Allow remote debugging?" dialog here whenever it
+    // treats this as a new external attach request. Serialize only the attach
+    // itself so approval prompts do not race across yoetz processes.
+    let client = with_chrome_approval_lock(ctx.show_approval_guidance, || async {
+        CdpMcpClient::connect_to_running_chrome(ctx.cdp_endpoint.as_deref())
+            .await
+            .map_err(cdp_attach_hint)
+    })
+    .await?;
+    debug_phase("phase=attach ok");
+    Ok(client)
+}
+
+async fn run_attached_recipe(
+    mut client: CdpMcpClient,
+    ctx: &DevtoolsMcpRecipeContext,
+    page_open_mode: InitialPageOpenMode,
+) -> Result<ChatgptRunResult> {
+    let browser_context_id = client
+        .resolve_browser_context_id(
+            ctx.browser_context_id.as_deref(),
+            ctx.profile_email.as_deref(),
+        )
+        .with_context(|| match (
+            ctx.browser_context_id.as_deref(),
+            ctx.profile_email.as_deref(),
+        ) {
+            (Some(context_id), Some(email)) => format!(
+                "resolve Chrome browser context for browser_context_id `{context_id}` / profile_email `{email}`"
+            ),
+            (Some(context_id), None) => {
+                format!("resolve Chrome browser context for browser_context_id `{context_id}`")
+            }
+            (None, Some(email)) => {
+                format!("resolve Chrome browser context for profile_email `{email}`")
+            }
+            (None, None) => "resolve Chrome browser context".to_string(),
+        })?;
+
+    let marked_url = chatgpt_web::mark_chatgpt_url(&ctx.run_id);
+    let page_id = open_initial_chatgpt_page(
+        &client,
+        &marked_url,
+        browser_context_id.as_deref(),
+        page_open_mode,
+    )
+    .await
+    .with_context(|| format!("chrome-devtools-mcp new_page on `{marked_url}`"))?;
+    let set_window_name_js = chatgpt_web::build_set_window_name_js(&ctx.run_id);
+    client
+        .evaluate_script(&set_window_name_js, vec![])
+        .await
+        .context("mark yoetz-owned ChatGPT tab with window.name")?;
 
     // Step 2: wait for the composer to mount, then select the best model the
     // user can actually access. When `model` is `auto` or empty, prefer the
@@ -146,6 +254,9 @@ pub async fn run(ctx: &DevtoolsMcpRecipeContext) -> Result<ChatgptRunResult> {
     // if the selector UI is unavailable.
     wait_for_composer_ready(&client, /* focus_composer */ true).await?;
     let model_used = maybe_select_model(&client, &ctx.model).await?;
+    if ctx.disable_extended {
+        maybe_disable_extended(&client).await?;
+    }
 
     // Step 3: upload the bundle if we have a path.
     //
@@ -172,15 +283,18 @@ pub async fn run(ctx: &DevtoolsMcpRecipeContext) -> Result<ChatgptRunResult> {
 
     // Make sure the composer is still focused (upload step may have stolen
     // focus to the file picker).
-    let refocus_js = r##"
-() => {
-  const composer = document.querySelector("#prompt-textarea, div[contenteditable='true'][role='textbox']");
+    let composer_selector_json = chatgpt_web::composer_selector_json();
+    let refocus_js = format!(
+        r##"
+() => {{
+  const composer = document.querySelector({composer_selector_json});
   if (composer) composer.focus();
   return !!composer;
-}
-"##;
+}}
+"##
+    );
     let _ = client
-        .evaluate_script(refocus_js, vec![])
+        .evaluate_script(&refocus_js, vec![])
         .await
         .context("refocus composer after upload")?;
 
@@ -189,37 +303,22 @@ pub async fn run(ctx: &DevtoolsMcpRecipeContext) -> Result<ChatgptRunResult> {
         .await
         .context("type_text into ChatGPT composer")?;
 
-    // Step 5: click the send button via JS (CSS selector).
-    //
-    // We match by data-testid with a fallback chain because the testid has
-    // bounced between `send-button` / `fruitjuice-send-button` / back. Also
-    // fall back to the last submit button in the composer form.
-    let click_send_js = r##"
-() => {
-  const candidates = [
-    "[data-testid='send-button']",
-    "[data-testid='fruitjuice-send-button']",
-    "form button[type='submit']:last-of-type",
-  ];
-  for (const sel of candidates) {
-    const btn = document.querySelector(sel);
-    if (btn && !btn.disabled) {
-      btn.click();
-      return sel;
-    }
-  }
-  return null;
-}
-"##;
+    let click_send_js = chatgpt_web::build_send_button_click_function();
     let clicked = client
-        .evaluate_script(click_send_js, vec![])
+        .evaluate_script(&click_send_js, vec![])
         .await
         .context("evaluate_script click send button")?;
-    if clicked == serde_json::Value::Null {
+    if clicked.get("status").and_then(serde_json::Value::as_str) != Some("sent") {
         return Err(anyhow!(
-            "could not find an enabled ChatGPT send button (tried data-testid='send-button', fruitjuice-send-button, form button[type='submit']:last-of-type)"
+            "could not find an enabled ChatGPT send button. diagnostics={}",
+            clicked
+                .get("diagnostics")
+                .cloned()
+                .unwrap_or(serde_json::Value::Null)
         ));
     }
+    let response_baseline =
+        parse_response_baseline(&clicked).context("parse ChatGPT response baseline before send")?;
 
     // Step 6: stable-idle polling for response completion.
     //
@@ -230,9 +329,16 @@ pub async fn run(ctx: &DevtoolsMcpRecipeContext) -> Result<ChatgptRunResult> {
     // This replaces the unreliable "Regenerate" button wait_for. Agent Y
     // research showed "Regenerate" is missing or inconsistently placed in
     // many ChatGPT flows (Custom GPT, Canvas, certain Pro modes).
-    let response_text = poll_for_stable_response(&client, ctx.response_timeout_ms)
-        .await
-        .context("stable-idle polling for ChatGPT response")?;
+    let response_text = poll_for_stable_response(
+        &mut client,
+        ctx,
+        &page_id,
+        response_baseline,
+        ctx.response_timeout_ms,
+        ctx.response_poll_interval_ms,
+    )
+    .await
+    .context("stable-idle polling for ChatGPT response")?;
 
     Ok(ChatgptRunResult {
         response: response_text,
@@ -240,22 +346,110 @@ pub async fn run(ctx: &DevtoolsMcpRecipeContext) -> Result<ChatgptRunResult> {
     })
 }
 
-pub async fn check_auth(cdp_endpoint: Option<&str>) -> Result<()> {
-    let client = CdpMcpClient::connect_to_running_chrome(cdp_endpoint)
+async fn open_initial_chatgpt_page(
+    client: &CdpMcpClient,
+    marked_url: &str,
+    browser_context_id: Option<&str>,
+    mode: InitialPageOpenMode,
+) -> Result<String> {
+    debug_phase(&format!(
+        "phase=new_page strategy={} url={marked_url}",
+        mode.debug_strategy()
+    ));
+    let page = match mode {
+        InitialPageOpenMode::CreateTarget => {
+            client
+                .new_page(
+                    marked_url,
+                    /* background */ false,
+                    30_000,
+                    browser_context_id,
+                )
+                .await?
+        }
+        InitialPageOpenMode::RecoverViaExistingAnchor => {
+            client
+                .open_chatgpt_page_via_existing_anchor(
+                    marked_url,
+                    /* background */ false,
+                    30_000,
+                    browser_context_id,
+                )
+                .await
+                .with_context(|| format!("recover ChatGPT page open for `{marked_url}`"))?
+        }
+    };
+    debug_phase("phase=new_page ok");
+    Ok(page.page_id)
+}
+
+async fn open_page_via_blank_target(
+    client: &CdpMcpClient,
+    url: &str,
+    background: bool,
+    timeout_ms: u64,
+    browser_context_id: Option<&str>,
+) -> Result<()> {
+    // On Chrome builds where CreateTarget itself still works, opening
+    // `about:blank` first avoids touching user tabs and gives yoetz a clean
+    // anchor before navigating to ChatGPT. When Chrome blocks CreateTarget
+    // altogether, the recipe reconnect path recovers via existing anchors
+    // instead of looping on more CreateTarget calls.
+    client
+        .new_page("about:blank", background, timeout_ms, browser_context_id)
         .await
-        .map_err(cdp_attach_hint)?;
+        .context("create blank Chrome page before ChatGPT navigation")?;
+    client
+        .navigate_page(url, timeout_ms)
+        .await
+        .with_context(|| format!("navigate blank Chrome page to `{url}`"))?;
+    Ok(())
+}
+
+async fn open_initial_chatgpt_probe_page(
+    client: &CdpMcpClient,
+    url: &str,
+    timeout_ms: u64,
+) -> Result<()> {
+    match open_page_via_blank_target(client, url, /* background */ true, timeout_ms, None).await {
+        Ok(()) => Ok(()),
+        Err(err) if is_external_create_target_block_error(&err) => client
+            .open_chatgpt_page_via_existing_anchor(
+                url, /* background */ true, timeout_ms, None,
+            )
+            .await
+            .with_context(|| format!("recover auth probe page open for `{url}`"))
+            .map(|_| ()),
+        Err(err) => Err(err),
+    }
+}
+
+pub async fn check_auth(cdp_endpoint: Option<&str>, show_approval_guidance: bool) -> Result<()> {
+    let client = with_chrome_approval_lock(show_approval_guidance, || async {
+        CdpMcpClient::connect_to_running_chrome(cdp_endpoint)
+            .await
+            .map_err(cdp_attach_hint)
+    })
+    .await?;
     let used_probe_page = client
         .select_chatgpt_page_for_probe(30_000)
         .await
         .context("select existing ChatGPT page for auth probe")?
         .is_none();
     if used_probe_page {
-        client
-            .new_page(CHATGPT_URL, /* background */ true, 30_000)
+        open_initial_chatgpt_probe_page(&client, chatgpt_web::CHATGPT_URL, 30_000)
             .await
-            .context("chrome-devtools-mcp new_page on chatgpt.com")?;
+            .context("chrome-devtools-mcp open auth probe on chatgpt.com")?;
     }
     let result = wait_for_composer_ready(&client, /* focus_composer */ false).await;
+    if !used_probe_page && result.is_err() {
+        open_initial_chatgpt_probe_page(&client, chatgpt_web::CHATGPT_URL, 30_000)
+            .await
+            .context("chrome-devtools-mcp probe retry on chatgpt.com")?;
+        let retry = wait_for_composer_ready(&client, /* focus_composer */ false).await;
+        let _ = client.close_selected_page(true);
+        return retry;
+    }
     if used_probe_page {
         let _ = client.close_selected_page(true);
     }
@@ -263,13 +457,7 @@ pub async fn check_auth(cdp_endpoint: Option<&str>) -> Result<()> {
 }
 
 async fn wait_for_composer_ready(client: &CdpMcpClient, focus_composer: bool) -> Result<()> {
-    let composer_state = client
-        .evaluate_script(
-            WAIT_FOR_COMPOSER_JS,
-            vec![serde_json::Value::Bool(focus_composer)],
-        )
-        .await
-        .context("evaluate_script wait-for-composer")?;
+    let composer_state = evaluate_wait_for_composer_state(client, focus_composer).await?;
     match composer_state
         .get("status")
         .and_then(serde_json::Value::as_str)
@@ -312,6 +500,42 @@ async fn wait_for_composer_ready(client: &CdpMcpClient, focus_composer: bool) ->
     }
 }
 
+async fn evaluate_wait_for_composer_state(
+    client: &CdpMcpClient,
+    focus_composer: bool,
+) -> Result<serde_json::Value> {
+    let script = build_wait_for_composer_script(focus_composer);
+    let mut last_err = None;
+    for attempt in 0..3 {
+        match client.evaluate_script(&script, vec![]).await {
+            Ok(state) => return Ok(state),
+            Err(err) => {
+                let retryable = should_retry_wait_for_composer_error(&err);
+                last_err = Some(err);
+                if retryable && attempt < 2 {
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                    continue;
+                }
+                break;
+            }
+        }
+    }
+    Err(last_err.expect("wait-for-composer attempts should record an error"))
+        .context("evaluate_script wait-for-composer")
+}
+
+fn should_retry_wait_for_composer_error(err: &anyhow::Error) -> bool {
+    let message = format!("{err:#}").to_ascii_lowercase();
+    message.contains("execution context")
+        || message.contains("context with specified id")
+        || message.contains("cannot find context")
+        || message.contains("cannot find object with id")
+        || message.contains("frame not found")
+        || message.contains("target closed")
+        || message.contains("session closed")
+        || message.contains("navigation")
+}
+
 async fn maybe_select_model(
     client: &CdpMcpClient,
     requested_model: &str,
@@ -325,18 +549,20 @@ async fn maybe_select_model(
         .get("status")
         .and_then(serde_json::Value::as_str)
         .unwrap_or("unknown");
-    let model_used = selection
-        .get("modelUsed")
-        .and_then(serde_json::Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned);
+    let model_used = chatgpt_web::select_reported_chatgpt_model(&selection, requested_model);
     match status {
-        "selected" | "already-selected" | "kept-current" | "kept-current-no-selector" => {
-            Ok(model_used)
-        }
+        "selected" | "already-selected" => Ok(model_used),
         "missing-selector" => Err(anyhow!(
             "ChatGPT model selector button not found. {}",
+            format_page_probe_summary(&selection)
+        )),
+        "selection-mismatch" => Err(anyhow!(
+            "requested ChatGPT model `{}` was not actually selected.{} {}",
+            selection
+                .get("requested")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or(requested_model),
+            format_model_selection_diagnostics(&selection),
             format_page_probe_summary(&selection)
         )),
         "not-found" => {
@@ -344,8 +570,21 @@ async fn maybe_select_model(
                 .get("requested")
                 .and_then(serde_json::Value::as_str)
                 .unwrap_or(requested_model);
+            let available = selection
+                .get("availableItems")
+                .and_then(serde_json::Value::as_array)
+                .map(|items| {
+                    items
+                        .iter()
+                        .filter_map(serde_json::Value::as_str)
+                        .filter(|value| !value.trim().is_empty())
+                        .collect::<Vec<_>>()
+                })
+                .filter(|items| !items.is_empty())
+                .map(|items| format!(" Available options: {}.", items.join(", ")))
+                .unwrap_or_default();
             Err(anyhow!(
-                "requested ChatGPT model `{requested}` was not available in the current session. {}",
+                "requested ChatGPT model `{requested}` was not available in the current session.{available} {}",
                 format_page_probe_summary(&selection)
             ))
         }
@@ -355,149 +594,102 @@ async fn maybe_select_model(
     }
 }
 
-fn build_model_selection_script(requested_model: &str) -> String {
-    let requested_model =
-        serde_json::to_string(requested_model).expect("serialize requested model");
+fn format_model_selection_diagnostics(selection: &serde_json::Value) -> String {
+    let selected_label = selection
+        .get("selectedLabel")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| format!(" selected_label={value:?};"))
+        .unwrap_or_default();
+    let target_test_id = selection
+        .get("targetTestId")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| format!(" target_testid={value:?};"))
+        .unwrap_or_default();
+    let target_checked = selection
+        .get("targetChecked")
+        .and_then(serde_json::Value::as_bool)
+        .map(|value| format!(" target_checked={value};"))
+        .unwrap_or_default();
+    let menu_reopen_attempts = selection
+        .get("menuReopenAttempts")
+        .and_then(serde_json::Value::as_u64)
+        .map(|value| format!(" menu_reopen_attempts={value};"))
+        .unwrap_or_default();
+    let selector_expanded = selection
+        .get("selectorExpanded")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| format!(" selector_expanded={value:?};"))
+        .unwrap_or_default();
+    let item_count = selection
+        .get("itemCount")
+        .and_then(serde_json::Value::as_u64)
+        .map(|value| format!(" item_count={value};"))
+        .unwrap_or_default();
+    let available_items = selection
+        .get("availableItemsAfter")
+        .and_then(serde_json::Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .collect::<Vec<_>>()
+        })
+        .filter(|items| !items.is_empty())
+        .map(|items| format!(" available_after=[{}];", items.join(", ")))
+        .unwrap_or_default();
+
     format!(
-        r##"
-async () => {{
-  const requested = {requested_model};
-  const normalize = (value) => String(value || "").replace(/\s+/g, " ").trim();
-  const toHaystack = (value) => normalize(value).toLowerCase();
-  const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-  const realClick = (el) => {{
-    el.dispatchEvent(new PointerEvent("pointerdown", {{ bubbles: true, cancelable: true, pointerId: 1 }}));
-    el.dispatchEvent(new MouseEvent("mousedown", {{ bubbles: true, cancelable: true }}));
-    el.dispatchEvent(new PointerEvent("pointerup", {{ bubbles: true, cancelable: true, pointerId: 1 }}));
-    el.dispatchEvent(new MouseEvent("mouseup", {{ bubbles: true, cancelable: true }}));
-    el.dispatchEvent(new MouseEvent("click", {{ bubbles: true, cancelable: true }}));
-  }};
-  const selectorButton = document.querySelector(
-    "[data-testid='model-switcher-dropdown-button'], button[aria-label='Model selector'], button[aria-label='Model selector menu']"
-  );
-  const currentLabel = normalize(
-    selectorButton?.querySelector?.("[data-testid='selected-model'], [data-testid='model-switcher-selected-model']")?.textContent ||
-    selectorButton?.innerText ||
-    selectorButton?.textContent ||
-    selectorButton?.getAttribute?.("aria-label") ||
-    ""
-  );
-  const responseBase = {{
-    requested,
-    currentLabel,
-    url: window.location.href || "",
-    title: document.title || "",
-    bodyText: normalize(document.body?.innerText || "").slice(0, 240),
-  }};
-  const requestedTrimmed = normalize(requested);
-  const requestedLower = requestedTrimmed.toLowerCase();
-  const autoMode = !requestedTrimmed || requestedLower === "auto";
-
-  if (!selectorButton) {{
-    return {{
-      ...responseBase,
-      status: autoMode ? "kept-current-no-selector" : "missing-selector",
-      modelUsed: currentLabel || null,
-    }};
-  }}
-
-  const readItems = () => Array.from(document.querySelectorAll("[role='menuitem'], [data-testid^='model-switcher-']"))
-    .map((el) => {{
-      const text = normalize(el.innerText || el.textContent || el.getAttribute?.("aria-label") || el.getAttribute?.("title") || "");
-      const testId = normalize(el.getAttribute?.("data-testid") || "");
-      const haystack = `${{testId}} ${{text}}`.toLowerCase();
-      return {{ el, text, testId, haystack }};
-    }})
-    .filter((item) => item.text || item.testId);
-
-  let items = readItems();
-  if (items.length === 0) {{
-    realClick(selectorButton);
-    await wait(350);
-    items = readItems();
-  }}
-
-  if (items.length === 0) {{
-    return {{
-      ...responseBase,
-      status: autoMode ? "kept-current" : "not-found",
-      modelUsed: currentLabel || null,
-    }};
-  }}
-
-  const requestedNeedles = (() => {{
-    if (autoMode) return [];
-    const needles = new Set([requestedLower]);
-    if (requestedLower.includes("gpt-5")) {{
-      needles.add("gpt-5");
-      needles.add("gpt 5");
-    }}
-    if (requestedLower.includes("pro")) needles.add("pro");
-    if (requestedLower.includes("thinking")) needles.add("thinking");
-    if (requestedLower.includes("instant") || requestedLower.includes("5-3")) {{
-      needles.add("instant");
-      needles.add("5-3");
-    }}
-    return Array.from(needles);
-  }})();
-
-  const score = (haystack) => {{
-    let total = 0;
-    if (/gpt[- ]?5/.test(haystack)) total += 100;
-    if (/\bpro\b/.test(haystack)) total += 90;
-    if (/thinking/.test(haystack)) total += 60;
-    if (/instant/.test(haystack) || /\b5[- ]?3\b/.test(haystack)) total += 30;
-    return total;
-  }};
-
-  let target = null;
-  if (autoMode) {{
-    target = items
-      .map((item) => ({{ ...item, score: score(item.haystack) }}))
-      .sort((left, right) => right.score - left.score || right.text.length - left.text.length)[0];
-    if (!target || target.score <= 0) {{
-      return {{
-        ...responseBase,
-        status: "kept-current",
-        modelUsed: currentLabel || null,
-      }};
-    }}
-  }} else {{
-    target =
-      items.find((item) => item.testId.toLowerCase() === `model-switcher-${{requestedLower}}`) ||
-      items.find((item) => requestedNeedles.some((needle) => item.haystack.includes(needle))) ||
-      null;
-    if (!target) {{
-      return {{
-        ...responseBase,
-        status: "not-found",
-        modelUsed: currentLabel || null,
-      }};
-    }}
-  }}
-
-  const targetNeedles = autoMode
-    ? [target.haystack]
-    : requestedNeedles;
-  const currentHaystack = toHaystack(currentLabel);
-  if (currentHaystack && targetNeedles.some((needle) => needle && currentHaystack.includes(needle))) {{
-    return {{
-      ...responseBase,
-      status: "already-selected",
-      modelUsed: target.text || currentLabel || requestedTrimmed || null,
-    }};
-  }}
-
-  realClick(target.el);
-  await wait(300);
-  return {{
-    ...responseBase,
-    status: "selected",
-    modelUsed: target.text || requestedTrimmed || currentLabel || null,
-  }};
-}}
-"##,
+        "{}{}{}{}{}{}{}",
+        selected_label,
+        target_test_id,
+        target_checked,
+        menu_reopen_attempts,
+        selector_expanded,
+        item_count,
+        available_items
     )
+}
+
+async fn maybe_disable_extended(client: &CdpMcpClient) -> Result<()> {
+    let script = r##"
+() => {
+  const button = document.querySelector("button[aria-label*='click to remove'][aria-label*='Extended'], button[aria-label*='remove'][aria-label*='Extended']");
+  if (!button) return "already-off";
+  button.click();
+  return "disabled";
+}
+"##;
+    let _ = client
+        .evaluate_script(script, vec![])
+        .await
+        .context("evaluate_script disable Extended Pro")?;
+    Ok(())
+}
+
+fn parse_response_baseline(state: &serde_json::Value) -> Result<ResponseBaseline> {
+    let assistant_count = state
+        .get("assistantCountBeforeSend")
+        .and_then(serde_json::Value::as_i64)
+        .ok_or_else(|| anyhow!("missing assistantCountBeforeSend in send payload"))?;
+    let assistant_last_len = state
+        .get("assistantLastLenBeforeSend")
+        .and_then(serde_json::Value::as_i64)
+        .ok_or_else(|| anyhow!("missing assistantLastLenBeforeSend in send payload"))?;
+    Ok(ResponseBaseline {
+        assistant_count,
+        assistant_last_len,
+    })
+}
+
+fn build_model_selection_script(requested_model: &str) -> String {
+    chatgpt_web::build_model_selection_function(requested_model)
 }
 
 /// Rewrite a CDP attach failure with actionable guidance.
@@ -508,11 +700,35 @@ async () => {{
 /// Instead of leaking the raw reqwest error, point the user at the fix.
 fn cdp_attach_hint(err: anyhow::Error) -> anyhow::Error {
     let raw = format!("{err:#}");
+    let raw_lower = raw.to_lowercase();
     // Preserve approval-dialog errors verbatim so the outer fallback funnel can
     // classify them as "stop, user needs to click Allow" rather than
     // "transport broken, try the next one."
-    if raw.to_lowercase().contains("allow remote debugging") {
+    if raw_lower.contains("allow remote debugging") {
         return err.context("chrome-devtools-mcp attach to running Chrome");
+    }
+    if raw_lower.contains("timed out waiting for chrome websocket handshake")
+        || (raw_lower.contains("connecting to chrome websocket")
+            && raw_lower.contains("websocket handshake")
+            && raw_lower.contains("timed out"))
+    {
+        return anyhow!("{}", approval_wait_message())
+            .context("chrome-devtools-mcp attach to running Chrome")
+            .context(err);
+    }
+    if raw_lower.contains("resource temporarily unavailable")
+        && raw_lower.contains("connecting to chrome websocket")
+    {
+        return anyhow!("{}", approval_wait_message())
+            .context("chrome-devtools-mcp attach to running Chrome")
+            .context(err);
+    }
+    if raw_lower.contains("connecting to chrome websocket") && raw_lower.contains("403 forbidden") {
+        return anyhow!(
+            "Chrome rejected the remote debugging client (403 Forbidden). Chrome may still be showing an \"Allow remote debugging?\" dialog — click Allow and retry. If you intentionally blocked the dialog, re-enable remote debugging approval and try again."
+        )
+        .context("chrome-devtools-mcp attach to running Chrome")
+        .context(err);
     }
     err.context(
         "chrome-devtools-mcp could not reach Chrome's CDP endpoint. \
@@ -523,11 +739,119 @@ fn cdp_attach_hint(err: anyhow::Error) -> anyhow::Error {
     )
 }
 
+fn emit_stable_idle_warning(message: &str) {
+    if std::io::stderr().is_terminal() {
+        eprintln!("{message}");
+    }
+}
+
+fn approval_wait_message() -> String {
+    let timeout_secs = configured_ws_handshake_timeout_ms() / 1_000;
+    format!(
+        "live browser attach timed out ({timeout_secs}s). Chrome may be showing an \"Allow remote debugging?\" dialog — click Allow, then retry."
+    )
+}
+
+async fn with_chrome_approval_lock<T, F, Fut>(show_approval_guidance: bool, action: F) -> Result<T>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<T>>,
+{
+    with_chrome_approval_lock_using(
+        show_approval_guidance,
+        crate::browser::acquire_chrome_approval_lock,
+        action,
+    )
+    .await
+}
+
+trait ApprovalLockState {
+    fn waited(&self) -> bool;
+}
+
+impl ApprovalLockState for crate::browser::ChromeApprovalLock {
+    fn waited(&self) -> bool {
+        self.waited()
+    }
+}
+
+async fn with_chrome_approval_lock_using<T, L, Acquire, F, Fut>(
+    show_approval_guidance: bool,
+    acquire_lock: Acquire,
+    action: F,
+) -> Result<T>
+where
+    L: ApprovalLockState,
+    Acquire: FnOnce() -> Result<L>,
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<T>>,
+{
+    let approval_lock = acquire_lock()?;
+    emit_chrome_approval_guidance(show_approval_guidance, approval_lock.waited());
+    let _approval_lock = approval_lock;
+    action().await
+}
+
+fn emit_chrome_approval_guidance(show_approval_guidance: bool, waited: bool) {
+    if !show_approval_guidance {
+        return;
+    }
+    if waited {
+        eprintln!(
+            "info: another yoetz process is already requesting Chrome approval; waiting for it to finish before trying the chrome-devtools-mcp transport"
+        );
+    }
+    eprintln!(
+        "info: connecting to Chrome via chrome-devtools-mcp — if prompted, click Allow in Chrome's remote debugging dialog"
+    );
+}
+
+fn configured_ws_handshake_timeout_ms() -> u64 {
+    std::env::var("YOETZ_CDP_WS_HANDSHAKE_TIMEOUT_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(30_000)
+}
+
+fn cdp_debug_enabled() -> bool {
+    std::env::var(super::client::YOETZ_DEBUG_CDP_ENV)
+        .map(|value| {
+            let trimmed = value.trim();
+            !trimmed.is_empty()
+                && !trimmed.eq_ignore_ascii_case("0")
+                && !trimmed.eq_ignore_ascii_case("false")
+        })
+        .unwrap_or(false)
+}
+
+fn debug_phase(message: &str) {
+    if cdp_debug_enabled() {
+        eprintln!("info: chrome-devtools-mcp {message}");
+    }
+}
+
 fn is_closed_cdp_transport_error(err: &anyhow::Error) -> bool {
     let raw = format!("{err:#}").to_lowercase();
     raw.contains("underlying connection is closed")
         || raw.contains("connectionclosed")
         || raw.contains("received shutdown message")
+}
+
+fn should_retry_initial_new_page_after_reconnect(err: &anyhow::Error) -> bool {
+    let raw = format!("{err:#}");
+    is_closed_cdp_transport_error(err)
+        && !is_external_create_target_block_error(err)
+        && raw.contains("chrome-devtools-mcp new_page on")
+        && raw.contains("creating a new Chrome page for")
+}
+
+fn emit_transport_retry_notice(ctx: &DevtoolsMcpRecipeContext) {
+    if ctx.show_approval_guidance || std::io::stderr().is_terminal() {
+        eprintln!(
+            "info: Chrome dropped the initial CDP session while opening the ChatGPT tab; reconnecting once and falling back to existing-anchor recovery. Chrome may prompt again."
+        );
+    }
 }
 
 fn classify_live_chatgpt_page_issue(
@@ -710,14 +1034,32 @@ async fn try_upload_via_file_input(
 
 async fn wait_for_file_input_uid(client: &CdpMcpClient, timeout_ms: u64) -> Result<Option<String>> {
     let deadline = std::time::Instant::now() + Duration::from_millis(timeout_ms);
+    let scope_script = chatgpt_web::build_scope_composer_file_input_function();
 
     loop {
-        let snapshot = client
-            .take_snapshot(false)
+        // Tag the composer-scoped file input with our marker before taking a
+        // snapshot. Without this scoping, a page-wide first-match walk can
+        // return an unrelated hidden file input (review finding #10) and we'd
+        // silently inject the bundle into the wrong element.
+        let scope_result = client
+            .evaluate_script(&scope_script, vec![])
             .await
-            .context("take snapshot while searching for file input")?;
-        if let Some(uid) = snapshot.find_file_input_uid() {
-            return Ok(Some(uid));
+            .context("scope composer file input before snapshot")?;
+        let scope_status = scope_result
+            .get("status")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("unknown");
+
+        if scope_status == "marked" {
+            let snapshot = client
+                .take_snapshot(false)
+                .await
+                .context("take snapshot while searching for marked file input")?;
+            if let Some(uid) =
+                snapshot.find_marked_file_input_uid(chatgpt_web::COMPOSER_FILE_INPUT_MARKER)
+            {
+                return Ok(Some(uid));
+            }
         }
 
         if std::time::Instant::now() >= deadline {
@@ -742,32 +1084,34 @@ async fn click_upload_candidate(client: &CdpMcpClient, candidate_id: &str) -> Re
 }
 
 async fn click_upload_menu_item(client: &CdpMcpClient) -> Result<bool> {
-    let script = r##"
-() => {
-  const selectors = ["[role='menuitem']", "button", "[role='button']", "label", "li"];
-  const nodes = Array.from(document.querySelectorAll(selectors.join(",")));
-  const target = nodes.find((el) => {
-    const text = `${el.innerText || ""} ${el.getAttribute?.("aria-label") || ""} ${el.getAttribute?.("title") || ""}`
-      .replace(/\s+/g, " ")
-      .trim()
-      .toLowerCase();
-    return /upload from computer|from computer|upload files|choose files|browse/i.test(text);
-  });
-  if (!target) return false;
-  target.click();
-  return true;
-}
-"##;
-
-    Ok(client.evaluate_script(script, vec![]).await? == serde_json::Value::Bool(true))
+    let script = chatgpt_web::build_upload_menu_item_click_function();
+    Ok(client
+        .evaluate_script(&script, vec![])
+        .await?
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+        == Some("clicked"))
 }
 
 async fn collect_upload_diagnostics(client: &CdpMcpClient) -> Result<serde_json::Value> {
-    let script = r##"
+    let script = build_collect_upload_diagnostics_script();
+
+    client
+        .evaluate_script(&script, vec![])
+        .await
+        .context("evaluate upload diagnostics")
+}
+
+fn build_collect_upload_diagnostics_script() -> String {
+    r##"
 () => {
   const composer = document.querySelector("#prompt-textarea, div[contenteditable='true'][role='textbox']");
   const composerRect = composer?.getBoundingClientRect() || null;
   const composerForm = composer?.closest("form") || null;
+
+  document
+    .querySelectorAll("[data-yoetz-upload-candidate]")
+    .forEach((el) => el.removeAttribute("data-yoetz-upload-candidate"));
 
   const clip = (value, max = 160) =>
     String(value || "").replace(/\s+/g, " ").trim().slice(0, max);
@@ -857,12 +1201,8 @@ async fn collect_upload_diagnostics(client: &CdpMcpClient) -> Result<serde_json:
     candidates,
   };
 }
-"##;
-
-    client
-        .evaluate_script(script, vec![])
-        .await
-        .context("evaluate upload diagnostics")
+"##
+    .to_string()
 }
 
 fn describe_upload_candidate(candidate: &serde_json::Value) -> String {
@@ -894,49 +1234,7 @@ fn format_upload_diagnostics(diagnostics: &serde_json::Value) -> String {
 }
 
 async fn wait_for_attachment_visible(client: &CdpMcpClient, file_name: &str) -> Result<()> {
-    let file_name_json = serde_json::to_string(file_name)?;
-    let file_stem = std::path::Path::new(file_name)
-        .file_stem()
-        .and_then(|value| value.to_str())
-        .unwrap_or(file_name);
-    let file_stem_json = serde_json::to_string(file_stem)?;
-    let script = format!(
-        r#"
-async () => {{
-  const fileName = {file_name_json};
-  const fileStem = {file_stem_json};
-  const deadline = Date.now() + {ATTACHMENT_VERIFY_WAIT_MS};
-  const clip = (value, max = 120) => String(value || "").replace(/\s+/g, " ").trim().slice(0, max);
-  while (Date.now() < deadline) {{
-    const visibleEvidence = Array.from(document.querySelectorAll("button, span, div, li"))
-      .map((el) => {{
-        const text = clip(el.innerText || el.textContent || "");
-        const ariaLabel = clip(el.getAttribute?.("aria-label") || "");
-        const title = clip(el.getAttribute?.("title") || "");
-        return {{ text, ariaLabel, title }};
-      }})
-      .filter((entry) => {{
-        const combined = `${{entry.text}} ${{entry.ariaLabel}} ${{entry.title}}`;
-        return combined.includes(fileName) || (fileStem && combined.includes(fileStem));
-      }})
-      .slice(0, 6);
-
-    if (visibleEvidence.length > 0) {{
-      return {{ ok: true, visibleEvidence }};
-    }}
-
-    await new Promise((resolve) => setTimeout(resolve, 250));
-  }}
-
-  const inputs = Array.from(document.querySelectorAll("input[type='file']")).map((input) => ({{
-    fileNames: Array.from(input.files || []).map((file) => file.name),
-    multiple: !!input.multiple,
-  }}));
-  return {{ ok: false, inputs }};
-}}
-"#
-    );
-
+    let script = build_wait_for_attachment_visible_script(file_name)?;
     let evidence = client
         .evaluate_script(&script, vec![])
         .await
@@ -951,62 +1249,47 @@ async () => {{
     ))
 }
 
+fn build_wait_for_attachment_visible_script(file_name: &str) -> Result<String> {
+    let probe_function_json =
+        serde_json::to_string(&chatgpt_web::build_attachment_probe_function(file_name)?)?;
+    Ok(format!(
+        r##"
+async () => {{
+  const probe = eval("(" + {probe_function_json} + ")");
+  const deadline = Date.now() + {ATTACHMENT_VERIFY_WAIT_MS};
+  while (Date.now() < deadline) {{
+    const state = probe();
+    if (state?.ok) {{
+      return state;
+    }}
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }}
+  return probe();
+}}
+"##,
+        probe_function_json = probe_function_json,
+    ))
+}
+
 /// Stable-idle polling for ChatGPT response completion.
 ///
-/// Ported from the v0.2.33 Pro Extended auto-poll heuristic. Returns the
-/// final assistant message text once the response has been idle for
-/// `STABLE_IDLE_CONSECUTIVE_POLLS * POLL_INTERVAL_MS` milliseconds.
+/// Returns the final assistant message text once a post-send assistant turn
+/// has been idle for the shared ChatGPT stable-idle threshold.
 async fn poll_for_stable_response(
-    client: &CdpMcpClient,
+    client: &mut CdpMcpClient,
+    ctx: &DevtoolsMcpRecipeContext,
+    page_id: &str,
+    baseline: ResponseBaseline,
     overall_timeout_ms: u64,
+    poll_interval_ms: u64,
 ) -> Result<String> {
-    let read_state_js = r##"
-() => {
-  const nodes = Array.from(document.querySelectorAll("[data-message-author-role='assistant']"));
-  const stopSelectors = [
-    "[data-testid='stop-button']",
-    "[data-testid='fruitjuice-stop-button']",
-    "button[aria-label*='Stop']",
-    "button[aria-label*='stop']",
-  ];
-  const stopGenerating = stopSelectors.some((sel) => {
-    const el = document.querySelector(sel);
-    if (!el) return false;
-    const style = window.getComputedStyle(el);
-    return style.display !== "none" && style.visibility !== "hidden" && !el.disabled;
-  });
-  if (nodes.length === 0) {
-    return {
-      ready: false,
-      count: 0,
-      length: 0,
-      text: null,
-      streaming: stopGenerating,
-      stopGenerating,
-    };
-  }
-  const last = nodes[nodes.length - 1];
-  const streaming =
-    stopGenerating ||
-    !!last.querySelector(".result-streaming") ||
-    last.classList.contains("result-streaming");
-  const text = last.innerText || "";
-  return {
-    ready: !streaming && text.length > 0,
-    count: nodes.length,
-    length: text.length,
-    text,
-    streaming,
-    stopGenerating,
-  };
-}
-"##;
-
+    let read_state_js = response_poll_state_script();
     let start = std::time::Instant::now();
     let overall_timeout = Duration::from_millis(overall_timeout_ms);
-    let mut last_count: i64 = -1;
-    let mut last_length: i64 = -1;
-    let mut stable_polls: u32 = 0;
+    let stable_idle_threshold_ms = chatgpt_web::stable_idle_threshold_ms(poll_interval_ms);
+    let mut idle_since: Option<std::time::Instant> = None;
+    let mut idle_anchor: Option<(i64, i64)> = None;
+    let mut reconnect_used = false;
 
     loop {
         if start.elapsed() > overall_timeout {
@@ -1015,71 +1298,297 @@ async fn poll_for_stable_response(
             ));
         }
 
-        tokio::time::sleep(Duration::from_millis(POLL_INTERVAL_MS)).await;
+        tokio::time::sleep(Duration::from_millis(poll_interval_ms)).await;
 
-        let state = match client.evaluate_script(read_state_js, vec![]).await {
+        let state = match client.evaluate_script(&read_state_js, vec![]).await {
             Ok(state) => state,
             Err(err) => {
-                if is_closed_cdp_transport_error(&err) {
-                    return Err(err.context(
-                        "chrome-devtools-mcp lost the Chrome websocket while waiting for the ChatGPT response",
-                    ));
+                match classify_response_poll_eval_error(&err, reconnect_used) {
+                    ResponsePollEvalFailureAction::ReconnectAndRetry => {
+                        emit_stable_idle_warning(
+                            "warn: stable-idle poll lost the Chrome websocket; reconnecting once to the existing ChatGPT tab",
+                        );
+                        *client = reconnect_response_poll_client(ctx, page_id)
+                            .await
+                            .context("recover Chrome websocket during ChatGPT response wait")?;
+                        reconnect_used = true;
+                        continue;
+                    }
+                    ResponsePollEvalFailureAction::Fail => {
+                        return Err(err.context(
+                            "chrome-devtools-mcp lost the Chrome websocket while waiting for the ChatGPT response",
+                        ));
+                    }
+                    ResponsePollEvalFailureAction::RetrySameClient => {}
                 }
                 // Treat transient eval errors as non-fatal; keep polling.
-                eprintln!("warn: stable-idle poll eval failed ({err:#}), retrying");
+                emit_stable_idle_warning(&format!(
+                    "warn: stable-idle poll eval failed ({err:#}), retrying"
+                ));
                 continue;
             }
         };
 
         let Some(obj) = state.as_object() else {
-            eprintln!("warn: stable-idle poll returned non-object: {state}");
+            emit_stable_idle_warning(&format!(
+                "warn: stable-idle poll returned non-object: {state}"
+            ));
             continue;
         };
 
-        let ready = obj.get("ready").and_then(|v| v.as_bool()).unwrap_or(false);
-        let count = obj.get("count").and_then(|v| v.as_i64()).unwrap_or(0);
-        let length = obj.get("length").and_then(|v| v.as_i64()).unwrap_or(0);
-        let streaming = obj
-            .get("streaming")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(true);
-
-        if !ready || streaming {
-            // Reset stability counter; still streaming.
-            last_count = count;
-            last_length = length;
-            stable_polls = 0;
-            continue;
+        let poll_state = parse_response_poll_state(obj).context("parse stable-idle poll state")?;
+        if !poll_state.error.is_empty() {
+            return Err(anyhow!("ChatGPT error: {}", poll_state.error));
         }
-
-        // `ready == true && !streaming`: candidate complete. Check stability.
-        if count == last_count && length == last_length {
-            stable_polls += 1;
-            if stable_polls >= STABLE_IDLE_CONSECUTIVE_POLLS {
-                let text = obj
-                    .get("text")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                if text.is_empty() {
-                    return Err(anyhow!(
-                        "stable-idle reached but assistant message text is empty"
-                    ));
-                }
-                return Ok(text);
+        match classify_response_completion(&poll_state, baseline) {
+            ResponseCompletionVerdict::Generating => {
+                idle_since = None;
+                idle_anchor = None;
             }
-        } else {
-            // State changed between polls — still technically streaming.
-            last_count = count;
-            last_length = length;
-            stable_polls = 1; // First stable observation at the new state
+            ResponseCompletionVerdict::CopyButton => {
+                if !poll_state.text.is_empty() {
+                    return Ok(poll_state.text);
+                }
+                let extracted = read_latest_assistant_text(client)
+                    .await
+                    .context("read latest assistant text after copy-button completion")?;
+                if !extracted.is_empty() {
+                    return Ok(extracted);
+                }
+                idle_since = Some(std::time::Instant::now());
+                idle_anchor = Some((poll_state.assistant_count, poll_state.assistant_last_len));
+            }
+            ResponseCompletionVerdict::Idle => {
+                let anchor = (poll_state.assistant_count, poll_state.assistant_last_len);
+                let stable_for_ms = match (idle_since, idle_anchor) {
+                    (Some(since), Some(previous_anchor)) if previous_anchor == anchor => {
+                        std::time::Instant::now()
+                            .duration_since(since)
+                            .as_millis()
+                            .min(u128::from(u64::MAX)) as u64
+                    }
+                    _ => {
+                        idle_since = Some(std::time::Instant::now());
+                        idle_anchor = Some(anchor);
+                        0
+                    }
+                };
+                if stable_for_ms >= stable_idle_threshold_ms {
+                    if poll_state.text.is_empty() {
+                        return Err(anyhow!(
+                            "stable-idle reached but assistant message text is empty"
+                        ));
+                    }
+                    return Ok(poll_state.text);
+                }
+            }
         }
     }
+}
+
+async fn reconnect_response_poll_client(
+    ctx: &DevtoolsMcpRecipeContext,
+    page_id: &str,
+) -> Result<CdpMcpClient> {
+    let client = connect_client(ctx)
+        .await
+        .context("reconnect Chrome websocket for stable-idle polling")?;
+    client
+        .select_page_target(page_id, 30_000)
+        .with_context(|| format!("reattach to ChatGPT page target `{page_id}` after reconnect"))?;
+    Ok(client)
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum ResponsePollEvalFailureAction {
+    RetrySameClient,
+    ReconnectAndRetry,
+    Fail,
+}
+
+fn classify_response_poll_eval_error(
+    err: &anyhow::Error,
+    reconnect_used: bool,
+) -> ResponsePollEvalFailureAction {
+    if !is_closed_cdp_transport_error(err) {
+        return ResponsePollEvalFailureAction::RetrySameClient;
+    }
+    if reconnect_used {
+        ResponsePollEvalFailureAction::Fail
+    } else {
+        ResponsePollEvalFailureAction::ReconnectAndRetry
+    }
+}
+
+fn response_poll_state_script() -> String {
+    let send_button_selector_json = chatgpt_web::send_button_selector_json();
+    let stop_button_selector_json = chatgpt_web::stop_button_selector_json();
+    format!(
+        r##"
+() => {{
+  const nodes = Array.from(document.querySelectorAll("[data-message-author-role='assistant']"));
+  const send = Array.from(document.querySelectorAll({send_button_selector_json})).find((button) => {{
+    const rect = button.getBoundingClientRect();
+    const style = window.getComputedStyle(button);
+    return rect.width > 0 &&
+      rect.height > 0 &&
+      style.visibility !== "hidden" &&
+      style.display !== "none";
+  }}) || null;
+  const stopButton = document.querySelector({stop_button_selector_json});
+  const stopGenerating = !!stopButton && !stopButton.disabled;
+  const thinking = document.querySelector(".result-thinking, [data-testid*='thinking'], [class*='thinking']");
+  if (nodes.length === 0) {{
+    return {{
+      ready: false,
+      count: 0,
+      length: 0,
+      text: null,
+      streaming: stopGenerating,
+      stopGenerating,
+      thinking: !!thinking,
+      copyButtons: 0,
+      sendState: !send ? "missing" : send.disabled ? "disabled" : "enabled",
+      error: "",
+    }};
+  }}
+  const last = nodes[nodes.length - 1];
+  const turnRoot =
+    last.closest(".agent-turn, [class*='agent-turn'], [class*='turn-messages']") ||
+    last.parentElement?.parentElement ||
+    last.parentElement ||
+    document;
+  const copyButtons = turnRoot.querySelectorAll("button[aria-label*='Copy'], button[data-testid*='copy']").length;
+  const errEl = document.querySelector('[class*="error-toast"], [data-testid*="error"], [role="alert"]');
+  const errText = errEl ? (errEl.innerText || "").substring(0, 100).toLowerCase() : "";
+  const markers = ["network error","something went wrong","error generating","attachment failed","upload failed","too many requests"];
+  const error = markers.find((marker) => errText.includes(marker)) || "";
+  const streaming =
+    stopGenerating ||
+    !!last.querySelector(".result-streaming") ||
+    last.classList.contains("result-streaming");
+  const text = last.innerText || "";
+  return {{
+    count: nodes.length,
+    length: text.length,
+    text,
+    streaming,
+    sendState: !send ? "missing" : send.disabled ? "disabled" : "enabled",
+    hasStopButton: stopGenerating,
+    thinking: !!thinking,
+    copyButtons,
+    error,
+  }};
+}}
+"##,
+        send_button_selector_json = send_button_selector_json,
+        stop_button_selector_json = stop_button_selector_json,
+    )
+}
+
+fn parse_response_poll_state(
+    obj: &serde_json::Map<String, serde_json::Value>,
+) -> Result<ResponsePollState> {
+    Ok(ResponsePollState {
+        assistant_count: obj
+            .get("count")
+            .and_then(serde_json::Value::as_i64)
+            .unwrap_or(0),
+        assistant_last_len: obj
+            .get("length")
+            .and_then(serde_json::Value::as_i64)
+            .unwrap_or(0),
+        text: obj
+            .get("text")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+        streaming: obj
+            .get("streaming")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(true),
+        send_state: match obj
+            .get("sendState")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("missing")
+        {
+            "enabled" => ResponseSendState::Enabled,
+            "disabled" => ResponseSendState::Disabled,
+            "missing" => ResponseSendState::Missing,
+            other => return Err(anyhow!("invalid send state `{other}`")),
+        },
+        has_stop_button: obj
+            .get("hasStopButton")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false),
+        has_thinking_indicator: obj
+            .get("thinking")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false),
+        copy_button_count: obj
+            .get("copyButtons")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0) as usize,
+        error: obj
+            .get("error")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+    })
+}
+
+fn classify_response_completion(
+    state: &ResponsePollState,
+    baseline: ResponseBaseline,
+) -> ResponseCompletionVerdict {
+    let composer_idle = matches!(
+        state.send_state,
+        ResponseSendState::Enabled | ResponseSendState::Missing
+    );
+    if state.streaming || !composer_idle || state.has_stop_button || state.has_thinking_indicator {
+        return ResponseCompletionVerdict::Generating;
+    }
+    let new_message = state.assistant_count > baseline.assistant_count;
+    if new_message && state.copy_button_count > 0 {
+        return ResponseCompletionVerdict::CopyButton;
+    }
+    // We intentionally treat only monotonic assistant growth as forward
+    // progress. If ChatGPT ever performs an in-place rewrite with the same
+    // message count and length, we keep waiting until the hard response timeout
+    // rather than risk classifying a stale pre-send turn as complete.
+    let same_message_grew = state.assistant_count == baseline.assistant_count
+        && state.assistant_last_len > baseline.assistant_last_len;
+    if (new_message && state.assistant_last_len > 0) || same_message_grew {
+        ResponseCompletionVerdict::Idle
+    } else {
+        ResponseCompletionVerdict::Generating
+    }
+}
+
+async fn read_latest_assistant_text(client: &CdpMcpClient) -> Result<String> {
+    let script = r##"
+() => {
+  const nodes = Array.from(document.querySelectorAll("[data-message-author-role='assistant']"));
+  if (nodes.length === 0) return "";
+  return nodes[nodes.length - 1].innerText || "";
+}
+"##;
+    let value = client
+        .evaluate_script(script, vec![])
+        .await
+        .context("evaluate latest assistant text")?;
+    Ok(value
+        .as_str()
+        .map(str::trim)
+        .unwrap_or_default()
+        .to_string())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
 
     #[tokio::test]
     async fn run_errors_without_bundle() {
@@ -1100,10 +1609,45 @@ mod tests {
     // is already broken. We instead rely on the `const { }` block below,
     // which fails the build if any of these invariants regress.
     const _CONST_SANITY: () = {
-        assert!(POLL_INTERVAL_MS >= 1_000);
-        assert!(STABLE_IDLE_CONSECUTIVE_POLLS >= 2);
-        assert!(!CHATGPT_URL.is_empty());
+        assert!(chatgpt_web::STABLE_IDLE_FLOOR_MS >= 1_000);
+        assert!(chatgpt_web::STABLE_IDLE_INTERVAL_MULTIPLIER >= 2);
+        assert!(!chatgpt_web::CHATGPT_URL.is_empty());
     };
+
+    fn lock_env() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        #[allow(unsafe_code)]
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var(key).ok();
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        #[allow(unsafe_code)]
+        fn drop(&mut self) {
+            match self.previous.as_deref() {
+                Some(value) => unsafe {
+                    std::env::set_var(self.key, value);
+                },
+                None => unsafe {
+                    std::env::remove_var(self.key);
+                },
+            }
+        }
+    }
 
     #[test]
     fn cdp_attach_hint_preserves_approval_dialog_errors() {
@@ -1120,6 +1664,46 @@ mod tests {
     }
 
     #[test]
+    #[serial]
+    fn approval_wait_message_uses_configured_handshake_timeout() {
+        let _guard = lock_env();
+        let _timeout = EnvVarGuard::set("YOETZ_CDP_WS_HANDSHAKE_TIMEOUT_MS", "120000");
+        assert!(approval_wait_message().contains("120s"));
+    }
+
+    #[tokio::test]
+    async fn with_chrome_approval_lock_acquires_before_running_action() {
+        #[derive(Clone, Copy)]
+        struct FakeLock;
+
+        impl ApprovalLockState for FakeLock {
+            fn waited(&self) -> bool {
+                false
+            }
+        }
+
+        let acquired = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let acquired_for_action = acquired.clone();
+
+        with_chrome_approval_lock_using(
+            false,
+            || {
+                acquired.store(true, std::sync::atomic::Ordering::SeqCst);
+                Ok::<FakeLock, anyhow::Error>(FakeLock)
+            },
+            || async move {
+                assert!(
+                    acquired_for_action.load(std::sync::atomic::Ordering::SeqCst),
+                    "approval lock should be acquired before the action runs"
+                );
+                Ok::<(), anyhow::Error>(())
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    #[test]
     fn cdp_attach_hint_wraps_other_errors_with_actionable_guidance() {
         let err =
             anyhow!("requesting `http://127.0.0.1:9222/json/version` failed: connection refused");
@@ -1129,6 +1713,30 @@ mod tests {
         assert!(msg.contains("Chrome 136+"));
         // Original error chain is preserved.
         assert!(msg.contains("connection refused"));
+    }
+
+    #[test]
+    fn cdp_attach_hint_rewrites_websocket_handshake_timeouts_as_approval_waits() {
+        let err = anyhow!(
+            "connecting to Chrome websocket `ws://127.0.0.1:9222/devtools/browser/test` failed: timed out waiting for Chrome websocket handshake"
+        );
+        let rewritten = cdp_attach_hint(err);
+        let msg = format!("{rewritten:#}");
+        assert!(msg.contains("Allow remote debugging"));
+        assert!(!msg.contains("chrome://inspect"));
+    }
+
+    #[test]
+    fn cdp_attach_hint_rewrites_forbidden_websocket_handshakes_with_block_guidance() {
+        let err = anyhow!(
+            "connecting to Chrome websocket `ws://127.0.0.1:9222/devtools/browser/test` failed: HTTP error: 403 Forbidden"
+        );
+        let rewritten = cdp_attach_hint(err);
+        let msg = format!("{rewritten:#}");
+        assert!(msg.contains("403 Forbidden"));
+        assert!(msg.contains("Chrome rejected the remote debugging client"));
+        assert!(msg.contains("click Allow"));
+        assert!(!msg.contains("chrome://inspect"));
     }
 
     #[test]
@@ -1173,6 +1781,32 @@ mod tests {
     }
 
     #[test]
+    fn wait_for_composer_retry_classifier_matches_transient_eval_failures() {
+        assert!(should_retry_wait_for_composer_error(&anyhow!(
+            "Runtime.evaluate failed: Execution context was destroyed."
+        )));
+        assert!(should_retry_wait_for_composer_error(&anyhow!(
+            "Protocol error: Cannot find context with specified id"
+        )));
+        assert!(should_retry_wait_for_composer_error(&anyhow!(
+            "Target closed"
+        )));
+        assert!(!should_retry_wait_for_composer_error(&anyhow!(
+            "chatgpt login required in the attached Chrome session"
+        )));
+    }
+
+    #[test]
+    fn wait_for_composer_script_embeds_focus_flag_without_snapshot_args() {
+        let focused = build_wait_for_composer_script(true);
+        assert!(focused.contains("const focusComposer = true;"));
+        assert!(!focused.contains("async (focusComposer = true)"));
+
+        let unfocused = build_wait_for_composer_script(false);
+        assert!(unfocused.contains("const focusComposer = false;"));
+    }
+
+    #[test]
     fn closed_cdp_transport_errors_are_classified() {
         let err = anyhow!("Unable to make method calls because underlying connection is closed");
         assert!(is_closed_cdp_transport_error(&err));
@@ -1181,15 +1815,188 @@ mod tests {
     }
 
     #[test]
+    fn initial_new_page_closed_transport_errors_trigger_retry() {
+        let err = anyhow!(
+            "chrome-devtools-mcp new_page on `https://chatgpt.com/?_yoetz=test`: creating a new Chrome page for `https://chatgpt.com/?_yoetz=test` failed: Unable to make method calls because underlying connection is closed"
+        );
+        assert!(should_retry_initial_new_page_after_reconnect(&err));
+    }
+
+    #[test]
+    fn retry_classifier_ignores_non_new_page_closed_transport_errors() {
+        let err = anyhow!(
+            "mark yoetz-owned ChatGPT tab with window.name: Unable to make method calls because underlying connection is closed"
+        );
+        assert!(!should_retry_initial_new_page_after_reconnect(&err));
+    }
+
+    #[test]
+    fn retry_classifier_skips_external_create_target_block_errors() {
+        let err = anyhow!(
+            "chrome-devtools-mcp new_page on `https://chatgpt.com/?_yoetz=test`: creating a new Chrome page for `https://chatgpt.com/?_yoetz=test` failed: Chrome's default-profile CDP endpoint likely rejected external `Target.createTarget` while opening `https://chatgpt.com/?_yoetz=test`. Chrome 146+/147 can allow attach/read operations but close the session on new-tab creation for untrusted clients. First, open chrome://inspect/#remote-debugging, refresh Discover network targets (or Open dedicated DevTools for Node), and retry. If Chrome still closes the session, launch Chrome with `--remote-debugging-port=9222 --user-data-dir=/tmp/chrome-debug` and pass `--cdp`, or use Chrome for Testing. Unable to make method calls because underlying connection is closed"
+        );
+        assert!(!should_retry_initial_new_page_after_reconnect(&err));
+    }
+
+    #[test]
+    fn external_create_target_block_still_triggers_recovery_after_reconnect() {
+        let err = anyhow!(
+            "chrome-devtools-mcp new_page on `https://chatgpt.com/?_yoetz=test`: creating a new Chrome page for `https://chatgpt.com/?_yoetz=test` failed: Chrome's default-profile CDP endpoint likely rejected external `Target.createTarget` while opening `https://chatgpt.com/?_yoetz=test`. Chrome 146+/147 can allow attach/read operations but close the session on new-tab creation for untrusted clients. First, open chrome://inspect/#remote-debugging, refresh Discover network targets (or Open dedicated DevTools for Node), and retry. If Chrome still closes the session, launch Chrome with `--remote-debugging-port=9222 --user-data-dir=/tmp/chrome-debug` and pass `--cdp`, or use Chrome for Testing. Unable to make method calls because underlying connection is closed"
+        );
+        assert!(should_recover_initial_page_open_after_reconnect(&err));
+    }
+
+    #[test]
+    fn initial_page_retry_uses_existing_anchor_recovery() {
+        assert_eq!(
+            retry_initial_page_open_mode(),
+            InitialPageOpenMode::RecoverViaExistingAnchor
+        );
+        assert_eq!(
+            retry_initial_page_open_mode().debug_strategy(),
+            "recover_via_existing_anchor"
+        );
+    }
+
+    #[test]
+    fn response_poll_closed_transport_reconnects_only_once() {
+        let closed = anyhow!("Unable to make method calls because underlying connection is closed");
+        let other = anyhow!("Execution context was destroyed");
+
+        assert_eq!(
+            classify_response_poll_eval_error(&closed, false),
+            ResponsePollEvalFailureAction::ReconnectAndRetry
+        );
+        assert_eq!(
+            classify_response_poll_eval_error(&closed, true),
+            ResponsePollEvalFailureAction::Fail
+        );
+        assert_eq!(
+            classify_response_poll_eval_error(&other, false),
+            ResponsePollEvalFailureAction::RetrySameClient
+        );
+    }
+
+    #[test]
     fn model_selection_script_supports_auto_and_explicit_modes() {
         let auto_script = build_model_selection_script("auto");
         assert!(auto_script.contains(r#"const requested = "auto";"#));
-        assert!(auto_script.contains(r#"/gpt[- ]?5/"#));
-        assert!(auto_script.contains(r#""kept-current-no-selector""#));
+        assert!(!auto_script.contains(r#""kept-current-no-selector""#));
+        assert!(auto_script.contains("const deriveRequestedTier = (value) =>"));
+        assert!(auto_script.contains("const classifyTier = (item) =>"));
+        assert!(auto_script.contains("const buildTierRankings = (entries) =>"));
 
         let explicit_script = build_model_selection_script("gpt-5-4-pro");
         assert!(explicit_script.contains(r#"const requested = "gpt-5-4-pro";"#));
-        assert!(explicit_script.contains("requestedNeedles"));
-        assert!(explicit_script.contains("model-switcher-${requestedLower}"));
+        assert!(explicit_script.contains("\"gpt-5-pro\":\"gpt-5-4-pro\""));
+        assert!(!explicit_script.contains("\"gpt-5-3-pro\""));
+        assert!(explicit_script.contains("const selectBestTierItem = (entries, slug, rankings) =>"));
+        assert!(explicit_script.contains("availableItems"));
+    }
+
+    #[test]
+    fn classify_response_completion_rejects_stale_prior_response() {
+        let baseline = ResponseBaseline {
+            assistant_count: 2,
+            assistant_last_len: 120,
+        };
+        let stale = ResponsePollState {
+            assistant_count: 2,
+            assistant_last_len: 120,
+            text: "old answer".to_string(),
+            streaming: false,
+            send_state: ResponseSendState::Enabled,
+            has_stop_button: false,
+            has_thinking_indicator: false,
+            copy_button_count: 0,
+            error: String::new(),
+        };
+        assert_eq!(
+            classify_response_completion(&stale, baseline),
+            ResponseCompletionVerdict::Generating
+        );
+    }
+
+    #[test]
+    fn classify_response_completion_accepts_new_or_growing_post_send_response() {
+        let baseline = ResponseBaseline {
+            assistant_count: 2,
+            assistant_last_len: 120,
+        };
+        let new_message = ResponsePollState {
+            assistant_count: 3,
+            assistant_last_len: 18,
+            text: "new answer".to_string(),
+            streaming: false,
+            send_state: ResponseSendState::Enabled,
+            has_stop_button: false,
+            has_thinking_indicator: false,
+            copy_button_count: 0,
+            error: String::new(),
+        };
+        assert_eq!(
+            classify_response_completion(&new_message, baseline),
+            ResponseCompletionVerdict::Idle
+        );
+
+        let same_message_grew = ResponsePollState {
+            assistant_count: 2,
+            assistant_last_len: 140,
+            text: "expanded answer".to_string(),
+            streaming: false,
+            send_state: ResponseSendState::Enabled,
+            has_stop_button: false,
+            has_thinking_indicator: false,
+            copy_button_count: 0,
+            error: String::new(),
+        };
+        assert_eq!(
+            classify_response_completion(&same_message_grew, baseline),
+            ResponseCompletionVerdict::Idle
+        );
+    }
+
+    #[test]
+    fn classify_response_completion_accepts_copy_button_on_new_message() {
+        let baseline = ResponseBaseline {
+            assistant_count: 2,
+            assistant_last_len: 120,
+        };
+        let completed = ResponsePollState {
+            assistant_count: 3,
+            assistant_last_len: 0,
+            text: "done".to_string(),
+            streaming: false,
+            send_state: ResponseSendState::Missing,
+            has_stop_button: false,
+            has_thinking_indicator: false,
+            copy_button_count: 1,
+            error: String::new(),
+        };
+        assert_eq!(
+            classify_response_completion(&completed, baseline),
+            ResponseCompletionVerdict::CopyButton
+        );
+    }
+
+    #[test]
+    fn attachment_visibility_script_matches_file_name_variable() {
+        let script = build_wait_for_attachment_visible_script("bundle.txt").unwrap();
+        assert!(script.contains("name === fileName"));
+        assert!(!script.contains("exactName"));
+    }
+
+    #[test]
+    fn upload_diagnostics_script_cleans_previous_candidate_ids() {
+        let script = build_collect_upload_diagnostics_script();
+        assert!(script.contains("querySelectorAll(\"[data-yoetz-upload-candidate]\")"));
+        assert!(script.contains("removeAttribute(\"data-yoetz-upload-candidate\")"));
+    }
+
+    #[test]
+    fn response_poll_script_looks_for_copy_buttons_on_turn_root() {
+        let script = response_poll_state_script();
+        assert!(script.contains("last.closest(\".agent-turn"));
+        assert!(script.contains("turnRoot.querySelectorAll"));
     }
 }

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
@@ -3,17 +3,20 @@
 
 use anyhow::{anyhow, bail, Context, Result};
 use headless_chrome::{
-    browser::tab::element::Element, protocol::cdp::Target::CreateTarget, Browser, Tab,
+    browser::tab::element::Element,
+    protocol::cdp::Target::{CreateTarget, TargetInfo},
+    Browser, Tab,
 };
 use reqwest::Url;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde_json::Value;
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     io::{Read, Write},
     net::TcpStream,
     path::{Path, PathBuf},
+    process::Command,
     sync::{Arc, Mutex},
     time::{Duration, Instant, SystemTime},
 };
@@ -25,6 +28,66 @@ const DEFAULT_LOCAL_CDP_ENDPOINT: &str = "http://127.0.0.1:9222";
 // session alive for long-running recipes.
 const CDP_SESSION_IDLE_TIMEOUT_SECS: u64 = 60 * 60;
 const DISCOVERY_HTTP_TIMEOUT_MS: u64 = 750;
+
+/// Environment flag that opts into verbose CDP error rendering. When unset we
+/// redact tab samples and inferred emails from error output so a casual error
+/// does not leak a picture of what the user has open in Chrome (review
+/// finding #9).
+pub const YOETZ_DEBUG_CDP_ENV: &str = "YOETZ_DEBUG_CDP";
+
+/// Environment flag that opts into trusting CDP endpoints that redirect to a
+/// different host/port. Default is localhost-only: the websocket reported by
+/// `/json/version` must live on the same host:port we probed, otherwise we
+/// refuse to attach (review finding #5 — CDP discovery must not follow
+/// arbitrary cross-host redirects).
+pub const YOETZ_CDP_ALLOW_REMOTE_ENV: &str = "YOETZ_CDP_ALLOW_REMOTE";
+
+pub(crate) fn cdp_remote_redirects_allowed() -> bool {
+    std::env::var(YOETZ_CDP_ALLOW_REMOTE_ENV)
+        .map(|value| {
+            let trimmed = value.trim();
+            !trimmed.is_empty()
+                && !trimmed.eq_ignore_ascii_case("0")
+                && !trimmed.eq_ignore_ascii_case("false")
+        })
+        .unwrap_or(false)
+}
+
+pub(crate) fn is_loopback_host(host: Option<&str>) -> bool {
+    let Some(host) = host else {
+        return false;
+    };
+    let host = host.trim().to_ascii_lowercase();
+    matches!(
+        host.as_str(),
+        "localhost" | "127.0.0.1" | "[::1]" | "::1" | "0.0.0.0"
+    )
+}
+
+fn cdp_debug_enabled() -> bool {
+    std::env::var(YOETZ_DEBUG_CDP_ENV)
+        .map(|value| {
+            let trimmed = value.trim();
+            !trimmed.is_empty()
+                && !trimmed.eq_ignore_ascii_case("0")
+                && !trimmed.eq_ignore_ascii_case("false")
+        })
+        .unwrap_or(false)
+}
+
+/// Origins where a signed-in email naturally shows up in tab titles or URLs.
+/// All other tabs are ignored when inferring which Chrome profile hosts which
+/// email, so an unrelated or adversarially-named tab cannot steer
+/// `profile_email` matching (review finding #9 — profile_email spoofing).
+const EMAIL_INFERENCE_TRUSTED_ORIGINS: &[&str] = &[
+    "accounts.google.com",
+    "myaccount.google.com",
+    "mail.google.com",
+    "calendar.google.com",
+    "auth.openai.com",
+    "chatgpt.com",
+    "platform.openai.com",
+];
 
 pub struct CdpMcpClient {
     browser: Browser,
@@ -96,11 +159,20 @@ impl Snapshot {
         count_nodes(&self.raw, role)
     }
 
-    pub fn find_file_input_uid(&self) -> Option<String> {
+    /// Find the uid of a file input that has been explicitly scoped to the
+    /// composer by [`crate::chatgpt_web::build_scope_composer_file_input_function`].
+    /// Returns `None` if no such input is marked — callers must keep polling
+    /// rather than falling back to the first page-wide file input, which could
+    /// be an unrelated hidden control (review finding #10).
+    pub fn find_marked_file_input_uid(&self, marker: &str) -> Option<String> {
+        if marker.is_empty() {
+            return None;
+        }
         walk_snapshot(&self.raw, &mut |node| {
             let tag = node.get("tag").and_then(Value::as_str)?;
             let input_type = node.get("type").and_then(Value::as_str)?;
-            if tag == "input" && input_type == "file" {
+            let name = node.get("name").and_then(Value::as_str).unwrap_or("");
+            if tag == "input" && input_type == "file" && name == marker {
                 node.get("id")
                     .and_then(Value::as_str)
                     .map(ToOwned::to_owned)
@@ -122,6 +194,8 @@ pub struct RunningChromeTarget {
     pub source_path: PathBuf,
     pub browser_name: String,
     pub chatgpt_tab_count: usize,
+    pub page_target_count: usize,
+    pub page_samples: Vec<String>,
     pub modified_at: Option<SystemTime>,
 }
 
@@ -138,10 +212,106 @@ impl RunningChromeTarget {
                 self.source_path.display(),
                 self.chatgpt_tab_count
             )
+        } else if !self.page_samples.is_empty() {
+            format!(
+                "{} at {} (chatgpt tabs: 0; pages: {}; sample tabs: {})",
+                self.browser_name,
+                self.source_path.display(),
+                self.page_target_count,
+                self.page_samples.join(", ")
+            )
+        } else if self.page_target_count > 0 {
+            format!(
+                "{} at {} (chatgpt tabs: 0; pages: {})",
+                self.browser_name,
+                self.source_path.display(),
+                self.page_target_count
+            )
         } else {
-            format!("{} at {}", self.browser_name, self.source_path.display())
+            format!(
+                "{} at {} (chatgpt tabs: 0; no page targets)",
+                self.browser_name,
+                self.source_path.display()
+            )
         }
     }
+}
+
+pub fn browser_id_from_ws_endpoint(endpoint: &str) -> Option<String> {
+    endpoint
+        .split("/devtools/browser/")
+        .nth(1)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct DevtoolsActivePortFile {
+    pub path: PathBuf,
+    pub ws_endpoint: Option<String>,
+    pub modified_at: Option<SystemTime>,
+    pub healthy: bool,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ChromiumProcessSummary {
+    pub pid: u32,
+    pub browser_name: String,
+    pub command: String,
+    pub has_remote_debugging: bool,
+    pub user_data_dir: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct BrowserContextSummary {
+    pub id: Option<String>,
+    pub inferred_emails: Vec<String>,
+    pub chatgpt_tab_count: usize,
+    pub page_target_count: usize,
+    pub sample_tabs: Vec<String>,
+}
+
+impl BrowserContextSummary {
+    fn matches_email(&self, requested_email: &str) -> bool {
+        let wanted = requested_email.trim().to_ascii_lowercase();
+        self.inferred_emails.iter().any(|email| email == &wanted)
+    }
+
+    fn render_for_error(&self) -> String {
+        let label = self.id.as_deref().unwrap_or("<default-context>");
+        let verbose = cdp_debug_enabled();
+        let emails = if !verbose {
+            if self.inferred_emails.is_empty() {
+                "none".to_string()
+            } else {
+                format!(
+                    "{} inferred (set {YOETZ_DEBUG_CDP_ENV}=1 to reveal)",
+                    self.inferred_emails.len()
+                )
+            }
+        } else if self.inferred_emails.is_empty() {
+            "unknown-email".to_string()
+        } else {
+            self.inferred_emails.join(", ")
+        };
+        let base = format!(
+            "{label} [emails: {emails}; chatgpt tabs: {}; pages: {}",
+            self.chatgpt_tab_count, self.page_target_count
+        );
+        if verbose && !self.sample_tabs.is_empty() {
+            format!("{base}; sample tabs: {}]", self.sample_tabs.join(", "))
+        } else {
+            format!("{base}]")
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct BrowserContextPage {
+    browser_context_id: Option<String>,
+    title: String,
+    url: String,
 }
 
 impl CdpMcpClient {
@@ -164,11 +334,54 @@ impl CdpMcpClient {
         url: &str,
         background: bool,
         timeout_ms: u64,
+        browser_context_id: Option<&str>,
     ) -> Result<NewPageResult> {
-        let tab = self
-            .browser
-            .new_tab_with_options(create_target(url, background))
-            .with_context(|| format!("creating a new Chrome page for `{url}` failed"))?;
+        let tab = match self.browser.new_tab_with_options(create_target(
+            url,
+            background,
+            browser_context_id,
+        )) {
+            Ok(tab) => tab,
+            Err(err) if browser_context_id.is_some() && is_missing_browser_context_error(&err) => {
+                let browser_context_id = browser_context_id.expect("checked is_some");
+                match self
+                    .open_page_via_existing_context_tab(
+                        url,
+                        background,
+                        timeout_ms,
+                        Some(browser_context_id),
+                    )
+                    .await
+                {
+                    Ok(tab) => tab,
+                    Err(open_err) => self
+                        .reuse_existing_context_tab(
+                            url,
+                            background,
+                            timeout_ms,
+                            browser_context_id,
+                        )
+                        .await
+                        .with_context(|| {
+                            format!(
+                                "Chrome rejected browser_context_id `{browser_context_id}` for direct target creation, and opening a new tab from an existing page also failed"
+                            )
+                        })
+                        .context(open_err)?,
+                }
+            }
+            Err(err) => {
+                let err = anyhow!(err);
+                let err = if should_classify_external_create_target_block(&err, browser_context_id)
+                {
+                    err.context(external_create_target_block_guidance(url))
+                } else {
+                    err
+                };
+                return Err(err)
+                    .with_context(|| format!("creating a new Chrome page for `{url}` failed"));
+            }
+        };
         configure_tab_timeout(&tab, timeout_ms);
         tab.wait_until_navigated()
             .with_context(|| format!("waiting for Chrome page `{url}` to finish navigating"))?;
@@ -179,17 +392,131 @@ impl CdpMcpClient {
         })
     }
 
-    pub async fn reuse_chatgpt_page(&self, timeout_ms: u64) -> Result<ReusedPageResult> {
-        let candidates = self.chatgpt_tabs();
-        let tab = select_chatgpt_reuse_tab(candidates, timeout_ms)?;
+    pub async fn open_page_via_existing_tab(
+        &self,
+        url: &str,
+        background: bool,
+        timeout_ms: u64,
+        browser_context_id: Option<&str>,
+    ) -> Result<NewPageResult> {
+        let tab = self
+            .open_page_via_existing_context_tab(url, background, timeout_ms, browser_context_id)
+            .await?;
         configure_tab_timeout(&tab, timeout_ms);
-        let _ = tab.activate();
-        let _ = tab.bring_to_front();
+        tab.wait_until_navigated()
+            .with_context(|| format!("waiting for Chrome page `{url}` to finish navigating"))?;
         self.set_selected_tab(tab.clone());
 
-        Ok(ReusedPageResult {
+        Ok(NewPageResult {
             page_id: tab.get_target_id().to_string(),
-            url: tab.get_url(),
+        })
+    }
+
+    pub async fn open_chatgpt_page_via_existing_anchor(
+        &self,
+        url: &str,
+        background: bool,
+        timeout_ms: u64,
+        browser_context_id: Option<&str>,
+    ) -> Result<NewPageResult> {
+        let page_targets = self
+            .wait_for_recovery_anchor_candidates(browser_context_id, timeout_ms.min(3_000))
+            .await?;
+        let chatgpt_anchor_target = page_targets
+            .iter()
+            .find(|target| is_chatgpt_url(&target.url))
+            .cloned();
+        let safe_anchor_target = page_targets
+            .iter()
+            .filter_map(|target| context_tab_reuse_rank(&target.url).map(|rank| (rank, target)))
+            .min_by_key(|(rank, _)| *rank)
+            .map(|(_, target)| target.clone());
+        let strategy = choose_chatgpt_recovery_strategy(
+            chatgpt_anchor_target.is_some(),
+            safe_anchor_target
+                .as_ref()
+                .map(|target| target.url.as_str()),
+            browser_context_id,
+            url,
+        )?;
+        let tab = match strategy {
+            ChatgptRecoveryStrategy::ReuseExistingChatgptTab => {
+                let anchor =
+                    chatgpt_anchor_target.expect("strategy requires a ChatGPT anchor target");
+                eprintln!(
+                    "warn: {YOETZ_ALLOW_MUTATE_EXISTING_CHATGPT_TAB_ENV}=1 — navigating existing ChatGPT tab `{}` to `{url}`",
+                    anchor.url
+                );
+                self.reuse_page_target(&anchor, url, background, timeout_ms)
+                    .await?
+            }
+            ChatgptRecoveryStrategy::ExistingChatgptAnchor => {
+                let anchor =
+                    chatgpt_anchor_target.expect("strategy requires a ChatGPT anchor target");
+                self.open_page_via_anchor_target(
+                    &anchor,
+                    url,
+                    background,
+                    timeout_ms,
+                    browser_context_id,
+                    "existing ChatGPT tab",
+                )
+                .await?
+            }
+            ChatgptRecoveryStrategy::ExistingSafeAnchor => {
+                let anchor = safe_anchor_target.expect("strategy requires a safe anchor target");
+                match self
+                    .open_page_via_anchor_target(
+                        &anchor,
+                        url,
+                        background,
+                        timeout_ms,
+                        browser_context_id,
+                        "yoetz-safe tab",
+                    )
+                    .await
+                {
+                    Ok(tab) => tab,
+                    Err(open_err) => self
+                        .reuse_page_target(&anchor, url, background, timeout_ms)
+                        .await
+                        .context(open_err)?,
+                }
+            }
+            ChatgptRecoveryStrategy::AnyUserPageAnchor => {
+                // Operator opted in via YOETZ_ALLOW_USER_TAB_ANCHOR. Use the
+                // first page-type tab in the context as the `window.open`
+                // anchor. We DO NOT navigate the anchor; we only run a
+                // `window.open(marked_url, '_blank')` in it, which spawns a
+                // sibling yoetz-owned tab.
+                let anchor = page_targets.into_iter().next().with_context(|| {
+                    format!(
+                        "YOETZ_ALLOW_USER_TAB_ANCHOR was set, but {} still has no existing page-type tabs to use as a `window.open` anchor for `{url}`",
+                        browser_context_label(browser_context_id)
+                    )
+                })?;
+                eprintln!(
+                    "warn: YOETZ_ALLOW_USER_TAB_ANCHOR=1 — using user tab `{}` as window.open anchor (anchor is not navigated; yoetz only spawns a sibling tab from it)",
+                    anchor.url
+                );
+                self.open_page_via_anchor_target(
+                    &anchor,
+                    url,
+                    background,
+                    timeout_ms,
+                    browser_context_id,
+                    "opt-in user tab",
+                )
+                .await?
+            }
+        };
+        configure_tab_timeout(&tab, timeout_ms);
+        tab.wait_until_navigated()
+            .with_context(|| format!("waiting for Chrome page `{url}` to finish navigating"))?;
+        self.set_selected_tab(tab.clone());
+
+        Ok(NewPageResult {
+            page_id: tab.get_target_id().to_string(),
         })
     }
 
@@ -197,12 +524,27 @@ impl CdpMcpClient {
         &self,
         timeout_ms: u64,
     ) -> Result<Option<ReusedPageResult>> {
-        let candidates = self.chatgpt_tabs();
+        let candidates = if mutate_existing_chatgpt_tab_allowed() {
+            // Explicit operator opt-in: auth probing may attach to an existing
+            // user-owned ChatGPT tab instead of requiring a yoetz-owned probe
+            // tab. This avoids fighting Chrome's new-target restrictions on
+            // logged-in default profiles.
+            self.chatgpt_page_targets(None)?
+        } else {
+            // Default: only reuse a ChatGPT tab that yoetz itself stamped with
+            // `?_yoetz=<run-id>`. Touching a user-owned ChatGPT conversation —
+            // even just for a read-only probe — violates the fresh-tab contract
+            // and can surface yoetz's automation on an in-flight chat.
+            self.chatgpt_page_targets(None)?
+                .into_iter()
+                .filter(|target| is_yoetz_owned_url(&target.url))
+                .collect::<Vec<_>>()
+        };
         if candidates.is_empty() {
             return Ok(None);
         }
 
-        let tab = select_chatgpt_probe_tab(candidates, timeout_ms);
+        let tab = self.select_chatgpt_probe_target(candidates, timeout_ms)?;
         configure_tab_timeout(&tab, timeout_ms);
         self.set_selected_tab(tab.clone());
 
@@ -282,9 +624,19 @@ impl CdpMcpClient {
             let _ = element.click();
         }
 
-        let input = tab
-            .find_element("input[type='file']")
-            .context("no file input became available after clicking the upload affordance")?;
+        // The uid lookup failed, meaning the scoped snapshot target is no
+        // longer in the DOM. Limit the fallback to the composer-scoped marker
+        // (`title="yoetz-upload-target"`) so we never inject the bundle into
+        // an unrelated hidden file input (review finding #10).
+        let marker_selector = format!(
+            "input[type='file'][title='{}']",
+            crate::chatgpt_web::COMPOSER_FILE_INPUT_MARKER
+        );
+        let input = tab.find_element(&marker_selector).with_context(|| {
+            format!(
+                "no composer-scoped file input (`{marker_selector}`) was available after clicking the upload affordance"
+            )
+        })?;
         let result = inject_files_on_input(&tab, &input, file_path, uid);
         let _ = tab.set_file_chooser_dialog_interception(false, None);
         result
@@ -332,6 +684,13 @@ impl CdpMcpClient {
         Ok(response.get("value").cloned().unwrap_or(Value::Null))
     }
 
+    pub fn select_page_target(&self, target_id: &str, timeout_ms: u64) -> Result<()> {
+        let tab = self.attach_page_target(target_id)?;
+        configure_tab_timeout(&tab, timeout_ms);
+        self.set_selected_tab(tab);
+        Ok(())
+    }
+
     pub fn close_selected_page(&self, fire_unload: bool) -> Result<()> {
         let tab = self.selected_tab()?;
         tab.close(fire_unload)
@@ -353,17 +712,464 @@ impl CdpMcpClient {
             .context("no Chrome page is currently selected; call `new_page` first")
     }
 
-    fn chatgpt_tabs(&self) -> Vec<Arc<Tab>> {
-        self.browser.register_missing_tabs();
-        self.browser
-            .get_tabs()
-            .lock()
-            .unwrap()
-            .iter()
-            .filter(|tab| is_chatgpt_url(&tab.get_url()))
-            .cloned()
-            .collect::<Vec<_>>()
+    pub fn browser_context_summaries(&self) -> Result<Vec<BrowserContextSummary>> {
+        Ok(summarize_browser_contexts(&self.browser_context_pages()?))
     }
+
+    pub fn resolve_browser_context_id(
+        &self,
+        explicit_context_id: Option<&str>,
+        requested_email: Option<&str>,
+    ) -> Result<Option<String>> {
+        let explicit_context_id = explicit_context_id
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let requested_email = requested_email
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        if explicit_context_id.is_none() && requested_email.is_none() {
+            return Ok(None);
+        }
+
+        let contexts = self.browser_context_summaries()?;
+        if let Some(context_id) = explicit_context_id {
+            let selected = contexts
+                .iter()
+                .find(|context| context.id.as_deref() == Some(context_id))
+                .with_context(|| {
+                    format!(
+                        "browser_context_id `{context_id}` did not match any live Chrome browser context. Available contexts: {}",
+                        render_browser_contexts_for_error(&contexts)
+                    )
+                })?;
+            if let Some(requested_email) = requested_email {
+                if !selected.matches_email(requested_email) {
+                    bail!(
+                        "browser_context_id `{context_id}` did not match profile_email `{requested_email}`. Selected context: {}",
+                        selected.render_for_error()
+                    );
+                }
+            }
+            return Ok(Some(context_id.to_string()));
+        }
+
+        self.resolve_browser_context_id_for_email(&contexts, requested_email)
+    }
+
+    fn resolve_browser_context_id_for_email(
+        &self,
+        contexts: &[BrowserContextSummary],
+        requested_email: Option<&str>,
+    ) -> Result<Option<String>> {
+        let Some(requested_email) = requested_email
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            return Ok(None);
+        };
+
+        let matches = contexts
+            .iter()
+            .filter(|context| context.matches_email(requested_email))
+            .collect::<Vec<_>>();
+        match matches.len() {
+            0 => bail!(
+                "profile_email `{requested_email}` did not match any live Chrome browser context. Available contexts: {}",
+                render_browser_contexts_for_error(contexts)
+            ),
+            1 => Ok(matches[0].id.clone()),
+            _ => bail!(
+                "profile_email `{requested_email}` matched multiple live Chrome browser contexts. Matching contexts: {}",
+                matches
+                    .iter()
+                    .map(|context| context.render_for_error())
+                    .collect::<Vec<_>>()
+                    .join(" | ")
+            ),
+        }
+    }
+
+    fn browser_context_pages(&self) -> Result<Vec<BrowserContextPage>> {
+        Ok(self
+            .browser
+            .get_page_targets()?
+            .into_iter()
+            .map(browser_context_page_from_target_info)
+            .collect::<Vec<_>>())
+    }
+
+    fn page_targets_in_optional_browser_context(
+        &self,
+        browser_context_id: Option<&str>,
+    ) -> Result<Vec<TargetInfo>> {
+        Ok(self
+            .browser
+            .get_page_targets()?
+            .into_iter()
+            .filter(|target| {
+                browser_context_id
+                    .is_none_or(|expected| target.browser_context_id.as_deref() == Some(expected))
+            })
+            .collect::<Vec<_>>())
+    }
+
+    async fn wait_for_recovery_anchor_candidates(
+        &self,
+        browser_context_id: Option<&str>,
+        timeout_ms: u64,
+    ) -> Result<Vec<TargetInfo>> {
+        let deadline = Instant::now() + Duration::from_millis(timeout_ms.max(1));
+        let mut last_count = None;
+        loop {
+            let page_targets = self.page_targets_in_optional_browser_context(browser_context_id)?;
+            if cdp_debug_enabled() && last_count != Some(page_targets.len()) {
+                eprintln!(
+                    "info: chrome-devtools-mcp recovery anchor scan in {}: page_targets={}",
+                    browser_context_label(browser_context_id),
+                    page_targets.len(),
+                );
+                last_count = Some(page_targets.len());
+            }
+            if !page_targets.is_empty() || Instant::now() >= deadline {
+                return Ok(page_targets);
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+    }
+
+    fn select_reusable_optional_context_target(
+        &self,
+        browser_context_id: Option<&str>,
+    ) -> Result<Option<TargetInfo>> {
+        Ok(self
+            .page_targets_in_optional_browser_context(browser_context_id)?
+            .into_iter()
+            .filter_map(|target| context_tab_reuse_rank(&target.url).map(|rank| (rank, target)))
+            .min_by_key(|(rank, _)| *rank)
+            .map(|(_, target)| target))
+    }
+
+    fn attach_page_target(&self, target_id: &str) -> Result<Arc<Tab>> {
+        self.browser
+            .attach_to_page_target(target_id)?
+            .with_context(|| format!("page target `{target_id}` disappeared before attach"))
+    }
+
+    async fn open_page_via_anchor_target(
+        &self,
+        anchor_target: &TargetInfo,
+        url: &str,
+        background: bool,
+        timeout_ms: u64,
+        browser_context_id: Option<&str>,
+        anchor_label: &str,
+    ) -> Result<Arc<Tab>> {
+        let before = self
+            .page_targets_in_optional_browser_context(browser_context_id)?
+            .into_iter()
+            .map(|target| target.target_id)
+            .collect::<BTreeSet<_>>();
+        let anchor = self.attach_page_target(&anchor_target.target_id)?;
+        configure_tab_timeout(&anchor, timeout_ms);
+        anchor
+            .evaluate(&build_window_open_expression(url)?, false)
+            .with_context(|| {
+                format!("opening a new Chrome page for `{url}` from {anchor_label} failed")
+            })?;
+
+        let deadline = Instant::now() + Duration::from_millis(timeout_ms);
+        loop {
+            let maybe_target = self
+                .page_targets_in_optional_browser_context(browser_context_id)?
+                .into_iter()
+                .find(|target| {
+                    !before.contains(&target.target_id)
+                        && (target.url.is_empty()
+                            || target.url == "about:blank"
+                            || target.url.starts_with(url))
+                });
+            if let Some(target) = maybe_target {
+                let tab = self.attach_page_target(&target.target_id)?;
+                if !background {
+                    let _ = tab.activate();
+                    let _ = tab.bring_to_front();
+                }
+                return Ok(tab);
+            }
+
+            if Instant::now() >= deadline {
+                bail!(
+                    "no new tab for `{url}` appeared in {} within {timeout_ms}ms",
+                    browser_context_label(browser_context_id)
+                );
+            }
+
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+    }
+
+    async fn open_page_via_existing_context_tab(
+        &self,
+        url: &str,
+        background: bool,
+        timeout_ms: u64,
+        browser_context_id: Option<&str>,
+    ) -> Result<Arc<Tab>> {
+        // Never execute our `window.open(...)` script inside a tab we don't
+        // own. Running JS on an arbitrary user tab (Meet, Gmail, etc.) even
+        // for a benign side-effect is a leak of yoetz's automation surface
+        // into the user's private browsing context. Restrict the anchor to
+        // blank / yoetz-owned tabs — the same surface that
+        // `context_tab_reuse_rank` deems safe to touch.
+        let anchor = self
+            .select_reusable_optional_context_target(browser_context_id)?
+            .with_context(|| {
+                format!(
+                    "Chrome rejected {} for direct target creation, and there is no yoetz-safe (blank or yoetz-owned) tab in that context to open `{url}` from without touching user tabs",
+                    browser_context_label(browser_context_id)
+                )
+            })?;
+        self.open_page_via_anchor_target(
+            &anchor,
+            url,
+            background,
+            timeout_ms,
+            browser_context_id,
+            &browser_context_label(browser_context_id),
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "Chrome rejected {} for direct target creation",
+                browser_context_label(browser_context_id)
+            )
+        })
+    }
+
+    async fn reuse_existing_context_tab(
+        &self,
+        url: &str,
+        background: bool,
+        timeout_ms: u64,
+        browser_context_id: &str,
+    ) -> Result<Arc<Tab>> {
+        self.reuse_existing_optional_context_tab(url, background, timeout_ms, Some(browser_context_id))
+            .await
+            .with_context(|| {
+                format!(
+                    "Chrome rejected browser_context_id `{browser_context_id}` for direct target creation"
+                )
+            })
+    }
+
+    async fn reuse_page_target(
+        &self,
+        target: &TargetInfo,
+        url: &str,
+        background: bool,
+        timeout_ms: u64,
+    ) -> Result<Arc<Tab>> {
+        let tab = self.attach_page_target(&target.target_id)?;
+        configure_tab_timeout(&tab, timeout_ms);
+        if !background {
+            let _ = tab.activate();
+            let _ = tab.bring_to_front();
+        }
+        tab.navigate_to(url)
+            .with_context(|| {
+                format!(
+                    "navigating existing page target `{}` to `{url}` failed",
+                    target.target_id
+                )
+            })?
+            .wait_until_navigated()
+            .with_context(|| {
+                format!(
+                    "waiting for page target `{}` to finish navigating to `{url}` failed",
+                    target.target_id
+                )
+            })?;
+        Ok(tab)
+    }
+
+    fn chatgpt_page_targets(&self, browser_context_id: Option<&str>) -> Result<Vec<TargetInfo>> {
+        Ok(self
+            .page_targets_in_optional_browser_context(browser_context_id)?
+            .iter()
+            .filter(|target| is_chatgpt_url(&target.url))
+            .cloned()
+            .collect::<Vec<_>>())
+    }
+
+    fn select_chatgpt_probe_target(
+        &self,
+        candidates: Vec<TargetInfo>,
+        timeout_ms: u64,
+    ) -> Result<Arc<Tab>> {
+        if candidates.len() == 1 {
+            return self.attach_page_target(&candidates[0].target_id);
+        }
+
+        let probes = candidates
+            .iter()
+            .map(|target| self.probe_chatgpt_target(target, timeout_ms))
+            .collect::<Vec<_>>();
+        let index = choose_chatgpt_probe_index(&probes);
+        self.attach_page_target(&candidates[index].target_id)
+    }
+
+    fn probe_chatgpt_target(&self, target: &TargetInfo, timeout_ms: u64) -> ChatgptTabProbe {
+        self.attach_page_target(&target.target_id)
+            .map(|tab| probe_chatgpt_tab(&tab, timeout_ms))
+            .unwrap_or_else(|_| ChatgptTabProbe {
+                url: target.url.clone(),
+                visible: false,
+                has_focus: false,
+                is_generating: false,
+            })
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum ChatgptRecoveryStrategy {
+    ReuseExistingChatgptTab,
+    ExistingChatgptAnchor,
+    ExistingSafeAnchor,
+    /// Caller opted in via YOETZ_ALLOW_USER_TAB_ANCHOR. Pick any existing
+    /// page as the `window.open` anchor — the anchor itself is not
+    /// navigated; we only run `window.open(marked_url, '_blank')` on it to
+    /// spawn a sibling tab.
+    AnyUserPageAnchor,
+}
+
+pub(crate) fn is_external_create_target_block_error(err: &anyhow::Error) -> bool {
+    let message = format!("{err:#}").to_ascii_lowercase();
+    message.contains("target.createtarget")
+        && message.contains("chrome://inspect/#remote-debugging")
+        && message.contains("new-tab creation")
+}
+
+fn should_classify_external_create_target_block(
+    err: &anyhow::Error,
+    browser_context_id: Option<&str>,
+) -> bool {
+    browser_context_id.is_none() && is_closed_cdp_transport_error(err)
+}
+
+/// Environment flag that opts into using any existing user tab as the
+/// `window.open` anchor for the ChatGPT recovery flow. Default: off.
+///
+/// The anchor is never navigated away from; yoetz only runs
+/// `window.open(marked_url, '_blank')` inside it to spawn a fresh
+/// yoetz-owned tab. But that still executes a one-off JS call inside a tab
+/// yoetz does not own — which we refuse by default (review finding #8 and
+/// the Meet-tab near-miss). Set this env var when the operator has
+/// explicitly consented to yoetz touching arbitrary tabs on this run.
+pub const YOETZ_ALLOW_USER_TAB_ANCHOR_ENV: &str = "YOETZ_ALLOW_USER_TAB_ANCHOR";
+
+pub(crate) fn user_tab_anchor_allowed() -> bool {
+    std::env::var(YOETZ_ALLOW_USER_TAB_ANCHOR_ENV)
+        .map(|value| {
+            let trimmed = value.trim();
+            !trimmed.is_empty()
+                && !trimmed.eq_ignore_ascii_case("0")
+                && !trimmed.eq_ignore_ascii_case("false")
+        })
+        .unwrap_or(false)
+}
+
+/// Stronger opt-in than YOETZ_ALLOW_USER_TAB_ANCHOR: allow yoetz to directly
+/// navigate an existing ChatGPT tab instead of insisting on opening a fresh
+/// sibling tab. This is useful on locked-down default-profile Chrome builds
+/// where new target creation is the main failure mode, but it mutates the
+/// user's current ChatGPT page and therefore remains opt-in.
+pub const YOETZ_ALLOW_MUTATE_EXISTING_CHATGPT_TAB_ENV: &str =
+    "YOETZ_ALLOW_MUTATE_EXISTING_CHATGPT_TAB";
+
+fn mutate_existing_chatgpt_tab_allowed() -> bool {
+    std::env::var(YOETZ_ALLOW_MUTATE_EXISTING_CHATGPT_TAB_ENV)
+        .map(|value| {
+            let trimmed = value.trim();
+            !trimmed.is_empty()
+                && !trimmed.eq_ignore_ascii_case("0")
+                && !trimmed.eq_ignore_ascii_case("false")
+        })
+        .unwrap_or(false)
+}
+
+fn choose_chatgpt_recovery_strategy(
+    has_chatgpt_anchor: bool,
+    safe_anchor_url: Option<&str>,
+    browser_context_id: Option<&str>,
+    url: &str,
+) -> Result<ChatgptRecoveryStrategy> {
+    if has_chatgpt_anchor {
+        if mutate_existing_chatgpt_tab_allowed() {
+            return Ok(ChatgptRecoveryStrategy::ReuseExistingChatgptTab);
+        }
+        return Ok(ChatgptRecoveryStrategy::ExistingChatgptAnchor);
+    }
+    if safe_anchor_url.is_some_and(|value| context_tab_reuse_rank(value).is_some()) {
+        return Ok(ChatgptRecoveryStrategy::ExistingSafeAnchor);
+    }
+    if user_tab_anchor_allowed() {
+        // Caller opted in via YOETZ_ALLOW_USER_TAB_ANCHOR=1. Use any existing
+        // page as the `window.open` anchor — the anchor is still not
+        // navigated; we just spawn a sibling tab from it. Marked user-opt-in
+        // so the default still refuses to touch non-yoetz tabs.
+        return Ok(ChatgptRecoveryStrategy::AnyUserPageAnchor);
+    }
+    bail!(
+        "Chrome rejected {} for direct target creation, and there is no existing ChatGPT tab or yoetz-safe (blank or yoetz-owned) tab in that context to open `{url}` from without touching user tabs. Set {}=1 to explicitly allow yoetz to use any existing tab as the window.open anchor (the anchor itself is not navigated).",
+        browser_context_label(browser_context_id),
+        YOETZ_ALLOW_USER_TAB_ANCHOR_ENV
+    );
+}
+
+fn is_closed_cdp_transport_error(err: &anyhow::Error) -> bool {
+    let message = format!("{err:#}").to_ascii_lowercase();
+    message.contains("underlying connection is closed")
+        || message.contains("connectionclosed")
+        || message.contains("received shutdown message")
+}
+
+fn external_create_target_block_guidance(url: &str) -> String {
+    format!(
+        "Chrome's default-profile CDP endpoint likely rejected external `Target.createTarget` while opening `{url}`. Chrome 146+/147 can allow attach/read operations but close the session on new-tab creation for untrusted clients. First, open chrome://inspect/#remote-debugging, refresh Discover network targets (or Open dedicated DevTools for Node), and retry. If Chrome still closes the session, launch Chrome with `--remote-debugging-port=9222 --user-data-dir=/tmp/chrome-debug` and pass `--cdp`, or use Chrome for Testing."
+    )
+}
+
+impl CdpMcpClient {
+    async fn reuse_existing_optional_context_tab(
+        &self,
+        url: &str,
+        background: bool,
+        timeout_ms: u64,
+        browser_context_id: Option<&str>,
+    ) -> Result<Arc<Tab>> {
+        let target = self
+            .select_reusable_optional_context_target(browser_context_id)?
+            .with_context(|| {
+                format!(
+                    "there is no reusable blank or yoetz-owned tab in {} to navigate to `{url}`",
+                    browser_context_label(browser_context_id)
+                )
+            })?;
+        self.reuse_page_target(&target, url, background, timeout_ms)
+            .await
+            .with_context(|| {
+                format!(
+                    "navigating an existing Chrome tab to `{url}` inside {} failed",
+                    browser_context_label(browser_context_id)
+                )
+            })
+    }
+}
+
+fn browser_context_label(browser_context_id: Option<&str>) -> String {
+    browser_context_id
+        .map(|id| format!("browser_context_id `{id}`"))
+        .unwrap_or_else(|| "the default browser context".to_string())
 }
 
 fn resolve_connect_ws_endpoint(cdp_endpoint: Option<&str>) -> Result<String> {
@@ -413,7 +1219,56 @@ pub fn discover_running_chrome_targets() -> Vec<RunningChromeTarget> {
     targets
 }
 
-fn create_target(url: &str, background: bool) -> CreateTarget {
+pub fn discover_devtools_active_port_files() -> Vec<DevtoolsActivePortFile> {
+    let mut files = Vec::new();
+    for path in devtools_active_port_candidates() {
+        let Ok(contents) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let modified_at = std::fs::metadata(&path)
+            .ok()
+            .and_then(|metadata| metadata.modified().ok());
+        let ws_endpoint = parse_devtools_active_port(&contents, None);
+        let healthy = ws_endpoint
+            .as_deref()
+            .and_then(|endpoint| describe_running_chrome_target(endpoint, &path, modified_at))
+            .is_some();
+        files.push(DevtoolsActivePortFile {
+            path,
+            ws_endpoint,
+            modified_at,
+            healthy,
+        });
+    }
+    files
+}
+
+pub fn discover_local_chromium_processes() -> Vec<ChromiumProcessSummary> {
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    {
+        let Ok(output) = Command::new("ps")
+            .args(["axww", "-o", "pid=,command="])
+            .output()
+        else {
+            return Vec::new();
+        };
+        if !output.status.success() {
+            return Vec::new();
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        stdout
+            .lines()
+            .filter_map(parse_local_chromium_process_line)
+            .collect()
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        Vec::new()
+    }
+}
+
+fn create_target(url: &str, background: bool, browser_context_id: Option<&str>) -> CreateTarget {
     CreateTarget {
         url: url.to_owned(),
         left: None,
@@ -421,7 +1276,7 @@ fn create_target(url: &str, background: bool) -> CreateTarget {
         width: None,
         height: None,
         window_state: None,
-        browser_context_id: None,
+        browser_context_id: browser_context_id.map(str::to_owned),
         enable_begin_frame_control: None,
         new_window: None,
         background: Some(background),
@@ -432,24 +1287,6 @@ fn create_target(url: &str, background: bool) -> CreateTarget {
 
 fn configure_tab_timeout(tab: &Arc<Tab>, timeout_ms: u64) {
     tab.set_default_timeout(Duration::from_millis(timeout_ms.max(1)));
-}
-
-fn select_chatgpt_reuse_tab(candidates: Vec<Arc<Tab>>, timeout_ms: u64) -> Result<Arc<Tab>> {
-    match candidates.len() {
-        0 => bail!("thread=reuse requires an existing ChatGPT tab, but none are currently open"),
-        1 => Ok(candidates.into_iter().next().expect("single candidate")),
-        _ => {
-            let probes = candidates
-                .iter()
-                .map(|tab| probe_chatgpt_tab(tab, timeout_ms))
-                .collect::<Vec<_>>();
-            let index = choose_chatgpt_reuse_probe(&probes)?;
-            Ok(candidates
-                .into_iter()
-                .nth(index)
-                .expect("chosen probe index should map to a candidate"))
-        }
-    }
 }
 
 fn select_chatgpt_probe_tab(candidates: Vec<Arc<Tab>>, timeout_ms: u64) -> Arc<Tab> {
@@ -476,65 +1313,6 @@ struct ChatgptTabProbe {
     is_generating: bool,
 }
 
-fn choose_chatgpt_reuse_probe(probes: &[ChatgptTabProbe]) -> Result<usize> {
-    if probes.is_empty() {
-        bail!("no ChatGPT tabs were available for reuse");
-    }
-
-    let available = probes
-        .iter()
-        .enumerate()
-        .filter(|(_, probe)| !probe.is_generating)
-        .map(|(index, _)| index)
-        .collect::<Vec<_>>();
-    if available.is_empty() {
-        bail!(
-            "thread=reuse found ChatGPT tabs, but all of them are still generating. \
-             Wait for the current run to finish or use `--var thread=fresh`."
-        );
-    }
-
-    let focused = probes
-        .iter()
-        .enumerate()
-        .filter(|(index, probe)| probe.has_focus && available.contains(index))
-        .map(|(index, _)| index)
-        .collect::<Vec<_>>();
-    if focused.len() == 1 {
-        return Ok(focused[0]);
-    }
-
-    let visible = probes
-        .iter()
-        .enumerate()
-        .filter(|(index, probe)| probe.visible && available.contains(index))
-        .map(|(index, _)| index)
-        .collect::<Vec<_>>();
-    if visible.len() == 1 {
-        return Ok(visible[0]);
-    }
-
-    if available.len() == 1 {
-        return Ok(available[0]);
-    }
-
-    let rendered = probes
-        .iter()
-        .enumerate()
-        .map(|(index, probe)| {
-            format!(
-                "#{index}: visible={}, focus={}, generating={}, url={}",
-                probe.visible, probe.has_focus, probe.is_generating, probe.url
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("; ");
-    bail!(
-        "thread=reuse found multiple ChatGPT tabs but could not identify a unique active tab. \
-         Keep only one ChatGPT tab visible or use `--var thread=fresh`. Candidates: {rendered}"
-    );
-}
-
 fn choose_chatgpt_probe_index(probes: &[ChatgptTabProbe]) -> usize {
     let focused = probes
         .iter()
@@ -557,6 +1335,181 @@ fn choose_chatgpt_probe_index(probes: &[ChatgptTabProbe]) -> usize {
     }
 
     0
+}
+
+pub(crate) fn infer_email_hints(title: &str, url: &str) -> Vec<String> {
+    // Spoofing guard: only trust emails that appear on origins where the
+    // signed-in user's own email naturally surfaces. Every other tab — news
+    // sites, social feeds, chat apps — can carry arbitrary `foo@bar.com`
+    // tokens that must not influence `profile_email` matching (review
+    // finding #9).
+    if !is_trusted_email_origin(url) {
+        return Vec::new();
+    }
+    let mut hints = BTreeSet::new();
+    for source in [title, url] {
+        for token in source.split(email_split_char) {
+            let trimmed = trim_email_token(token);
+            if looks_like_email(trimmed) {
+                hints.insert(trimmed.to_ascii_lowercase());
+            }
+        }
+    }
+    hints.into_iter().collect()
+}
+
+pub(crate) fn is_trusted_email_origin(url: &str) -> bool {
+    let Ok(parsed) = Url::parse(url.trim()) else {
+        return false;
+    };
+    let scheme = parsed.scheme();
+    if scheme != "http" && scheme != "https" {
+        return false;
+    }
+    let Some(host) = parsed.host_str() else {
+        return false;
+    };
+    let host = host.to_ascii_lowercase();
+    EMAIL_INFERENCE_TRUSTED_ORIGINS
+        .iter()
+        .any(|trusted| host == *trusted || host.ends_with(&format!(".{trusted}")))
+}
+
+fn summarize_browser_contexts(pages: &[BrowserContextPage]) -> Vec<BrowserContextSummary> {
+    let mut grouped = BTreeMap::<Option<String>, Vec<&BrowserContextPage>>::new();
+    for page in pages {
+        grouped
+            .entry(page.browser_context_id.clone())
+            .or_default()
+            .push(page);
+    }
+
+    grouped
+        .into_iter()
+        .map(|(id, pages)| {
+            let inferred_emails = pages
+                .iter()
+                .flat_map(|page| infer_email_hints(&page.title, &page.url))
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
+            let chatgpt_tab_count = pages
+                .iter()
+                .filter(|page| is_chatgpt_url(&page.url))
+                .count();
+            let sample_tabs = pages
+                .iter()
+                .filter_map(|page| summarize_context_page(page))
+                .take(4)
+                .collect::<Vec<_>>();
+            BrowserContextSummary {
+                id,
+                inferred_emails,
+                chatgpt_tab_count,
+                page_target_count: pages.len(),
+                sample_tabs,
+            }
+        })
+        .collect()
+}
+
+fn browser_context_page_from_target_info(info: TargetInfo) -> BrowserContextPage {
+    BrowserContextPage {
+        browser_context_id: info.browser_context_id,
+        title: info.title,
+        url: info.url,
+    }
+}
+
+fn summarize_context_page(page: &BrowserContextPage) -> Option<String> {
+    let title = page.title.trim();
+    if !title.is_empty() {
+        return Some(title.to_string());
+    }
+    let url = page.url.trim();
+    if url.is_empty() {
+        return None;
+    }
+    Some(url.to_string())
+}
+
+fn render_browser_contexts_for_error(contexts: &[BrowserContextSummary]) -> String {
+    if contexts.is_empty() {
+        return "<none>".to_string();
+    }
+    contexts
+        .iter()
+        .map(BrowserContextSummary::render_for_error)
+        .collect::<Vec<_>>()
+        .join(" | ")
+}
+
+fn is_missing_browser_context_error(err: &anyhow::Error) -> bool {
+    let raw = format!("{err:#}").to_ascii_lowercase();
+    raw.contains("failed to find browser context with id")
+}
+
+fn build_window_open_expression(url: &str) -> Result<String> {
+    Ok(format!(
+        "window.open({}, '_blank');",
+        serde_json::to_string(url).context("serializing window.open url")?
+    ))
+}
+
+fn email_split_char(ch: char) -> bool {
+    ch.is_whitespace()
+        || matches!(
+            ch,
+            '<' | '>'
+                | '('
+                | ')'
+                | '['
+                | ']'
+                | '{'
+                | '}'
+                | '"'
+                | '\''
+                | '|'
+                | ','
+                | ';'
+                | '/'
+                | '?'
+                | '&'
+                | '='
+                | ':'
+        )
+}
+
+fn trim_email_token(token: &str) -> &str {
+    token.trim_matches(|ch: char| {
+        matches!(
+            ch,
+            '.' | ':' | '!' | '?' | '/' | '\\' | '#' | '&' | '=' | '%'
+        )
+    })
+}
+
+fn looks_like_email(candidate: &str) -> bool {
+    let Some((local, domain)) = candidate.split_once('@') else {
+        return false;
+    };
+    if local.is_empty()
+        || domain.is_empty()
+        || domain.starts_with('.')
+        || domain.ends_with('.')
+        || !domain.contains('.')
+    {
+        return false;
+    }
+    local.chars().all(is_email_local_char) && domain.chars().all(is_email_domain_char)
+}
+
+fn is_email_local_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '%' | '+' | '-')
+}
+
+fn is_email_domain_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-')
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -632,7 +1585,14 @@ fn inject_files_on_input(
 
 fn resolve_browser_websocket(parsed: &Url) -> Result<String> {
     match parsed.scheme() {
-        "ws" | "wss" => Ok(parsed.as_str().to_owned()),
+        "ws" | "wss" => {
+            if !is_loopback_host(parsed.host_str()) && !cdp_remote_redirects_allowed() {
+                bail!(
+                    "Chrome CDP endpoint `{parsed}` is not on localhost; set {YOETZ_CDP_ALLOW_REMOTE_ENV}=1 to allow remote CDP targets"
+                );
+            }
+            Ok(parsed.as_str().to_owned())
+        }
         _ => {
             if let Some(ws_endpoint) = resolve_devtools_active_port_ws(parsed) {
                 return Ok(ws_endpoint);
@@ -663,8 +1623,34 @@ fn resolve_browser_websocket_via_json_version(endpoint: &Url) -> Result<String> 
     .join()
     .map_err(|_| anyhow!("requesting `{version_url}` panicked"))??;
 
-    browser_websocket_from_json_version_payload(&payload)
-        .with_context(|| format!("`{version_url}` did not expose a valid browser websocket URL"))
+    let raw_ws = browser_websocket_from_json_version_payload(&payload)
+        .with_context(|| format!("`{version_url}` did not expose a valid browser websocket URL"))?;
+    validate_discovered_ws_host(&raw_ws, endpoint).with_context(|| {
+        format!("`{version_url}` returned a websocket URL pointing at a different host/port")
+    })?;
+    Ok(raw_ws)
+}
+
+fn validate_discovered_ws_host(ws_endpoint: &str, origin: &Url) -> Result<()> {
+    let parsed = Url::parse(ws_endpoint)
+        .with_context(|| format!("parsing discovered websocket URL `{ws_endpoint}` failed"))?;
+    let origin_host = origin.host_str();
+    let origin_port = origin.port_or_known_default();
+    let ws_host = parsed.host_str();
+    let ws_port = parsed.port_or_known_default();
+    if origin_host == ws_host && origin_port == ws_port {
+        return Ok(());
+    }
+    if cdp_remote_redirects_allowed() {
+        return Ok(());
+    }
+    // Default: refuse to follow a CDP discovery that points at a different
+    // host/port than the one we originally dialed. Set
+    // YOETZ_CDP_ALLOW_REMOTE=1 to opt in (review finding #5).
+    bail!(
+        "discovered websocket `{ws_endpoint}` is on a different host/port than the requested endpoint `{origin}`; \
+         set {YOETZ_CDP_ALLOW_REMOTE_ENV}=1 to allow cross-host CDP redirects"
+    )
 }
 
 fn browser_version_url(endpoint: &Url) -> Result<Url> {
@@ -729,28 +1715,164 @@ fn describe_running_chrome_target(
         .filter(|browser| !browser.is_empty())
         .map(ToOwned::to_owned)
         .unwrap_or_else(|| browser_name_from_source_path(source_path));
-    let chatgpt_tab_count = fetch_chatgpt_tab_count(ws_endpoint).unwrap_or(0);
+    let target_summary = fetch_target_list_summary(ws_endpoint).unwrap_or_default();
     Some(RunningChromeTarget {
         ws_endpoint: ws_endpoint.to_string(),
         source_path: source_path.to_path_buf(),
         browser_name,
-        chatgpt_tab_count,
+        chatgpt_tab_count: target_summary.chatgpt_tab_count,
+        page_target_count: target_summary.page_target_count,
+        page_samples: target_summary.page_samples,
         modified_at,
     })
 }
 
-fn fetch_chatgpt_tab_count(ws_endpoint: &str) -> Option<usize> {
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
+struct TargetListSummary {
+    chatgpt_tab_count: usize,
+    page_target_count: usize,
+    page_samples: Vec<String>,
+}
+
+fn fetch_target_list_summary(ws_endpoint: &str) -> Option<TargetListSummary> {
     let entries = local_http_json::<Vec<DevtoolsTargetListEntry>>(ws_endpoint, "/json/list")?;
-    Some(
-        entries
-            .iter()
-            .filter(|entry| entry.target_type.as_deref() == Some("page"))
-            .filter(|entry| {
-                entry.url.as_deref().is_some_and(is_chatgpt_url)
-                    || (entry.url.as_deref().is_none() && is_chatgpt_title(entry.title.as_deref()))
-            })
-            .count(),
-    )
+    let page_entries = entries
+        .iter()
+        .filter(|entry| entry.target_type.as_deref() == Some("page"))
+        .collect::<Vec<_>>();
+    let chatgpt_tab_count = page_entries
+        .iter()
+        .filter(|entry| {
+            entry.url.as_deref().is_some_and(is_chatgpt_url)
+                || (entry.url.as_deref().is_none() && is_chatgpt_title(entry.title.as_deref()))
+        })
+        .count();
+    let page_samples = page_entries
+        .iter()
+        .filter_map(|entry| summarize_page_target(entry))
+        .take(3)
+        .collect::<Vec<_>>();
+    Some(TargetListSummary {
+        chatgpt_tab_count,
+        page_target_count: page_entries.len(),
+        page_samples,
+    })
+}
+
+fn summarize_page_target(entry: &DevtoolsTargetListEntry) -> Option<String> {
+    let title = entry.title.as_deref().map(str::trim).unwrap_or("");
+    if !title.is_empty() {
+        return Some(title.to_string());
+    }
+    let url = entry.url.as_deref()?.trim();
+    if url.is_empty() {
+        return None;
+    }
+    Some(url.to_string())
+}
+
+fn parse_local_chromium_process_line(line: &str) -> Option<ChromiumProcessSummary> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let mut parts = trimmed.splitn(2, char::is_whitespace);
+    let pid = parts.next()?.trim().parse().ok()?;
+    let command = parts.next()?.trim().to_string();
+    let browser_name = browser_name_from_process_command(&command)?;
+    if !is_top_level_chromium_browser_command(&command) {
+        return None;
+    }
+    let has_remote_debugging =
+        command.contains("--remote-debugging-port") || command.contains("--remote-debugging-pipe");
+    Some(ChromiumProcessSummary {
+        pid,
+        browser_name,
+        user_data_dir: extract_flag_value(&command, "--user-data-dir"),
+        command,
+        has_remote_debugging,
+    })
+}
+
+fn browser_name_from_process_command(command: &str) -> Option<String> {
+    let lower = command.to_ascii_lowercase();
+    if lower.contains("google chrome.app/contents/macos/google chrome")
+        || lower == "google chrome"
+        || lower.ends_with("/google chrome")
+    {
+        Some("Chrome".to_string())
+    } else if lower.contains("google chrome beta.app/contents/macos/google chrome beta")
+        || lower == "google chrome beta"
+        || lower.ends_with("/google chrome beta")
+    {
+        Some("Chrome Beta".to_string())
+    } else if lower.contains("google chrome canary.app/contents/macos/google chrome canary")
+        || lower == "google chrome canary"
+        || lower.ends_with("/google chrome canary")
+    {
+        Some("Chrome Canary".to_string())
+    } else if lower
+        .contains("google chrome for testing.app/contents/macos/google chrome for testing")
+        || lower == "google chrome for testing"
+        || lower.ends_with("/google chrome for testing")
+    {
+        Some("Chrome for Testing".to_string())
+    } else if lower.contains("brave browser.app/contents/macos/brave browser")
+        || lower == "brave-browser"
+        || lower.ends_with("/brave-browser")
+    {
+        Some("Brave".to_string())
+    } else if lower.contains("microsoft edge.app/contents/macos/microsoft edge")
+        || lower == "microsoft-edge"
+        || lower.ends_with("/microsoft-edge")
+        || lower == "msedge"
+    {
+        Some("Edge".to_string())
+    } else if lower.contains("arc.app/contents/macos/arc")
+        || lower == "arc"
+        || lower.ends_with("/arc")
+    {
+        Some("Arc".to_string())
+    } else if lower.contains("chromium.app/contents/macos/chromium")
+        || lower == "chromium"
+        || lower.ends_with("/chromium")
+    {
+        Some("Chromium".to_string())
+    } else {
+        None
+    }
+}
+
+fn is_top_level_chromium_browser_command(command: &str) -> bool {
+    let lower = command.to_ascii_lowercase();
+    !lower.contains("helper")
+        && !lower.contains("crashpad")
+        && !lower.contains("chrome-native-host")
+        && !lower.contains("chrome-devtools-mcp")
+        && !lower.contains("browserextensionhelper")
+        && !lower.contains("--type=")
+}
+
+fn extract_flag_value(command: &str, flag: &str) -> Option<String> {
+    let prefix = format!("{flag}=");
+    let start = command.find(&prefix)? + prefix.len();
+    let remainder = &command[start..];
+    if remainder.is_empty() {
+        return Some(String::new());
+    }
+    let value = if let Some(quote) = remainder
+        .chars()
+        .next()
+        .filter(|ch| *ch == '"' || *ch == '\'')
+    {
+        let quoted = &remainder[quote.len_utf8()..];
+        let end = quoted.find(quote).unwrap_or(quoted.len());
+        &quoted[..end]
+    } else {
+        let end = remainder.find(" --").unwrap_or(remainder.len());
+        remainder[..end].trim_end()
+    };
+    Some(value.trim_matches('"').trim_matches('\'').to_string())
 }
 
 fn local_http_json<T: DeserializeOwned>(ws_endpoint: &str, path: &str) -> Option<T> {
@@ -810,50 +1932,127 @@ fn is_localhost_host(endpoint: &Url) -> bool {
 
 fn devtools_active_port_candidates() -> Vec<PathBuf> {
     let home = home_dir_candidates();
+    let mut candidates = Vec::new();
+    let mut seen = BTreeSet::new();
     match std::env::consts::OS {
-        "macos" => home
-            .into_iter()
-            .flat_map(|home| {
-                [
+        "macos" => {
+            for home in home {
+                for path in [
                     home.join("Library/Application Support/Google/Chrome/DevToolsActivePort"),
-                    home.join(
-                        "Library/Application Support/Google/Chrome Canary/DevToolsActivePort",
-                    ),
+                    home.join("Library/Application Support/Google/Chrome Canary/DevToolsActivePort"),
+                    home.join("Library/Application Support/Google/Chrome Beta/DevToolsActivePort"),
+                    home.join("Library/Application Support/Google/Chrome for Testing/DevToolsActivePort"),
                     home.join("Library/Application Support/Chromium/DevToolsActivePort"),
-                    home.join(
-                        "Library/Application Support/BraveSoftware/Brave-Browser/DevToolsActivePort",
-                    ),
-                ]
-            })
-            .collect(),
-        "windows" => home
-            .into_iter()
-            .flat_map(|home| {
-                [
+                    home.join("Library/Application Support/BraveSoftware/Brave-Browser/DevToolsActivePort"),
+                    home.join("Library/Application Support/Microsoft Edge/DevToolsActivePort"),
+                    home.join("Library/Application Support/Arc/DevToolsActivePort"),
+                ] {
+                    push_devtools_active_port_candidate(path, &mut candidates, &mut seen);
+                }
+                for root in [
+                    home.join("Library/Application Support/Google"),
+                    home.join("Library/Application Support/Chromium"),
+                    home.join("Library/Application Support/BraveSoftware"),
+                    home.join("Library/Application Support/Microsoft Edge"),
+                    home.join("Library/Application Support/Arc"),
+                ] {
+                    collect_devtools_active_ports(&root, 4, &mut candidates, &mut seen);
+                }
+            }
+        }
+        "windows" => {
+            for home in home {
+                for path in [
                     home.join("AppData/Local/Google/Chrome/User Data/DevToolsActivePort"),
-                    home.join(
-                        "AppData/Local/Google/Chrome Beta/User Data/DevToolsActivePort",
-                    ),
+                    home.join("AppData/Local/Google/Chrome Beta/User Data/DevToolsActivePort"),
                     home.join("AppData/Local/Google/Chrome SxS/User Data/DevToolsActivePort"),
+                    home.join(
+                        "AppData/Local/Google/Chrome for Testing/User Data/DevToolsActivePort",
+                    ),
                     home.join("AppData/Local/Chromium/User Data/DevToolsActivePort"),
                     home.join(
                         "AppData/Local/BraveSoftware/Brave-Browser/User Data/DevToolsActivePort",
                     ),
-                ]
-            })
-            .collect(),
-        _ => home
-            .into_iter()
-            .flat_map(|home| {
-                [
+                    home.join("AppData/Local/Microsoft/Edge/User Data/DevToolsActivePort"),
+                ] {
+                    push_devtools_active_port_candidate(path, &mut candidates, &mut seen);
+                }
+                for root in [
+                    home.join("AppData/Local/Google"),
+                    home.join("AppData/Local/Chromium"),
+                    home.join("AppData/Local/BraveSoftware"),
+                    home.join("AppData/Local/Microsoft"),
+                ] {
+                    collect_devtools_active_ports(&root, 4, &mut candidates, &mut seen);
+                }
+            }
+        }
+        _ => {
+            for home in home {
+                for path in [
                     home.join(".config/google-chrome/DevToolsActivePort"),
                     home.join(".config/chromium/DevToolsActivePort"),
                     home.join(".config/google-chrome-beta/DevToolsActivePort"),
                     home.join(".config/google-chrome-unstable/DevToolsActivePort"),
+                    home.join(".config/google-chrome-for-testing/DevToolsActivePort"),
                     home.join(".config/BraveSoftware/Brave-Browser/DevToolsActivePort"),
-                ]
-            })
-            .collect(),
+                    home.join(".config/microsoft-edge/DevToolsActivePort"),
+                    home.join(".config/Arc/DevToolsActivePort"),
+                ] {
+                    push_devtools_active_port_candidate(path, &mut candidates, &mut seen);
+                }
+                for root in [
+                    home.join(".config/google-chrome"),
+                    home.join(".config/chromium"),
+                    home.join(".config/BraveSoftware"),
+                    home.join(".config/microsoft-edge"),
+                    home.join(".config/Arc"),
+                ] {
+                    collect_devtools_active_ports(&root, 4, &mut candidates, &mut seen);
+                }
+            }
+        }
+    }
+    candidates
+}
+
+fn push_devtools_active_port_candidate(
+    path: PathBuf,
+    candidates: &mut Vec<PathBuf>,
+    seen: &mut BTreeSet<PathBuf>,
+) {
+    if seen.insert(path.clone()) {
+        candidates.push(path);
+    }
+}
+
+fn collect_devtools_active_ports(
+    root: &Path,
+    depth_remaining: usize,
+    candidates: &mut Vec<PathBuf>,
+    seen: &mut BTreeSet<PathBuf>,
+) {
+    if depth_remaining == 0 {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path
+            .file_name()
+            .is_some_and(|name| name == "DevToolsActivePort")
+        {
+            push_devtools_active_port_candidate(path, candidates, seen);
+            continue;
+        }
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() {
+            collect_devtools_active_ports(&path, depth_remaining - 1, candidates, seen);
+        }
     }
 }
 
@@ -875,8 +2074,14 @@ fn browser_name_from_source_path(source_path: &Path) -> String {
     let path = source_path.to_string_lossy().to_lowercase();
     if path.contains("chrome canary") || path.contains("google-chrome-unstable") {
         "Chrome Canary".to_string()
+    } else if path.contains("chrome for testing") || path.contains("google-chrome-for-testing") {
+        "Chrome for Testing".to_string()
     } else if path.contains("chrome beta") || path.contains("google-chrome-beta") {
         "Chrome Beta".to_string()
+    } else if path.contains("microsoft edge") || path.contains("msedge") {
+        "Edge".to_string()
+    } else if path.contains("/arc/") {
+        "Arc".to_string()
     } else if path.contains("brave-browser") {
         "Brave".to_string()
     } else if path.contains("chromium") {
@@ -887,8 +2092,51 @@ fn browser_name_from_source_path(source_path: &Path) -> String {
 }
 
 fn is_chatgpt_url(url: &str) -> bool {
-    let haystack = url.to_ascii_lowercase();
-    haystack.contains("chatgpt.com") || haystack.contains("chat.openai.com")
+    let parsed = match Url::parse(url) {
+        Ok(parsed) => parsed,
+        Err(_) => return false,
+    };
+    matches!(
+        parsed
+            .host_str()
+            .map(|host| host.to_ascii_lowercase())
+            .as_deref(),
+        Some("chatgpt.com") | Some("chat.openai.com")
+    )
+}
+
+/// A yoetz-owned tab is one whose URL carries the `?_yoetz=<run-id>` or
+/// `&_yoetz=<run-id>` marker yoetz stamps on every fresh tab it creates.
+/// yoetz MUST NOT `evaluate`, `navigate`, or otherwise mutate any tab that
+/// does not pass this check — doing so risks leaking automation into a user
+/// conversation (see review finding #8 and the Meet-tab near-miss).
+fn is_yoetz_owned_url(url: &str) -> bool {
+    let normalized = url.trim().to_ascii_lowercase();
+    normalized.contains("?_yoetz=") || normalized.contains("&_yoetz=")
+}
+
+fn context_tab_reuse_rank(url: &str) -> Option<u8> {
+    let normalized = url.trim().to_ascii_lowercase();
+    // Only reuse a ChatGPT tab if it is yoetz-owned (stamped with the
+    // `?_yoetz=<run-id>` or `&_yoetz=<run-id>` marker we apply to every
+    // fresh tab). Non-yoetz ChatGPT tabs are almost certainly an active
+    // user conversation and must not be hijacked by the reuse fallback
+    // (review finding #8 — fresh-tab contract).
+    if is_chatgpt_url(&normalized) {
+        if is_yoetz_owned_url(&normalized) {
+            Some(0)
+        } else {
+            None
+        }
+    } else if normalized.is_empty() || normalized == "about:blank" {
+        Some(1)
+    } else if normalized.starts_with("chrome://newtab")
+        || normalized.starts_with("chrome://new-tab-page")
+    {
+        Some(2)
+    } else {
+        None
+    }
 }
 
 fn is_chatgpt_title(title: Option<&str>) -> bool {
@@ -992,6 +2240,10 @@ fn build_snapshot_script(verbose: bool) -> String {
         r#"(() => {{
   const maxTextChars = {max_text_chars};
   let nextId = Number(window.__yoetzSnapshotNextId || 1);
+
+  document
+    .querySelectorAll("[data-yoetz-snapshot-id]")
+    .forEach((el) => el.removeAttribute("data-yoetz-snapshot-id"));
 
   const clip = (value) => {{
     if (typeof value !== "string") return "";
@@ -1300,6 +2552,33 @@ mod tests {
         (port, shutdown, handle)
     }
 
+    fn spawn_stalled_websocket_server() -> (u16, Arc<AtomicBool>, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        listener
+            .set_nonblocking(true)
+            .expect("listener should accept nonblocking mode");
+        let port = listener.local_addr().unwrap().port();
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_signal = shutdown.clone();
+        let handle = thread::spawn(move || {
+            while !shutdown_signal.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((_stream, _)) => {
+                        while !shutdown_signal.load(Ordering::Relaxed) {
+                            thread::sleep(Duration::from_millis(10));
+                        }
+                        break;
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+        (port, shutdown, handle)
+    }
+
     fn snapshot_fixture() -> Snapshot {
         Snapshot {
             raw: json!({
@@ -1336,68 +2615,6 @@ mod tests {
                 ]
             }),
         }
-    }
-
-    #[test]
-    fn choose_chatgpt_reuse_probe_prefers_unique_focus() {
-        let probes = vec![
-            ChatgptTabProbe {
-                url: "https://chatgpt.com/c/old".to_string(),
-                visible: false,
-                has_focus: false,
-                is_generating: false,
-            },
-            ChatgptTabProbe {
-                url: "https://chatgpt.com/c/current".to_string(),
-                visible: true,
-                has_focus: true,
-                is_generating: false,
-            },
-        ];
-
-        assert_eq!(choose_chatgpt_reuse_probe(&probes).unwrap(), 1);
-    }
-
-    #[test]
-    fn choose_chatgpt_reuse_probe_prefers_unique_visible_when_focus_missing() {
-        let probes = vec![
-            ChatgptTabProbe {
-                url: "https://chatgpt.com/c/old".to_string(),
-                visible: false,
-                has_focus: false,
-                is_generating: false,
-            },
-            ChatgptTabProbe {
-                url: "https://chatgpt.com/c/current".to_string(),
-                visible: true,
-                has_focus: false,
-                is_generating: false,
-            },
-        ];
-
-        assert_eq!(choose_chatgpt_reuse_probe(&probes).unwrap(), 1);
-    }
-
-    #[test]
-    fn choose_chatgpt_reuse_probe_rejects_ambiguous_tabs() {
-        let probes = vec![
-            ChatgptTabProbe {
-                url: "https://chatgpt.com/c/1".to_string(),
-                visible: false,
-                has_focus: false,
-                is_generating: false,
-            },
-            ChatgptTabProbe {
-                url: "https://chatgpt.com/c/2".to_string(),
-                visible: false,
-                has_focus: false,
-                is_generating: false,
-            },
-        ];
-
-        let err = choose_chatgpt_reuse_probe(&probes).unwrap_err();
-        assert!(err.to_string().contains("multiple ChatGPT tabs"));
-        assert!(err.to_string().contains("thread=fresh"));
     }
 
     #[test]
@@ -1441,44 +2658,340 @@ mod tests {
     }
 
     #[test]
-    fn choose_chatgpt_reuse_probe_skips_busy_tab() {
-        let probes = vec![
-            ChatgptTabProbe {
-                url: "https://chatgpt.com/c/busy".to_string(),
-                visible: true,
-                has_focus: true,
-                is_generating: true,
-            },
-            ChatgptTabProbe {
-                url: "https://chatgpt.com/c/idle".to_string(),
-                visible: false,
-                has_focus: false,
-                is_generating: false,
-            },
-        ];
+    fn infer_email_hints_extracts_emails_from_titles_and_urls() {
+        let hints = infer_email_hints(
+            "Inbox (6,096) - aviv.s@taboola.com - Taboola Mail",
+            "https://mail.google.com/mail/u/0/#inbox",
+        );
+        assert_eq!(hints, vec!["aviv.s@taboola.com".to_string()]);
 
-        assert_eq!(choose_chatgpt_reuse_probe(&probes).unwrap(), 1);
+        let from_url = infer_email_hints(
+            "Account chooser",
+            "https://accounts.google.com/AccountChooser?Email=avivsinai@gmail.com",
+        );
+        assert_eq!(from_url, vec!["avivsinai@gmail.com".to_string()]);
     }
 
     #[test]
-    fn choose_chatgpt_reuse_probe_rejects_all_busy_tabs() {
-        let probes = vec![
-            ChatgptTabProbe {
+    fn summarize_browser_contexts_groups_tabs_by_context_and_email() {
+        let contexts = summarize_browser_contexts(&[
+            BrowserContextPage {
+                browser_context_id: Some("ctx-personal".to_string()),
+                title: "Inbox (43,617) - avivsinai@gmail.com - Gmail".to_string(),
+                url: "https://mail.google.com/mail/u/0/#inbox".to_string(),
+            },
+            BrowserContextPage {
+                browser_context_id: Some("ctx-personal".to_string()),
+                title: "Personal Pro OK".to_string(),
                 url: "https://chatgpt.com/c/1".to_string(),
-                visible: true,
-                has_focus: true,
-                is_generating: true,
             },
-            ChatgptTabProbe {
-                url: "https://chatgpt.com/c/2".to_string(),
-                visible: false,
-                has_focus: false,
-                is_generating: true,
+            BrowserContextPage {
+                browser_context_id: Some("ctx-work".to_string()),
+                title: "Inbox (6,096) - aviv.s@taboola.com - Taboola Mail".to_string(),
+                url: "https://mail.google.com/mail/u/0/#inbox".to_string(),
             },
-        ];
+        ]);
 
-        let err = choose_chatgpt_reuse_probe(&probes).unwrap_err();
-        assert!(err.to_string().contains("still generating"));
+        assert_eq!(contexts.len(), 2);
+        assert!(contexts.iter().any(|context| {
+            context.id.as_deref() == Some("ctx-personal")
+                && context.inferred_emails == vec!["avivsinai@gmail.com".to_string()]
+                && context.chatgpt_tab_count == 1
+        }));
+        assert!(contexts.iter().any(|context| {
+            context.id.as_deref() == Some("ctx-work")
+                && context.inferred_emails == vec!["aviv.s@taboola.com".to_string()]
+                && context.chatgpt_tab_count == 0
+        }));
+    }
+
+    #[test]
+    fn browser_context_page_from_target_info_preserves_context_title_and_url() {
+        let page = browser_context_page_from_target_info(TargetInfo {
+            target_id: "target-1".to_string(),
+            Type: "page".to_string(),
+            title: "Inbox (43,617) - avivsinai@gmail.com - Gmail".to_string(),
+            url: "https://mail.google.com/mail/u/0/#inbox".to_string(),
+            attached: false,
+            opener_id: None,
+            can_access_opener: false,
+            opener_frame_id: None,
+            parent_frame_id: None,
+            browser_context_id: Some("ctx-personal".to_string()),
+            subtype: None,
+        });
+
+        assert_eq!(page.browser_context_id.as_deref(), Some("ctx-personal"));
+        assert_eq!(page.title, "Inbox (43,617) - avivsinai@gmail.com - Gmail");
+        assert_eq!(page.url, "https://mail.google.com/mail/u/0/#inbox");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn render_browser_contexts_for_error_redacts_details_by_default() {
+        // In the default (non-debug) mode, inferred emails and sample tab
+        // titles must not leak into routine error strings (review finding #9).
+        let previous = std::env::var(YOETZ_DEBUG_CDP_ENV).ok();
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::remove_var(YOETZ_DEBUG_CDP_ENV);
+        }
+        let rendered = render_browser_contexts_for_error(&[BrowserContextSummary {
+            id: Some("ctx-work".to_string()),
+            inferred_emails: vec!["aviv.s@taboola.com".to_string()],
+            chatgpt_tab_count: 1,
+            page_target_count: 3,
+            sample_tabs: vec!["Taboola Mail".to_string(), "ChatGPT".to_string()],
+        }]);
+        assert!(rendered.contains("ctx-work"));
+        assert!(
+            !rendered.contains("aviv.s@taboola.com"),
+            "default error rendering must not leak inferred emails; got: {rendered}"
+        );
+        assert!(
+            !rendered.contains("Taboola Mail"),
+            "default error rendering must not leak sample tab titles; got: {rendered}"
+        );
+        assert!(rendered.contains("1 inferred"));
+        if let Some(value) = previous {
+            #[allow(unsafe_code)]
+            unsafe {
+                std::env::set_var(YOETZ_DEBUG_CDP_ENV, value);
+            }
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn render_browser_contexts_for_error_verbose_under_debug_flag() {
+        // With the debug flag set (via the YOETZ_DEBUG_CDP env var or the CLI
+        // `--debug` wiring), full details are allowed so operators can still
+        // diagnose profile mismatches.
+        let previous = std::env::var(YOETZ_DEBUG_CDP_ENV).ok();
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::set_var(YOETZ_DEBUG_CDP_ENV, "1");
+        }
+        let rendered = render_browser_contexts_for_error(&[BrowserContextSummary {
+            id: Some("ctx-work".to_string()),
+            inferred_emails: vec!["aviv.s@taboola.com".to_string()],
+            chatgpt_tab_count: 1,
+            page_target_count: 3,
+            sample_tabs: vec!["Taboola Mail".to_string(), "ChatGPT".to_string()],
+        }]);
+        assert!(rendered.contains("ctx-work"));
+        assert!(rendered.contains("aviv.s@taboola.com"));
+        assert!(rendered.contains("Taboola Mail"));
+        match previous {
+            Some(value) => {
+                #[allow(unsafe_code)]
+                unsafe {
+                    std::env::set_var(YOETZ_DEBUG_CDP_ENV, value);
+                }
+            }
+            None => {
+                #[allow(unsafe_code)]
+                unsafe {
+                    std::env::remove_var(YOETZ_DEBUG_CDP_ENV);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn is_trusted_email_origin_accepts_known_identity_providers() {
+        assert!(is_trusted_email_origin(
+            "https://mail.google.com/mail/u/0/#inbox"
+        ));
+        assert!(is_trusted_email_origin(
+            "https://accounts.google.com/AccountChooser?Email=x@y.com"
+        ));
+        assert!(is_trusted_email_origin("https://chatgpt.com/settings"));
+    }
+
+    #[test]
+    fn is_trusted_email_origin_rejects_arbitrary_tabs() {
+        assert!(!is_trusted_email_origin("https://news.ycombinator.com/"));
+        assert!(!is_trusted_email_origin(
+            "https://attacker.example.com/?Email=a@b.com"
+        ));
+        assert!(!is_trusted_email_origin("about:blank"));
+        assert!(!is_trusted_email_origin(""));
+        // Domain-name trick: `.fake-accounts.google.com.evil.com` must not be
+        // accepted as a trusted subdomain.
+        assert!(!is_trusted_email_origin(
+            "https://accounts.google.com.evil.com/"
+        ));
+    }
+
+    #[test]
+    fn infer_email_hints_ignores_untrusted_origins() {
+        let hints = infer_email_hints(
+            "Look at attacker@example.com",
+            "https://social.example/news",
+        );
+        assert!(
+            hints.is_empty(),
+            "untrusted origins must not emit email hints"
+        );
+    }
+
+    #[test]
+    fn create_target_preserves_browser_context_id() {
+        let request = create_target("https://chatgpt.com", false, Some("ctx-work"));
+        assert_eq!(request.url, "https://chatgpt.com");
+        assert_eq!(request.browser_context_id.as_deref(), Some("ctx-work"));
+        assert_eq!(request.new_window, None);
+        assert_eq!(request.background, Some(false));
+    }
+
+    #[test]
+    fn external_create_target_block_error_is_detected() {
+        let err = anyhow!(
+            "creating a new Chrome page for `about:blank` failed: Chrome's default-profile CDP endpoint likely rejected external `Target.createTarget` while opening `about:blank`. Chrome 146+/147 can allow attach/read operations but close the session on new-tab creation for untrusted clients. First, open chrome://inspect/#remote-debugging, refresh Discover network targets (or Open dedicated DevTools for Node), and retry. If Chrome still closes the session, launch Chrome with `--remote-debugging-port=9222 --user-data-dir=/tmp/chrome-debug` and pass `--cdp`, or use Chrome for Testing. Unable to make method calls because underlying connection is closed"
+        );
+        assert!(is_external_create_target_block_error(&err));
+    }
+
+    #[test]
+    fn external_create_target_block_error_rejects_generic_inspect_guidance() {
+        let err = anyhow!(
+            "could not reach chrome's cdp endpoint. enable chrome://inspect/#remote-debugging"
+        );
+        assert!(!is_external_create_target_block_error(&err));
+    }
+
+    #[test]
+    fn browser_id_from_ws_endpoint_reads_devtools_suffix() {
+        let id = browser_id_from_ws_endpoint(
+            "ws://127.0.0.1:9222/devtools/browser/a1cbe996-1406-42e3-93d6-e9e5bcb66f4a",
+        );
+        assert_eq!(id.as_deref(), Some("a1cbe996-1406-42e3-93d6-e9e5bcb66f4a"));
+    }
+
+    #[test]
+    fn is_yoetz_owned_url_accepts_marker_and_rejects_unrelated_tabs() {
+        // The `?_yoetz=` (or `&_yoetz=`) marker is the single gate that
+        // decides whether yoetz may run JS / navigate against a tab. This
+        // test exists so the gate stays narrow — user tabs like Meet,
+        // Gmail, calendar must all be rejected, even when the tab URL
+        // contains suggestive substrings.
+        assert!(is_yoetz_owned_url(
+            "https://chatgpt.com/?_yoetz=20260419T073330Z_abc"
+        ));
+        assert!(is_yoetz_owned_url(
+            "https://chatgpt.com/c/xyz?foo=bar&_yoetz=run-abc"
+        ));
+        assert!(is_yoetz_owned_url("HTTPS://Chatgpt.com/?_YOETZ=ABC"));
+        assert!(!is_yoetz_owned_url("https://meet.google.com/abc-defg-hij"));
+        assert!(!is_yoetz_owned_url(
+            "https://mail.google.com/mail/u/0/#inbox"
+        ));
+        assert!(!is_yoetz_owned_url("https://chatgpt.com/c/abc"));
+        // Should not be fooled by an adversarial path that merely contains
+        // the substring without the `=` marker (e.g. a note app URL that
+        // happens to render the token).
+        assert!(!is_yoetz_owned_url("https://notes.example/_yoetz"));
+        assert!(!is_yoetz_owned_url("about:blank"));
+        assert!(!is_yoetz_owned_url(""));
+    }
+
+    #[test]
+    fn context_tab_reuse_rank_prefers_yoetz_owned_then_blank_tabs() {
+        // yoetz-owned ChatGPT tabs (`?_yoetz=` marker) are the only ChatGPT
+        // tabs we may reuse — any other ChatGPT tab may be a live user
+        // conversation and must be left alone (review finding #8).
+        assert_eq!(
+            context_tab_reuse_rank("https://chatgpt.com/?_yoetz=20260418T073330Z_abc"),
+            Some(0)
+        );
+        assert_eq!(
+            context_tab_reuse_rank("https://chatgpt.com/c/xyz?foo=bar&_yoetz=run-abc"),
+            Some(0)
+        );
+        assert_eq!(context_tab_reuse_rank("https://chatgpt.com/c/abc"), None);
+        assert_eq!(context_tab_reuse_rank("https://chatgpt.com/"), None);
+        assert_eq!(context_tab_reuse_rank("about:blank"), Some(1));
+        assert_eq!(context_tab_reuse_rank("chrome://newtab/"), Some(2));
+        assert_eq!(context_tab_reuse_rank("https://calendar.google.com"), None);
+    }
+
+    #[test]
+    fn recovery_opens_fresh_tab_via_existing_chatgpt_anchor_when_create_target_blocked() {
+        assert_eq!(
+            choose_chatgpt_recovery_strategy(
+                true,
+                Some("about:blank"),
+                None,
+                "https://chatgpt.com/?_yoetz=test"
+            )
+            .unwrap(),
+            ChatgptRecoveryStrategy::ExistingChatgptAnchor
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn recovery_can_reuse_existing_chatgpt_tab_when_operator_opted_in() {
+        let previous = std::env::var(YOETZ_ALLOW_MUTATE_EXISTING_CHATGPT_TAB_ENV).ok();
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::set_var(YOETZ_ALLOW_MUTATE_EXISTING_CHATGPT_TAB_ENV, "1");
+        }
+        let strategy = choose_chatgpt_recovery_strategy(
+            true,
+            Some("about:blank"),
+            None,
+            "https://chatgpt.com/?_yoetz=test",
+        )
+        .unwrap();
+        match previous {
+            Some(value) => {
+                #[allow(unsafe_code)]
+                unsafe {
+                    std::env::set_var(YOETZ_ALLOW_MUTATE_EXISTING_CHATGPT_TAB_ENV, value);
+                }
+            }
+            None => {
+                #[allow(unsafe_code)]
+                unsafe {
+                    std::env::remove_var(YOETZ_ALLOW_MUTATE_EXISTING_CHATGPT_TAB_ENV);
+                }
+            }
+        }
+        assert_eq!(strategy, ChatgptRecoveryStrategy::ReuseExistingChatgptTab);
+    }
+
+    #[test]
+    fn recovery_never_touches_non_yoetz_safe_anchors() {
+        let err = choose_chatgpt_recovery_strategy(
+            false,
+            Some("https://meet.google.com/abc-defg-hij"),
+            None,
+            "https://chatgpt.com/?_yoetz=test",
+        )
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("yoetz-safe"));
+        assert!(msg.contains("without touching user tabs"));
+    }
+
+    #[test]
+    fn missing_browser_context_error_matches_protocol_failure() {
+        let err = anyhow!(
+            "Method call error -32000: Failed to find browser context with id 643B374AEC2C8D298C82ECA3146A7330"
+        );
+        assert!(is_missing_browser_context_error(&err));
+    }
+
+    #[test]
+    fn build_window_open_expression_serializes_url() {
+        let expression =
+            build_window_open_expression("https://chatgpt.com/?q=taboola&note=\"pro\"").unwrap();
+        assert_eq!(
+            expression,
+            "window.open(\"https://chatgpt.com/?q=taboola&note=\\\"pro\\\"\", '_blank');"
+        );
     }
 
     #[test]
@@ -1512,6 +3025,67 @@ mod tests {
         let snapshot = snapshot_fixture();
         assert_eq!(snapshot.count_by_role("listitem"), 2);
         assert_eq!(snapshot.count_by_role("button"), 1);
+    }
+
+    #[test]
+    fn find_marked_file_input_uid_only_matches_composer_marker() {
+        // Even if a page has several hidden file inputs, only the one the
+        // composer-scope helper tagged should be returned — the rest are
+        // unrelated (e.g. avatar uploads, hidden dropzones).
+        let snapshot = Snapshot {
+            raw: json!({
+                "id": "root",
+                "role": "root_web_area",
+                "name": "ChatGPT",
+                "children": [
+                    {
+                        "id": "stray-upload",
+                        "role": "textbox",
+                        "tag": "input",
+                        "type": "file",
+                        "name": "avatar"
+                    },
+                    {
+                        "id": "composer-upload",
+                        "role": "textbox",
+                        "tag": "input",
+                        "type": "file",
+                        "name": crate::chatgpt_web::COMPOSER_FILE_INPUT_MARKER
+                    }
+                ]
+            }),
+        };
+        assert_eq!(
+            snapshot.find_marked_file_input_uid(crate::chatgpt_web::COMPOSER_FILE_INPUT_MARKER),
+            Some("composer-upload".to_owned())
+        );
+    }
+
+    #[test]
+    fn find_marked_file_input_uid_returns_none_when_unmarked() {
+        // Without the scope marker, we must refuse to guess — callers should
+        // keep polling rather than injecting into a random file input.
+        let snapshot = Snapshot {
+            raw: json!({
+                "id": "root",
+                "role": "root_web_area",
+                "name": "ChatGPT",
+                "children": [
+                    {
+                        "id": "stray-upload",
+                        "role": "textbox",
+                        "tag": "input",
+                        "type": "file",
+                        "name": "avatar"
+                    }
+                ]
+            }),
+        };
+        assert_eq!(
+            snapshot.find_marked_file_input_uid(crate::chatgpt_web::COMPOSER_FILE_INPUT_MARKER),
+            None
+        );
+        assert_eq!(snapshot.find_marked_file_input_uid(""), None);
     }
 
     #[test]
@@ -1553,6 +3127,82 @@ mod tests {
     }
 
     #[test]
+    fn validate_discovered_ws_host_accepts_same_host() {
+        let origin = Url::parse("http://127.0.0.1:9222/").unwrap();
+        validate_discovered_ws_host("ws://127.0.0.1:9222/devtools/browser/abc", &origin)
+            .expect("same host/port must pass");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn validate_discovered_ws_host_rejects_cross_host_redirect_by_default() {
+        // The websocket URL returned by `/json/version` must live on the same
+        // host:port we probed, otherwise we refuse to attach (review finding
+        // #5 — CDP discovery must not follow arbitrary cross-host redirects).
+        let previous = std::env::var(YOETZ_CDP_ALLOW_REMOTE_ENV).ok();
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::remove_var(YOETZ_CDP_ALLOW_REMOTE_ENV);
+        }
+        let origin = Url::parse("http://127.0.0.1:9222/").unwrap();
+        let err = validate_discovered_ws_host(
+            "ws://attacker.example.com:9222/devtools/browser/abc",
+            &origin,
+        )
+        .expect_err("cross-host redirect must be rejected by default");
+        let message = format!("{err:#}");
+        assert!(message.contains("different host/port"));
+        assert!(message.contains(YOETZ_CDP_ALLOW_REMOTE_ENV));
+        if let Some(value) = previous {
+            #[allow(unsafe_code)]
+            unsafe {
+                std::env::set_var(YOETZ_CDP_ALLOW_REMOTE_ENV, value);
+            }
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn validate_discovered_ws_host_allows_remote_when_opted_in() {
+        // Operators can override with YOETZ_CDP_ALLOW_REMOTE=1 for legitimate
+        // split-host setups (tunnels, remote Chrome for Testing, etc.).
+        let previous = std::env::var(YOETZ_CDP_ALLOW_REMOTE_ENV).ok();
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::set_var(YOETZ_CDP_ALLOW_REMOTE_ENV, "1");
+        }
+        let origin = Url::parse("http://127.0.0.1:9222/").unwrap();
+        validate_discovered_ws_host("ws://remote.example.com:9999/devtools/browser/abc", &origin)
+            .expect("opt-in should allow cross-host");
+        match previous {
+            Some(value) => {
+                #[allow(unsafe_code)]
+                unsafe {
+                    std::env::set_var(YOETZ_CDP_ALLOW_REMOTE_ENV, value);
+                }
+            }
+            None => {
+                #[allow(unsafe_code)]
+                unsafe {
+                    std::env::remove_var(YOETZ_CDP_ALLOW_REMOTE_ENV);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn is_loopback_host_accepts_loopback_aliases() {
+        assert!(is_loopback_host(Some("localhost")));
+        assert!(is_loopback_host(Some("LocalHost")));
+        assert!(is_loopback_host(Some("127.0.0.1")));
+        assert!(is_loopback_host(Some("::1")));
+        assert!(is_loopback_host(Some("0.0.0.0")));
+        assert!(!is_loopback_host(Some("attacker.example.com")));
+        assert!(!is_loopback_host(Some("10.0.0.5")));
+        assert!(!is_loopback_host(None));
+    }
+
+    #[test]
     fn parse_devtools_active_port_returns_browser_websocket() {
         let parsed =
             parse_devtools_active_port("9222\n/devtools/browser/from-active-port\n", Some(9222));
@@ -1578,6 +3228,39 @@ mod tests {
     }
 
     #[test]
+    fn connect_to_running_chrome_times_out_when_websocket_handshake_stalls() {
+        let _timeout_guard = EnvVarGuard::set("YOETZ_CDP_WS_HANDSHAKE_TIMEOUT_MS", "200");
+        let (port, shutdown, handle) = spawn_stalled_websocket_server();
+        let ws_endpoint = format!("ws://127.0.0.1:{port}/devtools/browser/stalled");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime");
+        let started = Instant::now();
+        let err =
+            match runtime.block_on(CdpMcpClient::connect_to_running_chrome(Some(&ws_endpoint))) {
+                Ok(_) => panic!("stalled websocket handshake should time out"),
+                Err(err) => err,
+            };
+        let elapsed = started.elapsed();
+
+        shutdown.store(true, Ordering::Relaxed);
+        let _ = handle.join();
+
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "expected stalled handshake to fail quickly, took {elapsed:?}"
+        );
+        let detail = format!("{err:#}");
+        assert!(
+            detail.contains("connecting to Chrome websocket")
+                || detail.contains("timed out connecting to Chrome websocket")
+                || detail.contains("Resource temporarily unavailable"),
+            "unexpected error detail: {detail}"
+        );
+    }
+
+    #[test]
     fn browser_name_from_source_path_prefers_family_specific_labels() {
         assert_eq!(
             browser_name_from_source_path(Path::new(
@@ -1593,6 +3276,24 @@ mod tests {
         );
         assert_eq!(
             browser_name_from_source_path(Path::new(
+                "/Users/test/Library/Application Support/Google/Chrome for Testing/DevToolsActivePort"
+            )),
+            "Chrome for Testing"
+        );
+        assert_eq!(
+            browser_name_from_source_path(Path::new(
+                "/Users/test/Library/Application Support/Microsoft Edge/DevToolsActivePort"
+            )),
+            "Edge"
+        );
+        assert_eq!(
+            browser_name_from_source_path(Path::new(
+                "/Users/test/Library/Application Support/Arc/DevToolsActivePort"
+            )),
+            "Arc"
+        );
+        assert_eq!(
+            browser_name_from_source_path(Path::new(
                 "/home/test/.config/chromium/DevToolsActivePort"
             )),
             "Chromium"
@@ -1603,11 +3304,20 @@ mod tests {
     fn chatgpt_matchers_cover_url_and_title_fallback() {
         assert!(is_chatgpt_url("https://chatgpt.com/c/123"));
         assert!(is_chatgpt_url("https://chat.openai.com/"));
+        assert!(!is_chatgpt_url("https://example.com/?ref=chatgpt.com"));
+        assert!(!is_chatgpt_url("not-a-url"));
         assert!(!is_chatgpt_url("https://example.com/"));
         assert!(is_chatgpt_title(Some("ChatGPT - New chat")));
         assert!(is_chatgpt_title(Some("ChatGPT Workspace")));
         assert!(!is_chatgpt_title(Some("Notes about ChatGPT pricing")));
         assert!(!is_chatgpt_title(Some("Docs")));
+    }
+
+    #[test]
+    fn snapshot_script_clears_previous_snapshot_ids_before_reassigning() {
+        let script = build_snapshot_script(false);
+        assert!(script.contains("querySelectorAll(\"[data-yoetz-snapshot-id]\")"));
+        assert!(script.contains("removeAttribute(\"data-yoetz-snapshot-id\")"));
     }
 
     #[test]
@@ -1631,5 +3341,54 @@ mod tests {
         assert_eq!(targets[0].source_path, healthy_path);
         assert_eq!(targets[0].browser_name, "Chrome");
         assert_eq!(targets[0].chatgpt_tab_count, 1);
+        assert_eq!(targets[0].page_target_count, 1);
+        assert_eq!(
+            targets[0].page_samples,
+            vec!["ChatGPT - New chat".to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_local_chromium_process_line_tracks_remote_debugging_and_user_data_dir() {
+        let summary = parse_local_chromium_process_line(
+            "2706 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --remote-debugging-port=9222 --user-data-dir=/tmp/chrome-debug",
+        )
+        .unwrap();
+        assert_eq!(summary.pid, 2706);
+        assert_eq!(summary.browser_name, "Chrome");
+        assert!(summary.has_remote_debugging);
+        assert_eq!(summary.user_data_dir.as_deref(), Some("/tmp/chrome-debug"));
+    }
+
+    #[test]
+    fn parse_local_chromium_process_line_preserves_user_data_dir_with_spaces() {
+        let summary = parse_local_chromium_process_line(
+            "2706 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --user-data-dir=\"/Users/Test User/chrome debug\" --remote-debugging-port=9222",
+        )
+        .unwrap();
+        assert_eq!(
+            summary.user_data_dir.as_deref(),
+            Some("/Users/Test User/chrome debug")
+        );
+    }
+
+    #[test]
+    fn parse_local_chromium_process_line_reads_unquoted_path_until_next_flag() {
+        let summary = parse_local_chromium_process_line(
+            "2706 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --user-data-dir=/Users/Test User/chrome debug --remote-debugging-port=9222",
+        )
+        .unwrap();
+        assert_eq!(
+            summary.user_data_dir.as_deref(),
+            Some("/Users/Test User/chrome debug")
+        );
+    }
+
+    #[test]
+    fn parse_local_chromium_process_line_ignores_helper_processes() {
+        let helper = parse_local_chromium_process_line(
+            "3188 /Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Helpers/Google Chrome Helper.app/Contents/MacOS/Google Chrome Helper --type=gpu-process",
+        );
+        assert!(helper.is_none());
     }
 }

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/mod.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/mod.rs
@@ -39,25 +39,20 @@ pub mod chatgpt;
 // shape (new_page → focus → upload → type → click → wait → extract) with
 // per-LLM selectors — trivial to add once the client plumbing is verified.
 
-use anyhow::{anyhow, Result};
+use crate::chatgpt_web;
+use anyhow::Result;
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 pub enum RecipeThreadMode {
     #[default]
     Fresh,
-    Reuse,
 }
 
 impl RecipeThreadMode {
     pub fn parse(raw: Option<&str>) -> Result<Self> {
-        match raw.unwrap_or("fresh").trim().to_ascii_lowercase().as_str() {
-            "" | "fresh" => Ok(Self::Fresh),
-            "reuse" => Ok(Self::Reuse),
-            other => Err(anyhow!(
-                "unsupported `thread` value `{other}`; expected `fresh` or `reuse`"
-            )),
-        }
+        chatgpt_web::validate_thread_mode(raw)?;
+        Ok(Self::Fresh)
     }
 }
 
@@ -91,12 +86,26 @@ pub struct DevtoolsMcpRecipeContext {
     /// User prompt to send alongside the bundle.
     pub prompt: String,
 
-    /// Whether the recipe should start a new conversation or reuse an
-    /// existing ChatGPT tab.
-    pub thread_mode: RecipeThreadMode,
+    /// Optional exact Chrome browser context ID to target. When set, yoetz
+    /// keeps all ChatGPT actions inside this live browserContextId.
+    pub browser_context_id: Option<String>,
+
+    /// Optional Chrome profile email selector. When set, yoetz resolves the
+    /// live Chrome browser context whose open tabs identify with this email
+    /// and keeps all ChatGPT actions inside that context.
+    pub profile_email: Option<String>,
+
+    /// Marker for the yoetz-owned ChatGPT tab created for this recipe run.
+    pub run_id: String,
 
     /// How long to wait for the full response before giving up, in ms.
     pub response_timeout_ms: u64,
+
+    /// Poll interval for stable-idle response detection, in ms.
+    pub response_poll_interval_ms: u64,
+
+    /// Whether to disable Extended Pro before sending.
+    pub disable_extended: bool,
 
     /// Whether to surface approval-dialog guidance to stderr in text mode.
     pub show_approval_guidance: bool,
@@ -110,8 +119,12 @@ impl Default for DevtoolsMcpRecipeContext {
             bundle_text: None,
             model: String::new(),
             prompt: String::new(),
-            thread_mode: RecipeThreadMode::Fresh,
+            browser_context_id: None,
+            profile_email: None,
+            run_id: String::new(),
             response_timeout_ms: 1_800_000, // 30 min default for ChatGPT Pro Extended
+            response_poll_interval_ms: 30_000,
+            disable_extended: false,
             show_approval_guidance: true,
         }
     }

--- a/crates/yoetz-cli/src/commands/ask.rs
+++ b/crates/yoetz-cli/src/commands/ask.rs
@@ -16,6 +16,31 @@ use yoetz_core::output::{write_json, write_jsonl, OutputFormat};
 use yoetz_core::session::{create_session_dir, write_json as write_json_file, write_text};
 use yoetz_core::types::{ArtifactPaths, PricingEstimate, RunResult, Usage};
 
+fn enforce_multimodal_budget_support(
+    has_images: bool,
+    has_video: bool,
+    max_cost_usd: Option<f64>,
+    daily_budget_usd: Option<f64>,
+    pricing: &mut PricingEstimate,
+) -> Result<()> {
+    if !has_images && !has_video {
+        return Ok(());
+    }
+
+    pricing.warnings.push(
+        "multimodal input pricing is not estimated yet; preflight budget enforcement is unavailable"
+            .to_string(),
+    );
+
+    if max_cost_usd.is_some() || daily_budget_usd.is_some() {
+        return Err(anyhow!(
+            "--max-cost-usd and --daily-budget-usd are not supported with image/video inputs yet because yoetz cannot estimate multimodal input cost accurately before the provider call"
+        ));
+    }
+
+    Ok(())
+}
+
 pub(crate) async fn handle_ask(
     ctx: &AppContext,
     args: AskArgs,
@@ -124,6 +149,13 @@ pub(crate) async fn handle_ask(
         registry_model_id.as_deref(),
         !image_inputs.is_empty(),
         video_input.is_some(),
+        &mut pricing,
+    )?;
+    enforce_multimodal_budget_support(
+        !image_inputs.is_empty(),
+        video_input.is_some(),
+        args.max_cost_usd,
+        args.daily_budget_usd,
         &mut pricing,
     )?;
 
@@ -321,5 +353,29 @@ pub(crate) async fn handle_ask(
             println!("{}", result.content);
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn multimodal_budget_support_warns_without_budget_flags() {
+        let mut pricing = PricingEstimate::default();
+        enforce_multimodal_budget_support(true, false, None, None, &mut pricing).unwrap();
+        assert_eq!(pricing.warnings.len(), 1);
+        assert!(pricing.warnings[0].contains("preflight budget enforcement"));
+    }
+
+    #[test]
+    fn multimodal_budget_support_rejects_budget_flags() {
+        let mut pricing = PricingEstimate::default();
+        let err = enforce_multimodal_budget_support(true, false, Some(1.0), None, &mut pricing)
+            .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("--max-cost-usd and --daily-budget-usd are not supported"));
+        assert_eq!(pricing.warnings.len(), 1);
     }
 }

--- a/crates/yoetz-cli/src/commands/bundle.rs
+++ b/crates/yoetz-cli/src/commands/bundle.rs
@@ -18,6 +18,7 @@ pub(crate) fn handle_bundle(
         max_file_bytes: args.max_file_bytes,
         max_total_bytes: args.max_total_bytes,
         include_all: args.all,
+        include_hidden: args.include_hidden || args.all,
         ..Default::default()
     };
 

--- a/crates/yoetz-cli/src/commands/council.rs
+++ b/crates/yoetz-cli/src/commands/council.rs
@@ -309,9 +309,11 @@ pub(crate) async fn handle_council(
         }
         if has_spend {
             if let Some(reservation) = budget_reservation {
-                let _ = reservation.commit(spend);
-            } else {
-                let _ = budget::record_spend_standalone(spend);
+                if let Err(e) = reservation.commit(spend) {
+                    eprintln!("warning: budget commit failed: {e}");
+                }
+            } else if let Err(e) = budget::record_spend_standalone(spend) {
+                eprintln!("warning: budget commit failed: {e}");
             }
         }
     }

--- a/crates/yoetz-cli/src/commands/generate.rs
+++ b/crates/yoetz-cli/src/commands/generate.rs
@@ -69,7 +69,6 @@ async fn handle_generate_image(
     }
 
     let images = parse_media_inputs(&args.image, &args.image_mime, MediaType::Image)?;
-    validate_video_generation_inputs(&provider, images.len())?;
 
     let session = create_session_dir()?;
     let media_dir = args
@@ -249,6 +248,7 @@ async fn handle_generate_video(
     );
 
     let images = parse_media_inputs(&args.image, &args.image_mime, MediaType::Image)?;
+    validate_video_generation_inputs(&provider, images.len())?;
 
     let session = create_session_dir()?;
     let media_dir = args

--- a/crates/yoetz-cli/src/commands/generate.rs
+++ b/crates/yoetz-cli/src/commands/generate.rs
@@ -15,6 +15,15 @@ use yoetz_core::output::{write_json, write_jsonl, OutputFormat};
 use yoetz_core::session::{create_session_dir, write_json as write_json_file};
 use yoetz_core::types::{ArtifactPaths, MediaGenerationResult, Usage};
 
+fn validate_video_generation_inputs(provider: &str, image_count: usize) -> Result<()> {
+    if provider == "openai" && image_count > 1 {
+        return Err(anyhow!(
+            "provider openai accepts at most one --image for video generation; got {image_count}"
+        ));
+    }
+    Ok(())
+}
+
 pub(crate) async fn handle_generate(
     ctx: &AppContext,
     args: GenerateArgs,
@@ -60,6 +69,7 @@ async fn handle_generate_image(
     }
 
     let images = parse_media_inputs(&args.image, &args.image_mime, MediaType::Image)?;
+    validate_video_generation_inputs(&provider, images.len())?;
 
     let session = create_session_dir()?;
     let media_dir = args
@@ -164,6 +174,24 @@ async fn handle_generate_image(
             }
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_video_generation_inputs_rejects_multiple_openai_images() {
+        let err = validate_video_generation_inputs("openai", 2).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("provider openai accepts at most one --image"));
+    }
+
+    #[test]
+    fn validate_video_generation_inputs_allows_gemini_multi_image() {
+        validate_video_generation_inputs("gemini", 2).unwrap();
     }
 }
 

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -23,17 +23,23 @@ use std::fs;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output, Stdio};
-use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 #[cfg(test)]
 use yoetz_core::paths::home_dir;
 
-use crate::browser;
+use crate::{browser, chatgpt_web};
 
 /// Cached dev-browser resolution.
 static DEV_BROWSER: OnceLock<String> = OnceLock::new();
+const DEV_BROWSER_INSTALL_GUIDANCE: &str = concat!(
+    "dev-browser not found in PATH or npm global prefix. Install it explicitly ",
+    "using a pinned, vetted binary/package, or set YOETZ_DEV_BROWSER_BIN to the ",
+    "exact executable to run."
+);
 
 /// Default timeout for dev-browser scripts in seconds.
 const DEFAULT_SCRIPT_TIMEOUT_SECS: u64 = 30;
@@ -45,12 +51,20 @@ const DEV_BROWSER_WAIT_POLL_MS: u64 = 100;
 const CHATGPT_POLL_TIMEOUT_MS_DEFAULT: u64 = 1_800_000;
 const CHATGPT_POLL_INTERVAL_MS_DEFAULT: u64 = 30_000;
 const CHATGPT_BROWSER_NAME: &str = "yoetz-chatgpt";
-const CHATGPT_PAGE_NAME: &str = "yoetz-chatgpt-main";
+const CHATGPT_AUTH_PROBE_PAGE_NAME: &str = "yoetz-chatgpt-main";
+const CHATGPT_RECIPE_PAGE_NAME_PREFIX: &str = "yoetz-chatgpt-run";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ChatgptPollSettings {
     pub timeout_ms: u64,
     pub interval_ms: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChatgptRecipeRunResult {
+    pub response: String,
+    pub model_used: Option<String>,
+    pub warnings: Vec<String>,
 }
 
 impl Default for ChatgptPollSettings {
@@ -193,9 +207,7 @@ fn npm_prefix_dev_browser_candidates(prefix: &Path, windows: bool) -> Vec<PathBu
 
 /// Resolve the dev-browser binary after installation has already been handled.
 fn resolve_dev_browser() -> Result<String> {
-    find_dev_browser()?.ok_or_else(|| {
-        anyhow!("dev-browser not found in PATH. Install manually: npm i -g dev-browser")
-    })
+    find_dev_browser()?.ok_or_else(missing_dev_browser_error)
 }
 
 /// Returns true if dev-browser is already available without side effects.
@@ -203,48 +215,16 @@ pub fn is_available() -> bool {
     find_dev_browser().is_ok_and(|bin| bin.is_some())
 }
 
-/// Ensure dev-browser is installed, auto-installing if needed.
+fn missing_dev_browser_error() -> anyhow::Error {
+    anyhow!(DEV_BROWSER_INSTALL_GUIDANCE)
+}
+
+/// Ensure dev-browser is already available without downloading code at runtime.
 pub fn ensure_installed() -> Result<()> {
     if find_dev_browser()?.is_some() {
         return Ok(());
     }
-
-    eprintln!("info: dev-browser not found, installing via npm...");
-    let output = Command::new("npm")
-        .args(["install", "-g", "dev-browser"])
-        .output()
-        .context("failed to run npm. Install dev-browser manually: npm i -g dev-browser")?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        let detail = if !stderr.is_empty() {
-            stderr
-        } else if !stdout.is_empty() {
-            stdout
-        } else {
-            format!("exit code {:?}", output.status.code())
-        };
-        return Err(anyhow!(
-            "npm install -g dev-browser failed: {detail}. Install manually: npm i -g dev-browser"
-        ));
-    }
-
-    // After install, re-run full discovery (PATH + npm prefix fallback).
-    if let Some(bin) = find_dev_browser()? {
-        let _ = DEV_BROWSER.set(bin);
-        eprintln!("info: dev-browser installed successfully");
-        return Ok(());
-    }
-    let hint = if cfg!(target_os = "macos") {
-        " On Homebrew Node, npm may not create PATH symlinks. \
-         Fix: ln -sf \"$(npm prefix -g)/lib/node_modules/dev-browser/bin/dev-browser-darwin-\"* \"$(npm prefix -g)/bin/dev-browser\""
-    } else {
-        ""
-    };
-    Err(anyhow!(
-        "dev-browser installed but not discoverable in PATH or npm prefix.{hint}"
-    ))
+    Err(missing_dev_browser_error())
 }
 
 /// Stop the dev-browser daemon explicitly. Returns true when a running daemon
@@ -290,11 +270,25 @@ fn resolve_dev_browser_connect_endpoint(cdp_endpoint: Option<&str>) -> Result<Op
     let url = Url::parse(endpoint)
         .with_context(|| format!("invalid Chrome CDP endpoint `{endpoint}`"))?;
     match url.scheme() {
-        "http" | "https" | "ws" | "wss" => Ok(Some(endpoint.to_string())),
-        other => Err(anyhow!(
-            "unsupported Chrome CDP endpoint scheme `{other}` in `{endpoint}`"
-        )),
+        "http" | "https" | "ws" | "wss" => {}
+        other => {
+            return Err(anyhow!(
+                "unsupported Chrome CDP endpoint scheme `{other}` in `{endpoint}`"
+            ));
+        }
     }
+    // Default: only forward localhost CDP endpoints. A non-loopback host can
+    // bounce dev-browser onto an unrelated Chrome instance; set
+    // YOETZ_CDP_ALLOW_REMOTE=1 to opt in (review finding #5).
+    if !crate::chrome_devtools_mcp::client::is_loopback_host(url.host_str())
+        && !crate::chrome_devtools_mcp::client::cdp_remote_redirects_allowed()
+    {
+        return Err(anyhow!(
+            "Chrome CDP endpoint `{endpoint}` is not on localhost; set {}=1 to allow remote CDP targets",
+            crate::chrome_devtools_mcp::client::YOETZ_CDP_ALLOW_REMOTE_ENV
+        ));
+    }
+    Ok(Some(endpoint.to_string()))
 }
 
 fn connect_args(
@@ -515,7 +509,12 @@ pub fn check_connection_with_endpoint(cdp_endpoint: Option<&str>) -> Result<()> 
 const pages = await browser.listPages();
 console.log("ok:" + pages.length);
 "#;
-    match run_script_connect_with_endpoint(script, Some(10), cdp_endpoint) {
+    match run_script_connect_with_browser_and_endpoint(
+        script,
+        Some(10),
+        Some(CHATGPT_BROWSER_NAME),
+        cdp_endpoint,
+    ) {
         Ok(stdout) if stdout.trim().starts_with("ok:") => Ok(()),
         Ok(stdout) => Err(anyhow!("dev-browser connection check failed: {stdout}")),
         Err(first_err) => {
@@ -526,8 +525,13 @@ console.log("ok:" + pages.length);
             }
             eprintln!("info: dev-browser connection timed out, retrying with longer timeout");
             std::thread::sleep(std::time::Duration::from_secs(2));
-            let stdout = run_script_connect_with_endpoint(script, Some(45), cdp_endpoint)
-                .context("dev-browser connection check failed after retry")?;
+            let stdout = run_script_connect_with_browser_and_endpoint(
+                script,
+                Some(45),
+                Some(CHATGPT_BROWSER_NAME),
+                cdp_endpoint,
+            )
+            .context("dev-browser connection check failed after retry")?;
             if stdout.trim().starts_with("ok:") {
                 Ok(())
             } else {
@@ -537,35 +541,72 @@ console.log("ok:" + pages.length);
     }
 }
 
-pub fn check_chatgpt_auth_with_endpoint(cdp_endpoint: Option<&str>) -> Result<bool> {
-    let script = r#"
-const page = await browser.newPage();
-try {
-    await page.goto("https://chatgpt.com/");
-    await page.waitForTimeout(3000);
-    // Check for the composer textarea — the most reliable auth marker.
-    // Text markers like "new chat" / "send a message" drift with UI updates.
-    const authenticated = await page.evaluate(() => {
-        if (document.querySelector('#prompt-textarea')) return true;
-        const text = document.body.innerText.toLowerCase();
-        return text.includes("send a message") || text.includes("ask anything")
-            || text.includes("what are you working on") || text.includes("new chat");
-    });
-    console.log(JSON.stringify({ authenticated }));
-} finally {
-    await page.close().catch(() => {});
+fn build_chatgpt_auth_probe_script(page_name: &str) -> String {
+    let page_name_json = serde_json::to_string(page_name).expect("serialize page name");
+    let chatgpt_url_json = serde_json::to_string(chatgpt_web::CHATGPT_URL).unwrap();
+    format!(
+        r##"
+const PAGE_NAME = {page_name_json};
+const CHATGPT_URL = {chatgpt_url_json};
+const normalize = (value) => String(value || "").replace(/\s+/g, " ").trim();
+const pages = await browser.listPages();
+const chatgptPage =
+  pages.find((entry) => entry.name === PAGE_NAME) ||
+  pages.find((entry) => normalize(entry.url).toLowerCase().includes("chatgpt.com"));
+const page = chatgptPage
+  ? await browser.getPage(chatgptPage.name || chatgptPage.id)
+  : await browser.getPage(PAGE_NAME);
+const currentUrl = normalize(page.url()).toLowerCase();
+if (!currentUrl.includes("chatgpt.com")) {{
+  await page.goto(CHATGPT_URL, {{ waitUntil: "domcontentloaded" }});
+}}
+await page.waitForTimeout(1500);
+const pageState = await page.evaluate(() => {{
+  const composer = document.querySelector('#prompt-textarea, [role="textbox"]');
+  const title = document.title || "";
+  const bodyText = String(document.body?.innerText || "").replace(/\s+/g, " ").trim().slice(0, 400);
+  return {{
+    authenticated: !!composer,
+    url: window.location.href || "",
+    title,
+    bodyText,
+  }};
+}});
+console.log(JSON.stringify(pageState));
+"##,
+        chatgpt_url_json = chatgpt_url_json,
+    )
 }
-"#;
-    let stdout = run_script_connect_with_endpoint(script, Some(30), cdp_endpoint)?;
-    let result: Value = serde_json::from_str(stdout.trim())
+
+#[derive(Debug, serde::Deserialize)]
+struct ChatgptAuthProbeResult {
+    authenticated: bool,
+    url: String,
+    title: String,
+    #[serde(rename = "bodyText")]
+    body_text: String,
+}
+
+fn chatgpt_page_probe_haystack(url: &str, title: &str, body_text: &str) -> String {
+    format!("{url} {title} {body_text}")
+}
+
+fn check_chatgpt_auth_with_endpoint(cdp_endpoint: Option<&str>) -> Result<ChatgptAuthProbeResult> {
+    let script = build_chatgpt_auth_probe_script(CHATGPT_AUTH_PROBE_PAGE_NAME);
+    let stdout = run_script_connect_with_browser_and_endpoint(
+        &script,
+        Some(30),
+        Some(CHATGPT_BROWSER_NAME),
+        cdp_endpoint,
+    )?;
+    let result: ChatgptAuthProbeResult = serde_json::from_str(stdout.trim())
         .with_context(|| format!("check_chatgpt_auth: malformed script output: {stdout}"))?;
-    result["authenticated"]
-        .as_bool()
-        .ok_or_else(|| anyhow!("check_chatgpt_auth: missing 'authenticated' field in: {stdout}"))
+    Ok(result)
 }
 
 /// Ensure the connected Chrome session can reach an authenticated ChatGPT page.
-/// Opens a temporary page — use only when not immediately followed by a recipe.
+/// Reuses the shared ChatGPT dev-browser slot when available so repeated checks
+/// do not force a fresh Chrome live-attach handshake.
 pub fn ensure_chatgpt_auth_with_page_check_and_endpoint(cdp_endpoint: Option<&str>) -> Result<()> {
     eprintln!("info: probing Chrome reachability via dev-browser");
     check_connection_with_endpoint(cdp_endpoint)
@@ -575,12 +616,20 @@ pub fn ensure_chatgpt_auth_with_page_check_and_endpoint(cdp_endpoint: Option<&st
         )?;
 
     eprintln!("info: probing ChatGPT auth state via dev-browser");
-    if check_chatgpt_auth_with_endpoint(cdp_endpoint)? {
+    let probe = check_chatgpt_auth_with_endpoint(cdp_endpoint)?;
+    if probe.authenticated {
         return Ok(());
     }
 
+    let haystack = chatgpt_page_probe_haystack(&probe.url, &probe.title, &probe.body_text);
+    if let Some(issue) = chatgpt_web::detect_auth_issue_text(&haystack, true) {
+        return Err(anyhow!("{issue}"));
+    }
+
     Err(anyhow!(
-        "chatgpt login required in the attached Chrome session. Log in there and try again."
+        "ChatGPT did not finish loading the composer on {}. Title: {:?}",
+        probe.url,
+        probe.title
     ))
 }
 
@@ -603,6 +652,8 @@ pub struct DevBrowserRecipeContext {
     pub paste_mode: bool,
     /// Custom prompt text.
     pub prompt: String,
+    /// Marker for the yoetz-owned ChatGPT tab created for this run.
+    pub run_id: String,
     /// ChatGPT response polling settings.
     pub poll_settings: ChatgptPollSettings,
     /// Allow an empty assistant response to count as success.
@@ -620,6 +671,7 @@ impl Default for DevBrowserRecipeContext {
             bundle_text: None,
             model: String::new(),
             prompt: "Review the attached file and provide your analysis.".to_string(),
+            run_id: String::new(),
             disable_extended: false,
             paste_mode: false,
             poll_settings: ChatgptPollSettings::default(),
@@ -656,7 +708,7 @@ fn parse_positive_u64_var(vars: &BTreeMap<String, String>, key: &str) -> Result<
     Ok(Some(value))
 }
 
-fn looks_like_dev_browser_connect_failure(err: &anyhow::Error) -> bool {
+pub(crate) fn is_dev_browser_connect_failure(err: &anyhow::Error) -> bool {
     let message = format!("{err:#}").to_lowercase();
     (message.contains("connectovercdp")
         || message.contains("auto-connect")
@@ -667,7 +719,7 @@ fn looks_like_dev_browser_connect_failure(err: &anyhow::Error) -> bool {
 }
 
 fn maybe_add_dev_browser_connect_guidance(err: anyhow::Error) -> anyhow::Error {
-    if looks_like_dev_browser_connect_failure(&err) {
+    if is_dev_browser_connect_failure(&err) {
         err.context(
             "dev-browser could not connect to Chrome. If Chrome is showing a remote debugging approval dialog, click Allow, then retry. If you recently upgraded yoetz, run `yoetz browser reset` once so the dev-browser daemon relaunches with the Chrome 147 compatibility flag. Raw transport error follows.",
         )
@@ -680,6 +732,77 @@ fn chatgpt_script_timeout_secs(poll_timeout_ms: u64) -> u64 {
     poll_timeout_ms.div_ceil(1000) + 60
 }
 
+fn chatgpt_wait_heartbeat_interval_ms(interval_ms: u64) -> u64 {
+    interval_ms.clamp(15_000, 60_000)
+}
+
+fn format_chatgpt_wait_duration(duration: Duration) -> String {
+    let total_secs = duration.as_secs();
+    let hours = total_secs / 3600;
+    let minutes = (total_secs % 3600) / 60;
+    let seconds = total_secs % 60;
+    if hours > 0 {
+        format!("{hours}h {minutes}m")
+    } else if minutes > 0 {
+        format!("{minutes}m {seconds}s")
+    } else {
+        format!("{seconds}s")
+    }
+}
+
+fn chatgpt_wait_progress_message(elapsed: Duration, poll_settings: ChatgptPollSettings) -> String {
+    format!(
+        "info: still waiting for the ChatGPT response (elapsed {}, timeout {}, poll every {}s)",
+        format_chatgpt_wait_duration(elapsed),
+        format_chatgpt_wait_duration(Duration::from_millis(poll_settings.timeout_ms)),
+        poll_settings.interval_ms / 1000
+    )
+}
+
+struct ChatgptWaitHeartbeat {
+    stop: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl ChatgptWaitHeartbeat {
+    fn start(poll_settings: ChatgptPollSettings) -> Self {
+        eprintln!(
+            "info: waiting for the ChatGPT response (timeout {}, poll every {}s)",
+            format_chatgpt_wait_duration(Duration::from_millis(poll_settings.timeout_ms)),
+            poll_settings.interval_ms / 1000
+        );
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_flag = Arc::clone(&stop);
+        let started_at = Instant::now();
+        let heartbeat_interval = Duration::from_millis(chatgpt_wait_heartbeat_interval_ms(
+            poll_settings.interval_ms,
+        ));
+        let handle = thread::spawn(move || {
+            while !stop_flag.load(Ordering::Relaxed) {
+                thread::sleep(heartbeat_interval);
+                if stop_flag.load(Ordering::Relaxed) {
+                    break;
+                }
+                eprintln!(
+                    "{}",
+                    chatgpt_wait_progress_message(started_at.elapsed(), poll_settings)
+                );
+            }
+        });
+        Self {
+            stop,
+            handle: Some(handle),
+        }
+    }
+
+    fn stop(mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
 #[derive(Debug, serde::Deserialize)]
 struct ChatgptPrepareResult {
     status: String,
@@ -687,7 +810,12 @@ struct ChatgptPrepareResult {
     logged_in: bool,
     #[serde(rename = "composerReady")]
     composer_ready: bool,
+    #[serde(rename = "modelUsed")]
+    model_used: Option<String>,
     url: String,
+    title: String,
+    #[serde(rename = "bodyText")]
+    body_text: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -696,6 +824,8 @@ struct ChatgptSendResult {
     error: Option<String>,
     #[serde(rename = "assistantCountBeforeSend")]
     assistant_count_before_send: Option<usize>,
+    #[serde(rename = "assistantLastLenBeforeSend")]
+    assistant_last_len_before_send: Option<usize>,
     warning: Option<String>,
 }
 
@@ -704,40 +834,63 @@ fn parse_script_json<T: serde::de::DeserializeOwned>(label: &str, stdout: &str) 
         .with_context(|| format!("{label}: malformed script output: {stdout}"))
 }
 
-fn build_chatgpt_prepare_script(page_name: &str, model: &str) -> String {
+fn classify_dev_browser_page_issue(
+    url: &str,
+    title: &str,
+    body_text: &str,
+) -> Option<&'static str> {
+    let haystack = chatgpt_page_probe_haystack(url, title, body_text);
+    chatgpt_web::detect_auth_issue_text(&haystack, true)
+}
+
+fn build_chatgpt_prepare_script(page_name: &str, model: &str, run_id: &str) -> String {
     let page_name_json = serde_json::to_string(page_name).unwrap();
     let model_json = serde_json::to_string(model).unwrap();
+    let marked_url_json = serde_json::to_string(&chatgpt_web::mark_chatgpt_url(run_id)).unwrap();
+    let window_name_json =
+        serde_json::to_string(&format!("yoetz:{run_id}")).expect("serialize yoetz window name");
+    let model_selection_function_json =
+        serde_json::to_string(&chatgpt_web::build_model_selection_function(model)).unwrap();
+    let composer_selector_json = chatgpt_web::composer_selector_json();
     format!(
         r##"
 const PAGE_NAME = {page_name_json};
 const MODEL = {model_json};
-const page = await browser.getPage(PAGE_NAME);
-const CHATGPT_URL = "https://chatgpt.com/";
-const COMPOSER_SELECTOR = "#prompt-textarea, [role='textbox']";
+const MARKED_URL = {marked_url_json};
+const WINDOW_NAME = {window_name_json};
+const MODEL_SELECTION_FUNCTION_SOURCE = {model_selection_function_json};
+const COMPOSER_SELECTOR = {composer_selector_json};
 const ASSISTANT_SELECTOR = "[data-message-author-role='assistant']";
 const NEW_CHAT_SELECTOR = "[data-testid='new-chat-button']";
-await page.goto(CHATGPT_URL, {{ waitUntil: "domcontentloaded" }});
+const page = await browser.getPage(PAGE_NAME);
+await page.goto(MARKED_URL, {{ waitUntil: "domcontentloaded" }});
 await page.waitForTimeout(800);
+await page.evaluate((name) => {{
+  window.name = name;
+  return window.name;
+}}, WINDOW_NAME);
 const loggedIn = (await page.locator("[data-testid='login-button']").first().count()) === 0;
-// QuickJS: keep this helper small and let Rust own the broader orchestration.
-// Playwright's page.evaluate accepts exactly one arg after the function, so
-// the selectors are passed as a single object.
-const readState = async () => await page.evaluate(({{ composerSelector, assistantSelector }}) => {{
-  const composer = document.querySelector(composerSelector);
-  const assistantCount = document.querySelectorAll(assistantSelector).length;
+const readState = async () => await page.evaluate(() => {{
+  const composer = document.querySelector("#prompt-textarea, [role='textbox']");
+  const assistantCount = document.querySelectorAll("[data-message-author-role='assistant']").length;
   const pathname = window.location.pathname || "/";
+  const title = document.title || "";
+  const bodyText = String(document.body?.innerText || "").replace(/\s+/g, " ").trim().slice(0, 400);
   return {{
     url: window.location.href,
+    title,
+    bodyText,
     pathname,
     onConversationPath: pathname.startsWith("/c/"),
     assistantCount,
     composerVisible: !!composer,
   }};
-}}, {{ composerSelector: COMPOSER_SELECTOR, assistantSelector: ASSISTANT_SELECTOR }});
+}});
 let state = await readState();
-let composerReady =
-  loggedIn &&
-  state.composerVisible &&
+let composerReady = loggedIn && state.composerVisible;
+let selectedModel = null;
+composerReady =
+  composerReady &&
   state.assistantCount === 0 &&
   !state.onConversationPath;
 if (loggedIn && !composerReady) {{
@@ -751,8 +904,9 @@ if (loggedIn && !composerReady) {{
     }}
     await page.waitForTimeout(1000);
     state = await readState();
+    composerReady = state.composerVisible;
     composerReady =
-      state.composerVisible &&
+      composerReady &&
       state.assistantCount === 0 &&
       !state.onConversationPath;
   }}
@@ -765,73 +919,50 @@ if (loggedIn && composerReady) {{
   }}
 }}
 if (loggedIn && composerReady) {{
-  const requested = (MODEL || "").trim().toLowerCase();
-  const autoMode = !requested || requested === "auto";
-  const modelBtn = page.locator("[data-testid='model-switcher-dropdown-button'], button[aria-label='Model selector']").first();
-  if (await modelBtn.count() > 0) {{
-    await modelBtn.waitFor({{ state: "visible", timeout: 5000 }});
-    await modelBtn.click({{ timeout: 5000 }});
-    await page.waitForTimeout(500);
-    const currentModel = String((await modelBtn.innerText().catch(() => "")) || "")
-      .replace(/\s+/g, " ")
-      .trim();
-    const items = await page.locator("[role='menuitem'], [data-testid^='model-switcher-']").evaluateAll((nodes) => nodes.map((node) => {{
-      const text = String(node.textContent || "").replace(/\s+/g, " ").trim();
-      const testId = node.getAttribute("data-testid") || "";
-      return {{ text, haystack: `${{testId}} ${{text}}`.toLowerCase() }};
-    }}));
-    if (items.length > 0) {{
-      if (autoMode) {{
-        const ranked = items
-          .map((item) => {{
-            let score = 0;
-            if (/gpt[- ]?5/.test(item.haystack)) score += 100;
-            if (/\bpro\b/.test(item.haystack)) score += 90;
-            if (/thinking/.test(item.haystack)) score += 60;
-            if (/instant/.test(item.haystack) || /\b5[- ]?3\b/.test(item.haystack)) score += 30;
-            return {{ ...item, score }};
-          }})
-          .sort((left, right) => right.score - left.score || right.text.length - left.text.length);
-        if (ranked[0] && ranked[0].score > 0 && !currentModel.toLowerCase().includes(ranked[0].text.toLowerCase())) {{
-          await page.locator("[role='menuitem'], [data-testid^='model-switcher-']").filter({{ hasText: new RegExp(ranked[0].text.replace(/[.*+?^${{}}()|[\]\\]/g, "\\$&"), "i") }}).first().click({{ timeout: 5000 }});
-        }}
-      }} else {{
-        const slug = requested;
-        const byTestId = page.locator(`[data-testid="model-switcher-${{slug}}"]`).first();
-        if (await byTestId.count() > 0) {{
-          await byTestId.click({{ timeout: 5000 }});
-        }} else {{
-          const matcher = slug.includes("thinking")
-            ? "thinking"
-            : slug.includes("pro")
-              ? "pro"
-              : slug.includes("instant") || slug.includes("5-3")
-                ? "instant"
-                : slug;
-          if (!currentModel.toLowerCase().includes(matcher)) {{
-            const menuItem = page.locator("[role='menuitem'], [data-testid^='model-switcher-']").filter({{ hasText: new RegExp(matcher, "i") }}).first();
-            await menuItem.waitFor({{ state: "visible", timeout: 5000 }});
-            await menuItem.click({{ timeout: 5000 }});
-          }}
-        }}
-      }}
-    }} else if (!autoMode) {{
-      throw new Error(`model '${{requested}}' not found`);
+  const selection = await page.evaluate((functionSource) => {{
+    const fn = eval("(" + functionSource + ")");
+    return fn();
+  }}, MODEL_SELECTION_FUNCTION_SOURCE);
+  const selectionStatus = selection?.status || "unknown";
+  if (!["selected", "already-selected"].includes(selectionStatus)) {{
+    const diagnostics = JSON.stringify({{
+      status: selectionStatus,
+      requested: selection?.requested || MODEL || "",
+      selectedLabel: selection?.selectedLabel || "",
+      targetTestId: selection?.targetTestId || "",
+      availableItems: selection?.availableItems || [],
+      availableItemsAfter: selection?.availableItemsAfter || [],
+    }});
+    if (selectionStatus === "missing-selector") {{
+      throw new Error("model selector button not found (" + diagnostics + ")");
     }}
-  }} else if (!autoMode) {{
-    throw new Error("model selector button not found");
+    if (selectionStatus === "not-found") {{
+      throw new Error("requested model '" + (selection?.requested || MODEL || "") + "' not found (" + diagnostics + ")");
+    }}
+    if (selectionStatus === "selection-mismatch") {{
+      throw new Error("requested model '" + (selection?.requested || MODEL || "") + "' was not selected (" + diagnostics + ")");
+    }}
+    throw new Error("unexpected model selection status '" + selectionStatus + "' (" + diagnostics + ")");
   }}
+  selectedModel = selection?.targetTestId || selection?.modelUsed || selection?.selectedLabel || null;
   await page.waitForTimeout(500);
 }}
 console.log(JSON.stringify({{
   status: !loggedIn ? "login_required" : composerReady ? "ready" : "not_ready",
   loggedIn,
   composerReady,
+  modelUsed: selectedModel,
   url: state.url,
+  title: state.title,
+  bodyText: state.bodyText,
 }}));
 "##,
         page_name_json = page_name_json,
         model_json = model_json,
+        marked_url_json = marked_url_json,
+        window_name_json = window_name_json,
+        model_selection_function_json = model_selection_function_json,
+        composer_selector_json = composer_selector_json,
     )
 }
 
@@ -841,11 +972,22 @@ fn build_chatgpt_send_script(
     delivery_text: &str,
     file_on_clipboard: bool,
     disable_extended: bool,
+    bundle_file_name: Option<&str>,
 ) -> String {
     let page_name_json = serde_json::to_string(page_name).unwrap();
     let file_on_clipboard_json = serde_json::to_string(&file_on_clipboard).unwrap();
     let delivery_text_json = serde_json::to_string(delivery_text).unwrap();
     let prompt_json = serde_json::to_string(prompt).unwrap();
+    let bundle_file_name_json = serde_json::to_string(&bundle_file_name).unwrap();
+    let composer_selector_json = chatgpt_web::composer_selector_json();
+    let send_button_selector_json = chatgpt_web::send_button_selector_json();
+    let stop_button_selector_json = chatgpt_web::stop_button_selector_json();
+    let send_click_function_json =
+        serde_json::to_string(&chatgpt_web::build_send_button_click_function()).unwrap();
+    let attachment_probe_function_json = bundle_file_name.map(|file_name| {
+        serde_json::to_string(&chatgpt_web::build_attachment_probe_function(file_name).unwrap())
+            .unwrap()
+    });
     format!(
         r##"
 const PAGE_NAME = {page_name_json};
@@ -853,8 +995,29 @@ const FILE_ON_CLIPBOARD = {file_on_clipboard_json};
 const DELIVERY_TEXT = {delivery_text_json};
 const PROMPT = {prompt_json};
 const DISABLE_EXTENDED = {disable_extended};
+const BUNDLE_FILE_NAME = {bundle_file_name_json};
+const COMPOSER_SELECTOR = {composer_selector_json};
+const SEND_BUTTON_SELECTOR = {send_button_selector_json};
+const STOP_BUTTON_SELECTOR = {stop_button_selector_json};
+const SEND_CLICK_FUNCTION_SOURCE = {send_click_function_json};
+const ATTACHMENT_PROBE_FUNCTION_SOURCE = {attachment_probe_function_json};
 const page = await browser.getPage(PAGE_NAME);
 let warning = null;
+const waitForAttachmentReady = async () => {{
+  if (!ATTACHMENT_PROBE_FUNCTION_SOURCE) return true;
+  const deadline = Date.now() + 30000;
+  while (Date.now() < deadline) {{
+    const state = await page.evaluate((functionSource) => {{
+      const fn = eval("(" + functionSource + ")");
+      return fn();
+    }}, ATTACHMENT_PROBE_FUNCTION_SOURCE);
+    if (state?.status === "done") {{
+      return true;
+    }}
+    await page.waitForTimeout(500);
+  }}
+  return false;
+}};
 if (DISABLE_EXTENDED) {{
   const extButton = page.locator("button[aria-label*='click to remove'][aria-label*='Extended'], button[aria-label*='remove'][aria-label*='Extended']").first();
   if (await extButton.count() > 0) {{
@@ -864,33 +1027,37 @@ if (DISABLE_EXTENDED) {{
     warning = "extended disable requested but toggle not found";
   }}
 }}
-const composer = page.locator("[role='textbox']").first();
+const composer = page.locator(COMPOSER_SELECTOR).first();
 if (FILE_ON_CLIPBOARD) {{
   await composer.waitFor({{ state: "visible", timeout: 15000 }});
   await composer.click();
   await page.keyboard.press("Meta+v");
-  await page.waitForTimeout(5000);
-  const attached = await page.evaluate(() => {{
-    return !!document.querySelector("[class*='file-tile'], [data-testid*='attachment']");
-  }});
+  const attached = await waitForAttachmentReady();
   if (!attached) {{
-    throw new Error("file not attached after clipboard paste");
+    throw new Error("file attachment did not finish uploading after clipboard paste");
   }}
 }}
 await composer.waitFor({{ state: "visible", timeout: 15000 }});
 await composer.click();
 await composer.pressSequentially(DELIVERY_TEXT, {{ delay: 15 }});
-const sendBtn = page.locator("[data-testid='send-button']").first();
-const readSendState = async () => await page.evaluate(() => {{
-  const send = document.querySelector("[data-testid='send-button']");
-  const composerEl = document.querySelector("#prompt-textarea, [role='textbox']");
+const sendBtn = page.locator(SEND_BUTTON_SELECTOR).first();
+const readSendState = async () => await page.evaluate((composerSelector, sendSelector, bundleFileName) => {{
+  const send = Array.from(document.querySelectorAll(sendSelector)).find((button) => {{
+    const rect = button.getBoundingClientRect();
+    const style = window.getComputedStyle(button);
+    return rect.width > 0 &&
+      rect.height > 0 &&
+      style.visibility !== "hidden" &&
+      style.display !== "none";
+  }}) || null;
+  const composerEl = document.querySelector(composerSelector);
   return {{
     sendButtonPresent: !!send,
     sendDisabled: send ? !!send.disabled : false,
     composerTextLength: (composerEl?.innerText || composerEl?.textContent || "").trim().length,
-    attachmentPresent: !!document.querySelector("[class*='file-tile'], [data-testid*='attachment']"),
+    attachmentPresent: !!bundleFileName,
   }};
-}});
+}}, COMPOSER_SELECTOR, SEND_BUTTON_SELECTOR, BUNDLE_FILE_NAME);
 const enableDeadline = Date.now() + 10000;
 let sendState = await readSendState();
 while (Date.now() < enableDeadline) {{
@@ -906,25 +1073,41 @@ if (await sendBtn.count() === 0 || !(await sendBtn.isEnabled())) {{
   }}));
   return;
 }}
-const assistantCountBeforeSend = await page.locator("[data-message-author-role='assistant']").count();
-await sendBtn.click();
+const sendClick = await page.evaluate((functionSource) => {{
+  const fn = eval("(" + functionSource + ")");
+  return fn();
+}}, SEND_CLICK_FUNCTION_SOURCE);
+if (sendClick?.status !== "sent") {{
+  console.log(JSON.stringify({{
+    status: "error",
+    error: "ChatGPT send click did not succeed: " + JSON.stringify(sendClick || null),
+    warning,
+  }}));
+  return;
+}}
 const transitionDeadline = Date.now() + 10000;
 let transitionState = null;
 while (Date.now() < transitionDeadline) {{
-  transitionState = await page.evaluate((baselineCount) => {{
-    const send = document.querySelector("[data-testid='send-button']");
-    const stopButton = document.querySelector("[data-testid='stop-button']");
+  transitionState = await page.evaluate((baselineCount, composerSelector, sendSelector, stopSelector, bundleFileName) => {{
+    const send = Array.from(document.querySelectorAll(sendSelector)).find((button) => {{
+      const rect = button.getBoundingClientRect();
+      const style = window.getComputedStyle(button);
+      return rect.width > 0 &&
+        rect.height > 0 &&
+        style.visibility !== "hidden" &&
+        style.display !== "none";
+    }}) || null;
+    const stopButton = document.querySelector(stopSelector);
     const assistantCount = document.querySelectorAll("[data-message-author-role='assistant']").length;
-    const composerEl = document.querySelector("#prompt-textarea, [role='textbox']");
+    const composerEl = document.querySelector(composerSelector);
     const composerText = (composerEl?.innerText || composerEl?.textContent || "").trim();
-    const attachmentPresent = !!document.querySelector("[class*='file-tile'], [data-testid*='attachment']");
     return {{
       sendButtonPresent: !!send,
       sendDisabled: send ? !!send.disabled : false,
       stopButtonPresent: !!stopButton,
       assistantCount,
       composerTextLength: composerText.length,
-      attachmentPresent,
+      attachmentPresent: !!bundleFileName,
       transitionObserved:
         !!stopButton ||
         assistantCount > baselineCount ||
@@ -932,7 +1115,7 @@ while (Date.now() < transitionDeadline) {{
         (!!send && !!send.disabled) ||
         composerText.length === 0,
     }};
-  }}, assistantCountBeforeSend);
+  }}, sendClick.assistantCountBeforeSend || 0, COMPOSER_SELECTOR, SEND_BUTTON_SELECTOR, STOP_BUTTON_SELECTOR, BUNDLE_FILE_NAME);
   if (transitionState.transitionObserved) break;
   await page.waitForTimeout(500);
 }}
@@ -940,14 +1123,16 @@ if (!transitionState || !transitionState.transitionObserved) {{
   console.log(JSON.stringify({{
     status: "error",
     error: "ChatGPT send click did not trigger a UI transition within 10s. " + JSON.stringify(transitionState || {{}}),
-    assistantCountBeforeSend,
+    assistantCountBeforeSend: sendClick.assistantCountBeforeSend || 0,
+    assistantLastLenBeforeSend: sendClick.assistantLastLenBeforeSend || 0,
     warning,
   }}));
   return;
 }}
 console.log(JSON.stringify({{
         status: "sent",
-        assistantCountBeforeSend,
+        assistantCountBeforeSend: sendClick.assistantCountBeforeSend || 0,
+        assistantLastLenBeforeSend: sendClick.assistantLastLenBeforeSend || 0,
         warning,
 }}));
 "##,
@@ -955,6 +1140,13 @@ console.log(JSON.stringify({{
         file_on_clipboard_json = file_on_clipboard_json,
         delivery_text_json = delivery_text_json,
         prompt_json = prompt_json,
+        bundle_file_name_json = bundle_file_name_json,
+        composer_selector_json = composer_selector_json,
+        send_button_selector_json = send_button_selector_json,
+        stop_button_selector_json = stop_button_selector_json,
+        send_click_function_json = send_click_function_json,
+        attachment_probe_function_json =
+            attachment_probe_function_json.unwrap_or_else(|| "null".to_string()),
         disable_extended = disable_extended,
     )
 }
@@ -1009,34 +1201,52 @@ fn set_file_on_clipboard(path: &Path) -> Result<()> {
 fn build_chatgpt_poll_script(
     page_name: &str,
     assistant_count_before_send: usize,
+    assistant_last_len_before_send: usize,
     poll_settings: ChatgptPollSettings,
     allow_empty_response: bool,
 ) -> String {
     let page_name_json = serde_json::to_string(page_name).unwrap();
+    let stable_idle_threshold_ms = chatgpt_web::stable_idle_threshold_ms(poll_settings.interval_ms);
     format!(
         r#"
 const PAGE_NAME = {page_name_json};
-const BASELINE = {assistant_count_before_send};
+const BASELINE_COUNT = {assistant_count_before_send};
+const BASELINE_LAST_LEN = {assistant_last_len_before_send};
 const POLL_TIMEOUT_MS = {poll_timeout_ms};
 const POLL_INTERVAL_MS = {poll_interval_ms};
+const STABLE_IDLE_THRESHOLD_MS = {stable_idle_threshold_ms};
 const ALLOW_EMPTY_RESPONSE = {allow_empty_response};
 const page = await browser.getPage(PAGE_NAME);
 const start = Date.now();
-let lastResponseText = null;
+let stableSince = null;
+let stableKey = null;
 while (Date.now() - start < POLL_TIMEOUT_MS) {{
-  const state = await page.evaluate((baselineCount) => {{
+  const state = await page.evaluate((baselineCount, baselineLastLen) => {{
     const errorEl = document.querySelector("[role='alert'], [data-testid*='error']");
     const hasThinkingIndicator = !!document.querySelector(".result-thinking, [data-testid*='thinking']");
-    const assistantMessages = Array.from(document.querySelectorAll("[data-message-author-role='assistant']")).slice(baselineCount);
-    const response = assistantMessages.map((message) => message.innerText).join("\n---\n").trim();
+    const allAssistantMessages = Array.from(document.querySelectorAll("[data-message-author-role='assistant']"));
+    const assistantMessages = allAssistantMessages.slice(baselineCount);
+    const lastAssistantMessage = allAssistantMessages.length > 0 ? allAssistantMessages[allAssistantMessages.length - 1] : null;
+    const lastAssistantLen = (lastAssistantMessage?.innerText || "").length;
+    const newAssistantCount = assistantMessages.length;
+    const newMessage = allAssistantMessages.length > baselineCount;
+    const sameMessageGrew = allAssistantMessages.length === baselineCount && lastAssistantLen > baselineLastLen;
+    const response = (newMessage
+      ? assistantMessages.map((message) => message.innerText).join("\n---\n")
+      : (sameMessageGrew ? (lastAssistantMessage?.innerText || "") : "")
+    ).trim();
     return {{
       error: errorEl ? errorEl.innerText.slice(0, 200).trim() : null,
       hasThinkingIndicator,
       hasStopButton: !!document.querySelector("[data-testid='stop-button']"),
-      newAssistantCount: assistantMessages.length,
+      newAssistantCount,
+      assistantCount: allAssistantMessages.length,
+      lastAssistantLen,
+      newMessage,
+      sameMessageGrew,
       response,
     }};
-  }}, BASELINE);
+  }}, BASELINE_COUNT, BASELINE_LAST_LEN);
   if (state.error) {{
     console.log(JSON.stringify({{ status: "error", error: state.error }}));
     return;
@@ -1044,16 +1254,26 @@ while (Date.now() - start < POLL_TIMEOUT_MS) {{
   const completionCandidate =
     !state.hasStopButton &&
     !state.hasThinkingIndicator &&
-    state.newAssistantCount > 0 &&
-    (ALLOW_EMPTY_RESPONSE || state.response.length > 0);
+    ((state.newMessage && (ALLOW_EMPTY_RESPONSE || state.response.length > 0)) || state.sameMessageGrew);
   if (completionCandidate) {{
-    if (lastResponseText !== null && state.response === lastResponseText) {{
-      console.log(JSON.stringify({{ status: "ok", response: state.response }}));
-      return;
+    const responseKey = `${{state.assistantCount}}:${{state.lastAssistantLen}}:${{state.response.length}}`;
+    if (stableKey === responseKey) {{
+      if (stableSince !== null && (Date.now() - stableSince) >= STABLE_IDLE_THRESHOLD_MS) {{
+        console.log(JSON.stringify({{
+          status: "ok",
+          response: state.response,
+          stable_for_ms: Date.now() - stableSince,
+          stable_idle_threshold_ms: STABLE_IDLE_THRESHOLD_MS,
+        }}));
+        return;
+      }}
+    }} else {{
+      stableKey = responseKey;
+      stableSince = Date.now();
     }}
-    lastResponseText = state.response;
   }} else {{
-    lastResponseText = null;
+    stableKey = null;
+    stableSince = null;
   }}
   await page.waitForTimeout(POLL_INTERVAL_MS);
 }}
@@ -1064,8 +1284,10 @@ console.log(JSON.stringify({{
 "#,
         page_name_json = page_name_json,
         assistant_count_before_send = assistant_count_before_send,
+        assistant_last_len_before_send = assistant_last_len_before_send,
         poll_timeout_ms = poll_settings.timeout_ms,
         poll_interval_ms = poll_settings.interval_ms,
+        stable_idle_threshold_ms = stable_idle_threshold_ms,
         allow_empty_response = allow_empty_response,
     )
 }
@@ -1141,10 +1363,9 @@ fn parse_chatgpt_recipe_result(
 /// QuickJS/WASM sandboxes, and large scripts with many closures are prone to a
 /// GC assertion on disposal. Rust owns the orchestration; each script only does
 /// one browser phase and returns JSON over stdout.
-pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<String> {
-    let recipe_lock = browser::acquire_chatgpt_recipe_lock()?;
+pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<ChatgptRecipeRunResult> {
     let browser_name = CHATGPT_BROWSER_NAME.to_string();
-    let page_name = CHATGPT_PAGE_NAME.to_string();
+    let page_name = format!("{}-{}", CHATGPT_RECIPE_PAGE_NAME_PREFIX, ctx.run_id);
     let cdp_endpoint = ctx.cdp_endpoint.as_deref();
     let run_script = |script: &str, timeout_secs: Option<u64>| {
         run_script_connect_with_browser_and_endpoint(
@@ -1154,13 +1375,8 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<String> {
             cdp_endpoint,
         )
     };
-    if ctx.show_approval_guidance && recipe_lock.waited() {
-        eprintln!(
-            "info: another yoetz process is already using the shared ChatGPT dev-browser page; waiting for it to finish before reusing the tab"
-        );
-    }
 
-    let result = (|| -> Result<(String, Vec<String>)> {
+    let result = (|| -> Result<(String, Vec<String>, Option<String>)> {
         let mut warnings = Vec::new();
         let file_on_clipboard = if ctx.paste_mode {
             false
@@ -1184,7 +1400,7 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<String> {
             ctx.prompt.clone()
         };
 
-        let prepare_script = build_chatgpt_prepare_script(&page_name, &ctx.model);
+        let prepare_script = build_chatgpt_prepare_script(&page_name, &ctx.model, &ctx.run_id);
         let prepare_stdout = {
             let approval_lock = browser::acquire_chrome_approval_lock()?;
             if ctx.show_approval_guidance {
@@ -1201,17 +1417,30 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<String> {
         };
         let prepare: ChatgptPrepareResult =
             parse_script_json("parse chatgpt prepare result", &prepare_stdout)?;
+        let model_used = prepare
+            .model_used
+            .as_deref()
+            .and_then(chatgpt_web::canonical_chatgpt_model_slug);
+        let classified_issue =
+            classify_dev_browser_page_issue(&prepare.url, &prepare.title, &prepare.body_text);
         match prepare.status.as_str() {
             "ready" if prepare.logged_in && prepare.composer_ready => {}
             "login_required" => {
                 return Err(anyhow!(
-                    "chatgpt login required in the attached Chrome session. Log in there and try again."
+                    "{}",
+                    classified_issue.unwrap_or(
+                        "chatgpt login required in the attached Chrome session. Log in there and try again."
+                    )
                 ));
             }
             "not_ready" => {
+                if let Some(issue) = classified_issue {
+                    return Err(anyhow!("{issue}"));
+                }
                 return Err(anyhow!(
-                    "ChatGPT did not finish loading the composer on {}. Restart Chrome with chrome://inspect/#remote-debugging enabled and try again.",
-                    prepare.url
+                    "ChatGPT did not finish loading the composer on {} (title: {:?}). Restart Chrome with chrome://inspect/#remote-debugging enabled and try again.",
+                    prepare.url,
+                    prepare.title
                 ));
             }
             other => {
@@ -1228,6 +1457,10 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<String> {
             &delivery_text,
             file_on_clipboard,
             ctx.disable_extended,
+            ctx.bundle_path
+                .as_deref()
+                .and_then(|path| path.file_name())
+                .and_then(|value| value.to_str()),
         );
         let send_stdout = run_script(&send_script, Some(90))?;
         let send: ChatgptSendResult = parse_script_json("parse chatgpt send result", &send_stdout)?;
@@ -1250,24 +1483,37 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<String> {
         let poll_script = build_chatgpt_poll_script(
             &page_name,
             send.assistant_count_before_send.unwrap_or(0),
+            send.assistant_last_len_before_send.unwrap_or(0),
             ctx.poll_settings,
             ctx.allow_empty_response,
         );
-        let poll_stdout = run_script(
+        let wait_started_at = Instant::now();
+        let heartbeat = ChatgptWaitHeartbeat::start(ctx.poll_settings);
+        let poll_result = run_script(
             &poll_script,
             Some(chatgpt_script_timeout_secs(ctx.poll_settings.timeout_ms)),
-        )?;
+        );
+        heartbeat.stop();
+        let poll_stdout = poll_result?;
         let (response, mut poll_warnings) =
             parse_chatgpt_recipe_result(&poll_stdout, ctx.poll_settings.timeout_ms)?;
+        eprintln!(
+            "info: ChatGPT response completed after {}",
+            format_chatgpt_wait_duration(wait_started_at.elapsed())
+        );
         warnings.append(&mut poll_warnings);
-        Ok((response, warnings))
+        Ok((response, warnings, model_used))
     })();
 
-    let (response, warnings) = result?;
-    for warning in warnings {
+    let (response, warnings, model_used) = result?;
+    for warning in &warnings {
         eprintln!("warn: {warning}");
     }
-    Ok(response)
+    Ok(ChatgptRecipeRunResult {
+        response,
+        model_used,
+        warnings,
+    })
 }
 
 #[cfg(test)]
@@ -1341,10 +1587,10 @@ mod tests {
     fn looks_like_dev_browser_connect_failure_matches_connect_timeout() {
         let err =
             anyhow!("browser.newPage: Timeout 30000ms exceeded while waiting for connectOverCDP");
-        assert!(looks_like_dev_browser_connect_failure(&err));
+        assert!(is_dev_browser_connect_failure(&err));
 
         let other = anyhow!("ChatGPT response timed out after 900000ms");
-        assert!(!looks_like_dev_browser_connect_failure(&other));
+        assert!(!is_dev_browser_connect_failure(&other));
     }
 
     #[test]
@@ -1418,37 +1664,109 @@ mod tests {
             .unwrap(),
             Some("ws://127.0.0.1:9222/devtools/browser/test-browser-id".to_string())
         );
+        assert_eq!(
+            resolve_dev_browser_connect_endpoint(Some("http://localhost:9222")).unwrap(),
+            Some("http://localhost:9222".to_string())
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn resolve_dev_browser_connect_endpoint_rejects_remote_by_default() {
+        // Non-loopback CDP endpoints must be rejected unless the operator opts
+        // in via YOETZ_CDP_ALLOW_REMOTE=1 (review finding #5).
+        let previous =
+            std::env::var(crate::chrome_devtools_mcp::client::YOETZ_CDP_ALLOW_REMOTE_ENV).ok();
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::remove_var(crate::chrome_devtools_mcp::client::YOETZ_CDP_ALLOW_REMOTE_ENV);
+        }
+        let err = resolve_dev_browser_connect_endpoint(Some("http://attacker.example.com:9222"))
+            .expect_err("remote endpoints must be rejected by default");
+        let message = format!("{err:#}");
+        assert!(message.contains("not on localhost"));
+        assert!(message.contains(crate::chrome_devtools_mcp::client::YOETZ_CDP_ALLOW_REMOTE_ENV));
+        if let Some(value) = previous {
+            #[allow(unsafe_code)]
+            unsafe {
+                std::env::set_var(
+                    crate::chrome_devtools_mcp::client::YOETZ_CDP_ALLOW_REMOTE_ENV,
+                    value,
+                );
+            }
+        }
     }
 
     #[test]
     fn build_chatgpt_prepare_script_uses_named_page_and_login_check() {
-        let script = build_chatgpt_prepare_script("yoetz-chatgpt-test", "gpt-5-4-pro");
+        let script = build_chatgpt_prepare_script("yoetz-chatgpt-test", "gpt-5-4-pro", "run-123");
 
         assert!(script.contains("const PAGE_NAME = \"yoetz-chatgpt-test\";"));
         assert!(script.contains("const MODEL = \"gpt-5-4-pro\";"));
-        assert!(script.contains("const page = await browser.getPage(PAGE_NAME);"));
+        assert!(script.contains("const MARKED_URL = \"https://chatgpt.com/?_yoetz=run-123\";"));
+        assert!(script.contains("const WINDOW_NAME = \"yoetz:run-123\";"));
         assert!(
-            script.contains("await page.goto(CHATGPT_URL, { waitUntil: \"domcontentloaded\" });")
+            script.contains("await page.goto(MARKED_URL, { waitUntil: \"domcontentloaded\" });")
         );
+        assert!(script.contains("window.name = name;"));
         assert!(script.contains("[data-testid='login-button']"));
         assert!(script.contains("const NEW_CHAT_SELECTOR = \"[data-testid='new-chat-button']\";"));
+        assert!(script.contains("const MODEL_SELECTION_FUNCTION_SOURCE ="));
         assert!(script.contains("const canUseNewChat = attempt === 0;"));
         assert!(script.contains("await page.reload({ waitUntil: \"domcontentloaded\" });"));
-        assert!(script.contains("page.evaluate(({ composerSelector, assistantSelector })"));
-        assert!(!script.contains("page.evaluate((composerSelector, assistantSelector)"));
+        assert!(script.contains("page.evaluate(() => {"));
         assert!(script.contains("state.assistantCount === 0"));
         assert!(script.contains("pathname.startsWith(\"/c/\")"));
+        assert!(script.contains("const selection = await page.evaluate((functionSource) => {"));
+        assert!(script.contains("\\\"gpt-5-pro\\\":\\\"gpt-5-4-pro\\\""));
+        assert!(!script.contains("\\\"gpt-5-3-pro\\\""));
+        assert!(script.contains(
+            "requested model '\" + (selection?.requested || MODEL || \"\") + \"' was not selected"
+        ));
+        assert!(script.contains("let selectedModel = null;"));
+        assert!(script.contains(
+            "selectedModel = selection?.targetTestId || selection?.modelUsed || selection?.selectedLabel || null;"
+        ));
+        assert!(script.contains("modelUsed: selectedModel,"));
+        assert!(script.contains("bodyText"));
         assert!(script.contains(
             "status: !loggedIn ? \"login_required\" : composerReady ? \"ready\" : \"not_ready\""
         ));
     }
 
     #[test]
+    fn build_chatgpt_prepare_script_marks_a_yoetz_owned_tab() {
+        let script = build_chatgpt_prepare_script("yoetz-chatgpt-test", "pro", "run-456");
+        assert!(script.contains("const MARKED_URL = \"https://chatgpt.com/?_yoetz=run-456\";"));
+        assert!(script.contains("const WINDOW_NAME = \"yoetz:run-456\";"));
+        assert!(
+            script.contains("await page.goto(MARKED_URL, { waitUntil: \"domcontentloaded\" });")
+        );
+        assert!(script.contains("window.name = name;"));
+    }
+
+    #[test]
+    fn chatgpt_auth_probe_script_reuses_named_page_and_existing_tabs() {
+        let script = build_chatgpt_auth_probe_script("yoetz-chatgpt-test");
+
+        assert!(script.contains("const PAGE_NAME = \"yoetz-chatgpt-test\";"));
+        assert!(script.contains("const pages = await browser.listPages();"));
+        assert!(script.contains("pages.find((entry) => entry.name === PAGE_NAME)"));
+        assert!(script.contains("await browser.getPage(chatgptPage.name || chatgptPage.id)"));
+        assert!(script.contains("await browser.getPage(PAGE_NAME)"));
+        assert!(
+            script.contains("await page.goto(CHATGPT_URL, { waitUntil: \"domcontentloaded\" });")
+        );
+        assert!(script.contains("bodyText"));
+        assert!(!script.contains("browser.newPage()"));
+    }
+
+    #[test]
     fn chatgpt_recipe_uses_stable_browser_and_page_names() {
         assert_eq!(CHATGPT_BROWSER_NAME, "yoetz-chatgpt");
-        assert_eq!(CHATGPT_PAGE_NAME, "yoetz-chatgpt-main");
-        assert!(!CHATGPT_PAGE_NAME.contains("pid"));
-        assert!(!CHATGPT_PAGE_NAME.contains('_'));
+        assert_eq!(CHATGPT_AUTH_PROBE_PAGE_NAME, "yoetz-chatgpt-main");
+        assert_eq!(CHATGPT_RECIPE_PAGE_NAME_PREFIX, "yoetz-chatgpt-run");
+        assert!(!CHATGPT_AUTH_PROBE_PAGE_NAME.contains("pid"));
     }
 
     #[test]
@@ -1459,14 +1777,17 @@ mod tests {
             "Review this file.",
             true,
             true,
+            Some("bundle.txt"),
         );
 
         assert!(script.contains("const PAGE_NAME = \"yoetz-chatgpt-test\";"));
         assert!(script.contains("const FILE_ON_CLIPBOARD = true;"));
         assert!(script.contains("await composer.waitFor({ state: \"visible\", timeout: 15000 });"));
         assert!(script.contains("await page.keyboard.press(\"Meta+v\");"));
-        assert!(script.contains("file not attached after clipboard paste"));
-        assert!(script.contains("[class*='file-tile'], [data-testid*='attachment']"));
+        assert!(script.contains("file attachment did not finish uploading after clipboard paste"));
+        assert!(script.contains("const ATTACHMENT_PROBE_FUNCTION_SOURCE ="));
+        assert!(script.contains("const SEND_CLICK_FUNCTION_SOURCE ="));
+        assert!(script.contains("assistantLastLenBeforeSend"));
         assert!(script.contains("pressSequentially(DELIVERY_TEXT, { delay: 15 })"));
         assert!(script.contains("status: \"sent\""));
     }
@@ -1475,13 +1796,18 @@ mod tests {
     fn parse_script_json_reads_prepare_result() {
         let result: ChatgptPrepareResult = parse_script_json(
             "prepare",
-            r#"{"status":"ready","loggedIn":true,"composerReady":true,"url":"https://chatgpt.com/"}"#,
+            r#"{"status":"ready","loggedIn":true,"composerReady":true,"modelUsed":"model-switcher-gpt-5-4-pro","url":"https://chatgpt.com/","title":"ChatGPT","bodyText":"Send a message"}"#,
         )
         .unwrap();
 
         assert_eq!(result.status, "ready");
         assert!(result.logged_in);
         assert!(result.composer_ready);
+        assert_eq!(
+            result.model_used.as_deref(),
+            Some("model-switcher-gpt-5-4-pro")
+        );
+        assert_eq!(result.title, "ChatGPT");
     }
 
     #[test]
@@ -1489,6 +1815,7 @@ mod tests {
         let script = build_chatgpt_poll_script(
             "yoetz-chatgpt-test",
             3,
+            120,
             ChatgptPollSettings {
                 timeout_ms: 900_000,
                 interval_ms: 45_000,
@@ -1497,18 +1824,63 @@ mod tests {
         );
 
         assert!(script.contains("const PAGE_NAME = \"yoetz-chatgpt-test\";"));
-        assert!(script.contains("const BASELINE = 3;"));
+        assert!(script.contains("const BASELINE_COUNT = 3;"));
+        assert!(script.contains("const BASELINE_LAST_LEN = 120;"));
         assert!(script.contains("const POLL_TIMEOUT_MS = 900000;"));
         assert!(script.contains("const POLL_INTERVAL_MS = 45000;"));
+        assert!(script.contains("const STABLE_IDLE_THRESHOLD_MS = 135000;"));
         assert!(script.contains("const ALLOW_EMPTY_RESPONSE = false;"));
-        assert!(script.contains("let lastResponseText = null;"));
+        assert!(script.contains("let stableSince = null;"));
         assert!(script.contains(".result-thinking, [data-testid*='thinking']"));
         assert!(script.contains("[data-testid='stop-button']"));
         assert!(script.contains("[data-message-author-role='assistant']"));
-        assert!(script.contains("!state.hasThinkingIndicator"));
-        assert!(script.contains("state.response === lastResponseText"));
+        assert!(script.contains("sameMessageGrew"));
+        assert!(script.contains("stableKey === responseKey"));
         assert!(script.contains("status: \"ok\""));
         assert!(script.contains("status: \"timeout\""));
+    }
+
+    #[test]
+    fn classify_dev_browser_page_issue_matches_challenge_and_login_states() {
+        assert_eq!(
+            classify_dev_browser_page_issue(
+                "https://chatgpt.com/",
+                "Just a moment...",
+                "Verify you are human"
+            ),
+            Some(
+                "cloudflare challenge detected in the attached Chrome session. Solve it in your browser window and try again."
+            )
+        );
+        assert_eq!(
+            classify_dev_browser_page_issue(
+                "https://auth.openai.com/login",
+                "Log in",
+                "Continue with Google"
+            ),
+            Some("chatgpt login required in the attached Chrome session. Log in there and try again.")
+        );
+    }
+
+    #[test]
+    fn chatgpt_wait_heartbeat_interval_is_clamped() {
+        assert_eq!(chatgpt_wait_heartbeat_interval_ms(1_000), 15_000);
+        assert_eq!(chatgpt_wait_heartbeat_interval_ms(30_000), 30_000);
+        assert_eq!(chatgpt_wait_heartbeat_interval_ms(120_000), 60_000);
+    }
+
+    #[test]
+    fn chatgpt_wait_progress_message_is_human_readable() {
+        let message = chatgpt_wait_progress_message(
+            Duration::from_secs(95),
+            ChatgptPollSettings {
+                timeout_ms: 1_800_000,
+                interval_ms: 30_000,
+            },
+        );
+        assert!(message.contains("elapsed 1m 35s"));
+        assert!(message.contains("timeout 30m 0s"));
+        assert!(message.contains("poll every 30s"));
     }
 
     #[test]
@@ -1616,5 +1988,13 @@ mod tests {
         }
 
         assert!(command_is_available(script.to_str().unwrap()));
+    }
+
+    #[test]
+    fn missing_dev_browser_error_requires_explicit_install() {
+        let detail = missing_dev_browser_error().to_string();
+        assert!(detail.contains("Install it explicitly"));
+        assert!(detail.contains("YOETZ_DEV_BROWSER_BIN"));
+        assert!(!detail.contains("installing via npm"));
     }
 }

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -19,6 +19,8 @@ use std::time::Duration;
 
 mod browser;
 mod budget;
+mod chatgpt_recipe;
+mod chatgpt_web;
 mod chrome_devtools_mcp;
 mod commands;
 mod dev_browser;
@@ -60,8 +62,8 @@ struct Cli {
     #[arg(long, global = true)]
     output_schema: Option<PathBuf>,
 
-    #[arg(long, global = true)]
-    profile: Option<String>,
+    #[arg(long = "config-profile", global = true)]
+    config_profile: Option<String>,
 
     #[arg(long, global = true, default_value = "60")]
     timeout_secs: u64,
@@ -76,6 +78,7 @@ struct Cli {
 
 struct AppContext {
     config: Config,
+    browser_defaults: browser::BrowserDefaults,
     client: reqwest::Client,
     litellm: std::sync::Arc<LiteLLM>,
     output_final: Option<PathBuf>,
@@ -211,6 +214,7 @@ enum BrowserCommand {
     Recipe(BrowserRecipeArgs),
     Login(BrowserLoginArgs),
     Check(BrowserCheckArgs),
+    Doctor(BrowserDoctorArgs),
     /// Explicitly reset browser automation daemons. Use this when recovery is
     /// needed; yoetz does not silently recycle live-attach daemons for you.
     Reset(BrowserResetArgs),
@@ -219,6 +223,11 @@ enum BrowserCommand {
     /// Attach to a running Chrome instance and verify authentication.
     /// Auto-discovers via chrome://inspect (Chrome 144+), or use --cdp for explicit endpoint.
     Attach(BrowserAttachArgs),
+    /// Thin CDP smoke-test for CI/integration: attaches to the given CDP
+    /// endpoint, opens an `about:blank` tab, and reports JSON success. Does
+    /// not navigate to ChatGPT, does not probe authentication — so it is
+    /// safe to run against a fresh throwaway Chrome for Testing instance.
+    VerifyCdp(BrowserVerifyCdpArgs),
 }
 
 #[derive(Args)]
@@ -242,6 +251,10 @@ struct BrowserRecipeArgs {
     #[arg(long)]
     cdp: Option<String>,
 
+    /// Select a local Chrome browser by its published `/devtools/browser/<id>` suffix.
+    #[arg(long)]
+    browser_id: Option<String>,
+
     #[arg(long = "var", value_name = "KEY=VALUE")]
     vars: Vec<String>,
 }
@@ -253,6 +266,9 @@ struct BrowserLoginArgs {
     /// Connect to Chrome via CDP (explicit only, no auto-discovery for login)
     #[arg(long)]
     cdp: Option<String>,
+    /// Select a local Chrome browser by its published `/devtools/browser/<id>` suffix.
+    #[arg(long)]
+    browser_id: Option<String>,
 }
 
 #[derive(Args)]
@@ -263,6 +279,9 @@ struct BrowserCheckArgs {
     /// or config, then chrome://inspect auto-connect (Chrome 144+).
     #[arg(long)]
     cdp: Option<String>,
+    /// Select a local Chrome browser by its published `/devtools/browser/<id>` suffix.
+    #[arg(long)]
+    browser_id: Option<String>,
 }
 
 #[derive(Args)]
@@ -271,6 +290,30 @@ struct BrowserAttachArgs {
     /// or config, then chrome://inspect auto-connect (Chrome 144+).
     #[arg(long)]
     cdp: Option<String>,
+    /// Select a local Chrome browser by its published `/devtools/browser/<id>` suffix.
+    #[arg(long)]
+    browser_id: Option<String>,
+}
+
+#[derive(Args)]
+struct BrowserVerifyCdpArgs {
+    /// CDP endpoint (e.g. http://127.0.0.1:9222). Required — this command
+    /// exists to verify CI-launched Chrome for Testing instances, so it does
+    /// not fall back to auto-discovery.
+    #[arg(long)]
+    cdp: String,
+    /// Verification page URL (default `about:blank`). Must be a
+    /// yoetz-safe / throwaway URL — this subcommand will navigate to it.
+    #[arg(long, default_value = "about:blank")]
+    url: String,
+}
+
+#[derive(Args)]
+struct BrowserDoctorArgs {
+    /// Perform a live auto-connect probe against Chrome. This may trigger
+    /// Chrome's remote-debugging approval dialog.
+    #[arg(long)]
+    live: bool,
 }
 
 #[derive(Args)]
@@ -683,7 +726,7 @@ struct ModelEstimate {
     estimate_usd: Option<f64>,
 }
 
-const PROTECTED_DOTENV_ENV_VARS: &[&str] = &[
+const BASE_PROTECTED_DOTENV_ENV_VARS: &[&str] = &[
     "YOETZ_AGENT_BROWSER_BIN",
     "YOETZ_DEV_BROWSER_BIN",
     "YOETZ_SCRIPTS_DIR",
@@ -697,16 +740,34 @@ const PROTECTED_DOTENV_ENV_VARS: &[&str] = &[
     "GEMINI_API_KEY",
     "OPENROUTER_API_KEY",
     "XAI_API_KEY",
+    "LITELLM_API_KEY",
 ];
 
-fn snapshot_protected_dotenv_env() -> Vec<(&'static str, Option<String>)> {
-    PROTECTED_DOTENV_ENV_VARS
+fn protected_dotenv_env_vars(config: &Config) -> Vec<String> {
+    let mut keys = BASE_PROTECTED_DOTENV_ENV_VARS
         .iter()
-        .map(|&key| (key, env::var(key).ok()))
+        .map(|key| (*key).to_string())
+        .collect::<std::collections::BTreeSet<_>>();
+    for provider in config.providers.values() {
+        if let Some(key) = provider
+            .api_key_env
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            keys.insert(key.to_string());
+        }
+    }
+    keys.into_iter().collect()
+}
+
+fn snapshot_protected_dotenv_env(keys: &[String]) -> Vec<(String, Option<String>)> {
+    keys.iter()
+        .map(|key| (key.clone(), env::var(key).ok()))
         .collect()
 }
 
-fn restore_protected_dotenv_env(snapshot: &[(&str, Option<String>)]) {
+fn restore_protected_dotenv_env(snapshot: &[(String, Option<String>)]) {
     for (key, pre_value) in snapshot {
         let post_value = env::var(key).ok();
         if post_value != *pre_value {
@@ -721,29 +782,38 @@ fn restore_protected_dotenv_env(snapshot: &[(&str, Option<String>)]) {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let config = Config::load_with_profile(cli.config_profile.as_deref())?;
+    let browser_defaults =
+        browser::load_browser_defaults_with_profile(cli.config_profile.as_deref())?;
+
     // Capture security-sensitive env vars before dotenv loading.
     // CWD .env files must not override executable paths (supply-chain risk)
     // or redirect config, registry, browser targets, or API keys.
-    let protected_env = snapshot_protected_dotenv_env();
+    let protected_env_keys = protected_dotenv_env_vars(&config);
+    let protected_env = snapshot_protected_dotenv_env(&protected_env_keys);
 
     // Load environment files (.env.local takes precedence over .env)
     dotenvy::from_filename(".env.local").ok();
     dotenvy::dotenv().ok();
 
     restore_protected_dotenv_env(&protected_env);
-
-    let cli = Cli::parse();
     let format = resolve_format(cli.format.as_deref())?;
 
     if cli.debug {
         env::set_var("YOETZ_GEMINI_DEBUG", "1");
         env::set_var("LITELLM_GEMINI_DEBUG", "1");
+        // Unlock detailed CDP error rendering (inferred emails + sample tabs)
+        // when the user explicitly asks for debug output. Default remains
+        // redacted to avoid leaking browsing context in routine errors
+        // (review finding #9).
+        env::set_var(chrome_devtools_mcp::client::YOETZ_DEBUG_CDP_ENV, "1");
     }
-    let config = Config::load_with_profile(cli.profile.as_deref())?;
     let client = build_client(cli.timeout_secs)?;
     let litellm = std::sync::Arc::new(build_litellm(&config, client.clone())?);
     let ctx = AppContext {
         config,
+        browser_defaults,
         client,
         litellm,
         output_final: cli.output_final,
@@ -928,11 +998,20 @@ fn recipe_should_stop_live_transport_fallback(
     err: &anyhow::Error,
     selected_cdp_target: Option<&browser::ResolvedCdpTarget>,
     transport: browser::RecipeTransport,
+    recipe_vars: &std::collections::BTreeMap<String, String>,
 ) -> bool {
     if browser::is_chrome_approval_wait_error(err) {
         return true;
     }
-    if is_thread_reuse_error(err) {
+    if browser::is_chatgpt_auth_issue_error(err) {
+        return true;
+    }
+    if recipe_uses_chatgpt_browser_context_selector(recipe_vars)
+        && browser::is_chatgpt_profile_selector_visibility_error(err)
+    {
+        return true;
+    }
+    if browser::is_chatgpt_attached_page_error(err) {
         return true;
     }
 
@@ -941,13 +1020,6 @@ fn recipe_should_stop_live_transport_fallback(
     // targets and auto-selected targets remain advisory.
     selected_cdp_target.is_some_and(browser::ResolvedCdpTarget::is_authoritative)
         && !matches!(transport, browser::RecipeTransport::Manual)
-}
-
-fn is_thread_reuse_error(err: &anyhow::Error) -> bool {
-    err.chain().any(|cause| {
-        let message = cause.to_string();
-        message.contains("thread=reuse")
-    })
 }
 
 /// A transport is "pure live-CDP" if its only way to drive the browser is
@@ -972,6 +1044,38 @@ fn is_live_cdp_only_transport(transport: browser::RecipeTransport) -> bool {
 /// managed profile without CDP).
 fn recipe_should_skip_remaining_live_cdp_transports(err: &anyhow::Error) -> bool {
     browser::is_chrome_cdp_unreachable_error(err)
+}
+
+fn recipe_uses_chatgpt_browser_context_selector(
+    recipe_vars: &std::collections::BTreeMap<String, String>,
+) -> bool {
+    ["browser_context_id", "profile_email"]
+        .into_iter()
+        .any(|key| {
+            recipe_vars
+                .get(key)
+                .is_some_and(|value| !value.trim().is_empty())
+        })
+}
+
+fn constrain_chatgpt_transports_for_browser_context_selector(
+    transports: Vec<browser::RecipeTransport>,
+    recipe_vars: &std::collections::BTreeMap<String, String>,
+    is_chatgpt: bool,
+) -> Vec<browser::RecipeTransport> {
+    if !is_chatgpt || !recipe_uses_chatgpt_browser_context_selector(recipe_vars) {
+        return transports;
+    }
+
+    transports
+        .into_iter()
+        .filter(|transport| {
+            matches!(
+                transport,
+                browser::RecipeTransport::ChromeDevtoolsMcp | browser::RecipeTransport::Manual
+            )
+        })
+        .collect()
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1012,6 +1116,26 @@ fn browser_check_live_method(target: Option<&browser::ResolvedCdpTarget>) -> Str
     }
 }
 
+fn remember_browser_check_live_attach_failure(slot: &mut Option<String>, err: &anyhow::Error) {
+    if slot.is_none() && browser::is_chrome_cdp_unreachable_error(err) {
+        *slot = Some(format!("{err:#}"));
+    }
+}
+
+fn maybe_prefer_browser_check_live_attach_failure(
+    err: anyhow::Error,
+    prior_live_attach_failure: Option<&str>,
+) -> anyhow::Error {
+    if browser::is_chatgpt_auth_issue_error(&err) {
+        if let Some(prior) = prior_live_attach_failure {
+            return anyhow!(
+                "live Chrome attach failed before legacy fallback could verify ChatGPT auth.\n\nLive-attach error: {prior}\n\nLegacy fallback error: {err}"
+            );
+        }
+    }
+    err
+}
+
 fn maybe_print_auto_selected_cdp_target(
     target: Option<&browser::ResolvedCdpTarget>,
     format: OutputFormat,
@@ -1024,6 +1148,9 @@ fn maybe_print_auto_selected_cdp_target(
     };
     if target.is_auto_discovered() {
         eprintln!("info: {}", target.description);
+        if let Some(warning) = browser::auto_discovered_cdp_target_warning(target) {
+            eprintln!("warning: {warning}");
+        }
     }
 }
 
@@ -1071,8 +1198,14 @@ fn resolved_cdp_attach_failure(
     }
 }
 
-fn profile_forces_managed_browser(profile: Option<&Path>, cdp_override: Option<&str>) -> bool {
-    profile.is_some() && cdp_override.is_none()
+fn profile_forces_managed_browser(
+    profile: Option<&Path>,
+    cdp_override: Option<&str>,
+    browser_id: Option<&str>,
+) -> bool {
+    profile.is_some()
+        && cdp_override.is_none()
+        && browser_id.is_none_or(|value| value.trim().is_empty())
 }
 
 fn maybe_demote_auto_selected_cdp_target(
@@ -1086,7 +1219,7 @@ fn maybe_demote_auto_selected_cdp_target(
     if !selected.is_auto_discovered() {
         return;
     }
-    if browser::is_chrome_approval_wait_error(err) {
+    if !should_demote_auto_selected_cdp_target(err) {
         return;
     }
 
@@ -1099,6 +1232,27 @@ fn maybe_demote_auto_selected_cdp_target(
     if matches!(format, OutputFormat::Text | OutputFormat::Markdown) {
         eprintln!("info: {description} failed ({err}); continuing with fallback discovery");
     }
+}
+
+fn should_demote_auto_selected_cdp_target(err: &anyhow::Error) -> bool {
+    if browser::is_chrome_approval_wait_error(err) {
+        return false;
+    }
+    if browser::is_chatgpt_auth_issue_error(err) {
+        return false;
+    }
+    if browser::is_chrome_cdp_unreachable_error(err) {
+        return true;
+    }
+    let message = format!("{err:#}");
+    let message_lower = message.to_lowercase();
+    if message_lower.contains("could not reach chrome's cdp endpoint") {
+        return true;
+    }
+    if message.contains("selected running Chrome target failed") {
+        return true;
+    }
+    dev_browser::is_dev_browser_connect_failure(err)
 }
 
 fn maybe_remember_cdp_target(target: Option<&browser::ResolvedCdpTarget>, format: OutputFormat) {
@@ -1128,12 +1282,13 @@ fn default_daemon_recovery_error(original: Option<&anyhow::Error>) -> Option<any
 }
 
 async fn run_recipe_via_chrome_devtools_mcp(
+    ctx: &AppContext,
     recipe_args: &BrowserRecipeArgs,
     recipe_vars: &BTreeMap<String, String>,
     cdp_endpoint: Option<&str>,
     format: OutputFormat,
     is_chatgpt: bool,
-) -> Result<()> {
+) -> Result<Value> {
     if !is_chatgpt {
         return Err(anyhow!(
             "chrome-devtools-mcp transport currently supports only the built-in `chatgpt` recipe; \
@@ -1160,63 +1315,143 @@ async fn run_recipe_via_chrome_devtools_mcp(
         ));
     }
 
-    // Use the existing dev-browser poll settings resolver so the response
-    // timeout env/recipe-var knobs stay symmetric with the dev-browser path.
-    let poll_settings = dev_browser::resolve_chatgpt_poll_settings(recipe_vars)?;
-    let thread_mode = chrome_devtools_mcp::RecipeThreadMode::parse(
-        recipe_vars.get("thread").map(String::as_str),
-    )?;
-
-    let ctx = chrome_devtools_mcp::DevtoolsMcpRecipeContext {
+    let recipe_spec = build_chatgpt_recipe_spec(recipe_args, recipe_vars)?;
+    let recipe_ctx = chrome_devtools_mcp::DevtoolsMcpRecipeContext {
         cdp_endpoint: cdp_endpoint.map(str::to_owned),
-        bundle_path: recipe_args.bundle.clone(),
+        bundle_path: recipe_spec.bundle_path.clone(),
         bundle_text: None,
+        model: recipe_spec.model.clone(),
+        prompt: recipe_spec.prompt.clone(),
+        browser_context_id: recipe_spec.browser_context_id.clone(),
+        profile_email: recipe_spec.profile_email.clone(),
+        run_id: recipe_spec.run_id.clone(),
+        response_timeout_ms: recipe_spec.wait_timeout_ms,
+        response_poll_interval_ms: recipe_spec.wait_interval_ms,
+        disable_extended: recipe_spec.disable_extended,
+        show_approval_guidance: matches!(format, OutputFormat::Text | OutputFormat::Markdown),
+    };
+
+    let response = chrome_devtools_mcp::chatgpt::run(&recipe_ctx).await?;
+    let payload = chatgpt_recipe::ChatgptRecipeOutput {
+        transport: "chrome-devtools-mcp".to_string(),
+        backend: "chrome-devtools-mcp".to_string(),
+        response: response.response,
+        model_used: response.model_used,
+        warnings: Vec::new(),
+        fallback_used: false,
+        delivery_mode: chatgpt_recipe::ChatgptDeliveryMode::FileUpload,
+        auto_paste_fallback: false,
+    }
+    .to_value();
+    maybe_write_output(ctx, &payload)?;
+
+    match format {
+        OutputFormat::Json => {
+            write_json(&payload)?;
+        }
+        OutputFormat::Jsonl => {
+            let event = chatgpt_recipe::ChatgptRecipeOutput {
+                transport: "chrome-devtools-mcp".to_string(),
+                backend: "chrome-devtools-mcp".to_string(),
+                response: payload["response"].as_str().unwrap_or_default().to_string(),
+                model_used: payload["model_used"].as_str().map(str::to_owned),
+                warnings: payload["warnings"]
+                    .as_array()
+                    .map(|items| {
+                        items
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .map(str::to_owned)
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default(),
+                fallback_used: false,
+                delivery_mode: chatgpt_recipe::ChatgptDeliveryMode::FileUpload,
+                auto_paste_fallback: false,
+            }
+            .to_recipe_complete_event();
+            write_jsonl("browser.recipe", &event)?;
+        }
+        OutputFormat::Text | OutputFormat::Markdown => {
+            println!("{}", payload["response"].as_str().unwrap_or_default());
+        }
+    }
+
+    Ok(payload)
+}
+
+fn build_chatgpt_recipe_spec(
+    recipe_args: &BrowserRecipeArgs,
+    recipe_vars: &BTreeMap<String, String>,
+) -> Result<chatgpt_recipe::ChatgptRecipeSpec> {
+    let poll_settings = dev_browser::resolve_chatgpt_poll_settings(recipe_vars)?;
+    chrome_devtools_mcp::RecipeThreadMode::parse(recipe_vars.get("thread").map(String::as_str))?;
+    Ok(chatgpt_recipe::ChatgptRecipeSpec {
+        bundle_path: recipe_args.bundle.clone(),
         model: recipe_vars.get("model").cloned().unwrap_or_default(),
         prompt: recipe_vars
             .get("prompt")
             .cloned()
             .unwrap_or_else(|| "Review the attached file and provide your analysis.".to_string()),
-        thread_mode,
-        response_timeout_ms: poll_settings.timeout_ms,
-        show_approval_guidance: matches!(format, OutputFormat::Text | OutputFormat::Markdown),
+        browser_context_id: recipe_vars
+            .get("browser_context_id")
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty()),
+        profile_email: recipe_vars
+            .get("profile_email")
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty()),
+        run_id: recipe_vars.get("run_id").cloned().unwrap_or_default(),
+        wait_timeout_ms: poll_settings.timeout_ms,
+        wait_interval_ms: poll_settings.interval_ms,
+        disable_extended: recipe_vars
+            .get("extended")
+            .is_some_and(|value| value == "false"),
+    })
+}
+
+fn resolve_dev_browser_delivery_mode(
+    recipe_args: &BrowserRecipeArgs,
+    recipe_vars: &BTreeMap<String, String>,
+) -> Result<(bool, Option<String>, bool)> {
+    resolve_dev_browser_delivery_mode_for_platform(
+        cfg!(target_os = "macos"),
+        recipe_args,
+        recipe_vars,
+    )
+}
+
+fn resolve_dev_browser_delivery_mode_for_platform(
+    supports_clipboard_file_upload: bool,
+    recipe_args: &BrowserRecipeArgs,
+    recipe_vars: &BTreeMap<String, String>,
+) -> Result<(bool, Option<String>, bool)> {
+    let requested_paste_mode = recipe_vars
+        .get("paste")
+        .is_some_and(|value| value == "true");
+    let auto_paste_fallback =
+        !requested_paste_mode && recipe_args.bundle.is_some() && !supports_clipboard_file_upload;
+    let effective_paste_mode = requested_paste_mode || auto_paste_fallback;
+    let bundle_text = if effective_paste_mode {
+        recipe_args
+            .bundle
+            .as_ref()
+            .map(fs::read_to_string)
+            .transpose()?
+    } else {
+        None
     };
-
-    let response = chrome_devtools_mcp::chatgpt::run(&ctx).await?;
-
-    match format {
-        OutputFormat::Json => {
-            let payload = json!({
-                "status": "ok",
-                "backend": "chrome-devtools-mcp",
-                "response": response.response,
-                "model_used": response.model_used,
-            });
-            write_json(&payload)?;
-        }
-        OutputFormat::Jsonl => {
-            let payload = json!({
-                "type": "recipe_complete",
-                "backend": "chrome-devtools-mcp",
-                "response": response.response,
-                "model_used": response.model_used,
-            });
-            write_jsonl("browser.recipe", &payload)?;
-        }
-        OutputFormat::Text | OutputFormat::Markdown => {
-            println!("{}", response.response);
-        }
-    }
-
-    Ok(())
+    Ok((effective_paste_mode, bundle_text, auto_paste_fallback))
 }
 
 fn run_recipe_via_dev_browser(
+    ctx: &AppContext,
     recipe_args: &BrowserRecipeArgs,
     recipe_vars: &BTreeMap<String, String>,
     cdp_endpoint: Option<&str>,
     format: OutputFormat,
     is_chatgpt: bool,
-) -> Result<()> {
+) -> Result<Value> {
     if !is_chatgpt {
         return Err(anyhow!(
             "dev-browser transport currently supports only the built-in `chatgpt` recipe"
@@ -1233,32 +1468,26 @@ fn run_recipe_via_dev_browser(
     // named page. Avoid a separate pre-flight attach here because it can trigger
     // a fresh approval-gated CDP connection and block an otherwise working flow.
 
-    let paste_mode = recipe_vars
-        .get("paste")
-        .is_some_and(|value| value == "true");
-    let bundle_text = if paste_mode {
-        recipe_args
-            .bundle
-            .as_ref()
-            .map(fs::read_to_string)
-            .transpose()?
-    } else {
-        None
-    };
-    let poll_settings = dev_browser::resolve_chatgpt_poll_settings(recipe_vars)?;
+    let (paste_mode, bundle_text, auto_paste_fallback) =
+        resolve_dev_browser_delivery_mode(recipe_args, recipe_vars)?;
+    if auto_paste_fallback {
+        eprintln!(
+            "info: dev-browser clipboard file upload requires macOS; falling back to paste mode for this run"
+        );
+    }
+    let recipe_spec = build_chatgpt_recipe_spec(recipe_args, recipe_vars)?;
     let recipe_ctx = dev_browser::DevBrowserRecipeContext {
-        bundle_path: recipe_args.bundle.clone(),
+        bundle_path: recipe_spec.bundle_path.clone(),
         bundle_text,
-        model: recipe_vars.get("model").cloned().unwrap_or_default(),
-        disable_extended: recipe_vars
-            .get("extended")
-            .is_some_and(|value| value == "false"),
+        model: recipe_spec.model.clone(),
+        disable_extended: recipe_spec.disable_extended,
         paste_mode,
-        prompt: recipe_vars
-            .get("prompt")
-            .cloned()
-            .unwrap_or_else(|| "Review the attached file and provide your analysis.".to_string()),
-        poll_settings,
+        prompt: recipe_spec.prompt.clone(),
+        run_id: recipe_spec.run_id.clone(),
+        poll_settings: dev_browser::ChatgptPollSettings {
+            timeout_ms: recipe_spec.wait_timeout_ms,
+            interval_ms: recipe_spec.wait_interval_ms,
+        },
         allow_empty_response: recipe_vars
             .get("allow_empty_response")
             .is_some_and(|value| value == "true"),
@@ -1267,32 +1496,40 @@ fn run_recipe_via_dev_browser(
     };
 
     let response = dev_browser::run_chatgpt_recipe(&recipe_ctx)?;
+    let output = chatgpt_recipe::ChatgptRecipeOutput {
+        transport: "dev-browser".to_string(),
+        backend: "dev-browser".to_string(),
+        response: response.response,
+        model_used: response.model_used,
+        warnings: response.warnings,
+        fallback_used: true,
+        delivery_mode: if paste_mode {
+            chatgpt_recipe::ChatgptDeliveryMode::Paste
+        } else {
+            chatgpt_recipe::ChatgptDeliveryMode::FileUpload
+        },
+        auto_paste_fallback,
+    };
+    let payload = output.to_value();
+    maybe_write_output(ctx, &payload)?;
     match format {
         OutputFormat::Json => {
-            let payload = json!({
-                "status": "ok",
-                "backend": "dev-browser",
-                "response": response,
-            });
             write_json(&payload)?;
         }
         OutputFormat::Jsonl => {
-            let payload = json!({
-                "type": "recipe_complete",
-                "backend": "dev-browser",
-                "response": response,
-            });
-            write_jsonl("browser.recipe", &payload)?;
+            let event = output.to_recipe_complete_event();
+            write_jsonl("browser.recipe", &event)?;
         }
         OutputFormat::Text | OutputFormat::Markdown => {
-            println!("{response}");
+            println!("{}", payload["response"].as_str().unwrap_or_default());
         }
     }
 
-    Ok(())
+    Ok(payload)
 }
 
 fn run_recipe_via_agent_browser(
+    ctx: &AppContext,
     recipe: browser::Recipe,
     recipe_args: &BrowserRecipeArgs,
     recipe_vars: BTreeMap<String, String>,
@@ -1300,12 +1537,13 @@ fn run_recipe_via_agent_browser(
     format: OutputFormat,
     is_chatgpt: bool,
     selected_cdp_target: &mut Option<browser::ResolvedCdpTarget>,
-) -> Result<()> {
+) -> Result<Value> {
     let needs_auth = is_chatgpt;
     let live_connection = if needs_auth {
         if profile_forces_managed_browser(
             recipe_args.profile.as_deref(),
             recipe_args.cdp.as_deref(),
+            recipe_args.browser_id.as_deref(),
         ) {
             None
         } else {
@@ -1412,9 +1650,14 @@ fn run_recipe_via_agent_browser(
     };
 
     if let Some(connection) = live_connection {
-        browser::run_recipe_with_live_connection(recipe, recipe_ctx, &connection, format)
+        let payload =
+            browser::run_recipe_with_live_connection(recipe, recipe_ctx, &connection, format)?;
+        maybe_write_output(ctx, &payload)?;
+        Ok(payload)
     } else {
-        browser::run_recipe(recipe, recipe_ctx, format)
+        let payload = browser::run_recipe(recipe, recipe_ctx, format)?;
+        maybe_write_output(ctx, &payload)?;
+        Ok(payload)
     }
 }
 
@@ -1442,16 +1685,29 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
         }
         BrowserCommand::Login(login_args) => {
             let profile_dir =
-                browser::resolve_profile_dir(&ctx.config, login_args.profile.as_ref())?;
+                browser::resolve_profile_dir(&ctx.browser_defaults, login_args.profile.as_ref())?;
 
-            // If --cdp explicitly passed, try CDP first (login is conservative:
-            // no auto-discovery unless user explicitly requests it)
-            if let Some(ref cdp_url) = login_args.cdp {
-                match browser::try_cdp_attach(cdp_url, "https://chatgpt.com/") {
+            // If --cdp / --browser-id explicitly passed, try CDP first (login is
+            // conservative: no auto-discovery unless user explicitly requests it).
+            if let Some(explicit_target) = browser::resolve_cdp_target_with_selector(
+                login_args.cdp.as_deref(),
+                login_args.browser_id.as_deref(),
+                &ctx.browser_defaults,
+                false,
+            )? {
+                let cdp_url = explicit_target.endpoint.clone();
+                match browser::try_cdp_attach(&cdp_url, "https://chatgpt.com/") {
                     Ok(()) => {
                         let payload = json!({
                             "status": "ok",
-                            "method": "cdp_explicit",
+                            "method": if login_args.cdp.is_some() {
+                                "cdp_explicit".to_string()
+                            } else {
+                                format!(
+                                    "browser_id: {}",
+                                    login_args.browser_id.as_deref().unwrap_or_default()
+                                )
+                            },
                             "endpoint": cdp_url,
                             "profile": profile_dir.to_string_lossy(),
                         });
@@ -1540,37 +1796,65 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             let managed_profile_only = profile_forces_managed_browser(
                 check_args.profile.as_deref(),
                 check_args.cdp.as_deref(),
+                check_args.browser_id.as_deref(),
             );
-            let mut resolved_cdp_target = browser::resolve_cdp_target_with_implicit(
+            let explicit_browser_target =
+                check_args.cdp.is_some() || check_args.browser_id.is_some();
+            let mut resolved_cdp_target = browser::resolve_cdp_target_with_selector(
                 check_args.cdp.as_deref(),
-                &ctx.config,
+                check_args.browser_id.as_deref(),
+                &ctx.browser_defaults,
                 !managed_profile_only,
             )?;
             maybe_print_auto_selected_cdp_target(resolved_cdp_target.as_ref(), format);
-            if let Some(ref cdp_url) = check_args.cdp {
-                chrome_devtools_mcp::chatgpt::check_auth(Some(cdp_url))
+            let show_approval_guidance =
+                matches!(format, OutputFormat::Text | OutputFormat::Markdown);
+            if explicit_browser_target {
+                let cdp_url = resolved_cdp_target
+                    .as_ref()
+                    .map(|target| target.endpoint.as_str())
+                    .expect("explicit browser target should resolve");
+                chrome_devtools_mcp::chatgpt::check_auth(Some(cdp_url), show_approval_guidance)
                     .await
                     .map_err(explicit_cdp_attach_failure)?;
                 maybe_remember_cdp_target(resolved_cdp_target.as_ref(), format);
                 let payload = json!({
                     "status": "ok",
-                    "method": format!("cdp: {cdp_url}"),
+                    "method": if check_args.cdp.is_some() {
+                        format!("cdp: {cdp_url}")
+                    } else {
+                        format!(
+                            "browser_id: {}",
+                            check_args.browser_id.as_deref().unwrap_or_default()
+                        )
+                    },
                     "transport": "chrome-devtools-mcp",
                 });
                 return match format {
                     OutputFormat::Json => write_json(&payload),
                     OutputFormat::Jsonl => write_jsonl("browser.check", &payload),
                     OutputFormat::Text | OutputFormat::Markdown => {
-                        println!("Browser authenticated via cdp: {cdp_url} (chrome-devtools-mcp)");
+                        println!(
+                            "Browser authenticated via {} (chrome-devtools-mcp)",
+                            if check_args.cdp.is_some() {
+                                format!("cdp: {cdp_url}")
+                            } else {
+                                format!(
+                                    "browser_id {}",
+                                    check_args.browser_id.as_deref().unwrap_or_default()
+                                )
+                            }
+                        );
                         Ok(())
                     }
                 };
             }
 
             let profile_dir =
-                browser::resolve_profile_dir(&ctx.config, check_args.profile.as_ref())?;
+                browser::resolve_profile_dir(&ctx.browser_defaults, check_args.profile.as_ref())?;
             let transports =
                 browser_check_transports(browser::use_dev_browser(), managed_profile_only);
+            let mut prior_live_attach_failure: Option<String> = None;
 
             for transport in transports {
                 match transport {
@@ -1578,7 +1862,12 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         let cdp_endpoint = resolved_cdp_target
                             .as_ref()
                             .map(|target| target.endpoint.as_str());
-                        match chrome_devtools_mcp::chatgpt::check_auth(cdp_endpoint).await {
+                        match chrome_devtools_mcp::chatgpt::check_auth(
+                            cdp_endpoint,
+                            show_approval_guidance,
+                        )
+                        .await
+                        {
                             Ok(()) => {
                                 maybe_remember_cdp_target(resolved_cdp_target.as_ref(), format);
                                 let method =
@@ -1605,6 +1894,10 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                                 if browser::is_chrome_approval_wait_error(&e) {
                                     return Err(e);
                                 }
+                                remember_browser_check_live_attach_failure(
+                                    &mut prior_live_attach_failure,
+                                    &e,
+                                );
                                 if resolved_cdp_target
                                     .as_ref()
                                     .is_some_and(browser::ResolvedCdpTarget::is_authoritative)
@@ -1666,6 +1959,10 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                                 if browser::is_chrome_approval_wait_error(&e) {
                                     return Err(e);
                                 }
+                                remember_browser_check_live_attach_failure(
+                                    &mut prior_live_attach_failure,
+                                    &e,
+                                );
                                 if resolved_cdp_target
                                     .as_ref()
                                     .is_some_and(browser::ResolvedCdpTarget::is_authoritative)
@@ -1700,7 +1997,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                                 .as_ref()
                                 .map(|target| target.endpoint.as_str());
                             browser::resolve_browser_connection(
-                                &ctx.config,
+                                &ctx.browser_defaults,
                                 fallback_cdp.or(check_args.cdp.as_deref()),
                                 &profile_dir,
                                 "https://chatgpt.com/",
@@ -1709,7 +2006,10 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                                 if let Some(recovery) = default_daemon_recovery_error(Some(&e)) {
                                     return recovery;
                                 }
-                                e
+                                maybe_prefer_browser_check_live_attach_failure(
+                                    e,
+                                    prior_live_attach_failure.as_deref(),
+                                )
                             })?
                         };
                         let method = match &connection {
@@ -1749,6 +2049,17 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
 
             unreachable!("browser check transport list must include a fallback transport")
         }
+        BrowserCommand::Doctor(args) => {
+            let report = browser::browser_doctor_report(args.live);
+            match format {
+                OutputFormat::Json => write_json(&json!({ "report": report })),
+                OutputFormat::Jsonl => write_jsonl("browser.doctor", &json!({ "report": report })),
+                OutputFormat::Text | OutputFormat::Markdown => {
+                    println!("{report}");
+                    Ok(())
+                }
+            }
+        }
         BrowserCommand::Reset(_) => {
             let dev_browser_stopped = if browser::use_dev_browser() {
                 dev_browser::stop_daemon()?
@@ -1782,7 +2093,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
         }
         BrowserCommand::SyncCookies(sync_args) => {
             let profile_dir =
-                browser::resolve_profile_dir(&ctx.config, sync_args.profile.as_ref())?;
+                browser::resolve_profile_dir(&ctx.browser_defaults, sync_args.profile.as_ref())?;
             if matches!(format, OutputFormat::Text | OutputFormat::Markdown) {
                 if let Some(guidance) = browser::cookie_sync_guidance() {
                     eprintln!("{guidance}");
@@ -1820,21 +2131,33 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             let content = fs::read_to_string(&recipe_path)
                 .with_context(|| format!("read recipe {}", recipe_path.display()))?;
             let recipe: browser::Recipe = serde_yml::from_str(&content)?;
-            let recipe_vars =
+            let mut recipe_vars =
                 browser::build_recipe_vars(recipe.defaults.as_ref(), &recipe_args.vars)?;
             let profile_dir =
-                browser::resolve_profile_dir(&ctx.config, recipe_args.profile.as_ref())?;
+                browser::resolve_profile_dir(&ctx.browser_defaults, recipe_args.profile.as_ref())?;
             let is_chatgpt = is_chatgpt_recipe(&recipe, &recipe_path);
-            let mut resolved_cdp_target = browser::resolve_cdp_target_with_implicit(
+            if is_chatgpt {
+                chatgpt_web::validate_thread_mode(recipe_vars.get("thread").map(String::as_str))?;
+                recipe_vars
+                    .entry("run_id".to_string())
+                    .or_insert_with(chatgpt_web::generate_run_id);
+            }
+            let mut resolved_cdp_target = browser::resolve_cdp_target_with_selector(
                 recipe_args.cdp.as_deref(),
-                &ctx.config,
+                recipe_args.browser_id.as_deref(),
+                &ctx.browser_defaults,
                 !profile_forces_managed_browser(
                     recipe_args.profile.as_deref(),
                     recipe_args.cdp.as_deref(),
+                    recipe_args.browser_id.as_deref(),
                 ),
             )?;
             maybe_print_auto_selected_cdp_target(resolved_cdp_target.as_ref(), format);
-            let transports = browser::recipe_transports(&recipe, is_chatgpt);
+            let transports = constrain_chatgpt_transports_for_browser_context_selector(
+                browser::recipe_transports(&recipe, is_chatgpt),
+                &recipe_vars,
+                is_chatgpt,
+            );
             let manual_fallback =
                 manual_browser_recipe_fallback(&recipe_path, recipe_args.bundle.as_deref());
             let mut transport_errors = Vec::new();
@@ -1860,6 +2183,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
 
                 let result = match transport {
                     browser::RecipeTransport::DevBrowser => run_recipe_via_dev_browser(
+                        ctx,
                         &recipe_args,
                         &recipe_vars,
                         cdp_endpoint.as_deref(),
@@ -1867,6 +2191,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         is_chatgpt,
                     ),
                     browser::RecipeTransport::AgentBrowser => run_recipe_via_agent_browser(
+                        ctx,
                         recipe.clone(),
                         &recipe_args,
                         recipe_vars.clone(),
@@ -1877,6 +2202,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                     ),
                     browser::RecipeTransport::ChromeDevtoolsMcp => {
                         run_recipe_via_chrome_devtools_mcp(
+                            ctx,
                             &recipe_args,
                             &recipe_vars,
                             cdp_endpoint.as_deref(),
@@ -1889,7 +2215,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 };
 
                 match result {
-                    Ok(()) => {
+                    Ok(_payload) => {
                         if matches!(
                             transport,
                             browser::RecipeTransport::ChromeDevtoolsMcp
@@ -1915,6 +2241,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                             &err,
                             resolved_cdp_target.as_ref(),
                             transport,
+                            &recipe_vars,
                         ) {
                             transport_errors.push((transport, recipe_transport_error_detail(&err)));
                             if recipe_has_remaining_manual_fallback(&transports, index) {
@@ -1943,8 +2270,14 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
         }
         BrowserCommand::Attach(attach_args) => {
             // Try explicit CDP first, then auto-connect. No cookie fallback for attach.
-            let mut resolved_cdp_target =
-                browser::resolve_cdp_target(attach_args.cdp.as_deref(), &ctx.config)?;
+            let explicit_browser_target =
+                attach_args.cdp.is_some() || attach_args.browser_id.is_some();
+            let mut resolved_cdp_target = browser::resolve_cdp_target_with_selector(
+                attach_args.cdp.as_deref(),
+                attach_args.browser_id.as_deref(),
+                &ctx.browser_defaults,
+                true,
+            )?;
             maybe_print_auto_selected_cdp_target(resolved_cdp_target.as_ref(), format);
             let cdp_endpoint = resolved_cdp_target
                 .as_ref()
@@ -1957,9 +2290,14 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         let payload = json!({
                             "status": "ok",
                             "method": if attach_args.cdp.is_some() {
-                                "cdp_explicit"
+                                "cdp_explicit".to_string()
+                            } else if attach_args.browser_id.is_some() {
+                                format!(
+                                    "browser_id: {}",
+                                    attach_args.browser_id.as_deref().unwrap_or_default()
+                                )
                             } else {
-                                "cdp_selected"
+                                "cdp_selected".to_string()
                             },
                             "endpoint": endpoint,
                         });
@@ -1967,12 +2305,27 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                             OutputFormat::Json => write_json(&payload),
                             OutputFormat::Jsonl => write_jsonl("browser.attach", &payload),
                             OutputFormat::Text | OutputFormat::Markdown => {
-                                println!("Attached via CDP: {endpoint}");
+                                println!(
+                                    "Attached via {}",
+                                    if attach_args.cdp.is_some() {
+                                        format!("CDP: {endpoint}")
+                                    } else if attach_args.browser_id.is_some() {
+                                        format!(
+                                            "browser_id {} ({endpoint})",
+                                            attach_args.browser_id.as_deref().unwrap_or_default()
+                                        )
+                                    } else {
+                                        format!("CDP: {endpoint}")
+                                    }
+                                );
                                 Ok(())
                             }
                         };
                     }
-                    Err(e) if attach_args.cdp.is_some() => {
+                    Err(e) if explicit_browser_target => {
+                        if let Some(target) = resolved_cdp_target.as_ref() {
+                            return Err(resolved_cdp_attach_failure(e, target));
+                        }
                         return Err(explicit_cdp_attach_failure(e));
                     }
                     Err(e)
@@ -2028,6 +2381,39 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                  Note: since Chrome 136, --remote-debugging-port is ignored on the default profile.\n\
                  See: https://developer.chrome.com/blog/remote-debugging-port"
             ))
+        }
+        BrowserCommand::VerifyCdp(args) => {
+            // Thin CDP smoke: attach and open an `about:blank` tab. Used by
+            // the real-browser CI lane (review finding #13) against a fresh
+            // Chrome for Testing instance so the deeper `check` / `attach`
+            // auth-probe path is not exercised.
+            let client = chrome_devtools_mcp::client::CdpMcpClient::connect_to_running_chrome(
+                Some(&args.cdp),
+            )
+            .await
+            .with_context(|| format!("attaching to CDP endpoint `{}`", args.cdp))?;
+            let new_page = client
+                .new_page(&args.url, /* background */ true, 15_000, None)
+                .await
+                .with_context(|| format!("opening `{}` against `{}`", args.url, args.cdp))?;
+            let payload = json!({
+                "status": "ok",
+                "endpoint": args.cdp,
+                "url": args.url,
+                "page_id": new_page.page_id,
+            });
+            let _ = client.close_selected_page(true);
+            match format {
+                OutputFormat::Json => write_json(&payload),
+                OutputFormat::Jsonl => write_jsonl("browser.verify_cdp", &payload),
+                OutputFormat::Text | OutputFormat::Markdown => {
+                    println!(
+                        "verify-cdp ok: endpoint={} page={}",
+                        args.cdp, new_page.page_id
+                    );
+                    Ok(())
+                }
+            }
         }
     }
 }
@@ -2243,7 +2629,7 @@ fn parse_media_inputs(
     let kind_label = media_type_label(&kind);
     let overrides = normalize_mime_overrides(values.len(), mimes, kind_label)?;
     let mut out = Vec::with_capacity(values.len());
-    for (value, mime) in values.iter().zip(overrides.into_iter()) {
+    for (value, mime) in values.iter().zip(overrides) {
         out.push(parse_media_input(value, mime.as_deref(), kind.clone())?);
     }
     Ok(out)
@@ -2344,10 +2730,27 @@ fn markdown_fence(content: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn normalize_model_name(model: &str) -> String {
         normalize_model_name_with_aliases(model, &std::collections::HashMap::new())
+    }
+
+    fn test_app_context() -> AppContext {
+        let config = Config::default();
+        let client = build_client(1).expect("build reqwest client");
+        let litellm = Arc::new(build_litellm(&config, client.clone()).expect("build litellm"));
+        AppContext {
+            config,
+            browser_defaults: browser::BrowserDefaults::default(),
+            client,
+            litellm,
+            output_final: None,
+            output_schema: None,
+            debug: false,
+            allow_unknown: false,
+        }
     }
 
     fn temp_schema_path() -> PathBuf {
@@ -2356,6 +2759,14 @@ mod tests {
             .unwrap()
             .as_nanos();
         std::env::temp_dir().join(format!("yoetz_schema_{nanos}.json"))
+    }
+
+    fn temp_output_path(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}_{nanos}.json"))
     }
 
     #[test]
@@ -2397,6 +2808,27 @@ mod tests {
         let fmt = resolve_response_format(None, Some(path.clone()), None).unwrap();
         assert!(fmt.is_some());
         let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn maybe_write_output_writes_output_final_json() {
+        let output_path = temp_output_path("yoetz_browser_recipe_output");
+        let mut ctx = test_app_context();
+        ctx.output_final = Some(output_path.clone());
+
+        let payload = json!({
+            "status": "ok",
+            "backend": "dev-browser",
+            "response": "review text",
+        });
+
+        maybe_write_output(&ctx, &payload).unwrap();
+
+        let written: Value =
+            serde_json::from_str(&fs::read_to_string(&output_path).unwrap()).unwrap();
+        assert_eq!(written, payload);
+
+        let _ = fs::remove_file(output_path);
     }
 
     #[test]
@@ -2511,12 +2943,30 @@ mod tests {
             "YOETZ_BROWSER_CDP",
             "YOETZ_BROWSER_TARGET_PATH",
             "YOETZ_BROWSER_PROFILE",
+            "LITELLM_API_KEY",
         ] {
             assert!(
-                PROTECTED_DOTENV_ENV_VARS.contains(&key),
+                BASE_PROTECTED_DOTENV_ENV_VARS.contains(&key),
                 "{key} must stay protected"
             );
         }
+    }
+
+    #[test]
+    fn protected_dotenv_env_vars_include_custom_provider_api_key_envs() {
+        let mut config = Config::default();
+        config.providers.insert(
+            "corp".to_string(),
+            yoetz_core::config::ProviderConfig {
+                api_key_env: Some("CORP_LLM_TOKEN".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let protected = protected_dotenv_env_vars(&config);
+
+        assert!(protected.iter().any(|key| key == "CORP_LLM_TOKEN"));
+        assert!(protected.iter().any(|key| key == "LITELLM_API_KEY"));
     }
 
     #[test]
@@ -2524,32 +2974,47 @@ mod tests {
         let err = anyhow!(
             "live browser attach timed out (30s). Chrome may be showing an \"Allow remote debugging?\" dialog — please click Allow in Chrome, then retry."
         );
+        let vars = std::collections::BTreeMap::new();
         assert!(recipe_should_stop_live_transport_fallback(
             &err,
             None,
-            browser::RecipeTransport::ChromeDevtoolsMcp
+            browser::RecipeTransport::ChromeDevtoolsMcp,
+            &vars,
         ));
     }
 
     #[test]
-    fn recipe_should_stop_live_transport_fallback_on_thread_reuse_errors() {
-        let err = anyhow!(
-            "thread=reuse found multiple ChatGPT tabs but could not identify a unique active tab"
+    fn recipe_should_stop_live_transport_fallback_on_chatgpt_page_errors() {
+        let model_mismatch = anyhow!(
+            "requested ChatGPT model `pro` was not actually selected. Current page: url=https://chatgpt.com/, title=\"ChatGPT\""
         );
+        let auth_issue = anyhow!(
+            "chatgpt login required in the attached Chrome session. Log in there and try again."
+        );
+        let vars = std::collections::BTreeMap::new();
         assert!(recipe_should_stop_live_transport_fallback(
-            &err,
+            &model_mismatch,
             None,
-            browser::RecipeTransport::ChromeDevtoolsMcp
+            browser::RecipeTransport::ChromeDevtoolsMcp,
+            &vars,
+        ));
+        assert!(recipe_should_stop_live_transport_fallback(
+            &auth_issue,
+            None,
+            browser::RecipeTransport::ChromeDevtoolsMcp,
+            &vars,
         ));
     }
 
     #[test]
     fn recipe_should_not_stop_live_transport_fallback_on_non_approval_error() {
         let err = anyhow!("chatgpt send button not found");
+        let vars = std::collections::BTreeMap::new();
         assert!(!recipe_should_stop_live_transport_fallback(
             &err,
             None,
-            browser::RecipeTransport::ChromeDevtoolsMcp
+            browser::RecipeTransport::ChromeDevtoolsMcp,
+            &vars,
         ));
     }
 
@@ -2558,14 +3023,33 @@ mod tests {
         let err = anyhow!("chrome-devtools-mcp new_page on chatgpt.com");
         let target = browser::resolve_cdp_target(
             Some("ws://127.0.0.1:9222/devtools/browser/example"),
-            &Config::default(),
+            &browser::BrowserDefaults::default(),
         )
         .unwrap()
         .unwrap();
+        let vars = std::collections::BTreeMap::new();
         assert!(recipe_should_stop_live_transport_fallback(
             &err,
             Some(&target),
-            browser::RecipeTransport::ChromeDevtoolsMcp
+            browser::RecipeTransport::ChromeDevtoolsMcp,
+            &vars,
+        ));
+    }
+
+    #[test]
+    fn recipe_should_stop_profile_email_fallback_on_visibility_errors() {
+        let err = anyhow!(
+            "profile_email `aviv.s@taboola.com` did not match any live Chrome browser context"
+        );
+        let vars = std::collections::BTreeMap::from([(
+            "profile_email".to_string(),
+            "aviv.s@taboola.com".to_string(),
+        )]);
+        assert!(recipe_should_stop_live_transport_fallback(
+            &err,
+            None,
+            browser::RecipeTransport::ChromeDevtoolsMcp,
+            &vars,
         ));
     }
 
@@ -2593,7 +3077,8 @@ mod tests {
         assert!(!recipe_should_stop_live_transport_fallback(
             &err,
             None,
-            browser::RecipeTransport::ChromeDevtoolsMcp
+            browser::RecipeTransport::ChromeDevtoolsMcp,
+            &std::collections::BTreeMap::new(),
         ));
     }
 
@@ -2657,6 +3142,73 @@ mod tests {
     }
 
     #[test]
+    fn recipe_uses_chatgpt_browser_context_selector_detects_email_and_context_id() {
+        let mut vars = std::collections::BTreeMap::new();
+        assert!(!recipe_uses_chatgpt_browser_context_selector(&vars));
+
+        vars.insert(
+            "profile_email".to_string(),
+            "avivsinai@gmail.com".to_string(),
+        );
+        assert!(recipe_uses_chatgpt_browser_context_selector(&vars));
+
+        vars.clear();
+        vars.insert("browser_context_id".to_string(), "ctx-123".to_string());
+        assert!(recipe_uses_chatgpt_browser_context_selector(&vars));
+    }
+
+    #[test]
+    fn constrain_chatgpt_transports_for_browser_context_selector_keeps_only_mcp_and_manual() {
+        let mut vars = std::collections::BTreeMap::new();
+        vars.insert(
+            "profile_email".to_string(),
+            "avivsinai@gmail.com".to_string(),
+        );
+        let transports = constrain_chatgpt_transports_for_browser_context_selector(
+            vec![
+                browser::RecipeTransport::ChromeDevtoolsMcp,
+                browser::RecipeTransport::DevBrowser,
+                browser::RecipeTransport::AgentBrowser,
+                browser::RecipeTransport::Manual,
+            ],
+            &vars,
+            true,
+        );
+        assert_eq!(
+            transports,
+            vec![
+                browser::RecipeTransport::ChromeDevtoolsMcp,
+                browser::RecipeTransport::Manual
+            ]
+        );
+    }
+
+    #[test]
+    fn constrain_chatgpt_transports_for_exact_browser_context_id_keeps_only_mcp_and_manual() {
+        let vars = std::collections::BTreeMap::from([(
+            "browser_context_id".to_string(),
+            "ctx-123".to_string(),
+        )]);
+        let transports = constrain_chatgpt_transports_for_browser_context_selector(
+            vec![
+                browser::RecipeTransport::ChromeDevtoolsMcp,
+                browser::RecipeTransport::DevBrowser,
+                browser::RecipeTransport::AgentBrowser,
+                browser::RecipeTransport::Manual,
+            ],
+            &vars,
+            true,
+        );
+        assert_eq!(
+            transports,
+            vec![
+                browser::RecipeTransport::ChromeDevtoolsMcp,
+                browser::RecipeTransport::Manual
+            ]
+        );
+    }
+
+    #[test]
     fn browser_check_prefers_cdp_before_other_transports() {
         assert_eq!(
             browser_check_transports(false, false),
@@ -2683,15 +3235,115 @@ mod tests {
     fn browser_check_live_method_uses_auto_connect_for_implicit_targets() {
         assert_eq!(browser_check_live_method(None), "auto_connect");
 
-        let mut config = Config::default();
-        config.defaults.browser_cdp = Some("ws://127.0.0.1:9222/devtools/browser/config".into());
-        let configured = browser::resolve_cdp_target(None, &config)
+        let browser_defaults = browser::BrowserDefaults {
+            cdp: Some("ws://127.0.0.1:9222/devtools/browser/config".into()),
+            ..Default::default()
+        };
+        let configured = browser::resolve_cdp_target(None, &browser_defaults)
             .unwrap()
             .expect("configured target");
         assert_eq!(
             browser_check_live_method(Some(&configured)),
             "cdp: ws://127.0.0.1:9222/devtools/browser/config"
         );
+    }
+
+    #[test]
+    fn browser_check_prefers_live_attach_failure_over_legacy_login_error() {
+        let err = maybe_prefer_browser_check_live_attach_failure(
+            anyhow!("chatgpt login required. Run `yoetz browser login` and try again."),
+            Some("dev-browser could not connect to Chrome. Enable remote debugging: chrome://inspect/#remote-debugging"),
+        );
+        let message = err.to_string();
+        assert!(message.contains("live Chrome attach failed"));
+        assert!(message.contains("chrome://inspect/#remote-debugging"));
+        assert!(message.contains("chatgpt login required"));
+    }
+
+    #[test]
+    fn browser_check_keeps_legacy_error_without_prior_live_attach_failure() {
+        let err = maybe_prefer_browser_check_live_attach_failure(
+            anyhow!("chatgpt login required. Run `yoetz browser login` and try again."),
+            None,
+        );
+        assert_eq!(
+            err.to_string(),
+            "chatgpt login required. Run `yoetz browser login` and try again."
+        );
+    }
+
+    #[test]
+    fn auto_selected_cdp_target_is_not_demoted_for_chatgpt_ui_auth_issues() {
+        let login_err = anyhow!(
+            "chatgpt login required in the attached Chrome session. Log in there and try again."
+        );
+        let challenge_err = anyhow!(
+            "cloudflare challenge detected in the attached Chrome session. Solve it in your browser window and try again."
+        );
+        assert!(!should_demote_auto_selected_cdp_target(&login_err));
+        assert!(!should_demote_auto_selected_cdp_target(&challenge_err));
+    }
+
+    #[test]
+    fn auto_selected_cdp_target_is_demoted_for_transport_level_attach_failures() {
+        let cdp_err = anyhow!(
+            "chrome-devtools-mcp could not reach Chrome's CDP endpoint. request failed: connection refused"
+        );
+        let dev_browser_err =
+            anyhow!("browser.newPage: Timeout 30000ms exceeded while waiting for connectOverCDP");
+        assert!(should_demote_auto_selected_cdp_target(&cdp_err));
+        assert!(should_demote_auto_selected_cdp_target(&dev_browser_err));
+    }
+
+    #[test]
+    fn browser_sync_cookies_cli_accepts_profile_path() {
+        let cli = Cli::try_parse_from([
+            "yoetz",
+            "browser",
+            "sync-cookies",
+            "--profile",
+            "/tmp/yoetz-browser-profile",
+        ])
+        .expect("browser sync-cookies args should parse");
+
+        match cli.command {
+            Commands::Browser(BrowserArgs {
+                command: BrowserCommand::SyncCookies(args),
+            }) => {
+                assert_eq!(
+                    args.profile.as_deref(),
+                    Some(Path::new("/tmp/yoetz-browser-profile"))
+                );
+            }
+            _ => panic!("unexpected command parsed"),
+        }
+    }
+
+    #[test]
+    fn config_profile_and_browser_profile_flags_do_not_collide() {
+        let cli = Cli::try_parse_from([
+            "yoetz",
+            "--config-profile",
+            "work",
+            "browser",
+            "sync-cookies",
+            "--profile",
+            "/tmp/yoetz-browser-profile",
+        ])
+        .expect("config and browser profile args should parse together");
+
+        assert_eq!(cli.config_profile.as_deref(), Some("work"));
+        match cli.command {
+            Commands::Browser(BrowserArgs {
+                command: BrowserCommand::SyncCookies(args),
+            }) => {
+                assert_eq!(
+                    args.profile.as_deref(),
+                    Some(Path::new("/tmp/yoetz-browser-profile"))
+                );
+            }
+            _ => panic!("unexpected command parsed"),
+        }
     }
 
     #[tokio::test]
@@ -2704,10 +3356,12 @@ mod tests {
             bundle: None,
             profile: None,
             cdp: None,
+            browser_id: None,
             vars: vec![],
         };
         let recipe_vars = BTreeMap::new();
         let err = run_recipe_via_chrome_devtools_mcp(
+            &test_app_context(),
             &recipe_args,
             &recipe_vars,
             None,
@@ -2731,10 +3385,12 @@ mod tests {
             bundle: None,
             profile: Some(PathBuf::from("/tmp/ignored")),
             cdp: None,
+            browser_id: None,
             vars: vec![],
         };
         let recipe_vars = BTreeMap::new();
         let err = run_recipe_via_chrome_devtools_mcp(
+            &test_app_context(),
             &recipe_args,
             &recipe_vars,
             None,
@@ -2754,10 +3410,12 @@ mod tests {
             bundle: Some(PathBuf::from("/tmp/bundle.md")),
             profile: None,
             cdp: None,
+            browser_id: None,
             vars: vec![],
         };
         let recipe_vars = BTreeMap::from([("paste".to_string(), "true".to_string())]);
         let err = run_recipe_via_chrome_devtools_mcp(
+            &test_app_context(),
             &recipe_args,
             &recipe_vars,
             None,
@@ -2778,10 +3436,12 @@ mod tests {
             bundle: None,
             profile: None,
             cdp: None,
+            browser_id: None,
             vars: vec![],
         };
         let recipe_vars = BTreeMap::new();
         let err = run_recipe_via_chrome_devtools_mcp(
+            &test_app_context(),
             &recipe_args,
             &recipe_vars,
             None,
@@ -2802,10 +3462,12 @@ mod tests {
             bundle: Some(PathBuf::from("/tmp/bundle.md")),
             profile: None,
             cdp: None,
+            browser_id: None,
             vars: vec![],
         };
         let recipe_vars = BTreeMap::from([("thread".to_string(), "sideways".to_string())]);
         let err = run_recipe_via_chrome_devtools_mcp(
+            &test_app_context(),
             &recipe_args,
             &recipe_vars,
             None,
@@ -2817,7 +3479,161 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("thread"));
         assert!(msg.contains("fresh"));
-        assert!(msg.contains("reuse"));
+    }
+
+    #[tokio::test]
+    async fn run_recipe_via_chrome_devtools_mcp_rejects_thread_reuse() {
+        let recipe_args = BrowserRecipeArgs {
+            recipe: PathBuf::from("recipes/chatgpt.yaml"),
+            bundle: Some(PathBuf::from("/tmp/bundle.md")),
+            profile: None,
+            cdp: None,
+            browser_id: None,
+            vars: vec![],
+        };
+        let recipe_vars = BTreeMap::from([("thread".to_string(), "reuse".to_string())]);
+        let err = run_recipe_via_chrome_devtools_mcp(
+            &test_app_context(),
+            &recipe_args,
+            &recipe_vars,
+            None,
+            OutputFormat::Text,
+            /* is_chatgpt */ true,
+        )
+        .await
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("thread=reuse is no longer supported"));
+        assert!(msg.contains("fresh ChatGPT tab"));
+    }
+
+    #[test]
+    fn resolve_dev_browser_delivery_mode_falls_back_to_paste_when_clipboard_upload_is_unavailable()
+    {
+        let bundle_path = temp_output_path("yoetz_bundle_text");
+        fs::write(&bundle_path, "bundle body").unwrap();
+        let recipe_args = BrowserRecipeArgs {
+            recipe: PathBuf::from("recipes/chatgpt.yaml"),
+            bundle: Some(bundle_path.clone()),
+            profile: None,
+            cdp: None,
+            browser_id: None,
+            vars: vec![],
+        };
+        let recipe_vars = BTreeMap::new();
+
+        let (paste_mode, bundle_text, auto_fallback) =
+            resolve_dev_browser_delivery_mode_for_platform(false, &recipe_args, &recipe_vars)
+                .unwrap();
+
+        assert!(paste_mode);
+        assert!(auto_fallback);
+        assert_eq!(bundle_text.as_deref(), Some("bundle body"));
+        let _ = fs::remove_file(bundle_path);
+    }
+
+    #[test]
+    fn build_chatgpt_recipe_spec_uses_shared_contract_fields() {
+        let recipe_args = BrowserRecipeArgs {
+            recipe: PathBuf::from("recipes/chatgpt.yaml"),
+            bundle: Some(PathBuf::from("/tmp/bundle.md")),
+            profile: None,
+            cdp: None,
+            browser_id: None,
+            vars: vec![],
+        };
+        let recipe_vars = BTreeMap::from([
+            ("model".to_string(), "pro".to_string()),
+            ("prompt".to_string(), "Review this repo".to_string()),
+            ("browser_context_id".to_string(), "ctx-123".to_string()),
+            ("profile_email".to_string(), "user@example.com".to_string()),
+            ("run_id".to_string(), "run-123".to_string()),
+            ("wait_timeout_ms".to_string(), "2400000".to_string()),
+            ("wait_interval_ms".to_string(), "45000".to_string()),
+            ("extended".to_string(), "false".to_string()),
+        ]);
+
+        let spec = build_chatgpt_recipe_spec(&recipe_args, &recipe_vars).unwrap();
+        assert_eq!(spec.bundle_path, Some(PathBuf::from("/tmp/bundle.md")));
+        assert_eq!(spec.model, "pro");
+        assert_eq!(spec.prompt, "Review this repo");
+        assert_eq!(spec.browser_context_id.as_deref(), Some("ctx-123"));
+        assert_eq!(spec.profile_email.as_deref(), Some("user@example.com"));
+        assert_eq!(spec.run_id, "run-123");
+        assert_eq!(spec.wait_timeout_ms, 2_400_000);
+        assert_eq!(spec.wait_interval_ms, 45_000);
+        assert!(spec.disable_extended);
+    }
+
+    #[test]
+    fn chatgpt_recipe_output_contract_event_includes_divergence_metadata() {
+        let output = crate::chatgpt_recipe::ChatgptRecipeOutput {
+            transport: "dev-browser".to_string(),
+            backend: "dev-browser".to_string(),
+            response: "ok".to_string(),
+            model_used: Some("gpt-5-4-pro".to_string()),
+            warnings: vec!["clipboard fallback".to_string()],
+            fallback_used: true,
+            delivery_mode: crate::chatgpt_recipe::ChatgptDeliveryMode::Paste,
+            auto_paste_fallback: true,
+        };
+
+        let event = output.to_recipe_complete_event();
+        assert_eq!(event["type"], "recipe_complete");
+        assert_eq!(event["transport"], "dev-browser");
+        assert_eq!(event["delivery_mode"], "paste");
+        assert_eq!(event["auto_paste_fallback"], true);
+        assert_eq!(event["warnings"], json!(["clipboard fallback"]));
+    }
+
+    #[test]
+    fn run_recipe_via_dev_browser_rejects_invalid_thread_mode_before_install_check() {
+        let recipe_args = BrowserRecipeArgs {
+            recipe: PathBuf::from("recipes/chatgpt.yaml"),
+            bundle: Some(PathBuf::from("/tmp/bundle.md")),
+            profile: None,
+            cdp: None,
+            browser_id: None,
+            vars: vec![],
+        };
+        let recipe_vars = BTreeMap::from([("thread".to_string(), "sideways".to_string())]);
+        let err = run_recipe_via_dev_browser(
+            &test_app_context(),
+            &recipe_args,
+            &recipe_vars,
+            None,
+            OutputFormat::Text,
+            /* is_chatgpt */ true,
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("thread"));
+        assert!(msg.contains("fresh"));
+    }
+
+    #[test]
+    fn run_recipe_via_dev_browser_rejects_thread_reuse_before_install_check() {
+        let recipe_args = BrowserRecipeArgs {
+            recipe: PathBuf::from("recipes/chatgpt.yaml"),
+            bundle: Some(PathBuf::from("/tmp/bundle.md")),
+            profile: None,
+            cdp: None,
+            browser_id: None,
+            vars: vec![],
+        };
+        let recipe_vars = BTreeMap::from([("thread".to_string(), "reuse".to_string())]);
+        let err = run_recipe_via_dev_browser(
+            &test_app_context(),
+            &recipe_args,
+            &recipe_vars,
+            None,
+            OutputFormat::Text,
+            /* is_chatgpt */ true,
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("thread=reuse is no longer supported"));
+        assert!(msg.contains("fresh ChatGPT tab"));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -2130,7 +2130,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 .with_context(|| format!("resolve recipe {:?}", recipe_args.recipe))?;
             let content = fs::read_to_string(&recipe_path)
                 .with_context(|| format!("read recipe {}", recipe_path.display()))?;
-            let recipe: browser::Recipe = serde_yml::from_str(&content)?;
+            let recipe: browser::Recipe = serde_yaml_ng::from_str(&content)?;
             let mut recipe_vars =
                 browser::build_recipe_vars(recipe.defaults.as_ref(), &recipe_args.vars)?;
             let profile_dir =

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -195,6 +195,9 @@ struct BundleArgs {
 
     #[arg(long)]
     all: bool,
+
+    #[arg(long, help = "Include dotfiles and dot-directories; implied by --all")]
+    include_hidden: bool,
 }
 
 #[derive(Args)]

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -1457,6 +1457,7 @@ fn run_recipe_via_dev_browser(
             "dev-browser transport currently supports only the built-in `chatgpt` recipe"
         ));
     }
+    chatgpt_web::validate_thread_mode(recipe_vars.get("thread").map(String::as_str))?;
     if recipe_args.profile.is_some() {
         return Err(anyhow!(
             "dev-browser transport does not support `--profile`; use `--cdp` to target a specific Chrome instance/profile"

--- a/crates/yoetz-cli/src/providers/gemini.rs
+++ b/crates/yoetz-cli/src/providers/gemini.rs
@@ -195,12 +195,7 @@ pub async fn generate_video_veo(
 
     let uri =
         extract_video_uri(&response).ok_or_else(|| anyhow!("missing video uri in response"))?;
-    validate_gemini_url(&uri, &auth.base_url, "download generated video")?;
-    if uri.starts_with("gs://") {
-        return Err(anyhow!(
-            "video is stored in GCS at {uri}; yoetz cannot download gs:// URIs without GCS credentials. Download with gsutil or gcloud and retry"
-        ));
-    }
+    validate_generated_video_download_uri(&uri, &auth.base_url)?;
 
     // Maximum download size for video files (500 MiB).
     const MAX_VIDEO_DOWNLOAD_BYTES: usize = 500 * 1024 * 1024;
@@ -508,6 +503,15 @@ fn extract_video_uri(resp: &Value) -> Option<String> {
     None
 }
 
+fn validate_generated_video_download_uri(uri: &str, base_url: &str) -> Result<()> {
+    if uri.starts_with("gs://") {
+        return Err(anyhow!(
+            "video is stored in GCS at {uri}; yoetz cannot download gs:// URIs without GCS credentials. Download with gsutil or gcloud and retry"
+        ));
+    }
+    validate_gemini_url(uri, base_url, "download generated video")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -566,6 +570,19 @@ mod tests {
             extract_video_uri(&resp),
             Some("gs://bucket/video.mp4".to_string())
         );
+    }
+
+    #[test]
+    fn validate_generated_video_download_uri_prefers_gcs_guidance() {
+        let err = validate_generated_video_download_uri(
+            "gs://bucket/video.mp4",
+            "https://generativelanguage.googleapis.com/v1beta",
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("video is stored in GCS"));
+        assert!(msg.contains("gs://bucket/video.mp4"));
+        assert!(!msg.contains("untrusted Gemini URL"));
     }
 
     #[test]

--- a/crates/yoetz-cli/tests/cli.rs
+++ b/crates/yoetz-cli/tests/cli.rs
@@ -420,6 +420,37 @@ fn bundle_all_includes_hidden_paths() {
 }
 
 #[test]
+fn generate_video_openai_rejects_multiple_images() {
+    let dir = tempfile::tempdir().unwrap();
+    let image_a = dir.path().join("a.png");
+    let image_b = dir.path().join("b.png");
+    fs::write(&image_a, [0u8, 1, 2, 3]).unwrap();
+    fs::write(&image_b, [0u8, 1, 2, 3]).unwrap();
+
+    yoetz()
+        .args([
+            "generate",
+            "video",
+            "--provider",
+            "openai",
+            "--model",
+            "sora-1",
+            "--prompt",
+            "animate this",
+            "--image",
+            image_a.to_str().unwrap(),
+            "--image",
+            image_b.to_str().unwrap(),
+            "--dry-run",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "provider openai accepts at most one --image for video generation",
+        ));
+}
+
+#[test]
 fn council_em_dash_in_prompt_parses() {
     let result = yoetz()
         .args([

--- a/crates/yoetz-cli/tests/cli.rs
+++ b/crates/yoetz-cli/tests/cli.rs
@@ -221,7 +221,8 @@ fn bundle_help() {
         .args(["bundle", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("--files"));
+        .stdout(predicate::str::contains("--files"))
+        .stdout(predicate::str::contains("--include-hidden"));
 }
 
 #[test]
@@ -394,6 +395,28 @@ fn bundle_prompt_file_without_files_succeeds() {
         .assert()
         .success()
         .stdout(predicate::str::contains("\"file_count\": 0"));
+}
+
+#[test]
+fn bundle_all_includes_hidden_paths() {
+    let dir = tempfile::tempdir().unwrap();
+    let workflows = dir.path().join(".github/workflows");
+    fs::create_dir_all(&workflows).unwrap();
+    fs::write(workflows.join("ci.yml"), "name: CI\n").unwrap();
+
+    yoetz()
+        .current_dir(dir.path())
+        .args([
+            "bundle",
+            "--prompt",
+            "review repo",
+            "--all",
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(".github/workflows/ci.yml"));
 }
 
 #[test]

--- a/crates/yoetz-core/src/bundle.rs
+++ b/crates/yoetz-core/src/bundle.rs
@@ -492,6 +492,37 @@ mod tests {
     }
 
     #[test]
+    fn bundle_walks_hidden_paths_when_requested() {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("yoetz_hidden_test_{nanos}"));
+        let workflows = root.join(".github/workflows");
+        fs::create_dir_all(&workflows).unwrap();
+
+        fs::write(root.join("visible.txt"), "visible").unwrap();
+        fs::write(workflows.join("ci.yml"), "name: CI\n").unwrap();
+
+        let bundle = build_bundle(
+            "prompt",
+            BundleOptions {
+                root: root.clone(),
+                include_all: true,
+                include_hidden: true,
+                ..BundleOptions::default()
+            },
+        )
+        .unwrap();
+
+        let paths: Vec<_> = bundle.files.iter().map(|f| f.path.as_str()).collect();
+        assert!(paths.contains(&"visible.txt"));
+        assert!(paths.contains(&".github/workflows/ci.yml"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
     fn bundle_dedups_same_file_across_direct_and_glob_inputs() {
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/crates/yoetz-core/src/config.rs
+++ b/crates/yoetz-core/src/config.rs
@@ -24,8 +24,6 @@ pub struct Defaults {
     pub model: Option<String>,
     pub provider: Option<String>,
     pub max_output_tokens: Option<usize>,
-    pub browser_profile: Option<String>,
-    pub browser_cdp: Option<String>,
 }
 
 /// Configuration for a single LLM provider (base URL, API key, kind).
@@ -107,25 +105,33 @@ impl Config {
             }
         }
         if let Some(aliases) = other.aliases {
-            self.aliases.extend(aliases);
+            if trusted {
+                self.aliases.extend(aliases);
+            } else {
+                eprintln!(
+                    "warning: ignoring [aliases] from untrusted config {}",
+                    source.display()
+                );
+            }
         }
     }
 }
 
 fn sanitize_untrusted_defaults(mut defaults: Defaults, source: &Path) -> Defaults {
-    if defaults.browser_profile.take().is_some() {
-        eprintln!(
-            "warning: ignoring defaults.browser_profile from untrusted config {}",
-            source.display()
-        );
-    }
-    if defaults.browser_cdp.take().is_some() {
-        eprintln!(
-            "warning: ignoring defaults.browser_cdp from untrusted config {}",
-            source.display()
-        );
-    }
+    warn_and_clear_untrusted_default(&mut defaults.profile, "profile", source);
+    warn_and_clear_untrusted_default(&mut defaults.model, "model", source);
+    warn_and_clear_untrusted_default(&mut defaults.provider, "provider", source);
+    warn_and_clear_untrusted_default(&mut defaults.max_output_tokens, "max_output_tokens", source);
     defaults
+}
+
+fn warn_and_clear_untrusted_default<T>(slot: &mut Option<T>, field: &str, source: &Path) {
+    if slot.take().is_some() {
+        eprintln!(
+            "warning: ignoring defaults.{field} from untrusted config {}",
+            source.display()
+        );
+    }
 }
 
 fn load_config_file(path: &Path) -> Result<ConfigFile> {
@@ -194,12 +200,6 @@ fn merge_defaults(target: &mut Defaults, other: Defaults) {
     if other.max_output_tokens.is_some() {
         target.max_output_tokens = other.max_output_tokens;
     }
-    if other.browser_profile.is_some() {
-        target.browser_profile = other.browser_profile;
-    }
-    if other.browser_cdp.is_some() {
-        target.browser_cdp = other.browser_cdp;
-    }
 }
 
 #[cfg(test)]
@@ -207,37 +207,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_config_with_browser_cdp() {
-        let toml_str = r#"
-[defaults]
-browser_cdp = "http://127.0.0.1:9222"
-"#;
-        let file: ConfigFile = toml::from_str(toml_str).unwrap();
-        assert_eq!(
-            file.defaults.unwrap().browser_cdp.as_deref(),
-            Some("http://127.0.0.1:9222")
-        );
-    }
-
-    #[test]
-    fn parse_config_without_browser_cdp_defaults_to_none() {
+    fn parse_config_defaults_without_browser_fields() {
         let toml_str = r#"
 [defaults]
 model = "gpt-5-4-pro"
 "#;
         let file: ConfigFile = toml::from_str(toml_str).unwrap();
-        assert!(file.defaults.unwrap().browser_cdp.is_none());
-    }
-
-    #[test]
-    fn merge_defaults_browser_cdp() {
-        let mut target = Defaults::default();
-        let other = Defaults {
-            browser_cdp: Some("http://127.0.0.1:9222".to_string()),
-            ..Default::default()
-        };
-        merge_defaults(&mut target, other);
-        assert_eq!(target.browser_cdp.as_deref(), Some("http://127.0.0.1:9222"));
+        assert_eq!(file.defaults.unwrap().model.as_deref(), Some("gpt-5-4-pro"));
     }
 
     #[test]
@@ -245,10 +221,10 @@ model = "gpt-5-4-pro"
         let mut config = Config::default();
         let file = ConfigFile {
             defaults: Some(Defaults {
+                profile: Some("repo-profile".to_string()),
                 model: Some("gpt-5-4-pro".to_string()),
-                browser_profile: Some("/tmp/evil-profile".to_string()),
-                browser_cdp: Some("http://evil.example.com:9222".to_string()),
-                ..Default::default()
+                provider: Some("evil".to_string()),
+                max_output_tokens: Some(99_999),
             }),
             providers: Some(HashMap::from([(
                 "evil".to_string(),
@@ -268,14 +244,11 @@ model = "gpt-5-4-pro"
             )])),
         };
         config.merge(file, false, Path::new("./yoetz.toml"));
-        // Safe fields applied
-        assert_eq!(config.defaults.model.as_deref(), Some("gpt-5-4-pro"));
-        assert!(config.defaults.browser_profile.is_none());
-        assert!(config.defaults.browser_cdp.is_none());
-        assert_eq!(
-            config.aliases.get("fast").map(|s| s.as_str()),
-            Some("gpt-5-4-pro")
-        );
+        assert!(config.defaults.profile.is_none());
+        assert!(config.defaults.model.is_none());
+        assert!(config.defaults.provider.is_none());
+        assert!(config.defaults.max_output_tokens.is_none());
+        assert!(config.aliases.is_empty());
         // Restricted fields skipped
         assert!(config.providers.is_empty());
         assert!(config.registry.openrouter_models_url.is_none());

--- a/crates/yoetz-core/src/media.rs
+++ b/crates/yoetz-core/src/media.rs
@@ -52,18 +52,22 @@ impl MediaInput {
     }
 
     pub fn from_path_with_mime(path: &Path, mime_override: Option<&str>) -> Result<Self> {
+        let metadata =
+            fs::metadata(path).with_context(|| format!("stat media input {}", path.display()))?;
+        if !metadata.is_file() {
+            return Err(anyhow!("media input is not a file: {}", path.display()));
+        }
         let mime = if let Some(mime) = mime_override {
             mime.to_string()
         } else {
             guess_mime(path)?
         };
         let media_type = media_type_from_mime(&mime)?;
-        let size_bytes = fs::metadata(path).ok().map(|m| m.len());
         Ok(Self {
             source: MediaSource::File(path.to_path_buf()),
             media_type,
             mime_type: mime,
-            size_bytes,
+            size_bytes: Some(metadata.len()),
         })
     }
 
@@ -209,6 +213,30 @@ mod tests {
         assert_eq!(input.media_type, MediaType::Image);
         assert_eq!(input.mime_type, "image/png");
         let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn media_input_from_missing_path_errors() {
+        let path = temp_path("png");
+        let err = MediaInput::from_path(&path).unwrap_err();
+        assert!(err.to_string().contains("stat media input"));
+    }
+
+    #[test]
+    fn media_input_from_directory_errors() {
+        let path = std::env::temp_dir().join(format!(
+            "yoetz_media_dir_test_{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&path).unwrap();
+        let err = MediaInput::from_path(&path).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains(&format!("media input is not a file: {}", path.display())));
+        let _ = fs::remove_dir_all(path);
     }
 
     #[test]

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -1,4 +1,9 @@
 name: chatgpt
+# Authoritative contract note:
+# The shared ChatGPT recipe request/output contract now lives in
+# `crates/yoetz-cli/src/chatgpt_recipe.rs`. This YAML still defines the
+# generic agent-browser action sequence, but MCP/dev-browser consume the same
+# typed Rust contract even when they do not execute these steps literally.
 # Transport order:
 #   1. chrome-devtools-mcp — direct CDP client against running Chrome 147+
 #      (uses vendored `headless_chrome`; NOT a bridge to the chrome-devtools-mcp
@@ -17,10 +22,15 @@ name: chatgpt
 #              best available model, preferring GPT-5/Pro when the account has it.
 #   extended — set to "false" to disable Extended Pro. Default: leave as-is.
 #   prompt   — prompt text to send with the attachment.
-#   thread   — "fresh" (default) opens a new ChatGPT conversation each call.
-#              "reuse" keeps the currently active ChatGPT tab/conversation so
-#              follow-up turns land in the same thread. Reuse requires the
-#              attached tab to already be on chatgpt.com.
+#   browser_context_id — exact Chrome `browserContextId` to target when multiple
+#              signed-in Chrome contexts are live in the same browser process.
+#   profile_email — signed-in Chrome profile email to target (for example
+#              `aviv.s@taboola.com`). Yoetz resolves this to a live
+#              `browserContextId` from the tabs currently open in Chrome.
+#   thread   — "fresh" (default). Every yoetz request opens a new ChatGPT tab
+#              marked with `?_yoetz=<run-id>` so the user's own ChatGPT tabs
+#              are never touched. Passing `thread=reuse` is rejected; parallel
+#              yoetz runs work automatically because each run owns its own tab.
 #   wait_timeout_ms  — overall response wait deadline in ms (default: 1800000 = 30min).
 #   wait_interval_ms — poll interval in ms (default: 30000 = 30s).
 
@@ -39,37 +49,27 @@ defaults:
   wait_interval_ms: "30000"
 
 steps:
-  # Step 1: navigate or stay put depending on `thread`.
-  # - thread=fresh (default): force a brand-new conversation by appending a
-  #   timestamp query param so the SPA router treats it as a real navigation
-  #   (otherwise it's a no-op and we'd reuse the old thread).
-  # - thread=reuse: stay on the current tab; fail-fast if it isn't chatgpt.com
-  #   so we don't accidentally type into some unrelated page.
-  - action: eval
-    args:
-      - |
-        (() => {
-          const thread = "{{thread}}";
-          if (thread === "reuse") {
-            if (location.host !== "chatgpt.com") {
-              throw new Error("thread=reuse requires the attached tab to be on chatgpt.com (current host: " + location.host + ")");
-            }
-            return "thread=reuse: staying on " + location.pathname;
-          }
-          window.location.href = 'https://chatgpt.com/?_yoetz=' + Date.now();
-          return "thread=fresh: navigating to new chat";
-        })()
+  # Step 1: always open a fresh yoetz-owned ChatGPT tab for this run.
+  - action: open
+    args: ["https://chatgpt.com/?_yoetz={{run_id}}"]
   - sleep_ms: 4000
 
-  # Step 2: safety net for thread=fresh — if we somehow landed on an existing
-  # conversation (URL contains /c/), click "New chat" to guarantee a clean
-  # slate. Skipped entirely when thread=reuse.
+  # Step 2: set a durable in-page backup marker before any recipe interaction.
   - action: eval
     args:
       - |
         (() => {
-          const thread = "{{thread}}";
-          if (thread === "reuse") return "skipped: thread=reuse";
+          window.name = "yoetz:{{run_id}}";
+          return "marked yoetz-owned chatgpt tab";
+        })()
+  - sleep_ms: 500
+
+  # Step 3: safety net — if we somehow landed on an existing conversation
+  # (URL contains /c/), click "New chat" to guarantee a clean slate.
+  - action: eval
+    args:
+      - |
+        (() => {
           if (!window.location.pathname.startsWith('/c/')) return "already new chat";
           const btn = document.querySelector(
             'a[href="/"], button[data-testid="create-new-chat-button"], nav a[class*="new"]'
@@ -80,91 +80,9 @@ steps:
         })()
   - sleep_ms: 2000
 
-  # Select model if --var model is provided.
-  # ChatGPT uses Radix UI for the dropdown — .click() alone does NOT open it.
-  # A full pointer event sequence (pointerdown→mousedown→pointerup→mouseup→click)
-  # is required, matching what a real mouse click dispatches.
-  - action: eval
-    args:
-      - |
-        (() => {
-          const raw = "{{model}}".trim();
-          const autoMode = !raw || raw.toLowerCase() === "auto";
-          const btn = document.querySelector(
-            '[data-testid="model-switcher-dropdown-button"], ' +
-            'button[aria-label="Model selector"]'
-          );
-          if (!btn) {
-            if (autoMode) return "kept current model: selector not found";
-            throw new Error("model selector button not found — ChatGPT may have changed their UI. Inspect the model picker for data-testid or aria-label attributes.");
-          }
-          btn.dispatchEvent(new PointerEvent('pointerdown', {bubbles: true, cancelable: true, pointerId: 1}));
-          btn.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, cancelable: true}));
-          btn.dispatchEvent(new PointerEvent('pointerup', {bubbles: true, cancelable: true, pointerId: 1}));
-          btn.dispatchEvent(new MouseEvent('mouseup', {bubbles: true, cancelable: true}));
-          btn.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}));
-          return autoMode ? "opened model selector for auto selection" : "opened model selector";
-        })()
-  - sleep_ms: 1200
-  - action: eval
-    args:
-      - |
-        (() => {
-          const raw = "{{model}}".trim();
-          const slug = raw.toLowerCase();
-          const autoMode = !slug || slug === "auto";
-          function realClick(el) {
-            el.dispatchEvent(new PointerEvent('pointerdown', {bubbles: true, cancelable: true, pointerId: 1}));
-            el.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, cancelable: true}));
-            el.dispatchEvent(new PointerEvent('pointerup', {bubbles: true, cancelable: true, pointerId: 1}));
-            el.dispatchEvent(new MouseEvent('mouseup', {bubbles: true, cancelable: true}));
-            el.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true}));
-          }
-          const items = Array.from(document.querySelectorAll('[role="menuitem"], [data-testid^="model-switcher-"]'))
-            .map((el) => {
-              const text = ((el.textContent || '').replace(/\s+/g, ' ').trim());
-              const testId = el.getAttribute('data-testid') || '';
-              return {el, text, haystack: (testId + ' ' + text).toLowerCase()};
-            })
-            .filter((item) => item.text || item.haystack);
-          if (items.length === 0) {
-            if (autoMode) return "kept current model: no menu items";
-            throw new Error("model selector opened but no model options were visible");
-          }
-          const currentLabel = (((document.querySelector('[data-testid="model-switcher-dropdown-button"], button[aria-label="Model selector"]') || {}).textContent) || '')
-            .replace(/\s+/g, ' ')
-            .trim()
-            .toLowerCase();
-          if (autoMode) {
-            const ranked = items
-              .map((item) => {
-                let score = 0;
-                if (/gpt[- ]?5/.test(item.haystack)) score += 100;
-                if (/\bpro\b/.test(item.haystack)) score += 90;
-                if (/thinking/.test(item.haystack)) score += 60;
-                if (/instant/.test(item.haystack) || /\b5[- ]?3\b/.test(item.haystack)) score += 30;
-                return {...item, score};
-              })
-              .sort((a, b) => b.score - a.score || b.text.length - a.text.length);
-            if (!ranked[0] || ranked[0].score <= 0) return "kept current model";
-            if (currentLabel && currentLabel.includes(ranked[0].text.toLowerCase())) {
-              return "kept current model: " + ranked[0].text;
-            }
-            realClick(ranked[0].el);
-            return "selected: " + ranked[0].text;
-          }
-          const names = {"gpt-5-4-pro":"pro","gpt-5-4-thinking":"thinking","gpt-5-3":"instant","pro":"pro","thinking":"thinking","instant":"instant"};
-          const target = names[slug] || slug;
-          const byTestId = document.querySelector('[data-testid="model-switcher-' + slug + '"]');
-          if (byTestId) { realClick(byTestId); return "selected: " + slug; }
-          const match = items.find(item => item.haystack.includes(target));
-          if (match) {
-            if (currentLabel && currentLabel.includes(target)) return "kept current model: " + match.text;
-            realClick(match.el);
-            return "selected: " + match.text;
-          }
-          throw new Error("model '" + slug + "' not found");
-        })()
+  # Model selection is handled by the built-in Rust action so MCP,
+  # dev-browser, and the generic browser transport share one selector.
+  - action: chatgpt_select_model
   - sleep_ms: 500
 
   # Disable Extended Pro only when explicitly requested (--var extended=false).
@@ -181,19 +99,8 @@ steps:
   - sleep_ms: 500
 
   # File attachment is the only delivery path.
-  # Open the attachment menu (button is "composer-plus-btn").
-  - action: eval
-    args:
-      - |
-        (() => {
-          const btn = document.querySelector(
-            'button[data-testid="composer-plus-btn"], ' +
-            'button[aria-label*="Attach"], button[aria-label*="attach"], button[data-testid*="attach"]'
-          );
-          if (!btn) return "skipped: attach button not found";
-          btn.click();
-          return "opened attachment UI";
-        })()
+  # Open the attachment menu.
+  - action: chatgpt_open_attachment_ui
   - sleep_ms: 500
 
   # Upload the bundle file.
@@ -225,24 +132,7 @@ steps:
   - sleep_ms: 500
 
   # Click send once the typed prompt has enabled the button.
-  - action: eval
-    args:
-      - |
-        (() => {
-          const btn = document.querySelector("button[data-testid='send-button']");
-          if (!btn) throw new Error("send button not found");
-          if (btn.disabled) {
-            const composerEl = document.querySelector("#prompt-textarea, [role='textbox']");
-            const state = {
-              url: window.location.href,
-              attachmentPresent: !!document.querySelector("[class*='file-tile'], [data-testid*='attachment']"),
-              composerTextLength: ((composerEl?.innerText || composerEl?.textContent || "").trim()).length,
-            };
-            throw new Error("send button disabled — page is likely recoverable: " + JSON.stringify(state));
-          }
-          btn.click();
-          return "sent";
-        })()
+  - action: chatgpt_send
 
   # Poll for response completion. Default 30min timeout for Extended Pro;
   # override with --var wait_timeout_ms=N or --var wait_interval_ms=N.

--- a/scripts/chatgpt-browser-canary.sh
+++ b/scripts/chatgpt-browser-canary.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Gated live ChatGPT browser canary.
+#
+# This verifies the real logged-in browser recipe path and the standardized
+# JSON contract, but only when the operator opts in explicitly. It is not safe
+# for default CI because it requires a live authenticated ChatGPT session.
+
+set -euo pipefail
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+[[ "${YOETZ_CHATGPT_CANARY:-}" == "1" ]] || die "set YOETZ_CHATGPT_CANARY=1 to run the live ChatGPT canary"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+yoetz_bin="${YOETZ_BIN:-${repo_root}/target/debug/yoetz}"
+[[ -x "${yoetz_bin}" ]] || die "yoetz binary not found or not executable: ${yoetz_bin}"
+
+cdp_endpoint="${YOETZ_CHATGPT_CDP:-${YOETZ_BROWSER_CDP:-}}"
+[[ -n "${cdp_endpoint}" ]] || die "set YOETZ_CHATGPT_CDP (or YOETZ_BROWSER_CDP) to the live Chrome CDP endpoint"
+
+command -v jq >/dev/null 2>&1 || die "required command not found: jq"
+
+export YOETZ_AGENT=1
+export YOETZ_ALLOW_MUTATE_EXISTING_CHATGPT_TAB="${YOETZ_ALLOW_MUTATE_EXISTING_CHATGPT_TAB:-1}"
+export YOETZ_ALLOW_USER_TAB_ANCHOR="${YOETZ_ALLOW_USER_TAB_ANCHOR:-1}"
+
+bundle_path="$("${yoetz_bin}" bundle -p 'Reply with exactly OK.' --format json | jq -r '.artifacts.bundle_md')"
+[[ -n "${bundle_path}" && -f "${bundle_path}" ]] || die "failed to create canary bundle"
+
+echo "==> running live ChatGPT browser canary via ${yoetz_bin}"
+result="$("${yoetz_bin}" browser recipe \
+  --recipe chatgpt \
+  --bundle "${bundle_path}" \
+  --cdp "${cdp_endpoint}" \
+  --var model=pro \
+  --var wait_timeout_ms="${YOETZ_CHATGPT_WAIT_TIMEOUT_MS:-2400000}" \
+  --format json)"
+
+echo "${result}"
+
+for field in status transport backend response model_used warnings fallback_used delivery_mode auto_paste_fallback; do
+  printf '%s' "${result}" | jq -e --arg field "${field}" 'has($field)' >/dev/null || die "missing JSON field: ${field}"
+done
+
+status="$(printf '%s' "${result}" | jq -r '.status')"
+model_used="$(printf '%s' "${result}" | jq -r '.model_used // empty')"
+delivery_mode="$(printf '%s' "${result}" | jq -r '.delivery_mode')"
+
+[[ "${status}" == "ok" ]] || die "recipe did not return status=ok"
+[[ -n "${model_used}" ]] || die "recipe did not report model_used"
+[[ "${delivery_mode}" == "file_upload" || "${delivery_mode}" == "paste" ]] || die "unexpected delivery_mode: ${delivery_mode}"
+
+echo "==> live ChatGPT canary passed"

--- a/scripts/ci-real-browser-smoke.sh
+++ b/scripts/ci-real-browser-smoke.sh
@@ -59,9 +59,17 @@ cleanup() {
 }
 trap cleanup EXIT
 
+chrome_extra_args=()
+if [[ "$(uname -s)" == "Linux" && ( -n "${CI:-}" || -n "${GITHUB_ACTIONS:-}" ) ]]; then
+  # Hosted Linux runners often install Chrome-for-Testing without a usable
+  # setuid sandbox helper, so headless launch fails unless we opt out here.
+  chrome_extra_args+=(--no-sandbox)
+fi
+
 echo "==> launching Chrome for Testing on port ${port}"
 "${chrome_bin}" \
   --headless=new \
+  "${chrome_extra_args[@]}" \
   --remote-debugging-port="${port}" \
   --user-data-dir="${data_dir}" \
   --no-first-run \

--- a/scripts/ci-real-browser-smoke.sh
+++ b/scripts/ci-real-browser-smoke.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# Real-browser CI smoke test.
+#
+# Launches a fresh Chrome for Testing instance on a random loopback port, then
+# drives the locally-built `yoetz` binary against it over CDP. Exits non-zero
+# on any failure so it can gate CI (review finding #13).
+#
+# Requires:
+#   - YOETZ_CHROME_BIN pointing at a Chrome (or Chrome for Testing) binary
+#   - `yoetz` binary built in release mode at the expected target path
+#     (override with YOETZ_BIN=...)
+#   - curl, jq
+#
+# The fixture is a throwaway user-data-dir under $TMPDIR so we never touch the
+# operator's real Chrome profile.
+
+set -euo pipefail
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+chrome_bin="${YOETZ_CHROME_BIN:-}"
+if [[ -z "${chrome_bin}" ]]; then
+  die "YOETZ_CHROME_BIN is not set; point it at a Chrome for Testing binary"
+fi
+if [[ ! -x "${chrome_bin}" ]]; then
+  die "Chrome binary is not executable: ${chrome_bin}"
+fi
+
+yoetz_bin="${YOETZ_BIN:-}"
+if [[ -z "${yoetz_bin}" ]]; then
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  yoetz_bin="${repo_root}/target/release/yoetz"
+fi
+if [[ ! -x "${yoetz_bin}" ]]; then
+  die "yoetz binary not found or not executable: ${yoetz_bin} (build with \`cargo build --release --bin yoetz\` or set YOETZ_BIN)"
+fi
+
+for cmd in curl jq; do
+  command -v "${cmd}" >/dev/null 2>&1 || die "required command not found: ${cmd}"
+done
+
+# Allocate a free TCP port without leaking the listener into Chrome's namespace.
+port="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')"
+[[ -n "${port}" ]] || die "failed to allocate a free port"
+
+data_dir="$(mktemp -d -t yoetz-ci-chrome.XXXXXXXX)"
+chrome_log="${data_dir}/chrome.log"
+
+cleanup() {
+  if [[ -n "${chrome_pid:-}" ]]; then
+    kill "${chrome_pid}" >/dev/null 2>&1 || true
+    wait "${chrome_pid}" 2>/dev/null || true
+  fi
+  rm -rf "${data_dir}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "==> launching Chrome for Testing on port ${port}"
+"${chrome_bin}" \
+  --headless=new \
+  --remote-debugging-port="${port}" \
+  --user-data-dir="${data_dir}" \
+  --no-first-run \
+  --no-default-browser-check \
+  --disable-features=Translate,MediaRouter \
+  --hide-scrollbars \
+  --mute-audio \
+  about:blank \
+  >"${chrome_log}" 2>&1 &
+chrome_pid=$!
+
+endpoint="http://127.0.0.1:${port}"
+deadline=$((SECONDS + 30))
+while (( SECONDS < deadline )); do
+  if curl -fsS --max-time 2 "${endpoint}/json/version" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "${chrome_pid}" >/dev/null 2>&1; then
+    echo "--- chrome log ---"
+    cat "${chrome_log}" >&2 || true
+    die "Chrome process exited before CDP became reachable"
+  fi
+  sleep 0.25
+done
+
+if ! curl -fsS --max-time 2 "${endpoint}/json/version" >/dev/null 2>&1; then
+  echo "--- chrome log ---"
+  cat "${chrome_log}" >&2 || true
+  die "Chrome CDP did not become reachable on ${endpoint} within 30s"
+fi
+
+echo "==> Chrome reachable at ${endpoint}"
+echo "==> exercising \`yoetz browser verify-cdp\` against the live CDP endpoint"
+
+export YOETZ_AGENT=1
+verify_output="$("${yoetz_bin}" browser verify-cdp --cdp "${endpoint}" --format json)"
+echo "${verify_output}"
+
+status="$(printf '%s' "${verify_output}" | jq -r '.status // empty')"
+page_id="$(printf '%s' "${verify_output}" | jq -r '.page_id // empty')"
+if [[ "${status}" != "ok" ]]; then
+  die "yoetz browser verify-cdp did not return status=ok (got ${status:-<empty>})"
+fi
+if [[ -z "${page_id}" ]]; then
+  die "yoetz browser verify-cdp did not report a page_id"
+fi
+echo "==> attach + fresh-tab creation verified; page_id=${page_id}"
+
+# Smoke: attaching twice must remain stable — no leaked daemons / wedged
+# sessions on the second call.
+"${yoetz_bin}" browser verify-cdp --cdp "${endpoint}" --format json >/dev/null
+echo "==> second attach also succeeded"
+
+echo "==> CI real-browser smoke passed"

--- a/scripts/setup-chatgpt-profile.sh
+++ b/scripts/setup-chatgpt-profile.sh
@@ -6,9 +6,40 @@ set -euo pipefail
 # Preserves AGENT_BROWSER_PROFILE for backward compatibility
 
 PROFILE_DIR="${AGENT_BROWSER_PROFILE:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+resolve_yoetz_bin() {
+    if [ -n "${YOETZ_BIN:-}" ]; then
+        printf '%s\n' "${YOETZ_BIN}"
+        return 0
+    fi
+
+    for candidate in \
+        "${REPO_ROOT}/target/release/yoetz" \
+        "${REPO_ROOT}/target/debug/yoetz"
+    do
+        if [ -x "${candidate}" ]; then
+            printf '%s\n' "${candidate}"
+            return 0
+        fi
+    done
+
+    if command -v yoetz >/dev/null 2>&1; then
+        command -v yoetz
+        return 0
+    fi
+
+    return 1
+}
+
+YOETZ_CMD="$(resolve_yoetz_bin)" || {
+    echo "error: could not find a yoetz binary. Build this repo first or set YOETZ_BIN." >&2
+    exit 1
+}
 
 if [ -n "$PROFILE_DIR" ]; then
-    yoetz browser login --profile "$PROFILE_DIR" "$@"
+    exec "$YOETZ_CMD" browser login --profile "$PROFILE_DIR" "$@"
 else
-    yoetz browser login "$@"
+    exec "$YOETZ_CMD" browser login "$@"
 fi

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -258,11 +258,9 @@ yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE"
 # can access, preferring GPT-5/Pro when available. Override it only if needed.
 yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE" --var model=gpt-5-4-pro
 
-# Reuse the currently active ChatGPT tab/conversation for a follow-up turn
-# instead of opening a fresh one (default is "fresh" — a fresh conversation
-# per call; whether that is a new tab or same-tab navigation depends on the
-# transport/session state). Requires the attached tab to already be on chatgpt.com.
-yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE" --var thread=reuse
+# Every request opens a fresh, yoetz-owned ChatGPT tab marked with ?_yoetz=<run-id>
+# so your own ChatGPT conversations are never touched. `--var thread=reuse` is
+# rejected — yoetz is always a fresh-tab consumer.
 ```
 
 The wait loop reports `completion_reason` in its JSON output:

--- a/skills/yoetz/references/commands.md
+++ b/skills/yoetz/references/commands.md
@@ -6,7 +6,7 @@
 |------|-------------|
 | `--format <json\|text>` | Output format (default: text) |
 | `--debug` | Print raw provider responses |
-| `--profile <name>` | Config profile to use |
+| `--config-profile <name>` | Config profile to use |
 | `--timeout-secs <N>` | Request timeout (default: 60) |
 | `--output-final <path>` | Write final output to file |
 | `--output-schema <path>` | JSON schema for structured output validation |

--- a/vendor/headless_chrome/src/browser/mod.rs
+++ b/vendor/headless_chrome/src/browser/mod.rs
@@ -23,7 +23,7 @@ use crate::browser::context::Context;
 use crate::util;
 use B::GetVersion;
 pub use B::GetVersionReturnObject;
-use Target::{CreateTarget, SetDiscoverTargets};
+use Target::{CreateTarget, FilterEntry, SetDiscoverTargets};
 
 #[cfg(feature = "fetch")]
 pub use fetcher::FetcherOptions;
@@ -170,7 +170,7 @@ impl Browser {
         trace!("Calling set discover");
         browser.call_method(SetDiscoverTargets {
             discover: true,
-            filter: None,
+            filter: Some(registerable_target_discovery_filter()),
         })?;
 
         Ok(browser)
@@ -287,9 +287,7 @@ impl Browser {
             .call_method(GetTargets { filter: None })?
             .target_infos
             .into_iter()
-            .find(|target| {
-                target.Type == "page" && target.target_id.as_str() == target_id
-            });
+            .find(|target| is_page_target(target) && target.target_id.as_str() == target_id);
 
         let Some(target) = target else {
             return Ok(None);
@@ -327,32 +325,59 @@ impl Browser {
         Ok(Context::new(self, context_id))
     }
 
+    pub fn get_targets(&self) -> Result<Vec<Target::TargetInfo>> {
+        Ok(self.call_method(GetTargets { filter: None })?.target_infos)
+    }
+
+    pub fn get_page_targets(&self) -> Result<Vec<Target::TargetInfo>> {
+        Ok(self
+            .get_targets()?
+            .into_iter()
+            .filter(is_page_target)
+            .collect())
+    }
+
+    pub fn attach_to_page_target(&self, target_id: &str) -> Result<Option<Arc<Tab>>> {
+        self.attach_tab_from_target_list(target_id)
+    }
+
     /// Adds tabs that have not been opened with new_tab to the list of tabs
     pub fn register_missing_tabs(&self) {
-        let targets = self.call_method(GetTargets { filter: None });
+        let Ok(targets) = self.call_method(GetTargets { filter: None }) else {
+            return;
+        };
 
         let mut tabs_lock = self.inner.tabs.lock().unwrap();
         let mut previous_target_id: String = String::default();
-        for target in targets.unwrap().target_infos {
-            let target_id = target.target_id.clone();
-
-            if tabs_lock
-                .iter()
-                .any(|t| t.get_target_id().clone() == target_id || !target.attached)
-            {
+        for target in targets.target_infos {
+            if !is_attachable_page_target(&target) {
                 previous_target_id = target.target_id;
                 continue;
             }
 
-            let tab = Tab::new(target, self.inner.transport.clone());
-            if let Ok(tab) = tab {
-                if let Some(index) = tabs_lock
-                    .iter()
-                    .position(|x| x.get_target_id().clone() == previous_target_id)
-                {
-                    tabs_lock.insert(index, Arc::new(tab));
-                } else {
-                    tabs_lock.push(Arc::new(tab));
+            let target_id = target.target_id.clone();
+
+            if tabs_lock.iter().any(|t| t.get_target_id().clone() == target_id) {
+                previous_target_id = target.target_id;
+                continue;
+            }
+
+            match Tab::new(target.clone(), self.inner.transport.clone()) {
+                Ok(tab) => {
+                    if let Some(index) = tabs_lock
+                        .iter()
+                        .position(|x| x.get_target_id().clone() == previous_target_id)
+                    {
+                        tabs_lock.insert(index, Arc::new(tab));
+                    } else {
+                        tabs_lock.push(Arc::new(tab));
+                    }
+                }
+                Err(err) => {
+                    emit_register_missing_tabs_debug(&format!(
+                        "failed to attach target {} ({}) while registering existing tabs: {err:#}",
+                        target.target_id, target.url
+                    ));
                 }
             }
 
@@ -386,8 +411,6 @@ impl Browser {
         idle_browser_timeout: Duration,
     ) {
         let tabs = Arc::clone(&self.inner.tabs);
-        let transport = Arc::clone(&self.inner.transport);
-
         std::thread::spawn(move || {
             trace!("Starting browser's event handling loop");
             loop {
@@ -423,52 +446,25 @@ impl Browser {
                                 // when Type == other and url == "" the next trigger would be AttachedToTarget
                                 // meaning the devtools has ben opened automatically..
                                 // for now ignoring devtools tabs to be in tabs..
-                                if target_info.Type == "page" {
-                                    if tabs
-                                        .lock()
-                                        .unwrap()
-                                        .iter()
-                                        .any(|tab| tab.get_target_id() == &target_info.target_id)
-                                    {
-                                        continue;
-                                    }
-                                    match Tab::new(target_info, Arc::clone(&transport)) {
-                                        Ok(new_tab) => {
-                                            let new_tab = Arc::new(new_tab);
-                                            let mut locked_tabs = tabs.lock().unwrap();
-                                            if locked_tabs.iter().any(|existing| {
-                                                existing.get_target_id() == new_tab.get_target_id()
-                                            }) {
-                                                continue;
-                                            }
-                                            locked_tabs.push(new_tab);
-                                        }
-                                        Err(_tab_creation_err) => {
-                                            info!("Failed to create a handle to new tab");
-                                            break;
-                                        }
-                                    }
+                                if let Some(existing_tab) = tabs
+                                    .lock()
+                                    .unwrap()
+                                    .iter()
+                                    .find(|tab| *tab.get_target_id() == target_info.target_id)
+                                    .cloned()
+                                {
+                                    existing_tab.update_target_info(target_info);
                                 }
                             }
                             Event::TargetInfoChanged(ev) => {
-                                let target_info = &ev.params.target_info;
+                                let target_info = ev.params.target_info;
                                 trace!("Target info changed: {target_info:?}");
-                                if target_info.Type == "page"
-                                    && !target_info.url.starts_with("devtools://")
+                                let locked_tabs = tabs.lock().unwrap();
+                                if let Some(updated_tab) = locked_tabs
+                                    .iter()
+                                    .find(|tab| *tab.get_target_id() == target_info.target_id)
                                 {
-                                    let locked_tabs = tabs.lock().unwrap();
-                                    if let Some(updated_tab) = locked_tabs
-                                        .iter()
-                                        .find(|tab| *tab.get_target_id() == target_info.target_id)
-                                    {
-                                        updated_tab.update_target_info(target_info.clone());
-                                    } else {
-                                        let raw_event = format!("{ev:?}");
-                                        trace!(
-                                            "Target info changed unhandled event: {}",
-                                            raw_event.chars().take(50).collect::<String>()
-                                        );
-                                    }
+                                    updated_tab.update_target_info(target_info.clone());
                                 }
                             }
                             Event::AttachedToTarget(ev) => {
@@ -518,6 +514,56 @@ impl Browser {
     pub(crate) fn process(&self) -> Option<&Process> {
         #[allow(clippy::used_underscore_binding)]
         self.inner.process.as_ref()
+    }
+}
+
+fn is_page_target(target: &Target::TargetInfo) -> bool {
+    matches!(target.Type.as_str(), "page" | "tab") && !target.url.starts_with("devtools://")
+}
+
+fn is_attachable_page_target(target: &Target::TargetInfo) -> bool {
+    // Discovery should still surface targets another frontend/client already
+    // attached to, but creating a new Tab handle for those targets is not
+    // reliable on modern Chrome: a second AttachToTarget can succeed while the
+    // first session-bound Page.enable immediately comes back as browser-level
+    // -32601 "method not found". Restrict auto-registration to unattached
+    // page/tab targets and leave already-attached targets visible only through
+    // get_page_targets()/GetTargets.
+    is_page_target(target) && !target.attached
+}
+
+fn registerable_target_discovery_filter() -> Target::TargetFilter {
+    vec![
+        FilterEntry {
+            exclude: Some(true),
+            Type: Some("browser".to_string()),
+        },
+        FilterEntry {
+            exclude: Some(false),
+            Type: Some("page".to_string()),
+        },
+        FilterEntry {
+            exclude: Some(false),
+            Type: Some("tab".to_string()),
+        },
+        FilterEntry {
+            exclude: Some(true),
+            Type: None,
+        },
+    ]
+}
+
+fn emit_register_missing_tabs_debug(message: &str) {
+    if std::env::var("YOETZ_DEBUG_CDP")
+        .map(|value| {
+            let trimmed = value.trim();
+            !trimmed.is_empty()
+                && !trimmed.eq_ignore_ascii_case("0")
+                && !trimmed.eq_ignore_ascii_case("false")
+        })
+        .unwrap_or(false)
+    {
+        eprintln!("info: headless_chrome {message}");
     }
 }
 
@@ -614,6 +660,7 @@ pub fn default_executable() -> Result<std::path::PathBuf, String> {
 #[cfg(test)]
 mod test {
     use super::Browser;
+    use crate::protocol::cdp::Target::TargetInfo;
 
     fn is_sync<T>()
     where
@@ -624,5 +671,76 @@ mod test {
     #[test]
     fn test_if_browser_is_sync() {
         is_sync::<Browser>();
+    }
+
+    fn target_info(kind: &str, attached: bool) -> TargetInfo {
+        TargetInfo {
+            target_id: "target-1".to_string(),
+            Type: kind.to_string(),
+            title: String::new(),
+            url: String::new(),
+            attached,
+            opener_id: None,
+            can_access_opener: false,
+            opener_frame_id: None,
+            parent_frame_id: None,
+            browser_context_id: None,
+            subtype: None,
+        }
+    }
+
+    #[test]
+    fn page_target_includes_page_and_tab_regardless_of_attachment() {
+        assert!(super::is_page_target(&target_info("page", false)));
+        assert!(super::is_page_target(&target_info("page", true)));
+        assert!(super::is_page_target(&target_info("tab", false)));
+        assert!(super::is_page_target(&target_info("tab", true)));
+    }
+
+    #[test]
+    fn attachable_page_target_requires_unattached_targets() {
+        assert!(super::is_attachable_page_target(&target_info("page", false)));
+        assert!(super::is_attachable_page_target(&target_info("tab", false)));
+        assert!(!super::is_attachable_page_target(&target_info("page", true)));
+        assert!(!super::is_attachable_page_target(&target_info("tab", true)));
+    }
+
+    #[test]
+    fn registerable_page_target_ignores_background_and_worker_targets() {
+        assert!(!super::is_page_target(&target_info(
+            "background_page",
+            true
+        )));
+        assert!(!super::is_page_target(&target_info(
+            "service_worker",
+            false
+        )));
+    }
+
+    #[test]
+    fn registerable_page_target_ignores_devtools_urls() {
+        let mut page = target_info("page", false);
+        page.url = "devtools://devtools/bundled/inspector.html".to_string();
+        assert!(!super::is_page_target(&page));
+        assert!(!super::is_attachable_page_target(&page));
+
+        let mut tab = target_info("tab", false);
+        tab.url = "devtools://devtools/bundled/inspector.html".to_string();
+        assert!(!super::is_page_target(&tab));
+        assert!(!super::is_attachable_page_target(&tab));
+    }
+
+    #[test]
+    fn registerable_target_discovery_filter_includes_page_and_tab_targets() {
+        let filter = super::registerable_target_discovery_filter();
+        assert_eq!(filter.len(), 4);
+        assert_eq!(filter[0].Type.as_deref(), Some("browser"));
+        assert_eq!(filter[0].exclude, Some(true));
+        assert_eq!(filter[1].Type.as_deref(), Some("page"));
+        assert_eq!(filter[1].exclude, Some(false));
+        assert_eq!(filter[2].Type.as_deref(), Some("tab"));
+        assert_eq!(filter[2].exclude, Some(false));
+        assert_eq!(filter[3].Type, None);
+        assert_eq!(filter[3].exclude, Some(true));
     }
 }

--- a/vendor/headless_chrome/src/browser/tab/mod.rs
+++ b/vendor/headless_chrome/src/browser/tab/mod.rs
@@ -218,7 +218,7 @@ impl Tab {
         let session_id = transport
             .call_method_on_browser(AttachToTarget {
                 target_id: target_id.clone(),
-                flatten: None,
+                flatten: Some(true),
             })?
             .session_id
             .into();

--- a/vendor/headless_chrome/src/browser/transport/mod.rs
+++ b/vendor/headless_chrome/src/browser/transport/mod.rs
@@ -7,7 +7,7 @@ use std::sync::mpsc::Sender;
 use std::sync::mpsc::{Receiver, RecvTimeoutError, TryRecvError};
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 
 use thiserror::Error;
 
@@ -17,14 +17,16 @@ use url::Url;
 use waiting_call_registry::WaitingCallRegistry;
 use web_socket_connection::WebSocketConnection;
 
-use crate::protocol::cdp::{Target, types::Event, types::Method};
+use crate::protocol::cdp::types::{Event, Method};
 
-use crate::types::{CallId, Message, parse_raw_message, parse_response};
+use crate::types::{CallId, Message, RoutedMessage, parse_raw_message, parse_response};
 
 use crate::util;
 
 mod waiting_call_registry;
 mod web_socket_connection;
+
+const DEFAULT_CALL_METHOD_TIMEOUT: Duration = Duration::from_secs(90);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SessionId(String);
@@ -138,18 +140,13 @@ impl Transport {
 
         match destination {
             MethodDestination::Target(session_id) => {
-                let message = message_text.clone();
-                let target_method = Target::SendMessageToTarget {
-                    target_id: None,
-                    session_id: Some(session_id.0),
-                    message,
-                };
+                let message_text = add_session_id_to_message(&message_text, &session_id)?;
                 trace!(
                     "Msg to tab: {}",
                     message_text.chars().take(300).collect::<String>()
                 );
-                if let Err(e) = self.call_method_on_browser(target_method) {
-                    warn!("Failed to call method on browser: {e:?}");
+                if let Err(e) = self.web_socket_connection.send_message(&message_text) {
+                    warn!("Failed to call method on target: {e:?}");
                     self.waiting_call_registry.unregister_call(call.id);
                     trace!("Unregistered callback: {:?}", call.id);
                     return Err(e);
@@ -171,8 +168,9 @@ impl Transport {
             params_string.chars().take(400).collect::<String>()
         );
 
-        let response_result = util::Wait::new(self.idle_browser_timeout, Duration::from_millis(5))
-            .until(|| response_rx.try_recv().ok());
+        let response_result =
+            util::Wait::new(call_method_timeout(self.idle_browser_timeout), Duration::from_millis(5))
+                .until(|| response_rx.try_recv().ok());
         trace!("received response for: {} {:?}", &call_id, params_string);
         parse_response::<C::ReturnObject>((response_result?)?)
     }
@@ -222,7 +220,7 @@ impl Transport {
 
     #[allow(clippy::too_many_arguments)]
     fn handle_incoming_messages(
-        messages_rx: Receiver<Message>,
+        messages_rx: Receiver<RoutedMessage>,
         waiting_call_registry: Arc<WaitingCallRegistry>,
         listeners: Listeners,
         open: Arc<AtomicBool>,
@@ -260,7 +258,12 @@ impl Transport {
                         }
                         break;
                     }
-                    Ok(message) => match message {
+                    Ok(routed_message) => {
+                        let RoutedMessage {
+                            session_id,
+                            payload,
+                        } = routed_message;
+                        match payload {
                         Message::ConnectionShutdown => {
                             info!("Received shutdown message");
                             break;
@@ -277,7 +280,19 @@ impl Transport {
                             }
                         }
 
-                        Message::Event(browser_event) => match browser_event {
+                        Message::Event(browser_event) => {
+                            if let Some(session_id) = session_id {
+                                let session_id = SessionId::from(session_id);
+                                if let Some(tx) = listeners
+                                    .lock()
+                                    .unwrap()
+                                    .get(&ListenerId::SessionId(session_id))
+                                {
+                                    tx.send(browser_event)
+                                        .expect("Couldn't send event to listener");
+                                }
+                            } else {
+                                match browser_event {
                             Event::ReceivedMessageFromTarget(target_message_event) => {
                                 let session_id = target_message_event.params.session_id.into();
                                 let raw_message = target_message_event.params.message;
@@ -285,7 +300,13 @@ impl Transport {
                                 let msg_res = parse_raw_message(&raw_message);
                                 match msg_res {
                                     Ok(target_message) => match target_message {
-                                        Message::Event(target_event) => {
+                                        RoutedMessage {
+                                            session_id: nested_session_id,
+                                            payload: Message::Event(target_event),
+                                        } => {
+                                            let session_id = nested_session_id
+                                                .map(SessionId::from)
+                                                .unwrap_or(session_id);
                                             if let Some(tx) = listeners
                                                 .lock()
                                                 .unwrap()
@@ -296,7 +317,10 @@ impl Transport {
                                             }
                                         }
 
-                                        Message::Response(resp) => {
+                                        RoutedMessage {
+                                            payload: Message::Response(resp),
+                                            ..
+                                        } => {
                                             if waiting_call_registry.resolve_call(resp).is_err() {
                                                 warn!(
                                                     "The browser registered a call but then closed its receiving channel"
@@ -304,7 +328,10 @@ impl Transport {
                                                 break;
                                             }
                                         }
-                                        Message::ConnectionShutdown => {}
+                                        RoutedMessage {
+                                            payload: Message::ConnectionShutdown,
+                                            ..
+                                        } => {}
                                     },
                                     Err(e) => {
                                         trace!(
@@ -330,7 +357,10 @@ impl Transport {
                                     }
                                 }
                             }
-                        },
+                                }
+                            }
+                        }
+                        }
                     },
                 }
             }
@@ -349,8 +379,46 @@ impl Transport {
     }
 }
 
+fn add_session_id_to_message(message_text: &str, session_id: &SessionId) -> Result<String> {
+    let mut message_value: serde_json::Value = serde_json::from_str(message_text)?;
+    let Some(message_obj) = message_value.as_object_mut() else {
+        return Err(anyhow!("serialized CDP method call was not a JSON object"));
+    };
+    message_obj.insert(
+        "sessionId".to_string(),
+        serde_json::Value::String(session_id.as_str().to_string()),
+    );
+    Ok(serde_json::to_string(&message_value)?)
+}
+
 impl Drop for Transport {
     fn drop(&mut self) {
         info!("dropping transport");
+    }
+}
+
+fn call_method_timeout(idle_browser_timeout: Duration) -> Duration {
+    idle_browser_timeout.min(DEFAULT_CALL_METHOD_TIMEOUT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DEFAULT_CALL_METHOD_TIMEOUT, call_method_timeout};
+    use std::time::Duration;
+
+    #[test]
+    fn call_method_timeout_caps_long_idle_sessions() {
+        assert_eq!(
+            call_method_timeout(Duration::from_secs(60 * 60)),
+            DEFAULT_CALL_METHOD_TIMEOUT
+        );
+    }
+
+    #[test]
+    fn call_method_timeout_respects_shorter_idle_timeout() {
+        assert_eq!(
+            call_method_timeout(Duration::from_secs(30)),
+            Duration::from_secs(30)
+        );
     }
 }

--- a/vendor/headless_chrome/src/browser/transport/web_socket_connection.rs
+++ b/vendor/headless_chrome/src/browser/transport/web_socket_connection.rs
@@ -1,20 +1,24 @@
-use std::net::TcpStream;
+use std::net::{TcpStream, ToSocketAddrs};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::mpsc;
+use std::time::Duration;
 
 use anyhow::Result;
 use log::{debug, info, trace, warn};
+use tungstenite::handshake::HandshakeError;
 use tungstenite::http::Response;
 use tungstenite::protocol::WebSocketConfig;
 use tungstenite::stream::MaybeTlsStream;
 use url::Url;
 
-use crate::types::{Message, parse_raw_message};
+use crate::types::{RoutedMessage, parse_raw_message};
 
 type TungsteniteWebsocketConnection = tungstenite::protocol::WebSocket<MaybeTlsStream<TcpStream>>;
 
 const READ_TIMEOUT_DURATION: std::time::Duration = std::time::Duration::from_millis(100);
+const DEFAULT_HANDSHAKE_TIMEOUT_DURATION: Duration = Duration::from_secs(30);
+const YOETZ_DEBUG_CDP_ENV: &str = "YOETZ_DEBUG_CDP";
 
 pub struct WebSocketConnection {
     connection: Arc<Mutex<TungsteniteWebsocketConnection>>,
@@ -33,7 +37,7 @@ impl WebSocketConnection {
     pub fn new(
         ws_url: &Url,
         process_id: Option<u32>,
-        messages_tx: mpsc::Sender<Message>,
+        messages_tx: mpsc::Sender<RoutedMessage>,
     ) -> Result<Self> {
         let (connection, _) = Self::websocket_connection(ws_url)?;
 
@@ -73,7 +77,7 @@ impl WebSocketConnection {
 
     fn dispatch_incoming_messages(
         receiver: Arc<Mutex<TungsteniteWebsocketConnection>>,
-        messages_tx: mpsc::Sender<Message>,
+        messages_tx: mpsc::Sender<RoutedMessage>,
         process_id: Option<u32>,
     ) {
         loop {
@@ -96,8 +100,16 @@ impl WebSocketConnection {
                     | tungstenite::Error::AlreadyClosed
                     | tungstenite::Error::Protocol(
                         tungstenite::error::ProtocolError::ResetWithoutClosingHandshake,
-                    ) => break,
+                    ) => {
+                        emit_debug_cdp_transport_message(&format!(
+                            "websocket closed for Chrome #{process_id:?}: {err}"
+                        ));
+                        break;
+                    }
                     error => {
+                        emit_debug_cdp_transport_message(&format!(
+                            "unhandled websocket error for Chrome #{process_id:?}: {error:?}"
+                        ));
                         panic!("Unhandled WebSocket error for Chrome #{process_id:?}: {error:?}");
                     }
                 },
@@ -118,6 +130,9 @@ impl WebSocketConnection {
                                 debug!(
                                     "Received close frame from Chrome #{process_id:?}: {code:?} {reason:?}",
                                 );
+                                emit_debug_cdp_transport_message(&format!(
+                                    "received close frame from Chrome #{process_id:?}: code={code:?} reason={reason:?}"
+                                ));
                                 match code {
                                     tungstenite::protocol::frame::coding::CloseCode::Normal => {
                                         debug!("Normal close code, shutting down");
@@ -140,7 +155,7 @@ impl WebSocketConnection {
         }
 
         info!("Sending shutdown message to message handling loop");
-        if messages_tx.send(Message::ConnectionShutdown).is_err() {
+        if messages_tx.send(RoutedMessage::connection_shutdown()).is_err() {
             warn!("Couldn't send message to transport loop telling it to shut down");
         }
     }
@@ -151,15 +166,15 @@ impl WebSocketConnection {
         tungstenite::WebSocket<MaybeTlsStream<TcpStream>>,
         Response<Option<Vec<u8>>>,
     )> {
-        let mut client = tungstenite::client::connect_with_config(
-            ws_url.as_str(),
+        let mut client = websocket_connection_with_timeout(
+            ws_url,
+            handshake_timeout_duration(),
             Some(
                 WebSocketConfig::default()
                     .accept_unmasked_frames(true)
                     .max_message_size(None)
                     .max_frame_size(None),
             ),
-            u8::MAX - 1,
         )?;
 
         let stream = client.0.get_mut();
@@ -175,6 +190,7 @@ impl WebSocketConnection {
             _ => todo!(),
         };
         stream.set_read_timeout(Some(READ_TIMEOUT_DURATION))?;
+        stream.set_write_timeout(None)?;
 
         debug!("Successfully connected to WebSocket: {ws_url}");
 
@@ -190,8 +206,85 @@ impl WebSocketConnection {
     }
 }
 
+fn emit_debug_cdp_transport_message(message: &str) {
+    if std::env::var(YOETZ_DEBUG_CDP_ENV)
+        .map(|value| {
+            let trimmed = value.trim();
+            !trimmed.is_empty()
+                && !trimmed.eq_ignore_ascii_case("0")
+                && !trimmed.eq_ignore_ascii_case("false")
+        })
+        .unwrap_or(false)
+    {
+        eprintln!("info: cdp-transport {message}");
+    }
+}
+
 impl Drop for WebSocketConnection {
     fn drop(&mut self) {
         info!("dropping websocket connection");
     }
+}
+
+fn handshake_timeout_duration() -> Duration {
+    std::env::var("YOETZ_CDP_WS_HANDSHAKE_TIMEOUT_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_HANDSHAKE_TIMEOUT_DURATION)
+}
+
+fn websocket_connection_with_timeout(
+    ws_url: &Url,
+    timeout: Duration,
+    config: Option<WebSocketConfig>,
+) -> Result<(
+    tungstenite::WebSocket<MaybeTlsStream<TcpStream>>,
+    Response<Option<Vec<u8>>>,
+)> {
+    let host = ws_url
+        .host_str()
+        .ok_or_else(|| anyhow::anyhow!("websocket URL is missing a host: {ws_url}"))?;
+    let port = ws_url
+        .port_or_known_default()
+        .ok_or_else(|| anyhow::anyhow!("websocket URL is missing a port: {ws_url}"))?;
+    let mut addrs = (host, port).to_socket_addrs()?;
+    let mut last_err = None;
+    let stream = addrs
+        .find_map(|addr| match TcpStream::connect_timeout(&addr, timeout) {
+            Ok(stream) => Some(stream),
+            Err(err) => {
+                last_err = Some(err);
+                None
+            }
+        })
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "timed out connecting to Chrome websocket {ws_url}: {}",
+                last_err
+                    .map(|err| err.to_string())
+                    .unwrap_or_else(|| "no reachable addresses".to_string())
+            )
+        })?;
+
+    stream.set_read_timeout(Some(timeout))?;
+    stream.set_write_timeout(Some(timeout))?;
+    stream.set_nodelay(true)?;
+
+    #[cfg(not(any(feature = "native-tls", feature = "rustls")))]
+    let client = tungstenite::client::client_with_config(
+        ws_url.as_str(),
+        MaybeTlsStream::Plain(stream),
+        config,
+    );
+    #[cfg(any(feature = "native-tls", feature = "rustls"))]
+    let client = tungstenite::client_tls_with_config(ws_url.as_str(), stream, config, None);
+
+    client.map_err(|err| match err {
+        HandshakeError::Failure(err) => err.into(),
+        HandshakeError::Interrupted(_) => {
+            anyhow::anyhow!("timed out waiting for Chrome websocket handshake")
+        }
+    })
 }

--- a/vendor/headless_chrome/src/types.rs
+++ b/vendor/headless_chrome/src/types.rs
@@ -56,6 +56,21 @@ pub enum Message {
     ConnectionShutdown,
 }
 
+#[derive(Debug, Clone)]
+pub struct RoutedMessage {
+    pub session_id: Option<String>,
+    pub payload: Message,
+}
+
+impl RoutedMessage {
+    pub fn connection_shutdown() -> Self {
+        Self {
+            session_id: None,
+            payload: Message::ConnectionShutdown,
+        }
+    }
+}
+
 #[derive(Deserialize, Serialize, Debug)]
 pub struct TransferMode {
     mode: String,
@@ -116,8 +131,16 @@ pub struct PrintToPdfOptions {
     pub generate_tagged_pdf: Option<bool>,
 }
 
-pub fn parse_raw_message(raw_message: &str) -> Result<Message> {
-    Ok(serde_json::from_str::<Message>(raw_message)?)
+pub fn parse_raw_message(raw_message: &str) -> Result<RoutedMessage> {
+    let raw_value: Value = serde_json::from_str(raw_message)?;
+    let session_id = raw_value
+        .get("sessionId")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    Ok(RoutedMessage {
+        session_id,
+        payload: serde_json::from_value::<Message>(raw_value)?,
+    })
 }
 
 #[derive(Clone, Debug)]
@@ -371,7 +394,29 @@ mod tests {
         ];
 
         for msg_string in &example_message_strings {
-            let _message: super::Message = parse_raw_message(msg_string).unwrap();
+            let _message: super::RoutedMessage = parse_raw_message(msg_string).unwrap();
         }
+    }
+
+    #[test]
+    fn parse_flat_session_event_and_response() {
+        env_logger::try_init().unwrap_or(());
+
+        let flat_event = parse_raw_message(
+            "{\"method\":\"Runtime.executionContextCreated\",\"params\":{\"context\":{\"id\":1,\"origin\":\"https://chatgpt.com\",\"name\":\"\",\"uniqueId\":\"abc123\",\"auxData\":{\"frameId\":\"frame-1\",\"isDefault\":true,\"type\":\"default\"}}},\"sessionId\":\"session-flat\"}",
+        )
+        .unwrap();
+        assert_eq!(flat_event.session_id.as_deref(), Some("session-flat"));
+        assert!(matches!(
+            flat_event.payload,
+            Message::Event(Event::RuntimeExecutionContextCreated(_))
+        ));
+
+        let flat_response = parse_raw_message(
+            "{\"id\":7,\"result\":{\"identifier\":\"binding-id\"},\"sessionId\":\"session-flat\"}",
+        )
+        .unwrap();
+        assert_eq!(flat_response.session_id.as_deref(), Some("session-flat"));
+        assert!(matches!(flat_response.payload, Message::Response(_)));
     }
 }


### PR DESCRIPTION
## Summary
- standardize the ChatGPT browser recipe contract across chrome-devtools-mcp, dev-browser, and the generic browser recipe
- harden the live Chrome path for modern CDP behavior, including flat-session routing, lazy target attach, and one reconnect-and-reattach attempt during long response polling
- add deterministic and CI-backed browser smoke coverage plus the gated live ChatGPT canary

## Verification
- cargo fmt --all
- cargo build -p yoetz --bin yoetz
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- YOETZ_CHROME_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" cargo test -p yoetz fake_chatgpt_fixture_ -- --ignored
- YOETZ_CHROME_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" YOETZ_BIN=./target/debug/yoetz ./scripts/ci-real-browser-smoke.sh

## Notes
- the last unattended live ChatGPT Pro browser run failed because Chrome dropped the websocket during stable-idle polling; this PR includes the reconnect path for that case
- Claude review is being requested in parallel via AMQ