### PR TITLE
chore(release): v0.2.54

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.2.53",
+  "version": "0.2.54",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.2.53",
+  "version": "0.2.54",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.54] - 2026-04-20
 ### Added
 
 - `yoetz browser verify-cdp --cdp <url>` — a thin CI-friendly smoke command
@@ -47,6 +48,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `yoetz browser recipe --recipe chatgpt` now reconnects once and reattaches to
   the same ChatGPT page target if Chrome drops the websocket during long
   stable-idle response polling, instead of failing the run immediately.
+- `yoetz browser recipe --recipe chatgpt` now prefers ChatGPT's visible tier
+  labels (`Pro`, `Thinking`, `Instant`) over stale `gpt-5-3-*` testid
+  suffixes when picking a model, and reopens the selector menu to verify the
+  radio state if the button label stays generic `ChatGPT`. Fixes `model=pro`
+  and `model=auto` falling back to Instant on the updated ChatGPT UI.
 - `scripts/setup-chatgpt-profile.sh` now prefers the repo-built yoetz binary,
   and the global config selector is `--config-profile`, avoiding collisions
   with browser subcommands that already use `--profile`.
@@ -56,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Untrusted repo-local config can no longer set global defaults or model
   aliases, and browser profile/CDP defaults remain restricted to trusted config
   paths only.
+
 
 ## [0.2.53] - 2026-04-14
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3190,7 +3190,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoetz"
-version = "0.2.53"
+version = "0.2.54"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "yoetz-core"
-version = "0.2.53"
+version = "0.2.54"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/yoetz-core", "crates/yoetz-cli"]
 
 [workspace.package]
-version = "0.2.53"
+version = "0.2.54"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yoetz
-version: 0.2.53
+version: 0.2.54
 description: >
   Fast CLI-first LLM council, bundler, and multimodal gateway. Use ONLY when user
   explicitly mentions "yoetz", "yoetz ask", "yoetz council", "yoetz review",


### PR DESCRIPTION
## Release

- updates `CHANGELOG.md` for `v0.2.54`
- bumps workspace version to `0.2.54`
- aligns skill/plugin metadata to `0.2.54`
- merge triggers .github/workflows/release.yml, which creates the tag and
  publishes the release
- GitHub release notes come from the committed `CHANGELOG.md` entry