### PR TITLE
feat(browser): Add live-attach owner for ChatGPT flows

### DIFF
--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -175,8 +175,22 @@ impl ResolvedCdpTarget {
         matches!(self.source, ResolvedCdpTargetSource::Flag)
     }
 
+    pub fn live_attach_target_key(&self) -> String {
+        if let Some(source_path) = &self.source_path {
+            return format!("source-path:{}", source_path.display());
+        }
+        if let Some(browser_id) = browser_id_from_ws_endpoint(&self.endpoint) {
+            return format!("browser-id:{browser_id}");
+        }
+        format!("endpoint:{}", self.endpoint)
+    }
+
     pub fn selected_running_target(&self) -> Option<&RunningChromeTarget> {
         self.selected_target.as_ref()
+    }
+
+    pub fn source_path(&self) -> Option<&Path> {
+        self.source_path.as_deref()
     }
 }
 
@@ -940,6 +954,7 @@ struct BrowserHelperProcessSummary {
 struct BrowserDoctorHelpers {
     agent_browser_default: DaemonState,
     agent_browser_default_pid: Option<u32>,
+    live_attach_daemon: crate::live_attach::DaemonSummary,
     dev_browser_processes: Vec<BrowserHelperProcessSummary>,
     external_mcp_processes: Vec<BrowserHelperProcessSummary>,
     recommended_actions: Vec<String>,
@@ -2044,6 +2059,15 @@ fn render_daemon_state(state: DaemonState) -> &'static str {
     }
 }
 
+fn render_live_attach_daemon_health(health: crate::live_attach::DaemonHealth) -> &'static str {
+    match health {
+        crate::live_attach::DaemonHealth::NotRunning => "not running",
+        crate::live_attach::DaemonHealth::Healthy => "healthy",
+        crate::live_attach::DaemonHealth::Busy => "busy",
+        crate::live_attach::DaemonHealth::Stale => "stale",
+    }
+}
+
 fn inspect_browser_helpers() -> BrowserDoctorHelpers {
     let helper_processes = discover_browser_helper_processes();
     let dev_browser_processes = helper_processes
@@ -2064,12 +2088,15 @@ fn inspect_browser_helpers() -> BrowserDoctorHelpers {
         .collect::<Vec<_>>();
     let agent_browser_default = inspect_default_daemon();
     let agent_browser_default_pid = default_daemon_pid();
+    let live_attach_daemon = crate::live_attach::inspect_daemon_sync();
 
     BrowserDoctorHelpers {
         agent_browser_default,
         agent_browser_default_pid,
+        live_attach_daemon: live_attach_daemon.clone(),
         recommended_actions: browser_doctor_recommended_actions(
             agent_browser_default,
+            &live_attach_daemon,
             &dev_browser_processes,
             &external_mcp_processes,
         ),
@@ -2080,11 +2107,20 @@ fn inspect_browser_helpers() -> BrowserDoctorHelpers {
 
 fn browser_doctor_recommended_actions(
     agent_browser_default: DaemonState,
+    live_attach_daemon: &crate::live_attach::DaemonSummary,
     dev_browser_processes: &[BrowserHelperProcessSummary],
     external_mcp_processes: &[BrowserHelperProcessSummary],
 ) -> Vec<String> {
     let mut actions = Vec::new();
 
+    if matches!(
+        live_attach_daemon.health,
+        crate::live_attach::DaemonHealth::Stale
+    ) {
+        actions.push(
+            "The yoetz live-attach daemon looks stale. Run `yoetz browser reset` before the next attach/check/recipe so the primary CDP owner restarts cleanly.".to_string(),
+        );
+    }
     if matches!(agent_browser_default, DaemonState::Stale) {
         actions.push(
             "Run `yoetz browser reset` before `yoetz browser attach`, `yoetz browser check`, or `yoetz browser recipe` to clear stale yoetz-owned helpers.".to_string(),
@@ -2955,6 +2991,31 @@ fn browser_doctor_report_with_discovery(
             .unwrap_or_default()
     ));
     lines.push("    note: only the default agent-browser session is inspected.".to_string());
+    lines.push(format!(
+        "  - yoetz live-attach daemon: {}{}",
+        render_live_attach_daemon_health(helpers.live_attach_daemon.health),
+        helpers
+            .live_attach_daemon
+            .pid
+            .map(|pid| format!(
+                " (pid {pid}, sessions {})",
+                helpers.live_attach_daemon.session_count
+            ))
+            .unwrap_or_default()
+    ));
+    lines.push(
+        "    note: this is the primary chrome-devtools-mcp owner for yoetz attach/check/chatgpt recipe flows."
+            .to_string(),
+    );
+    if matches!(
+        helpers.live_attach_daemon.health,
+        crate::live_attach::DaemonHealth::Busy
+    ) {
+        lines.push(
+            "    note: status ping timed out while the owner was busy; this is expected during long-running attach/check/recipe work."
+                .to_string(),
+        );
+    }
 
     if helpers.dev_browser_processes.is_empty() {
         lines.push("  - dev-browser daemon: not running".to_string());
@@ -4155,6 +4216,14 @@ mod tests {
         }
     }
 
+    fn no_live_attach_daemon() -> crate::live_attach::DaemonSummary {
+        crate::live_attach::DaemonSummary {
+            health: crate::live_attach::DaemonHealth::NotRunning,
+            pid: None,
+            session_count: 0,
+        }
+    }
+
     #[test]
     fn mark_probe_url_appends_param_without_existing_query() {
         let marked = mark_probe_url("https://chatgpt.com/", "run-abc");
@@ -4725,6 +4794,7 @@ browser_cdp = "http://evil.example.com:9222"
             &BrowserDoctorHelpers {
                 agent_browser_default: DaemonState::NoSocket,
                 agent_browser_default_pid: None,
+                live_attach_daemon: no_live_attach_daemon(),
                 dev_browser_processes: vec![],
                 external_mcp_processes: vec![],
                 recommended_actions: vec!["None required.".to_string()],
@@ -4758,6 +4828,7 @@ browser_cdp = "http://evil.example.com:9222"
             &BrowserDoctorHelpers {
                 agent_browser_default: DaemonState::NoSocket,
                 agent_browser_default_pid: None,
+                live_attach_daemon: no_live_attach_daemon(),
                 dev_browser_processes: vec![],
                 external_mcp_processes: vec![],
                 recommended_actions: vec!["None required.".to_string()],
@@ -4791,6 +4862,7 @@ browser_cdp = "http://evil.example.com:9222"
             &BrowserDoctorHelpers {
                 agent_browser_default: DaemonState::NoSocket,
                 agent_browser_default_pid: None,
+                live_attach_daemon: no_live_attach_daemon(),
                 dev_browser_processes: vec![],
                 external_mcp_processes: vec![],
                 recommended_actions: vec!["None required.".to_string()],
@@ -4817,6 +4889,7 @@ browser_cdp = "http://evil.example.com:9222"
             &BrowserDoctorHelpers {
                 agent_browser_default: DaemonState::NoSocket,
                 agent_browser_default_pid: None,
+                live_attach_daemon: no_live_attach_daemon(),
                 dev_browser_processes: vec![],
                 external_mcp_processes: vec![],
                 recommended_actions: vec!["None required.".to_string()],
@@ -4850,6 +4923,7 @@ browser_cdp = "http://evil.example.com:9222"
             &BrowserDoctorHelpers {
                 agent_browser_default: DaemonState::NoSocket,
                 agent_browser_default_pid: None,
+                live_attach_daemon: no_live_attach_daemon(),
                 dev_browser_processes: vec![],
                 external_mcp_processes: vec![],
                 recommended_actions: vec!["None required.".to_string()],
@@ -4884,6 +4958,7 @@ browser_cdp = "http://evil.example.com:9222"
             &BrowserDoctorHelpers {
                 agent_browser_default: DaemonState::NoSocket,
                 agent_browser_default_pid: None,
+                live_attach_daemon: no_live_attach_daemon(),
                 dev_browser_processes: vec![],
                 external_mcp_processes: vec![],
                 recommended_actions: vec!["None required.".to_string()],
@@ -4908,6 +4983,7 @@ browser_cdp = "http://evil.example.com:9222"
             &BrowserDoctorHelpers {
                 agent_browser_default: DaemonState::NoSocket,
                 agent_browser_default_pid: None,
+                live_attach_daemon: no_live_attach_daemon(),
                 dev_browser_processes: vec![],
                 external_mcp_processes: vec![],
                 recommended_actions: vec!["None required.".to_string()],
@@ -4928,6 +5004,11 @@ browser_cdp = "http://evil.example.com:9222"
             &BrowserDoctorHelpers {
                 agent_browser_default: DaemonState::Stale,
                 agent_browser_default_pid: Some(1234),
+                live_attach_daemon: crate::live_attach::DaemonSummary {
+                    health: crate::live_attach::DaemonHealth::Stale,
+                    pid: Some(4444),
+                    session_count: 0,
+                },
                 dev_browser_processes: vec![BrowserHelperProcessSummary {
                     pid: 2222,
                     kind: BrowserHelperProcessKind::DevBrowserDaemon,
@@ -4958,6 +5039,31 @@ browser_cdp = "http://evil.example.com:9222"
         assert!(report.contains("chrome-devtools-mcp watchdog (pid 3334)"));
         assert!(report.contains("Run `yoetz browser reset`"));
         assert!(report.contains("will not stop them"));
+    }
+
+    #[test]
+    fn browser_doctor_report_marks_busy_live_attach_daemon_without_reset_guidance() {
+        let report = browser_doctor_report_with_discovery(
+            &[],
+            &[],
+            &[],
+            &AutoConnectDoctorStatus::Unavailable("probe failed".to_string()),
+            &BrowserDoctorHelpers {
+                agent_browser_default: DaemonState::Healthy,
+                agent_browser_default_pid: Some(1234),
+                live_attach_daemon: crate::live_attach::DaemonSummary {
+                    health: crate::live_attach::DaemonHealth::Busy,
+                    pid: Some(4444),
+                    session_count: 0,
+                },
+                dev_browser_processes: vec![],
+                external_mcp_processes: vec![],
+                recommended_actions: vec!["None required.".to_string()],
+            },
+        );
+        assert!(report.contains("yoetz live-attach daemon: busy (pid 4444, sessions 0)"));
+        assert!(report.contains("status ping timed out while the owner was busy"));
+        assert!(!report.contains("looks stale"));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
@@ -36,6 +36,7 @@
 //! auto-poll already uses.
 
 use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
 use std::io::IsTerminal;
 use std::time::Duration;
 
@@ -96,7 +97,7 @@ fn build_wait_for_composer_script(focus_composer: bool) -> String {
     )
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ChatgptRunResult {
     pub response: String,
     pub model_used: Option<String>,
@@ -136,7 +137,7 @@ enum ResponseSendState {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-enum InitialPageOpenMode {
+pub enum InitialPageOpenMode {
     CreateTarget,
     RecoverViaExistingAnchor,
 }
@@ -150,11 +151,11 @@ impl InitialPageOpenMode {
     }
 }
 
-fn retry_initial_page_open_mode() -> InitialPageOpenMode {
+pub fn retry_initial_page_open_mode() -> InitialPageOpenMode {
     InitialPageOpenMode::RecoverViaExistingAnchor
 }
 
-fn should_recover_initial_page_open_after_reconnect(err: &anyhow::Error) -> bool {
+pub fn should_recover_initial_page_open_after_reconnect(err: &anyhow::Error) -> bool {
     should_retry_initial_new_page_after_reconnect(err) || is_external_create_target_block_error(err)
 }
 
@@ -193,12 +194,19 @@ async fn run_attached_recipe_with_reconnect(
 }
 
 async fn connect_client(ctx: &DevtoolsMcpRecipeContext) -> Result<CdpMcpClient> {
+    connect_client_with_approval_lock(ctx.cdp_endpoint.as_deref(), ctx.show_approval_guidance).await
+}
+
+pub async fn connect_client_with_approval_lock(
+    cdp_endpoint: Option<&str>,
+    show_approval_guidance: bool,
+) -> Result<CdpMcpClient> {
     // Step 0: attach directly to the user's running Chrome session.
     // Chrome may show an "Allow remote debugging?" dialog here whenever it
     // treats this as a new external attach request. Serialize only the attach
     // itself so approval prompts do not race across yoetz processes.
-    let client = with_chrome_approval_lock(ctx.show_approval_guidance, || async {
-        CdpMcpClient::connect_to_running_chrome(ctx.cdp_endpoint.as_deref())
+    let client = with_chrome_approval_lock(show_approval_guidance, || async {
+        CdpMcpClient::connect_to_running_chrome(cdp_endpoint)
             .await
             .map_err(cdp_attach_hint)
     })
@@ -233,9 +241,41 @@ async fn run_attached_recipe(
             (None, None) => "resolve Chrome browser context".to_string(),
         })?;
 
+    run_attached_recipe_inner(&mut client, ctx, browser_context_id, page_open_mode).await
+}
+
+pub async fn run_with_client(
+    client: &mut CdpMcpClient,
+    ctx: &DevtoolsMcpRecipeContext,
+    browser_context_id: Option<String>,
+) -> Result<ChatgptRunResult> {
+    run_with_client_using_page_open_mode(
+        client,
+        ctx,
+        browser_context_id,
+        InitialPageOpenMode::CreateTarget,
+    )
+    .await
+}
+
+pub async fn run_with_client_using_page_open_mode(
+    client: &mut CdpMcpClient,
+    ctx: &DevtoolsMcpRecipeContext,
+    browser_context_id: Option<String>,
+    page_open_mode: InitialPageOpenMode,
+) -> Result<ChatgptRunResult> {
+    run_attached_recipe_inner(client, ctx, browser_context_id, page_open_mode).await
+}
+
+async fn run_attached_recipe_inner(
+    client: &mut CdpMcpClient,
+    ctx: &DevtoolsMcpRecipeContext,
+    browser_context_id: Option<String>,
+    page_open_mode: InitialPageOpenMode,
+) -> Result<ChatgptRunResult> {
     let marked_url = chatgpt_web::mark_chatgpt_url(&ctx.run_id);
     let page_id = open_initial_chatgpt_page(
-        &client,
+        client,
         &marked_url,
         browser_context_id.as_deref(),
         page_open_mode,
@@ -252,10 +292,10 @@ async fn run_attached_recipe(
     // user can actually access. When `model` is `auto` or empty, prefer the
     // strongest available Pro/GPT-5 option and fall back to the current model
     // if the selector UI is unavailable.
-    wait_for_composer_ready(&client, /* focus_composer */ true).await?;
-    let model_used = maybe_select_model(&client, &ctx.model).await?;
+    wait_for_composer_ready(client, /* focus_composer */ true).await?;
+    let model_used = maybe_select_model(client, &ctx.model).await?;
     if ctx.disable_extended {
-        maybe_disable_extended(&client).await?;
+        maybe_disable_extended(client).await?;
     }
 
     // Step 3: upload the bundle if we have a path.
@@ -271,7 +311,7 @@ async fn run_attached_recipe(
         .bundle_path
         .as_ref()
         .context("ChatGPT recipe requires a bundle file path")?;
-    try_upload_bundle(&client, bundle_path)
+    try_upload_bundle(client, bundle_path)
         .await
         .context("upload bundle to ChatGPT")?;
 
@@ -330,7 +370,7 @@ async fn run_attached_recipe(
     // research showed "Regenerate" is missing or inconsistently placed in
     // many ChatGPT flows (Custom GPT, Canvas, certain Pro modes).
     let response_text = poll_for_stable_response(
-        &mut client,
+        client,
         ctx,
         &page_id,
         response_baseline,
@@ -410,12 +450,24 @@ async fn open_initial_chatgpt_probe_page(
     client: &CdpMcpClient,
     url: &str,
     timeout_ms: u64,
+    browser_context_id: Option<&str>,
 ) -> Result<()> {
-    match open_page_via_blank_target(client, url, /* background */ true, timeout_ms, None).await {
+    match open_page_via_blank_target(
+        client,
+        url,
+        /* background */ true,
+        timeout_ms,
+        browser_context_id,
+    )
+    .await
+    {
         Ok(()) => Ok(()),
         Err(err) if is_external_create_target_block_error(&err) => client
             .open_chatgpt_page_via_existing_anchor(
-                url, /* background */ true, timeout_ms, None,
+                url,
+                /* background */ true,
+                timeout_ms,
+                browser_context_id,
             )
             .await
             .with_context(|| format!("recover auth probe page open for `{url}`"))
@@ -425,32 +477,63 @@ async fn open_initial_chatgpt_probe_page(
 }
 
 pub async fn check_auth(cdp_endpoint: Option<&str>, show_approval_guidance: bool) -> Result<()> {
-    let client = with_chrome_approval_lock(show_approval_guidance, || async {
-        CdpMcpClient::connect_to_running_chrome(cdp_endpoint)
+    check_auth_with_control_run_id(cdp_endpoint, show_approval_guidance, None).await
+}
+
+async fn open_chatgpt_auth_probe_page(
+    client: &CdpMcpClient,
+    browser_context_id: Option<&str>,
+    control_run_id: Option<&str>,
+    timeout_ms: u64,
+) -> Result<()> {
+    let url = control_run_id
+        .map(chatgpt_web::mark_chatgpt_url)
+        .unwrap_or_else(|| chatgpt_web::CHATGPT_URL.to_string());
+    open_initial_chatgpt_probe_page(client, &url, timeout_ms, browser_context_id)
+        .await
+        .with_context(|| format!("chrome-devtools-mcp open auth probe on `{url}`"))?;
+    if let Some(control_run_id) = control_run_id {
+        let set_window_name_js = chatgpt_web::build_set_window_name_js(control_run_id);
+        client
+            .evaluate_script(&set_window_name_js, vec![])
             .await
-            .map_err(cdp_attach_hint)
-    })
-    .await?;
-    let used_probe_page = client
-        .select_chatgpt_page_for_probe(30_000)
+            .context("mark ChatGPT control tab with window.name")?;
+    }
+    Ok(())
+}
+
+pub async fn check_auth_with_control_run_id(
+    cdp_endpoint: Option<&str>,
+    show_approval_guidance: bool,
+    control_run_id: Option<&str>,
+) -> Result<()> {
+    let client = connect_client_with_approval_lock(cdp_endpoint, show_approval_guidance).await?;
+    ensure_chatgpt_control_tab_ready(&client, None, control_run_id).await
+}
+
+pub async fn ensure_chatgpt_control_tab_ready(
+    client: &CdpMcpClient,
+    browser_context_id: Option<&str>,
+    control_run_id: Option<&str>,
+) -> Result<()> {
+    let reused_existing_page = client
+        .select_chatgpt_page_for_probe(30_000, browser_context_id, control_run_id)
         .await
         .context("select existing ChatGPT page for auth probe")?
-        .is_none();
-    if used_probe_page {
-        open_initial_chatgpt_probe_page(&client, chatgpt_web::CHATGPT_URL, 30_000)
-            .await
-            .context("chrome-devtools-mcp open auth probe on chatgpt.com")?;
+        .is_some();
+    if !reused_existing_page {
+        open_chatgpt_auth_probe_page(client, browser_context_id, control_run_id, 30_000).await?;
     }
-    let result = wait_for_composer_ready(&client, /* focus_composer */ false).await;
-    if !used_probe_page && result.is_err() {
-        open_initial_chatgpt_probe_page(&client, chatgpt_web::CHATGPT_URL, 30_000)
-            .await
-            .context("chrome-devtools-mcp probe retry on chatgpt.com")?;
-        let retry = wait_for_composer_ready(&client, /* focus_composer */ false).await;
-        let _ = client.close_selected_page(true);
+    let result = wait_for_composer_ready(client, /* focus_composer */ false).await;
+    if reused_existing_page && result.is_err() {
+        open_chatgpt_auth_probe_page(client, browser_context_id, control_run_id, 30_000).await?;
+        let retry = wait_for_composer_ready(client, /* focus_composer */ false).await;
+        if control_run_id.is_none() {
+            let _ = client.close_selected_page(true);
+        }
         return retry;
     }
-    if used_probe_page {
+    if !reused_existing_page && control_run_id.is_none() {
         let _ = client.close_selected_page(true);
     }
     result

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
@@ -92,6 +92,7 @@ const EMAIL_INFERENCE_TRUSTED_ORIGINS: &[&str] = &[
 pub struct CdpMcpClient {
     browser: Browser,
     selected_tab: Mutex<Option<Arc<Tab>>>,
+    ws_endpoint: String,
 }
 
 #[derive(Debug, Clone)]
@@ -326,7 +327,12 @@ impl CdpMcpClient {
         Ok(Self {
             browser,
             selected_tab: Mutex::new(None),
+            ws_endpoint,
         })
+    }
+
+    pub fn ws_endpoint(&self) -> &str {
+        &self.ws_endpoint
     }
 
     pub async fn new_page(
@@ -523,19 +529,28 @@ impl CdpMcpClient {
     pub async fn select_chatgpt_page_for_probe(
         &self,
         timeout_ms: u64,
+        browser_context_id: Option<&str>,
+        preferred_run_id: Option<&str>,
     ) -> Result<Option<ReusedPageResult>> {
-        let candidates = if mutate_existing_chatgpt_tab_allowed() {
+        let candidates = if let Some(preferred_run_id) = preferred_run_id {
+            self.chatgpt_page_targets(browser_context_id)?
+                .into_iter()
+                .filter(|target| {
+                    yoetz_run_id_from_url(&target.url).as_deref() == Some(preferred_run_id)
+                })
+                .collect::<Vec<_>>()
+        } else if mutate_existing_chatgpt_tab_allowed() {
             // Explicit operator opt-in: auth probing may attach to an existing
             // user-owned ChatGPT tab instead of requiring a yoetz-owned probe
             // tab. This avoids fighting Chrome's new-target restrictions on
             // logged-in default profiles.
-            self.chatgpt_page_targets(None)?
+            self.chatgpt_page_targets(browser_context_id)?
         } else {
             // Default: only reuse a ChatGPT tab that yoetz itself stamped with
             // `?_yoetz=<run-id>`. Touching a user-owned ChatGPT conversation —
             // even just for a read-only probe — violates the fresh-tab contract
             // and can surface yoetz's automation on an in-flight chat.
-            self.chatgpt_page_targets(None)?
+            self.chatgpt_page_targets(browser_context_id)?
                 .into_iter()
                 .filter(|target| is_yoetz_owned_url(&target.url))
                 .collect::<Vec<_>>()
@@ -1126,7 +1141,7 @@ fn choose_chatgpt_recovery_strategy(
     );
 }
 
-fn is_closed_cdp_transport_error(err: &anyhow::Error) -> bool {
+pub fn is_closed_cdp_transport_error(err: &anyhow::Error) -> bool {
     let message = format!("{err:#}").to_ascii_lowercase();
     message.contains("underlying connection is closed")
         || message.contains("connectionclosed")
@@ -2105,14 +2120,21 @@ fn is_chatgpt_url(url: &str) -> bool {
     )
 }
 
+fn yoetz_run_id_from_url(url: &str) -> Option<String> {
+    let parsed = Url::parse(url).ok()?;
+    parsed
+        .query_pairs()
+        .find(|(key, _)| key.eq_ignore_ascii_case("_yoetz"))
+        .map(|(_, value)| value.into_owned())
+}
+
 /// A yoetz-owned tab is one whose URL carries the `?_yoetz=<run-id>` or
 /// `&_yoetz=<run-id>` marker yoetz stamps on every fresh tab it creates.
 /// yoetz MUST NOT `evaluate`, `navigate`, or otherwise mutate any tab that
 /// does not pass this check — doing so risks leaking automation into a user
 /// conversation (see review finding #8 and the Meet-tab near-miss).
 fn is_yoetz_owned_url(url: &str) -> bool {
-    let normalized = url.trim().to_ascii_lowercase();
-    normalized.contains("?_yoetz=") || normalized.contains("&_yoetz=")
+    yoetz_run_id_from_url(url).is_some()
 }
 
 fn context_tab_reuse_rank(url: &str) -> Option<u8> {
@@ -2894,6 +2916,22 @@ mod tests {
         assert!(!is_yoetz_owned_url("https://notes.example/_yoetz"));
         assert!(!is_yoetz_owned_url("about:blank"));
         assert!(!is_yoetz_owned_url(""));
+    }
+
+    #[test]
+    fn yoetz_run_id_from_url_extracts_exact_marker_value() {
+        assert_eq!(
+            yoetz_run_id_from_url("https://chatgpt.com/?_yoetz=run-123").as_deref(),
+            Some("run-123")
+        );
+        assert_eq!(
+            yoetz_run_id_from_url("https://chatgpt.com/c/abc?foo=bar&_yoetz=run-456").as_deref(),
+            Some("run-456")
+        );
+        assert_eq!(
+            yoetz_run_id_from_url("https://chatgpt.com/c/abc?foo=_yoetz=run-789").as_deref(),
+            None
+        );
     }
 
     #[test]

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/mod.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/mod.rs
@@ -41,6 +41,7 @@ pub mod chatgpt;
 
 use crate::chatgpt_web;
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
@@ -63,7 +64,7 @@ impl RecipeThreadMode {
 ///
 /// Construction of this struct is the boundary between yoetz-cli's `main.rs`
 /// dispatcher and the chrome_devtools_mcp recipe layer.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DevtoolsMcpRecipeContext {
     /// Explicit CDP endpoint (e.g. `http://127.0.0.1:9222`). `None` means
     /// "use the default localhost:9222 and resolve the browser websocket from

--- a/crates/yoetz-cli/src/live_attach.rs
+++ b/crates/yoetz-cli/src/live_attach.rs
@@ -1,0 +1,1609 @@
+use anyhow::{anyhow, Context, Result};
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::env;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, BufRead, BufReader, Write};
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader as AsyncBufReader};
+use tokio::net::{TcpListener, TcpStream};
+
+use crate::browser::ResolvedCdpTarget;
+use crate::chatgpt_web;
+use crate::chrome_devtools_mcp::{
+    self,
+    chatgpt::{self, ChatgptRunResult},
+    client::{
+        browser_id_from_ws_endpoint, discover_devtools_active_port_files,
+        discover_running_chrome_targets, is_closed_cdp_transport_error, CdpMcpClient,
+        DevtoolsActivePortFile, RunningChromeTarget,
+    },
+};
+use yoetz_core::paths::home_dir;
+
+const LIVE_ATTACH_STATE_FILENAME: &str = "live-attach.json";
+const LIVE_ATTACH_DAEMON_FILENAME: &str = "live-attach-daemon.json";
+const LIVE_ATTACH_DAEMON_LOCK_FILENAME: &str = "live-attach-daemon.lock";
+const LIVE_ATTACH_DAEMON_LOG_FILENAME: &str = "live-attach-daemon.log";
+const IMPLICIT_TARGET_KEY: &str = "implicit-default";
+const DEFAULT_CONTEXT_KEY: &str = "__default__";
+const DAEMON_START_TIMEOUT: Duration = Duration::from_secs(10);
+const DAEMON_START_POLL_MS: u64 = 100;
+const DAEMON_HEALTH_RPC_TIMEOUT: Duration = Duration::from_secs(5);
+const DAEMON_ENSURE_SESSION_TIMEOUT: Duration = Duration::from_secs(75);
+const DAEMON_RECIPE_RPC_GRACE: Duration = Duration::from_secs(120);
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LiveAttachStatus {
+    Attached,
+    AwaitingApproval,
+    Degraded,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DaemonHealth {
+    NotRunning,
+    Healthy,
+    Busy,
+    Stale,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LiveAttachTarget {
+    pub key: String,
+    pub connect_endpoint: Option<String>,
+    pub endpoint: Option<String>,
+    pub source_path: Option<PathBuf>,
+    pub browser_id: Option<String>,
+    pub implicit_default: bool,
+}
+
+impl LiveAttachTarget {
+    pub fn from_resolved(target: Option<&ResolvedCdpTarget>) -> Self {
+        match target {
+            Some(target) => Self {
+                key: target.live_attach_target_key(),
+                connect_endpoint: Some(target.endpoint.clone()),
+                endpoint: Some(target.endpoint.clone()),
+                source_path: target.source_path().map(Path::to_path_buf),
+                browser_id: browser_id_from_ws_endpoint(&target.endpoint),
+                implicit_default: false,
+            },
+            None => Self {
+                key: IMPLICIT_TARGET_KEY.to_string(),
+                connect_endpoint: None,
+                endpoint: None,
+                source_path: None,
+                browser_id: None,
+                implicit_default: true,
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LiveAttachSession {
+    pub target_key: String,
+    pub control_run_id: String,
+    pub browser_context_id: Option<String>,
+    pub status: LiveAttachStatus,
+    pub endpoint: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DaemonSummary {
+    pub health: DaemonHealth,
+    pub pid: Option<u32>,
+    pub session_count: usize,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct PersistedContextState {
+    browser_context_id: Option<String>,
+    control_run_id: String,
+    updated_at_unix_ms: u64,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+struct PersistedTargetState {
+    endpoint: Option<String>,
+    status: Option<LiveAttachStatus>,
+    updated_at_unix_ms: Option<u64>,
+    last_error: Option<String>,
+    contexts: BTreeMap<String, PersistedContextState>,
+}
+
+#[derive(Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+struct LiveAttachState {
+    sessions: BTreeMap<String, PersistedTargetState>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct DaemonMetadata {
+    pid: u32,
+    addr: String,
+    token: String,
+    started_at_unix_ms: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+enum DaemonRequest {
+    Ping {
+        token: String,
+    },
+    Status {
+        token: String,
+    },
+    Shutdown {
+        token: String,
+    },
+    EnsureSession {
+        token: String,
+        target: LiveAttachTarget,
+        browser_context_id: Option<String>,
+        profile_email: Option<String>,
+    },
+    RunRecipe {
+        token: String,
+        target: LiveAttachTarget,
+        recipe_ctx: chrome_devtools_mcp::DevtoolsMcpRecipeContext,
+    },
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+enum DaemonResponse {
+    Pong,
+    Status { session_count: usize },
+    Session { session: LiveAttachSession },
+    Recipe { result: ChatgptRunResult },
+    Error { message: String },
+}
+
+struct DaemonSession {
+    target: LiveAttachTarget,
+    client: CdpMcpClient,
+    selector_cache: BTreeMap<String, Option<String>>,
+}
+
+struct LiveAttachDaemon {
+    state: LiveAttachState,
+    sessions: BTreeMap<String, DaemonSession>,
+}
+
+impl LiveAttachDaemon {
+    fn load() -> Result<Self> {
+        Ok(Self {
+            state: load_state()?,
+            sessions: BTreeMap::new(),
+        })
+    }
+
+    async fn ensure_chatgpt_session(
+        &mut self,
+        target: LiveAttachTarget,
+        explicit_context_id: Option<&str>,
+        profile_email: Option<&str>,
+    ) -> Result<LiveAttachSession> {
+        let target_key = target.key.clone();
+        let mut session = self.take_or_connect_session(target).await?;
+        let mut reconnect_used = false;
+
+        loop {
+            let result = self
+                .ensure_chatgpt_session_with_session(
+                    &mut session,
+                    explicit_context_id,
+                    profile_email,
+                )
+                .await;
+
+            match result {
+                Ok(session_info) => {
+                    self.sessions.insert(target_key.clone(), session);
+                    return Ok(session_info);
+                }
+                Err(err) if !reconnect_used && is_closed_cdp_transport_error(&err) => {
+                    reconnect_used = true;
+                    self.reconnect_session_in_place(&mut session).await?;
+                }
+                Err(err) => {
+                    self.record_target_error(
+                        &target_key,
+                        session.target.endpoint.as_deref(),
+                        &err,
+                    )?;
+                    self.sessions.insert(target_key.clone(), session);
+                    return Err(err);
+                }
+            }
+        }
+    }
+
+    async fn ensure_chatgpt_session_with_session(
+        &mut self,
+        session: &mut DaemonSession,
+        explicit_context_id: Option<&str>,
+        profile_email: Option<&str>,
+    ) -> Result<LiveAttachSession> {
+        let (browser_context_id, control_run_id) = self
+            .ensure_chatgpt_control_tab_for_selectors(session, explicit_context_id, profile_email)
+            .await?;
+
+        self.record_target_success(
+            &session.target.key,
+            Some(session.client.ws_endpoint()),
+            browser_context_id.as_deref(),
+            &control_run_id,
+        )?;
+        session.target.endpoint = Some(session.client.ws_endpoint().to_string());
+
+        Ok(LiveAttachSession {
+            target_key: session.target.key.clone(),
+            control_run_id,
+            browser_context_id,
+            status: LiveAttachStatus::Attached,
+            endpoint: session.target.endpoint.clone(),
+        })
+    }
+
+    async fn run_chatgpt_recipe(
+        &mut self,
+        target: LiveAttachTarget,
+        mut recipe_ctx: chrome_devtools_mcp::DevtoolsMcpRecipeContext,
+    ) -> Result<ChatgptRunResult> {
+        let target_key = target.key.clone();
+        let mut session = self.take_or_connect_session(target).await?;
+        let mut reconnect_used = false;
+
+        if recipe_ctx.run_id.trim().is_empty() {
+            recipe_ctx.run_id = chatgpt_web::generate_run_id();
+        }
+
+        loop {
+            let result = self
+                .run_chatgpt_recipe_with_session(&mut session, &mut recipe_ctx)
+                .await;
+
+            match result {
+                Ok(result) => {
+                    self.sessions.insert(target_key.clone(), session);
+                    return Ok(result);
+                }
+                Err(err) if !reconnect_used && is_closed_cdp_transport_error(&err) => {
+                    reconnect_used = true;
+                    self.reconnect_session_in_place(&mut session).await?;
+                }
+                Err(err) => {
+                    self.record_target_error(
+                        &target_key,
+                        session.target.endpoint.as_deref(),
+                        &err,
+                    )?;
+                    self.sessions.insert(target_key.clone(), session);
+                    return Err(err);
+                }
+            }
+        }
+    }
+
+    async fn run_chatgpt_recipe_with_session(
+        &mut self,
+        session: &mut DaemonSession,
+        recipe_ctx: &mut chrome_devtools_mcp::DevtoolsMcpRecipeContext,
+    ) -> Result<ChatgptRunResult> {
+        let (browser_context_id, control_run_id) = self
+            .ensure_chatgpt_control_tab_for_selectors(
+                session,
+                recipe_ctx.browser_context_id.as_deref(),
+                recipe_ctx.profile_email.as_deref(),
+            )
+            .await?;
+        recipe_ctx.cdp_endpoint = Some(session.client.ws_endpoint().to_string());
+        let result = match chatgpt::run_with_client(
+            &mut session.client,
+            recipe_ctx,
+            browser_context_id.clone(),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(err) if chatgpt::should_recover_initial_page_open_after_reconnect(&err) => {
+                if recipe_ctx.show_approval_guidance {
+                    eprintln!(
+                        "info: chrome-devtools-mcp lost the first ChatGPT page open; reconnecting once and retrying via an existing yoetz-owned anchor"
+                    );
+                }
+                self.reconnect_session_in_place(session).await?;
+                let (retry_browser_context_id, retry_control_run_id) = self
+                    .ensure_chatgpt_control_tab_for_selectors(
+                        session,
+                        recipe_ctx.browser_context_id.as_deref(),
+                        recipe_ctx.profile_email.as_deref(),
+                    )
+                    .await?;
+                recipe_ctx.cdp_endpoint = Some(session.client.ws_endpoint().to_string());
+                let retry_result = chatgpt::run_with_client_using_page_open_mode(
+                    &mut session.client,
+                    recipe_ctx,
+                    retry_browser_context_id.clone(),
+                    chatgpt::retry_initial_page_open_mode(),
+                )
+                .await
+                .context("retrying ChatGPT page open after reconnect")
+                .context(err)?;
+                self.record_target_success(
+                    &session.target.key,
+                    Some(session.client.ws_endpoint()),
+                    retry_browser_context_id.as_deref(),
+                    &retry_control_run_id,
+                )?;
+                session.target.endpoint = Some(session.client.ws_endpoint().to_string());
+                return Ok(retry_result);
+            }
+            Err(err) => return Err(err),
+        };
+
+        self.record_target_success(
+            &session.target.key,
+            Some(session.client.ws_endpoint()),
+            browser_context_id.as_deref(),
+            &control_run_id,
+        )?;
+        session.target.endpoint = Some(session.client.ws_endpoint().to_string());
+
+        Ok(result)
+    }
+
+    async fn take_or_connect_session(&mut self, target: LiveAttachTarget) -> Result<DaemonSession> {
+        if let Some(session) = self.sessions.remove(&target.key) {
+            return Ok(session);
+        }
+
+        self.connect_session(target).await
+    }
+
+    async fn connect_session(&mut self, mut target: LiveAttachTarget) -> Result<DaemonSession> {
+        let endpoint = resolve_connect_endpoint(&target);
+        let client = chatgpt::connect_client_with_approval_lock(endpoint.as_deref(), false).await?;
+        let actual_endpoint = client.ws_endpoint().to_string();
+        self.ensure_target_record(&target.key).endpoint = Some(actual_endpoint.clone());
+        target.browser_id = browser_id_from_ws_endpoint(&actual_endpoint).or(target.browser_id);
+        target.endpoint = Some(actual_endpoint);
+
+        Ok(DaemonSession {
+            target,
+            client,
+            selector_cache: BTreeMap::new(),
+        })
+    }
+
+    async fn reconnect_session_in_place(&mut self, session: &mut DaemonSession) -> Result<()> {
+        *session = self.connect_session(session.target.clone()).await?;
+        Ok(())
+    }
+
+    async fn ensure_chatgpt_control_tab_for_selectors(
+        &mut self,
+        session: &mut DaemonSession,
+        explicit_context_id: Option<&str>,
+        profile_email: Option<&str>,
+    ) -> Result<(Option<String>, String)> {
+        let browser_context_id =
+            resolve_cached_browser_context_id(session, explicit_context_id, profile_email)?;
+        let control_run_id =
+            self.control_run_id_for(&session.target.key, browser_context_id.as_deref());
+        chatgpt::ensure_chatgpt_control_tab_ready(
+            &session.client,
+            browser_context_id.as_deref(),
+            Some(&control_run_id),
+        )
+        .await?;
+        Ok((browser_context_id, control_run_id))
+    }
+
+    fn ensure_target_record(&mut self, target_key: &str) -> &mut PersistedTargetState {
+        self.state
+            .sessions
+            .entry(target_key.to_string())
+            .or_default()
+    }
+
+    fn control_run_id_for(&mut self, target_key: &str, browser_context_id: Option<&str>) -> String {
+        let context_key = context_storage_key(browser_context_id);
+        let target = self.ensure_target_record(target_key);
+        let now = unix_ms_now();
+        let context = target
+            .contexts
+            .entry(context_key)
+            .or_insert_with(|| PersistedContextState {
+                browser_context_id: browser_context_id.map(str::to_owned),
+                control_run_id: chatgpt_web::generate_run_id(),
+                updated_at_unix_ms: now,
+            });
+        context.browser_context_id = browser_context_id.map(str::to_owned);
+        context.updated_at_unix_ms = now;
+        context.control_run_id.clone()
+    }
+
+    fn record_target_success(
+        &mut self,
+        target_key: &str,
+        endpoint: Option<&str>,
+        browser_context_id: Option<&str>,
+        control_run_id: &str,
+    ) -> Result<()> {
+        let now = unix_ms_now();
+        let target = self.ensure_target_record(target_key);
+        target.endpoint = endpoint
+            .map(str::to_owned)
+            .or_else(|| target.endpoint.clone());
+        target.status = Some(LiveAttachStatus::Attached);
+        target.updated_at_unix_ms = Some(now);
+        target.last_error = None;
+        target
+            .contexts
+            .entry(context_storage_key(browser_context_id))
+            .and_modify(|context| {
+                context.browser_context_id = browser_context_id.map(str::to_owned);
+                context.control_run_id = control_run_id.to_string();
+                context.updated_at_unix_ms = now;
+            })
+            .or_insert_with(|| PersistedContextState {
+                browser_context_id: browser_context_id.map(str::to_owned),
+                control_run_id: control_run_id.to_string(),
+                updated_at_unix_ms: now,
+            });
+        save_state(&self.state)
+    }
+
+    fn record_target_error(
+        &mut self,
+        target_key: &str,
+        endpoint: Option<&str>,
+        err: &anyhow::Error,
+    ) -> Result<()> {
+        let target = self.ensure_target_record(target_key);
+        target.endpoint = endpoint
+            .map(str::to_owned)
+            .or_else(|| target.endpoint.clone());
+        target.status = Some(if crate::browser::is_chrome_approval_wait_error(err) {
+            LiveAttachStatus::AwaitingApproval
+        } else {
+            LiveAttachStatus::Degraded
+        });
+        target.updated_at_unix_ms = Some(unix_ms_now());
+        target.last_error = Some(format!("{err:#}"));
+        save_state(&self.state)
+    }
+}
+
+pub async fn ensure_chatgpt_session(
+    cdp_target: Option<&ResolvedCdpTarget>,
+    browser_context_id: Option<&str>,
+    profile_email: Option<&str>,
+    show_approval_guidance: bool,
+) -> Result<LiveAttachSession> {
+    let target = LiveAttachTarget::from_resolved(cdp_target);
+    let daemon = ensure_daemon_running(show_approval_guidance).await?;
+    match daemon_round_trip(
+        &daemon,
+        DaemonRequest::EnsureSession {
+            token: daemon.token.clone(),
+            target,
+            browser_context_id: browser_context_id.map(str::to_owned),
+            profile_email: profile_email.map(str::to_owned),
+        },
+    )
+    .await?
+    {
+        DaemonResponse::Session { session } => Ok(session),
+        other => Err(anyhow!("unexpected live-attach daemon response: {other:?}")),
+    }
+}
+
+pub async fn run_chatgpt_recipe(
+    cdp_target: Option<&ResolvedCdpTarget>,
+    recipe_ctx: chrome_devtools_mcp::DevtoolsMcpRecipeContext,
+    show_approval_guidance: bool,
+) -> Result<ChatgptRunResult> {
+    let target = LiveAttachTarget::from_resolved(cdp_target);
+    let daemon = ensure_daemon_running(show_approval_guidance).await?;
+    match daemon_round_trip(
+        &daemon,
+        DaemonRequest::RunRecipe {
+            token: daemon.token.clone(),
+            target,
+            recipe_ctx,
+        },
+    )
+    .await?
+    {
+        DaemonResponse::Recipe { result } => Ok(result),
+        other => Err(anyhow!("unexpected live-attach daemon response: {other:?}")),
+    }
+}
+
+#[allow(dead_code)]
+pub async fn shutdown() -> Result<()> {
+    if let Some(daemon) = load_daemon_metadata()? {
+        let _ = request_daemon_shutdown(&daemon).await;
+    }
+    clear_daemon_metadata()
+}
+
+pub async fn reset() -> Result<()> {
+    if let Some(daemon) = load_daemon_metadata()? {
+        if request_daemon_shutdown(&daemon).await.is_err() {
+            let _ = terminate_daemon_process(daemon.pid);
+        }
+        let _ = clear_daemon_metadata();
+    }
+    clear_state()
+}
+
+pub async fn serve_daemon() -> Result<()> {
+    let listener = TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .context("bind yoetz live-attach daemon")?;
+    let metadata = DaemonMetadata {
+        pid: std::process::id(),
+        addr: listener
+            .local_addr()
+            .context("read yoetz live-attach daemon address")?
+            .to_string(),
+        token: chatgpt_web::generate_run_id(),
+        started_at_unix_ms: unix_ms_now(),
+    };
+    save_daemon_metadata(&metadata)?;
+    let _metadata_guard = DaemonMetadataGuard;
+    let mut daemon = LiveAttachDaemon::load()?;
+
+    loop {
+        let (socket, _) = listener
+            .accept()
+            .await
+            .context("accept yoetz live-attach client")?;
+        if handle_daemon_connection(socket, &metadata.token, &mut daemon).await? {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+pub fn inspect_daemon_sync() -> DaemonSummary {
+    let Some(metadata) = load_daemon_metadata().ok().flatten() else {
+        return DaemonSummary {
+            health: DaemonHealth::NotRunning,
+            pid: None,
+            session_count: 0,
+        };
+    };
+
+    match daemon_round_trip_blocking(
+        &metadata,
+        DaemonRequest::Status {
+            token: metadata.token.clone(),
+        },
+    ) {
+        Ok(DaemonResponse::Status { session_count }) => DaemonSummary {
+            health: DaemonHealth::Healthy,
+            pid: Some(metadata.pid),
+            session_count,
+        },
+        Err(err) if is_daemon_rpc_timeout_error(&err) => DaemonSummary {
+            health: DaemonHealth::Busy,
+            pid: Some(metadata.pid),
+            session_count: 0,
+        },
+        _ => DaemonSummary {
+            health: DaemonHealth::Stale,
+            pid: Some(metadata.pid),
+            session_count: 0,
+        },
+    }
+}
+
+async fn request_daemon_shutdown(daemon: &DaemonMetadata) -> Result<()> {
+    match daemon_round_trip(
+        daemon,
+        DaemonRequest::Shutdown {
+            token: daemon.token.clone(),
+        },
+    )
+    .await?
+    {
+        DaemonResponse::Pong => Ok(()),
+        other => Err(anyhow!(
+            "unexpected live-attach daemon shutdown response: {other:?}"
+        )),
+    }
+}
+
+fn daemon_rpc_timeout_error(addr: &str, timeout: Duration) -> anyhow::Error {
+    anyhow!(
+        "yoetz live-attach daemon at {addr} timed out after {}ms waiting for a response",
+        timeout.as_millis()
+    )
+}
+
+fn resolve_cached_browser_context_id(
+    session: &mut DaemonSession,
+    explicit_context_id: Option<&str>,
+    profile_email: Option<&str>,
+) -> Result<Option<String>> {
+    let selector_key = selector_cache_key(explicit_context_id, profile_email);
+    if let Some(cached) = session.selector_cache.get(&selector_key) {
+        return Ok(cached.clone());
+    }
+    let resolved = session
+        .client
+        .resolve_browser_context_id(explicit_context_id, profile_email)?;
+    session
+        .selector_cache
+        .insert(selector_key, resolved.clone());
+    Ok(resolved)
+}
+
+fn resolve_connect_endpoint(target: &LiveAttachTarget) -> Option<String> {
+    resolve_connect_endpoint_with_discovery(
+        target,
+        &discover_running_chrome_targets(),
+        &discover_devtools_active_port_files(),
+    )
+}
+
+fn resolve_connect_endpoint_with_discovery(
+    target: &LiveAttachTarget,
+    running_targets: &[RunningChromeTarget],
+    active_port_files: &[DevtoolsActivePortFile],
+) -> Option<String> {
+    if target.implicit_default {
+        return None;
+    }
+    if let Some(source_path) = target.source_path.as_deref() {
+        if let Some(endpoint) =
+            discover_endpoint_for_source_path(source_path, running_targets, active_port_files)
+        {
+            return Some(endpoint);
+        }
+    }
+    if let Some(browser_id) = target.browser_id.as_deref() {
+        if let Some(endpoint) =
+            discover_endpoint_for_browser_id(browser_id, running_targets, active_port_files)
+        {
+            return Some(endpoint);
+        }
+    }
+    target
+        .connect_endpoint
+        .clone()
+        .or_else(|| target.endpoint.clone())
+}
+
+fn discover_endpoint_for_source_path(
+    source_path: &Path,
+    running_targets: &[RunningChromeTarget],
+    active_port_files: &[DevtoolsActivePortFile],
+) -> Option<String> {
+    running_targets
+        .iter()
+        .find(|target| target.source_path.as_path() == source_path)
+        .map(|target| target.ws_endpoint.clone())
+        .or_else(|| {
+            active_port_files
+                .iter()
+                .find(|file| file.healthy && file.path.as_path() == source_path)
+                .and_then(|file| file.ws_endpoint.clone())
+        })
+}
+
+fn discover_endpoint_for_browser_id(
+    browser_id: &str,
+    running_targets: &[RunningChromeTarget],
+    active_port_files: &[DevtoolsActivePortFile],
+) -> Option<String> {
+    running_targets
+        .iter()
+        .find(|target| {
+            browser_id_from_ws_endpoint(&target.ws_endpoint).as_deref() == Some(browser_id)
+        })
+        .map(|target| target.ws_endpoint.clone())
+        .or_else(|| {
+            active_port_files
+                .iter()
+                .find(|file| {
+                    file.healthy
+                        && file
+                            .ws_endpoint
+                            .as_deref()
+                            .and_then(browser_id_from_ws_endpoint)
+                            .as_deref()
+                            == Some(browser_id)
+                })
+                .and_then(|file| file.ws_endpoint.clone())
+        })
+}
+
+async fn ensure_daemon_running(show_approval_guidance: bool) -> Result<DaemonMetadata> {
+    if let Some(metadata) = healthy_daemon_metadata().await? {
+        return Ok(metadata);
+    }
+
+    let _lock = acquire_waitable_lock(&daemon_lock_path(), "live-attach daemon lock")?;
+    if let Some(metadata) = healthy_daemon_metadata().await? {
+        return Ok(metadata);
+    }
+
+    if show_approval_guidance {
+        eprintln!(
+            "info: starting yoetz live-attach daemon so attach/check/recipe can reuse one Chrome CDP session"
+        );
+    }
+    spawn_daemon_process()?;
+
+    let deadline = tokio::time::Instant::now() + DAEMON_START_TIMEOUT;
+    loop {
+        if let Some(metadata) = healthy_daemon_metadata().await? {
+            return Ok(metadata);
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(anyhow!(
+                "yoetz live-attach daemon did not start within {}s; check {} for details",
+                DAEMON_START_TIMEOUT.as_secs(),
+                daemon_log_path().display()
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(DAEMON_START_POLL_MS)).await;
+    }
+}
+
+async fn healthy_daemon_metadata() -> Result<Option<DaemonMetadata>> {
+    healthy_daemon_metadata_with_timeout(DAEMON_HEALTH_RPC_TIMEOUT).await
+}
+
+async fn healthy_daemon_metadata_with_timeout(timeout: Duration) -> Result<Option<DaemonMetadata>> {
+    let Some(metadata) = load_daemon_metadata()? else {
+        return Ok(None);
+    };
+    // A long-running recipe can legitimately keep the single-owner daemon busy
+    // long enough for a health ping to time out. Preserve the metadata in that
+    // case so we do not spawn a second owner and trigger an extra Chrome attach.
+    match daemon_round_trip_with_timeout(
+        &metadata,
+        DaemonRequest::Ping {
+            token: metadata.token.clone(),
+        },
+        timeout,
+    )
+    .await
+    {
+        Ok(DaemonResponse::Pong) => Ok(Some(metadata)),
+        Err(err) if is_daemon_rpc_timeout_error(&err) => Ok(Some(metadata)),
+        _ => {
+            let _ = clear_daemon_metadata();
+            Ok(None)
+        }
+    }
+}
+
+async fn handle_daemon_connection(
+    socket: TcpStream,
+    token: &str,
+    daemon: &mut LiveAttachDaemon,
+) -> Result<bool> {
+    let mut reader = AsyncBufReader::new(socket);
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .await
+        .context("read yoetz live-attach request")?;
+
+    let request = serde_json::from_str::<DaemonRequest>(line.trim_end())
+        .context("parse yoetz live-attach request")?;
+    let shutdown = matches!(request, DaemonRequest::Shutdown { .. });
+    let response = match dispatch_daemon_request(request, token, daemon).await {
+        Ok(response) => response,
+        Err(err) => DaemonResponse::Error {
+            message: format!("{err:#}"),
+        },
+    };
+
+    let socket = reader.get_mut();
+    socket
+        .write_all(format!("{}\n", serde_json::to_string(&response)?).as_bytes())
+        .await
+        .context("write yoetz live-attach response")?;
+    socket
+        .flush()
+        .await
+        .context("flush yoetz live-attach response")?;
+
+    Ok(shutdown)
+}
+
+async fn dispatch_daemon_request(
+    request: DaemonRequest,
+    token: &str,
+    daemon: &mut LiveAttachDaemon,
+) -> Result<DaemonResponse> {
+    match request {
+        DaemonRequest::Ping {
+            token: request_token,
+        } => {
+            ensure_token(token, &request_token)?;
+            Ok(DaemonResponse::Pong)
+        }
+        DaemonRequest::Status {
+            token: request_token,
+        } => {
+            ensure_token(token, &request_token)?;
+            Ok(DaemonResponse::Status {
+                session_count: daemon.sessions.len(),
+            })
+        }
+        DaemonRequest::Shutdown {
+            token: request_token,
+        } => {
+            ensure_token(token, &request_token)?;
+            Ok(DaemonResponse::Pong)
+        }
+        DaemonRequest::EnsureSession {
+            token: request_token,
+            target,
+            browser_context_id,
+            profile_email,
+        } => {
+            ensure_token(token, &request_token)?;
+            let session = daemon
+                .ensure_chatgpt_session(
+                    target,
+                    browser_context_id.as_deref(),
+                    profile_email.as_deref(),
+                )
+                .await?;
+            Ok(DaemonResponse::Session { session })
+        }
+        DaemonRequest::RunRecipe {
+            token: request_token,
+            target,
+            recipe_ctx,
+        } => {
+            ensure_token(token, &request_token)?;
+            let result = daemon.run_chatgpt_recipe(target, recipe_ctx).await?;
+            Ok(DaemonResponse::Recipe { result })
+        }
+    }
+}
+
+fn ensure_token(expected: &str, actual: &str) -> Result<()> {
+    if expected == actual {
+        Ok(())
+    } else {
+        Err(anyhow!("invalid yoetz live-attach daemon token"))
+    }
+}
+
+async fn daemon_round_trip(
+    metadata: &DaemonMetadata,
+    request: DaemonRequest,
+) -> Result<DaemonResponse> {
+    let timeout = daemon_request_timeout(&request);
+    daemon_round_trip_with_timeout(metadata, request, timeout).await
+}
+
+fn daemon_request_timeout(request: &DaemonRequest) -> Duration {
+    match request {
+        DaemonRequest::Ping { .. }
+        | DaemonRequest::Status { .. }
+        | DaemonRequest::Shutdown { .. } => DAEMON_HEALTH_RPC_TIMEOUT,
+        DaemonRequest::EnsureSession { .. } => DAEMON_ENSURE_SESSION_TIMEOUT,
+        DaemonRequest::RunRecipe { recipe_ctx, .. } => {
+            Duration::from_millis(recipe_ctx.response_timeout_ms.saturating_add(
+                u64::try_from(DAEMON_RECIPE_RPC_GRACE.as_millis()).unwrap_or(u64::MAX),
+            ))
+        }
+    }
+}
+
+async fn daemon_round_trip_with_timeout(
+    metadata: &DaemonMetadata,
+    request: DaemonRequest,
+    timeout: Duration,
+) -> Result<DaemonResponse> {
+    tokio::time::timeout(timeout, daemon_round_trip_inner(metadata, request))
+        .await
+        .map_err(|_| daemon_rpc_timeout_error(&metadata.addr, timeout))?
+}
+
+fn daemon_round_trip_blocking(
+    metadata: &DaemonMetadata,
+    request: DaemonRequest,
+) -> Result<DaemonResponse> {
+    daemon_round_trip_blocking_with_timeout(metadata, request, DAEMON_HEALTH_RPC_TIMEOUT)
+}
+
+fn daemon_round_trip_blocking_with_timeout(
+    metadata: &DaemonMetadata,
+    request: DaemonRequest,
+    timeout: Duration,
+) -> Result<DaemonResponse> {
+    let addr = metadata
+        .addr
+        .parse::<SocketAddr>()
+        .with_context(|| format!("parse yoetz live-attach daemon address {}", metadata.addr))?;
+    let stream = std::net::TcpStream::connect_timeout(&addr, timeout).map_err(|err| {
+        daemon_blocking_io_error(
+            err,
+            &metadata.addr,
+            timeout,
+            &format!("connect to yoetz live-attach daemon at {}", metadata.addr),
+        )
+    })?;
+    stream
+        .set_read_timeout(Some(timeout))
+        .context("set yoetz live-attach daemon read timeout")?;
+    stream
+        .set_write_timeout(Some(timeout))
+        .context("set yoetz live-attach daemon write timeout")?;
+    let mut reader = BufReader::new(stream);
+    reader
+        .get_mut()
+        .write_all(format!("{}\n", serde_json::to_string(&request)?).as_bytes())
+        .map_err(|err| {
+            daemon_blocking_io_error(
+                err,
+                &metadata.addr,
+                timeout,
+                "write yoetz live-attach request",
+            )
+        })?;
+    reader.get_mut().flush().map_err(|err| {
+        daemon_blocking_io_error(
+            err,
+            &metadata.addr,
+            timeout,
+            "flush yoetz live-attach request",
+        )
+    })?;
+
+    let mut line = String::new();
+    reader.read_line(&mut line).map_err(|err| {
+        daemon_blocking_io_error(
+            err,
+            &metadata.addr,
+            timeout,
+            "read yoetz live-attach response",
+        )
+    })?;
+    let response = serde_json::from_str::<DaemonResponse>(line.trim_end())
+        .context("parse yoetz live-attach response")?;
+    match response {
+        DaemonResponse::Error { message } => Err(anyhow!(message)),
+        other => Ok(other),
+    }
+}
+
+fn daemon_blocking_io_error(
+    err: io::Error,
+    addr: &str,
+    timeout: Duration,
+    action: &str,
+) -> anyhow::Error {
+    if matches!(
+        err.kind(),
+        io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
+    ) {
+        daemon_rpc_timeout_error(addr, timeout)
+    } else {
+        anyhow::Error::new(err).context(action.to_string())
+    }
+}
+
+pub fn is_daemon_rpc_timeout_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        let message = cause.to_string();
+        message.contains("yoetz live-attach daemon at ") && message.contains("timed out")
+    })
+}
+
+async fn daemon_round_trip_inner(
+    metadata: &DaemonMetadata,
+    request: DaemonRequest,
+) -> Result<DaemonResponse> {
+    let stream = TcpStream::connect(&metadata.addr)
+        .await
+        .with_context(|| format!("connect to yoetz live-attach daemon at {}", metadata.addr))?;
+    let mut reader = AsyncBufReader::new(stream);
+    reader
+        .get_mut()
+        .write_all(format!("{}\n", serde_json::to_string(&request)?).as_bytes())
+        .await
+        .context("write yoetz live-attach request")?;
+    reader
+        .get_mut()
+        .flush()
+        .await
+        .context("flush yoetz live-attach request")?;
+
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .await
+        .context("read yoetz live-attach response")?;
+    let response = serde_json::from_str::<DaemonResponse>(line.trim_end())
+        .context("parse yoetz live-attach response")?;
+    match response {
+        DaemonResponse::Error { message } => Err(anyhow!(message)),
+        other => Ok(other),
+    }
+}
+
+fn spawn_daemon_process() -> Result<()> {
+    let exe = env::current_exe().context("resolve current yoetz executable")?;
+    let log_path = daemon_log_path();
+    if let Some(parent) = log_path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    let stdout = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .with_context(|| format!("open {}", log_path.display()))?;
+    let stderr = stdout
+        .try_clone()
+        .with_context(|| format!("clone {}", log_path.display()))?;
+
+    Command::new(exe)
+        .args(["browser", "live-attach-daemon"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr))
+        .spawn()
+        .context("spawn yoetz live-attach daemon")?;
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn terminate_daemon_process(pid: u32) -> Result<()> {
+    let status = Command::new("kill")
+        .args(["-TERM", &pid.to_string()])
+        .status()
+        .with_context(|| format!("send SIGTERM to yoetz live-attach daemon pid {pid}"))?;
+    if !status.success() {
+        let _ = Command::new("kill")
+            .args(["-KILL", &pid.to_string()])
+            .status();
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn terminate_daemon_process(_pid: u32) -> Result<()> {
+    Ok(())
+}
+
+fn acquire_waitable_lock(lock_path: &Path, action: &str) -> Result<File> {
+    if let Some(parent) = lock_path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(lock_path)
+        .with_context(|| format!("open {action} {}", lock_path.display()))?;
+
+    match file.try_lock_exclusive() {
+        Ok(()) => Ok(file),
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+            file.lock_exclusive()
+                .with_context(|| format!("lock {action} {}", lock_path.display()))?;
+            Ok(file)
+        }
+        Err(err) => Err(err).with_context(|| format!("lock {action} {}", lock_path.display())),
+    }
+}
+
+fn load_state() -> Result<LiveAttachState> {
+    let path = live_attach_state_path();
+    if !path.exists() {
+        return Ok(LiveAttachState::default());
+    }
+
+    let content = fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    match serde_json::from_str(&content) {
+        Ok(state) => Ok(state),
+        Err(_) => {
+            let _ = fs::remove_file(&path);
+            Ok(LiveAttachState::default())
+        }
+    }
+}
+
+fn save_state(state: &LiveAttachState) -> Result<()> {
+    write_json_file(&live_attach_state_path(), state)
+}
+
+fn clear_state() -> Result<()> {
+    remove_if_exists(&live_attach_state_path())
+}
+
+fn save_daemon_metadata(metadata: &DaemonMetadata) -> Result<()> {
+    write_json_file(&daemon_metadata_path(), metadata)
+}
+
+fn load_daemon_metadata() -> Result<Option<DaemonMetadata>> {
+    let path = daemon_metadata_path();
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let content = fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    match serde_json::from_str(&content) {
+        Ok(metadata) => Ok(Some(metadata)),
+        Err(_) => {
+            let _ = fs::remove_file(&path);
+            Ok(None)
+        }
+    }
+}
+
+fn clear_daemon_metadata() -> Result<()> {
+    remove_if_exists(&daemon_metadata_path())
+}
+
+fn write_json_file<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    let data = serde_json::to_string_pretty(value)?;
+    let tmp_path = path.with_extension(format!("tmp-{}", std::process::id()));
+    fs::write(&tmp_path, data).with_context(|| format!("write {}", tmp_path.display()))?;
+    fs::rename(&tmp_path, path)
+        .with_context(|| format!("rename {} -> {}", tmp_path.display(), path.display()))
+}
+
+fn remove_if_exists(path: &Path) -> Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err).with_context(|| format!("remove {}", path.display())),
+    }
+}
+
+fn selector_cache_key(explicit_context_id: Option<&str>, profile_email: Option<&str>) -> String {
+    format!(
+        "ctx={}|email={}",
+        explicit_context_id.unwrap_or_default(),
+        profile_email.unwrap_or_default()
+    )
+}
+
+fn context_storage_key(browser_context_id: Option<&str>) -> String {
+    browser_context_id
+        .unwrap_or(DEFAULT_CONTEXT_KEY)
+        .to_string()
+}
+
+fn live_attach_state_path() -> PathBuf {
+    path_from_env_or_home("YOETZ_LIVE_ATTACH_STATE_PATH", LIVE_ATTACH_STATE_FILENAME)
+}
+
+fn daemon_metadata_path() -> PathBuf {
+    path_from_env_or_home("YOETZ_LIVE_ATTACH_DAEMON_PATH", LIVE_ATTACH_DAEMON_FILENAME)
+}
+
+fn daemon_lock_path() -> PathBuf {
+    path_from_env_or_home(
+        "YOETZ_LIVE_ATTACH_DAEMON_LOCK_PATH",
+        LIVE_ATTACH_DAEMON_LOCK_FILENAME,
+    )
+}
+
+fn daemon_log_path() -> PathBuf {
+    path_from_env_or_home(
+        "YOETZ_LIVE_ATTACH_DAEMON_LOG_PATH",
+        LIVE_ATTACH_DAEMON_LOG_FILENAME,
+    )
+}
+
+fn path_from_env_or_home(env_key: &str, filename: &str) -> PathBuf {
+    if let Some(path) = env::var(env_key)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+    {
+        return PathBuf::from(path);
+    }
+    if let Some(home) = home_dir() {
+        return home.join(".yoetz").join(filename);
+    }
+    PathBuf::from(".yoetz").join(filename)
+}
+
+fn unix_ms_now() -> u64 {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    u64::try_from(millis).unwrap_or(u64::MAX)
+}
+
+struct DaemonMetadataGuard;
+
+impl Drop for DaemonMetadataGuard {
+    fn drop(&mut self) {
+        let _ = clear_daemon_metadata();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::ffi::OsString;
+    use std::sync::{mpsc, Mutex, MutexGuard, OnceLock};
+    use std::thread;
+    use std::time::Instant;
+    use tempfile::tempdir;
+
+    fn lock_env() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        #[allow(unsafe_code)]
+        fn set<K>(key: &'static str, value: K) -> Self
+        where
+            K: AsRef<std::ffi::OsStr>,
+        {
+            let original = env::var_os(key);
+            unsafe {
+                env::set_var(key, value);
+            }
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        #[allow(unsafe_code)]
+        fn drop(&mut self) {
+            match &self.original {
+                Some(value) => unsafe { env::set_var(self.key, value) },
+                None => unsafe { env::remove_var(self.key) },
+            }
+        }
+    }
+
+    #[test]
+    fn live_attach_target_uses_implicit_key_without_resolved_target() {
+        let target = LiveAttachTarget::from_resolved(None);
+        assert_eq!(target.key, IMPLICIT_TARGET_KEY);
+        assert_eq!(target.connect_endpoint, None);
+        assert_eq!(target.endpoint, None);
+        assert!(target.implicit_default);
+        assert_eq!(target.source_path, None);
+        assert_eq!(target.browser_id, None);
+    }
+
+    #[test]
+    fn selector_cache_key_distinguishes_context_and_email() {
+        assert_eq!(
+            selector_cache_key(Some("ctx-1"), Some("user@example.com")),
+            "ctx=ctx-1|email=user@example.com"
+        );
+        assert_eq!(selector_cache_key(None, None), "ctx=|email=");
+    }
+
+    #[test]
+    fn context_storage_key_uses_default_marker() {
+        assert_eq!(context_storage_key(None), DEFAULT_CONTEXT_KEY);
+        assert_eq!(context_storage_key(Some("ctx-work")), "ctx-work");
+    }
+
+    #[test]
+    #[serial]
+    fn reset_removes_state_and_daemon_metadata_files() {
+        let _guard = lock_env();
+        let dir = tempdir().unwrap();
+        let state_path = dir.path().join("live-attach.json");
+        let daemon_path = dir.path().join("live-attach-daemon.json");
+        let _state = EnvVarGuard::set("YOETZ_LIVE_ATTACH_STATE_PATH", &state_path);
+        let _daemon = EnvVarGuard::set("YOETZ_LIVE_ATTACH_DAEMON_PATH", &daemon_path);
+
+        save_state(&LiveAttachState {
+            sessions: BTreeMap::from([(
+                "implicit-default".to_string(),
+                PersistedTargetState {
+                    endpoint: Some("ws://127.0.0.1:9222/devtools/browser/test".to_string()),
+                    status: Some(LiveAttachStatus::Attached),
+                    updated_at_unix_ms: Some(unix_ms_now()),
+                    last_error: None,
+                    contexts: BTreeMap::new(),
+                },
+            )]),
+        })
+        .unwrap();
+        save_daemon_metadata(&DaemonMetadata {
+            pid: 1234,
+            addr: "127.0.0.1:39999".to_string(),
+            token: "token".to_string(),
+            started_at_unix_ms: unix_ms_now(),
+        })
+        .unwrap();
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(reset()).unwrap();
+        assert!(!state_path.exists());
+        assert!(!daemon_path.exists());
+    }
+
+    #[test]
+    #[serial]
+    fn invalid_persisted_state_is_cleared() {
+        let _guard = lock_env();
+        let dir = tempdir().unwrap();
+        let state_path = dir.path().join("live-attach.json");
+        let _state = EnvVarGuard::set("YOETZ_LIVE_ATTACH_STATE_PATH", &state_path);
+
+        fs::write(&state_path, "{not-json").unwrap();
+        let state = load_state().unwrap();
+
+        assert!(state.sessions.is_empty());
+        assert!(!state_path.exists());
+    }
+
+    #[test]
+    #[serial]
+    fn invalid_daemon_metadata_is_cleared() {
+        let _guard = lock_env();
+        let dir = tempdir().unwrap();
+        let daemon_path = dir.path().join("live-attach-daemon.json");
+        let _daemon = EnvVarGuard::set("YOETZ_LIVE_ATTACH_DAEMON_PATH", &daemon_path);
+
+        fs::write(&daemon_path, "{not-json").unwrap();
+        let metadata = load_daemon_metadata().unwrap();
+
+        assert!(metadata.is_none());
+        assert!(!daemon_path.exists());
+    }
+
+    #[test]
+    fn resolve_connect_endpoint_prefers_fresh_source_path_over_stale_endpoint() {
+        let source_path = PathBuf::from("/tmp/yoetz-profile");
+        let target = LiveAttachTarget {
+            key: "source-path:/tmp/yoetz-profile".to_string(),
+            connect_endpoint: Some("http://127.0.0.1:9222".to_string()),
+            endpoint: Some("ws://127.0.0.1:9222/devtools/browser/stale".to_string()),
+            source_path: Some(source_path.clone()),
+            browser_id: Some("stale".to_string()),
+            implicit_default: false,
+        };
+        let running_targets = vec![RunningChromeTarget {
+            ws_endpoint: "ws://127.0.0.1:9333/devtools/browser/fresh".to_string(),
+            source_path: source_path.clone(),
+            browser_name: "Chrome".to_string(),
+            chatgpt_tab_count: 1,
+            page_target_count: 3,
+            page_samples: vec![],
+            modified_at: None,
+        }];
+
+        assert_eq!(
+            resolve_connect_endpoint_with_discovery(&target, &running_targets, &[]),
+            Some("ws://127.0.0.1:9333/devtools/browser/fresh".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_connect_endpoint_prefers_fresh_browser_id_over_stale_endpoint() {
+        let target = LiveAttachTarget {
+            key: "browser-id:browser-123".to_string(),
+            connect_endpoint: Some("http://127.0.0.1:9222".to_string()),
+            endpoint: Some("ws://127.0.0.1:9222/devtools/browser/browser-123".to_string()),
+            source_path: None,
+            browser_id: Some("browser-123".to_string()),
+            implicit_default: false,
+        };
+        let running_targets = vec![RunningChromeTarget {
+            ws_endpoint: "ws://127.0.0.1:9333/devtools/browser/browser-123".to_string(),
+            source_path: PathBuf::from("/tmp/other-profile"),
+            browser_name: "Chrome".to_string(),
+            chatgpt_tab_count: 0,
+            page_target_count: 1,
+            page_samples: vec![],
+            modified_at: None,
+        }];
+
+        assert_eq!(
+            resolve_connect_endpoint_with_discovery(&target, &running_targets, &[]),
+            Some("ws://127.0.0.1:9333/devtools/browser/browser-123".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_connect_endpoint_implicit_default_ignores_persisted_endpoint() {
+        let target = LiveAttachTarget {
+            key: IMPLICIT_TARGET_KEY.to_string(),
+            connect_endpoint: Some("http://127.0.0.1:9222".to_string()),
+            endpoint: Some("ws://127.0.0.1:9222/devtools/browser/stale".to_string()),
+            source_path: None,
+            browser_id: None,
+            implicit_default: true,
+        };
+
+        assert_eq!(
+            resolve_connect_endpoint_with_discovery(&target, &[], &[]),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_connect_endpoint_prefers_original_http_connect_endpoint() {
+        let target = LiveAttachTarget {
+            key: "endpoint:http://127.0.0.1:9222".to_string(),
+            connect_endpoint: Some("http://127.0.0.1:9222".to_string()),
+            endpoint: Some("ws://127.0.0.1:9222/devtools/browser/stale".to_string()),
+            source_path: None,
+            browser_id: None,
+            implicit_default: false,
+        };
+
+        assert_eq!(
+            resolve_connect_endpoint_with_discovery(&target, &[], &[]),
+            Some("http://127.0.0.1:9222".to_string())
+        );
+    }
+
+    #[test]
+    fn daemon_request_timeout_scopes_long_running_operations() {
+        assert_eq!(
+            daemon_request_timeout(&DaemonRequest::Ping {
+                token: "token".to_string(),
+            }),
+            DAEMON_HEALTH_RPC_TIMEOUT
+        );
+        assert_eq!(
+            daemon_request_timeout(&DaemonRequest::EnsureSession {
+                token: "token".to_string(),
+                target: LiveAttachTarget::from_resolved(None),
+                browser_context_id: None,
+                profile_email: None,
+            }),
+            DAEMON_ENSURE_SESSION_TIMEOUT
+        );
+        assert_eq!(
+            daemon_request_timeout(&DaemonRequest::RunRecipe {
+                token: "token".to_string(),
+                target: LiveAttachTarget::from_resolved(None),
+                recipe_ctx: chrome_devtools_mcp::DevtoolsMcpRecipeContext {
+                    response_timeout_ms: 123_000,
+                    ..Default::default()
+                },
+            }),
+            Duration::from_millis(243_000)
+        );
+    }
+
+    fn spawn_unresponsive_server() -> (String, mpsc::Sender<()>, thread::JoinHandle<()>) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        let (shutdown_tx, shutdown_rx) = mpsc::channel();
+        let handle = thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let _stream = stream;
+            let _ = shutdown_rx.recv_timeout(Duration::from_secs(30));
+        });
+        (addr, shutdown_tx, handle)
+    }
+
+    #[test]
+    fn daemon_round_trip_blocking_times_out_against_unresponsive_server() {
+        let (addr, shutdown_tx, handle) = spawn_unresponsive_server();
+        let metadata = DaemonMetadata {
+            pid: 1234,
+            addr,
+            token: "token".to_string(),
+            started_at_unix_ms: unix_ms_now(),
+        };
+        let start = Instant::now();
+        let err = daemon_round_trip_blocking_with_timeout(
+            &metadata,
+            DaemonRequest::Status {
+                token: metadata.token.clone(),
+            },
+            Duration::from_millis(50),
+        )
+        .expect_err("unresponsive daemon should time out");
+
+        assert!(start.elapsed() < Duration::from_secs(1));
+        assert!(is_daemon_rpc_timeout_error(&err), "{err:#}");
+
+        let _ = shutdown_tx.send(());
+        let _ = handle.join();
+    }
+
+    #[test]
+    #[serial]
+    fn healthy_daemon_metadata_keeps_busy_daemon_metadata_on_timeout() {
+        let _guard = lock_env();
+        let dir = tempdir().unwrap();
+        let daemon_path = dir.path().join("live-attach-daemon.json");
+        let _daemon = EnvVarGuard::set("YOETZ_LIVE_ATTACH_DAEMON_PATH", &daemon_path);
+        let (addr, shutdown_tx, handle) = spawn_unresponsive_server();
+        let metadata = DaemonMetadata {
+            pid: 1234,
+            addr,
+            token: "token".to_string(),
+            started_at_unix_ms: unix_ms_now(),
+        };
+        save_daemon_metadata(&metadata).unwrap();
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let observed = runtime
+            .block_on(healthy_daemon_metadata_with_timeout(Duration::from_millis(
+                50,
+            )))
+            .unwrap();
+
+        assert_eq!(observed, Some(metadata));
+        assert!(
+            daemon_path.exists(),
+            "busy daemon metadata should be preserved"
+        );
+
+        let _ = shutdown_tx.send(());
+        let _ = handle.join();
+    }
+
+    #[test]
+    #[serial]
+    fn inspect_daemon_sync_reports_busy_on_timeout() {
+        let _guard = lock_env();
+        let dir = tempdir().unwrap();
+        let daemon_path = dir.path().join("live-attach-daemon.json");
+        let _daemon = EnvVarGuard::set("YOETZ_LIVE_ATTACH_DAEMON_PATH", &daemon_path);
+        let (addr, shutdown_tx, handle) = spawn_unresponsive_server();
+        let metadata = DaemonMetadata {
+            pid: 1234,
+            addr,
+            token: "token".to_string(),
+            started_at_unix_ms: unix_ms_now(),
+        };
+        save_daemon_metadata(&metadata).unwrap();
+
+        let summary = inspect_daemon_sync();
+
+        assert_eq!(
+            summary,
+            DaemonSummary {
+                health: DaemonHealth::Busy,
+                pid: Some(1234),
+                session_count: 0,
+            }
+        );
+        assert!(
+            daemon_path.exists(),
+            "busy daemon should not be treated as stale"
+        );
+
+        let _ = shutdown_tx.send(());
+        let _ = handle.join();
+    }
+}

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -26,6 +26,7 @@ mod commands;
 mod dev_browser;
 mod fuzzy;
 mod http;
+mod live_attach;
 mod providers;
 mod registry;
 
@@ -231,6 +232,8 @@ enum BrowserCommand {
     /// not navigate to ChatGPT, does not probe authentication — so it is
     /// safe to run against a fresh throwaway Chrome for Testing instance.
     VerifyCdp(BrowserVerifyCdpArgs),
+    #[command(hide = true, name = "live-attach-daemon")]
+    LiveAttachDaemon(BrowserLiveAttachDaemonArgs),
 }
 
 #[derive(Args)]
@@ -297,6 +300,9 @@ struct BrowserAttachArgs {
     #[arg(long)]
     browser_id: Option<String>,
 }
+
+#[derive(Args)]
+struct BrowserLiveAttachDaemonArgs {}
 
 #[derive(Args)]
 struct BrowserVerifyCdpArgs {
@@ -1003,6 +1009,9 @@ fn recipe_should_stop_live_transport_fallback(
     transport: browser::RecipeTransport,
     recipe_vars: &std::collections::BTreeMap<String, String>,
 ) -> bool {
+    if live_attach::is_daemon_rpc_timeout_error(err) {
+        return true;
+    }
     if browser::is_chrome_approval_wait_error(err) {
         return true;
     }
@@ -1123,6 +1132,12 @@ fn remember_browser_check_live_attach_failure(slot: &mut Option<String>, err: &a
     if slot.is_none() && browser::is_chrome_cdp_unreachable_error(err) {
         *slot = Some(format!("{err:#}"));
     }
+}
+
+fn live_attach_daemon_timeout_fallback_error(action: &str, err: anyhow::Error) -> anyhow::Error {
+    err.context(format!(
+        "yoetz live-attach daemon did not finish the {action} request within its operation window. Leaving the live owner intact instead of falling through to another browser transport. If this repeats, run `yoetz browser reset`."
+    ))
 }
 
 fn maybe_prefer_browser_check_live_attach_failure(
@@ -1288,7 +1303,7 @@ async fn run_recipe_via_chrome_devtools_mcp(
     ctx: &AppContext,
     recipe_args: &BrowserRecipeArgs,
     recipe_vars: &BTreeMap<String, String>,
-    cdp_endpoint: Option<&str>,
+    selected_cdp_target: Option<&browser::ResolvedCdpTarget>,
     format: OutputFormat,
     is_chatgpt: bool,
 ) -> Result<Value> {
@@ -1320,7 +1335,7 @@ async fn run_recipe_via_chrome_devtools_mcp(
 
     let recipe_spec = build_chatgpt_recipe_spec(recipe_args, recipe_vars)?;
     let recipe_ctx = chrome_devtools_mcp::DevtoolsMcpRecipeContext {
-        cdp_endpoint: cdp_endpoint.map(str::to_owned),
+        cdp_endpoint: selected_cdp_target.map(|target| target.endpoint.clone()),
         bundle_path: recipe_spec.bundle_path.clone(),
         bundle_text: None,
         model: recipe_spec.model.clone(),
@@ -1334,7 +1349,12 @@ async fn run_recipe_via_chrome_devtools_mcp(
         show_approval_guidance: matches!(format, OutputFormat::Text | OutputFormat::Markdown),
     };
 
-    let response = chrome_devtools_mcp::chatgpt::run(&recipe_ctx).await?;
+    let response = live_attach::run_chatgpt_recipe(
+        selected_cdp_target,
+        recipe_ctx,
+        matches!(format, OutputFormat::Text | OutputFormat::Markdown),
+    )
+    .await?;
     let payload = chatgpt_recipe::ChatgptRecipeOutput {
         transport: "chrome-devtools-mcp".to_string(),
         backend: "chrome-devtools-mcp".to_string(),
@@ -1404,7 +1424,11 @@ fn build_chatgpt_recipe_spec(
             .get("profile_email")
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty()),
-        run_id: recipe_vars.get("run_id").cloned().unwrap_or_default(),
+        run_id: recipe_vars
+            .get("run_id")
+            .cloned()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(chatgpt_web::generate_run_id),
         wait_timeout_ms: poll_settings.timeout_ms,
         wait_interval_ms: poll_settings.interval_ms,
         disable_extended: recipe_vars
@@ -1667,6 +1691,7 @@ fn run_recipe_via_agent_browser(
 
 async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputFormat) -> Result<()> {
     match args.command {
+        BrowserCommand::LiveAttachDaemon(_) => live_attach::serve_daemon().await,
         BrowserCommand::Exec(exec) => {
             // dev-browser exec: if args look like a script (single arg with
             // JS-like content or starts with "const"/"await"/"//"), run as script.
@@ -1818,9 +1843,14 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                     .as_ref()
                     .map(|target| target.endpoint.as_str())
                     .expect("explicit browser target should resolve");
-                chrome_devtools_mcp::chatgpt::check_auth(Some(cdp_url), show_approval_guidance)
-                    .await
-                    .map_err(explicit_cdp_attach_failure)?;
+                live_attach::ensure_chatgpt_session(
+                    resolved_cdp_target.as_ref(),
+                    None,
+                    None,
+                    show_approval_guidance,
+                )
+                .await
+                .map_err(explicit_cdp_attach_failure)?;
                 maybe_remember_cdp_target(resolved_cdp_target.as_ref(), format);
                 let payload = json!({
                     "status": "ok",
@@ -1863,16 +1893,15 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             for transport in transports {
                 match transport {
                     BrowserCheckTransport::ChromeDevtoolsMcp => {
-                        let cdp_endpoint = resolved_cdp_target
-                            .as_ref()
-                            .map(|target| target.endpoint.as_str());
-                        match chrome_devtools_mcp::chatgpt::check_auth(
-                            cdp_endpoint,
+                        match live_attach::ensure_chatgpt_session(
+                            resolved_cdp_target.as_ref(),
+                            None,
+                            None,
                             show_approval_guidance,
                         )
                         .await
                         {
-                            Ok(()) => {
+                            Ok(_) => {
                                 maybe_remember_cdp_target(resolved_cdp_target.as_ref(), format);
                                 let method =
                                     browser_check_live_method(resolved_cdp_target.as_ref());
@@ -1895,6 +1924,12 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                                 };
                             }
                             Err(e) => {
+                                if live_attach::is_daemon_rpc_timeout_error(&e) {
+                                    return Err(live_attach_daemon_timeout_fallback_error(
+                                        "browser check",
+                                        e,
+                                    ));
+                                }
                                 if browser::is_chrome_approval_wait_error(&e) {
                                     return Err(e);
                                 }
@@ -2070,6 +2105,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             } else {
                 false
             };
+            live_attach::reset().await?;
             browser::close_live_attach_session()?;
             browser::close_browser()?;
             let default_daemon_reset = browser::force_kill_stale_daemon();
@@ -2077,6 +2113,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             let payload = json!({
                 "status": "ok",
                 "dev_browser_daemon_stopped": dev_browser_stopped,
+                "live_attach_state_cleared": true,
                 "agent_browser_default": format!("{default_daemon_reset:?}"),
                 "agent_browser_cdp_session_closed": true,
             });
@@ -2209,7 +2246,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                             ctx,
                             &recipe_args,
                             &recipe_vars,
-                            cdp_endpoint.as_deref(),
+                            resolved_cdp_target.as_ref(),
                             format,
                             is_chatgpt,
                         )
@@ -2285,30 +2322,44 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             maybe_print_auto_selected_cdp_target(resolved_cdp_target.as_ref(), format);
             let cdp_endpoint = resolved_cdp_target
                 .as_ref()
-                .map(|target| target.endpoint.as_str());
+                .map(|target| target.endpoint.clone());
+            let show_approval_guidance =
+                matches!(format, OutputFormat::Text | OutputFormat::Markdown);
 
-            if let Some(endpoint) = cdp_endpoint {
-                match browser::try_cdp_attach(endpoint, "https://chatgpt.com/") {
-                    Ok(()) => {
+            if resolved_cdp_target.is_some() {
+                match live_attach::ensure_chatgpt_session(
+                    resolved_cdp_target.as_ref(),
+                    None,
+                    None,
+                    show_approval_guidance,
+                )
+                .await
+                {
+                    Ok(_) => {
                         maybe_remember_cdp_target(resolved_cdp_target.as_ref(), format);
+                        let method = if attach_args.cdp.is_some() {
+                            "cdp_explicit".to_string()
+                        } else if attach_args.browser_id.is_some() {
+                            format!(
+                                "browser_id: {}",
+                                attach_args.browser_id.as_deref().unwrap_or_default()
+                            )
+                        } else {
+                            "cdp_selected".to_string()
+                        };
                         let payload = json!({
                             "status": "ok",
-                            "method": if attach_args.cdp.is_some() {
-                                "cdp_explicit".to_string()
-                            } else if attach_args.browser_id.is_some() {
-                                format!(
-                                    "browser_id: {}",
-                                    attach_args.browser_id.as_deref().unwrap_or_default()
-                                )
-                            } else {
-                                "cdp_selected".to_string()
-                            },
-                            "endpoint": endpoint,
+                            "method": method,
+                            "endpoint": cdp_endpoint.as_deref(),
+                            "transport": "chrome-devtools-mcp",
                         });
                         return match format {
                             OutputFormat::Json => write_json(&payload),
                             OutputFormat::Jsonl => write_jsonl("browser.attach", &payload),
                             OutputFormat::Text | OutputFormat::Markdown => {
+                                let endpoint = cdp_endpoint
+                                    .as_deref()
+                                    .expect("resolved cdp target should have an endpoint");
                                 println!(
                                     "Attached via {}",
                                     if attach_args.cdp.is_some() {
@@ -2325,6 +2376,12 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                                 Ok(())
                             }
                         };
+                    }
+                    Err(e) if live_attach::is_daemon_rpc_timeout_error(&e) => {
+                        return Err(live_attach_daemon_timeout_fallback_error(
+                            "browser attach",
+                            e,
+                        ));
                     }
                     Err(e) if explicit_browser_target => {
                         if let Some(target) = resolved_cdp_target.as_ref() {
@@ -2348,6 +2405,44 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         maybe_demote_auto_selected_cdp_target(&mut resolved_cdp_target, format, &e);
                     }
                     Err(_) => {}
+                }
+            }
+
+            if resolved_cdp_target.is_none() {
+                match live_attach::ensure_chatgpt_session(None, None, None, show_approval_guidance)
+                    .await
+                {
+                    Ok(_) => {
+                        let payload = json!({
+                            "status": "ok",
+                            "method": "cdp_auto",
+                            "transport": "chrome-devtools-mcp",
+                        });
+                        return match format {
+                            OutputFormat::Json => write_json(&payload),
+                            OutputFormat::Jsonl => write_jsonl("browser.attach", &payload),
+                            OutputFormat::Text | OutputFormat::Markdown => {
+                                println!("Attached via chrome-devtools-mcp");
+                                Ok(())
+                            }
+                        };
+                    }
+                    Err(err) if live_attach::is_daemon_rpc_timeout_error(&err) => {
+                        return Err(live_attach_daemon_timeout_fallback_error(
+                            "browser attach",
+                            err,
+                        ));
+                    }
+                    Err(err) if explicit_browser_target => {
+                        return Err(explicit_cdp_attach_failure(err))
+                    }
+                    Err(err) => {
+                        if browser::is_chrome_approval_wait_error(&err)
+                            || browser::is_chatgpt_auth_issue_error(&err)
+                        {
+                            return Err(err);
+                        }
+                    }
                 }
             }
 
@@ -3011,6 +3106,20 @@ mod tests {
     }
 
     #[test]
+    fn recipe_should_stop_live_transport_fallback_on_live_attach_daemon_timeout() {
+        let err = anyhow!(
+            "yoetz live-attach daemon at 127.0.0.1:45555 timed out after 75000ms waiting for a response"
+        );
+        let vars = std::collections::BTreeMap::new();
+        assert!(recipe_should_stop_live_transport_fallback(
+            &err,
+            None,
+            browser::RecipeTransport::ChromeDevtoolsMcp,
+            &vars,
+        ));
+    }
+
+    #[test]
     fn recipe_should_not_stop_live_transport_fallback_on_non_approval_error() {
         let err = anyhow!("chatgpt send button not found");
         let vars = std::collections::BTreeMap::new();
@@ -3084,6 +3193,20 @@ mod tests {
             browser::RecipeTransport::ChromeDevtoolsMcp,
             &std::collections::BTreeMap::new(),
         ));
+    }
+
+    #[test]
+    fn live_attach_daemon_timeout_fallback_error_mentions_no_fallback() {
+        let err = live_attach_daemon_timeout_fallback_error(
+            "browser check",
+            anyhow!(
+                "yoetz live-attach daemon at 127.0.0.1:45555 timed out after 75000ms waiting for a response"
+            ),
+        );
+        let message = format!("{err:#}");
+        assert!(message.contains("browser check"));
+        assert!(message.contains("instead of falling through"));
+        assert!(message.contains("yoetz browser reset"));
     }
 
     #[test]

--- a/crates/yoetz-cli/tests/cli.rs
+++ b/crates/yoetz-cli/tests/cli.rs
@@ -287,11 +287,8 @@ fn browser_recipe_help_shows_cdp_flag() {
 
 #[test]
 fn browser_attach_explicit_cdp_failure_does_not_fallback() {
-    let (_dir, bin) = fake_agent_browser_failure_bin("connectOverCDP blew up");
-
     yoetz()
-        .args(["browser", "attach", "--cdp", "http://127.0.0.1:9222"])
-        .env("YOETZ_AGENT_BROWSER_BIN", &bin)
+        .args(["browser", "attach", "--cdp", "http://127.0.0.1:1"])
         .env("YOETZ_DEV_BROWSER_BIN", "/definitely/missing")
         .assert()
         .failure()

--- a/docs/decisions/ADR-001-live-attach-owner.md
+++ b/docs/decisions/ADR-001-live-attach-owner.md
@@ -1,0 +1,60 @@
+# ADR-001: Make `chrome-devtools-mcp` the Live Attach Owner
+
+## Status
+Accepted
+
+## Date
+2026-04-22
+
+## Context
+Yoetz had the right primitives for live Chrome work, but ownership was split:
+
+- `yoetz browser attach` used the older live-attach path in `browser.rs`
+- `yoetz browser check` partly used `chrome-devtools-mcp`
+- `yoetz browser recipe --recipe chatgpt` still opened its own fresh live attachment
+- ChatGPT auth probing still opened transient probe tabs instead of reusing one durable yoetz-owned tab
+- approval prompts and attach attempts were spread across multiple call sites
+
+That split increased reconnect churn and made the recurring Chrome "Allow remote debugging?" prompt worse than it needed to be.
+
+## Decision
+Make `chrome-devtools-mcp` the single yoetz-owned live-attach owner for ChatGPT-oriented live Chrome work.
+
+The concrete changes are:
+
+- add a daemon-backed owner in `crates/yoetz-cli/src/live_attach.rs`
+- route `attach`, the primary `check` path, and the ChatGPT `recipe` path through that owner
+- keep one durable yoetz-owned ChatGPT control tab per resolved browser context by persisting a stable `_yoetz=<run-id>` marker
+- reconnect from the logical target identity (`source-path`, `browser-id`, or implicit default discovery), not by blindly reusing the last websocket URL
+- preserve daemon metadata on bounded ping timeouts so a busy owner is not mistaken for a dead one, while `yoetz browser reset` still forcefully clears a wedged owner
+- keep `dev-browser` and `agent-browser` as fallback transports instead of peer live-session owners
+
+## Alternatives Considered
+
+### Keep three peer session owners
+- Pros: no refactor
+- Cons: repeated attach logic, repeated approval churn, transient probe tabs, unclear reset behavior
+- Rejected: this is the direct cause of the current fragmentation
+
+### Make `dev-browser` the live owner
+- Pros: existing named-page reuse
+- Cons: Playwright `connectOverCDP` remains the unstable transport on current Chrome default-profile flows
+- Rejected: wrong transport foundation for the default live path
+
+### Make `agent-browser` the live owner
+- Pros: existing daemon/session mechanics
+- Cons: the auto-connect path is intentionally not the canonical session owner for real-tab visibility, and managed/profile fallbacks are a different ownership model
+- Rejected: useful fallback, wrong primary owner
+
+### Build the full daemonized CDP supervisor now
+- Pros: closest to the final design
+- Cons: larger IPC and lifecycle change, higher regression risk, slower path to reducing actual churn
+- Rejected initially: the first safe step was to prove the owner boundary before pushing every flow onto it
+
+## Consequences
+
+- `attach`, `check`, and the ChatGPT `recipe` share one yoetz-owned CDP owner
+- repeated auth checks and recipe launches reuse the same control-tab identity for a resolved browser context instead of creating throwaway probe tabs
+- reconnect recovery now keeps the old `CreateTarget -> reconnect -> recover via existing anchor` behavior on the daemonized recipe path
+- a busy daemon times out cleanly instead of wedging `doctor`, `reset`, or later attach/check calls forever
+- `dev-browser` and `agent-browser` remain available, but only as fallback executors when the primary live owner is unavailable or unsuitable


### PR DESCRIPTION
## Summary\n- add a daemon-backed live-attach owner for browser attach/check/ChatGPT recipe flows\n- preserve logical reconnect identity across websocket churn and stop live-attach timeout fallback from fanning out into other transports\n- distinguish busy live-attach daemons from stale ones in browser doctor and document the owner model in ADR-001\n\n## Verification\n- cargo clippy -p yoetz --all-targets -- -D warnings\n- cargo test -p yoetz\n- cargo deny check advisories