### PR TITLE
build(deps): bump rustls-webpki to 0.103.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1929,9 +1929,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary
- bump `rustls-webpki` from `0.103.12` to `0.103.13` in `Cargo.lock`
- clear `RUSTSEC-2026-0104` on current `main` without a broader dependency refresh
- keep the fix scoped to the existing `rustls` dependency graph

## Verification
- [x] `cargo deny check advisories`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`

## Notes
- This replaces the stale advisory context from older PRs; current `Cargo Deny` on `main` is failing on `rustls-webpki`, not the older YAML advisory.
