### PR TITLE
ref(browser): drop legacy vocabulary from active paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1929,9 +1929,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -264,7 +264,7 @@ pub fn run_agent_browser(
     )
 }
 
-fn legacy_connection(
+fn managed_connection(
     profile_dir: Option<&Path>,
     profile_mode: BrowserProfileMode,
     use_stealth: bool,
@@ -434,12 +434,12 @@ fn run_agent_browser_with_options(
     headed: bool,
     profile_mode: BrowserProfileMode,
 ) -> Result<String> {
-    let connection = legacy_connection(profile_dir, profile_mode, use_stealth);
+    let connection = managed_connection(profile_dir, profile_mode, use_stealth);
     run_agent_browser_with_connection(args, format, connection.as_ref(), use_stealth, headed)
 }
 
 pub fn run_recipe(recipe: Recipe, ctx: RecipeContext, format: OutputFormat) -> Result<Value> {
-    let connection = legacy_connection(
+    let connection = managed_connection(
         ctx.profile_dir.as_deref(),
         ctx.profile_mode,
         ctx.use_stealth,
@@ -2322,7 +2322,7 @@ pub fn build_recipe_vars(
 /// Search for a yoetz data file (script or recipe) across standard locations.
 /// Order: YOETZ_SCRIPTS_DIR env, relative to exe, Homebrew share, XDG, ~/.local/share.
 fn find_data_file(subdir: &str, filename: &str) -> Result<PathBuf> {
-    // Check YOETZ_SCRIPTS_DIR env var (legacy, works for scripts)
+    // Check YOETZ_SCRIPTS_DIR env var (works for scripts)
     if subdir == "scripts" {
         if let Ok(dir) = env::var("YOETZ_SCRIPTS_DIR") {
             let path = PathBuf::from(dir).join(filename);
@@ -3437,7 +3437,7 @@ pub fn resolve_auth_mode(profile_dir: &Path, headed: bool) -> Result<BrowserProf
         BrowserConnection::CookieState { .. } => Ok(BrowserProfileMode::PreferState),
         BrowserConnection::Profile { .. } => Ok(BrowserProfileMode::ProfileOnly),
         BrowserConnection::Cdp { .. } | BrowserConnection::AutoConnect => Err(anyhow!(
-            "legacy auth mode cannot map a live browser connection"
+            "managed auth mode cannot map a live browser connection"
         )),
     }
 }

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -1132,7 +1132,7 @@ fn maybe_prefer_browser_check_live_attach_failure(
     if browser::is_chatgpt_auth_issue_error(&err) {
         if let Some(prior) = prior_live_attach_failure {
             return anyhow!(
-                "live Chrome attach failed before legacy fallback could verify ChatGPT auth.\n\nLive-attach error: {prior}\n\nLegacy fallback error: {err}"
+                "live Chrome attach failed before managed fallback could verify ChatGPT auth.\n\nLive-attach error: {prior}\n\nManaged fallback error: {err}"
             );
         }
     }
@@ -1278,7 +1278,7 @@ fn default_daemon_recovery_error(original: Option<&anyhow::Error>) -> Option<any
             "Chrome may be showing an \"Allow remote debugging?\" dialog. Click Allow, then retry.{suffix}"
         )),
         browser::DaemonState::Stale => Some(anyhow!(
-            "The legacy agent-browser daemon looks stale. Run `yoetz browser reset` and retry.{suffix}"
+            "The agent-browser default daemon looks stale. Run `yoetz browser reset` and retry.{suffix}"
         )),
         browser::DaemonState::NoSocket | browser::DaemonState::Healthy => None,
     }
@@ -2072,12 +2072,12 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             };
             browser::close_live_attach_session()?;
             browser::close_browser()?;
-            let legacy_reset = browser::force_kill_stale_daemon();
+            let default_daemon_reset = browser::force_kill_stale_daemon();
 
             let payload = json!({
                 "status": "ok",
                 "dev_browser_daemon_stopped": dev_browser_stopped,
-                "agent_browser_default": format!("{legacy_reset:?}"),
+                "agent_browser_default": format!("{default_daemon_reset:?}"),
                 "agent_browser_cdp_session_closed": true,
             });
             match format {
@@ -2090,7 +2090,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         println!("dev-browser daemon was not running.");
                     }
                     println!("Closed agent-browser live-attach session.");
-                    println!("Reset agent-browser default daemon state: {legacy_reset:?}.");
+                    println!("Reset agent-browser default daemon state: {default_daemon_reset:?}.");
                     Ok(())
                 }
             }
@@ -3253,7 +3253,7 @@ mod tests {
     }
 
     #[test]
-    fn browser_check_prefers_live_attach_failure_over_legacy_login_error() {
+    fn browser_check_prefers_live_attach_failure_over_managed_login_error() {
         let err = maybe_prefer_browser_check_live_attach_failure(
             anyhow!("chatgpt login required. Run `yoetz browser login` and try again."),
             Some("dev-browser could not connect to Chrome. Enable remote debugging: chrome://inspect/#remote-debugging"),
@@ -3265,7 +3265,7 @@ mod tests {
     }
 
     #[test]
-    fn browser_check_keeps_legacy_error_without_prior_live_attach_failure() {
+    fn browser_check_keeps_managed_error_without_prior_live_attach_failure() {
         let err = maybe_prefer_browser_check_live_attach_failure(
             anyhow!("chatgpt login required. Run `yoetz browser login` and try again."),
             None,

--- a/crates/yoetz-cli/tests/daemon_policy.rs
+++ b/crates/yoetz-cli/tests/daemon_policy.rs
@@ -28,7 +28,7 @@ fn main_keeps_destructive_recovery_scoped_to_browser_reset() {
     assert_eq!(
         occurrences(&main_rs, "browser::close_browser()?;"),
         1,
-        "legacy managed daemon close should only run in BrowserCommand::Reset"
+        "managed daemon close should only run in BrowserCommand::Reset"
     );
     assert_eq!(
         occurrences(&main_rs, "browser::close_live_attach_session()?;"),


### PR DESCRIPTION
## Summary
- rename the active browser helper from `legacy_connection` to `managed_connection`
- replace remaining live-path user-facing `legacy` wording with `managed` / `default` terminology
- keep the cleanup scoped to the active code and guardrail tests, without touching docs or schema fields

## Verification
- [x] `cargo clippy -p yoetz --all-targets -- -D warnings`
- [x] `cargo test -p yoetz browser_check_`
- [x] `cargo test -p yoetz --test daemon_policy`
- [x] `cargo deny check advisories`

## Notes
- This supersedes the stale wording-only PR #130 on top of current `main`.
- The wording avoids `managed-profile` because the non-live fallback can still use cookie state before a profile path.
- This branch temporarily includes the same `rustls-webpki` lockfile bump as #157 so CI stays green while `main` still fails Cargo Deny.
