### PR TITLE
fix(browser): stabilize running-profile review flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,7 +1264,7 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 [[package]]
 name = "litellm-rust"
 version = "0.1.2"
-source = "git+https://github.com/avivsinai/litellm-rust?rev=a147cfefdda4e3740b632c79dc71723468bdb3b1#a147cfefdda4e3740b632c79dc71723468bdb3b1"
+source = "git+https://github.com/avivsinai/litellm-rust?tag=v0.1.2#acf0514edf6b0fe1905970356091b8f63c3f40a9"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,8 +1263,8 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litellm-rust"
-version = "0.1.1"
-source = "git+https://github.com/avivsinai/litellm-rust?rev=241c57b3bf043a03150763c4ff4f88e1c8ae3f66#241c57b3bf043a03150763c4ff4f88e1c8ae3f66"
+version = "0.1.2"
+source = "git+https://github.com/avivsinai/litellm-rust?rev=a147cfefdda4e3740b632c79dc71723468bdb3b1#a147cfefdda4e3740b632c79dc71723468bdb3b1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/crates/yoetz-cli/Cargo.toml
+++ b/crates/yoetz-cli/Cargo.toml
@@ -21,7 +21,7 @@ workspace = true
 
 [dependencies]
 yoetz-core = { path = "../yoetz-core" }
-litellm-rust = { git = "https://github.com/avivsinai/litellm-rust", rev = "a147cfefdda4e3740b632c79dc71723468bdb3b1" }
+litellm-rust = { git = "https://github.com/avivsinai/litellm-rust", tag = "v0.1.2" }
 
 anyhow.workspace = true
 dotenvy.workspace = true

--- a/crates/yoetz-cli/Cargo.toml
+++ b/crates/yoetz-cli/Cargo.toml
@@ -21,7 +21,7 @@ workspace = true
 
 [dependencies]
 yoetz-core = { path = "../yoetz-core" }
-litellm-rust = { git = "https://github.com/avivsinai/litellm-rust", rev = "241c57b3bf043a03150763c4ff4f88e1c8ae3f66" }
+litellm-rust = { git = "https://github.com/avivsinai/litellm-rust", rev = "a147cfefdda4e3740b632c79dc71723468bdb3b1" }
 
 anyhow.workspace = true
 dotenvy.workspace = true

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -42,6 +42,8 @@ const CHATGPT_POLL_TOTAL_TIMEOUT_MS_DEFAULT: u64 = 1_800_000;
 const CHATGPT_POLL_COMMAND_TIMEOUT_MS_DEFAULT: u64 = 10_000;
 const CHATGPT_UPLOAD_POLL_ATTEMPTS_DEFAULT: usize = 30;
 const CHATGPT_UPLOAD_POLL_INTERVAL_MS_DEFAULT: u64 = 1_000;
+const CHATGPT_SEND_ENABLE_TIMEOUT_MS: u64 = 10_000;
+const CHATGPT_SEND_ENABLE_POLL_INTERVAL_MS: u64 = 250;
 const DAEMON_APPROVAL_GRACE_WINDOW: Duration = Duration::from_secs(30);
 const LIVE_ATTACH_COMMAND_TIMEOUT_MS: u64 = 30_000;
 const CDP_SESSION_NAME: &str = "yoetz-cdp";
@@ -499,6 +501,7 @@ fn run_recipe_with_connection(
     let collect_step_events = wants_json || (wants_jsonl && is_chatgpt_recipe);
     let mut events: Vec<Value> = Vec::new();
     let mut headed = ctx.headed;
+    let mut pending_chatgpt_send_baseline: Option<ChatgptResponseBaseline> = None;
 
     if let Some(connection) = connection {
         if connection.is_live_attach() {
@@ -564,6 +567,8 @@ fn run_recipe_with_connection(
                 interpolated_args.as_deref(),
                 step.timeout_ms,
                 connection,
+                ctx.vars.get("run_id").map(String::as_str),
+                pending_chatgpt_send_baseline.take(),
                 ctx.use_stealth,
                 headed,
             )
@@ -646,6 +651,7 @@ fn run_recipe_with_connection(
         if action == CHATGPT_SEND_ACTION {
             let stdout = run_chatgpt_send(connection, ctx.use_stealth, headed)
                 .with_context(|| format!("recipe step {idx} ({action}) failed"))?;
+            pending_chatgpt_send_baseline = parse_chatgpt_send_baseline_from_stdout(&stdout);
 
             if wants_json || wants_jsonl {
                 let stdout_value =
@@ -967,10 +973,18 @@ struct ChatgptPollOptions {
     timeout_ms: u64,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ChatgptResponseBaseline {
+    assistant_msg_count: usize,
+    assistant_last_len: usize,
+}
+
 fn run_chatgpt_wait_response(
     args: Option<&[String]>,
     timeout_ms: Option<u64>,
     connection: Option<&BrowserConnection>,
+    run_id: Option<&str>,
+    baseline: Option<ChatgptResponseBaseline>,
     use_stealth: bool,
     headed: bool,
 ) -> Result<String> {
@@ -978,9 +992,19 @@ fn run_chatgpt_wait_response(
     let command_timeout_ms = timeout_ms.unwrap_or(CHATGPT_POLL_COMMAND_TIMEOUT_MS_DEFAULT);
     let started_at = Instant::now();
     let deadline = started_at + Duration::from_millis(options.timeout_ms);
-    // Capture baseline assistant message state before send was clicked.
-    let baseline_dom =
-        inspect_chatgpt_dom_state(connection, use_stealth, headed, command_timeout_ms)?;
+    // Prefer the exact pre-send assistant counters returned by
+    // `chatgpt_send`; otherwise fall back to a fresh DOM baseline.
+    focus_chatgpt_run_tab_for_auto_connect(
+        connection,
+        run_id,
+        use_stealth,
+        headed,
+        command_timeout_ms,
+    )?;
+    let baseline_dom = match baseline {
+        Some(baseline) => baseline_dom_state(baseline),
+        None => inspect_chatgpt_dom_state(connection, use_stealth, headed, command_timeout_ms)?,
+    };
     let stable_idle_threshold_ms = chatgpt_stable_idle_threshold_ms(options.interval_ms);
     let mut last_dom = ChatgptDomState {
         send_state: ChatgptSendState::Missing,
@@ -1010,10 +1034,19 @@ fn run_chatgpt_wait_response(
             .saturating_duration_since(now)
             .as_millis()
             .min(u128::from(u64::MAX)) as u64;
-        thread::sleep(Duration::from_millis(options.interval_ms.min(remaining_ms)));
+        if let Some(delay) = chatgpt_wait_probe_delay(attempt, options.interval_ms, remaining_ms) {
+            thread::sleep(delay);
+        }
 
         completed_polls = attempt;
 
+        focus_chatgpt_run_tab_for_auto_connect(
+            connection,
+            run_id,
+            use_stealth,
+            headed,
+            command_timeout_ms,
+        )?;
         let dom = inspect_chatgpt_dom_state(connection, use_stealth, headed, command_timeout_ms)?;
         if !dom.error.is_empty() {
             return Err(anyhow!("ChatGPT error: {}", dom.error));
@@ -1023,6 +1056,13 @@ fn run_chatgpt_wait_response(
         match classify_chatgpt_completion(&dom, &baseline_dom) {
             CompletionVerdict::CopyButton => {
                 let elapsed_ms = started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+                focus_chatgpt_run_tab_for_auto_connect(
+                    connection,
+                    run_id,
+                    use_stealth,
+                    headed,
+                    command_timeout_ms,
+                )?;
                 let response = read_latest_chatgpt_response(
                     connection,
                     use_stealth,
@@ -1067,6 +1107,13 @@ fn run_chatgpt_wait_response(
                 if stable_for_ms >= stable_idle_threshold_ms {
                     let elapsed_ms =
                         started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+                    focus_chatgpt_run_tab_for_auto_connect(
+                        connection,
+                        run_id,
+                        use_stealth,
+                        headed,
+                        command_timeout_ms,
+                    )?;
                     let response = read_latest_chatgpt_response(
                         connection,
                         use_stealth,
@@ -1126,6 +1173,130 @@ fn run_chatgpt_wait_response(
     ))
 }
 
+fn chatgpt_wait_probe_delay(
+    attempt: usize,
+    interval_ms: u64,
+    remaining_ms: u64,
+) -> Option<Duration> {
+    if attempt == 1 {
+        None
+    } else {
+        Some(Duration::from_millis(interval_ms.min(remaining_ms)))
+    }
+}
+
+fn focus_chatgpt_run_tab_for_auto_connect(
+    connection: Option<&BrowserConnection>,
+    run_id: Option<&str>,
+    use_stealth: bool,
+    headed: bool,
+    timeout_ms: u64,
+) -> Result<()> {
+    let Some(connection @ BrowserConnection::AutoConnect) = connection else {
+        return Ok(());
+    };
+    let Some(run_id) = run_id.map(str::trim).filter(|run_id| !run_id.is_empty()) else {
+        return Ok(());
+    };
+
+    let tabs = list_live_attach_tabs(connection, use_stealth, headed, Some(timeout_ms))
+        .with_context(|| format!("list Chrome tabs while tracking yoetz run `{run_id}`"))?;
+    let marker_param = format!("_yoetz={run_id}");
+    if tabs
+        .iter()
+        .any(|tab| tab.active && tab.url.contains(&marker_param))
+    {
+        return Ok(());
+    }
+    if let Some(tab) = tabs.iter().find(|tab| tab.url.contains(&marker_param)) {
+        select_live_attach_tab(connection, tab.index, use_stealth, headed, timeout_ms)?;
+        return Ok(());
+    }
+
+    let run_marker = format!("yoetz:{run_id}");
+    for tab in chatgpt_run_tab_candidates(&tabs) {
+        select_live_attach_tab(connection, tab.index, use_stealth, headed, timeout_ms)?;
+        let identity =
+            inspect_current_live_attach_tab_identity(connection, use_stealth, headed, timeout_ms)?;
+        if identity.window_name == run_marker || identity.url.contains(&marker_param) {
+            return Ok(());
+        }
+    }
+
+    Err(mark_chatgpt_attached_page_error(anyhow!(
+        "yoetz-owned ChatGPT tab `{run_id}` was not visible in the attached Chrome session"
+    )))
+}
+
+fn select_live_attach_tab(
+    connection: &BrowserConnection,
+    index: usize,
+    use_stealth: bool,
+    headed: bool,
+    timeout_ms: u64,
+) -> Result<()> {
+    run_agent_browser_with_connection_timeout(
+        vec!["tab".to_string(), index.to_string()],
+        OutputFormat::Text,
+        Some(connection),
+        use_stealth,
+        headed,
+        Some(timeout_ms),
+    )?;
+    Ok(())
+}
+
+fn chatgpt_run_tab_candidates(tabs: &[AgentBrowserTab]) -> Vec<&AgentBrowserTab> {
+    let mut candidates = tabs
+        .iter()
+        .filter(|tab| is_chatgpt_tab(tab))
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|tab| (!tab.active, tab.index));
+    candidates
+}
+
+fn is_chatgpt_tab(tab: &AgentBrowserTab) -> bool {
+    let url = tab.url.to_ascii_lowercase();
+    let title = tab.title.to_ascii_lowercase();
+    url.contains("chatgpt.com") || title.contains("chatgpt")
+}
+
+#[derive(Debug, Deserialize)]
+struct LiveAttachTabIdentity {
+    #[serde(rename = "windowName", default)]
+    window_name: String,
+    #[serde(default)]
+    url: String,
+}
+
+fn inspect_current_live_attach_tab_identity(
+    connection: &BrowserConnection,
+    use_stealth: bool,
+    headed: bool,
+    timeout_ms: u64,
+) -> Result<LiveAttachTabIdentity> {
+    let expression = chatgpt_web::wrap_function_source_for_json_eval(
+        r#"
+() => ({
+  windowName: String(window.name || ""),
+  url: String(location.href || ""),
+})
+"#,
+    )?;
+    let stdout = run_agent_browser_with_connection_timeout(
+        vec!["eval".to_string(), expression],
+        OutputFormat::Text,
+        Some(connection),
+        use_stealth,
+        headed,
+        Some(timeout_ms),
+    )?;
+    let payload = parse_stdout_json(&stdout)
+        .with_context(|| format!("parse ChatGPT run-tab identity result: {stdout}"))?;
+    serde_json::from_value(payload)
+        .context("agent-browser run-tab identity payload did not match the expected shape")
+}
+
 /// Short-burst polling for ChatGPT file upload completion.
 /// Checks whether the upload spinner (`.animate-spin` SVG whose parent has
 /// `display: none` when done) has disappeared inside the file tile.
@@ -1152,6 +1323,7 @@ fn run_chatgpt_select_model(
         .get("model")
         .map(String::as_str)
         .unwrap_or_default();
+    let keep_current_model = chatgpt_web::should_keep_current_chatgpt_model(requested_model);
     let function = chatgpt_web::build_model_selection_function(requested_model);
     let expression = chatgpt_web::wrap_function_source_for_json_eval(&function)?;
     let stdout = run_agent_browser_with_connection_timeout(
@@ -1171,6 +1343,13 @@ fn run_chatgpt_select_model(
     let model_used = chatgpt_web::select_reported_chatgpt_model(&selection, requested_model);
     match status {
         "selected" | "already-selected" => {
+            Ok(json!({
+                "status": "ok",
+                "model_used": model_used,
+            })
+            .to_string())
+        }
+        "missing-selector" | "not-found" if keep_current_model => {
             Ok(json!({
                 "status": "ok",
                 "model_used": model_used,
@@ -1338,27 +1517,80 @@ fn run_chatgpt_send(
     let expression = chatgpt_web::wrap_function_source_for_json_eval(
         &chatgpt_web::build_send_button_click_function(),
     )?;
-    let stdout = run_agent_browser_with_connection_timeout(
-        vec!["eval".to_string(), expression],
-        OutputFormat::Text,
-        connection,
-        use_stealth,
-        headed,
-        Some(CHATGPT_POLL_COMMAND_TIMEOUT_MS_DEFAULT),
-    )?;
-    let result: Value = parse_stdout_json(&stdout)
-        .with_context(|| format!("parse ChatGPT send result: {stdout}"))?;
-    match result
-        .get("status")
-        .and_then(Value::as_str)
-        .unwrap_or("unknown")
-    {
-        "sent" => Ok(json!({"status": "ok"}).to_string()),
-        "not-ready" => Err(anyhow!(
-            "ChatGPT send button never became enabled after typing. {}",
-            result.get("diagnostics").cloned().unwrap_or(Value::Null)
-        )),
-        other => Err(anyhow!("unexpected ChatGPT send status `{other}`")),
+    let started_at = Instant::now();
+
+    loop {
+        let stdout = run_agent_browser_with_connection_timeout(
+            vec!["eval".to_string(), expression.clone()],
+            OutputFormat::Text,
+            connection,
+            use_stealth,
+            headed,
+            Some(CHATGPT_POLL_COMMAND_TIMEOUT_MS_DEFAULT),
+        )?;
+        let result: Value = parse_stdout_json(&stdout)
+            .with_context(|| format!("parse ChatGPT send result: {stdout}"))?;
+        match result
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+        {
+            "sent" => {
+                let baseline = parse_chatgpt_send_baseline(&result)
+                    .ok_or_else(|| anyhow!("missing assistant baseline in ChatGPT send payload"))?;
+                return Ok(json!({
+                    "status": "ok",
+                    "assistantCountBeforeSend": baseline.assistant_msg_count,
+                    "assistantLastLenBeforeSend": baseline.assistant_last_len,
+                })
+                .to_string());
+            }
+            "not-ready" => {
+                let diagnostics = result.get("diagnostics").cloned().unwrap_or(Value::Null);
+                if started_at.elapsed() >= Duration::from_millis(CHATGPT_SEND_ENABLE_TIMEOUT_MS) {
+                    return Err(anyhow!(
+                        "ChatGPT send button never became enabled after typing. {}",
+                        diagnostics
+                    ));
+                }
+                thread::sleep(Duration::from_millis(CHATGPT_SEND_ENABLE_POLL_INTERVAL_MS));
+            }
+            other => return Err(anyhow!("unexpected ChatGPT send status `{other}`")),
+        }
+    }
+}
+
+fn parse_chatgpt_send_baseline(result: &Value) -> Option<ChatgptResponseBaseline> {
+    let assistant_msg_count = result
+        .get("assistantCountBeforeSend")
+        .and_then(Value::as_u64)?
+        .try_into()
+        .ok()?;
+    let assistant_last_len = result
+        .get("assistantLastLenBeforeSend")
+        .and_then(Value::as_u64)?
+        .try_into()
+        .ok()?;
+    Some(ChatgptResponseBaseline {
+        assistant_msg_count,
+        assistant_last_len,
+    })
+}
+
+fn parse_chatgpt_send_baseline_from_stdout(stdout: &str) -> Option<ChatgptResponseBaseline> {
+    let payload = parse_stdout_json(stdout)?;
+    parse_chatgpt_send_baseline(&payload)
+}
+
+fn baseline_dom_state(baseline: ChatgptResponseBaseline) -> ChatgptDomState {
+    ChatgptDomState {
+        send_state: ChatgptSendState::Missing,
+        has_stop_button: false,
+        has_thinking_indicator: false,
+        copy_button_count: 0,
+        assistant_msg_count: baseline.assistant_msg_count,
+        assistant_last_len: baseline.assistant_last_len,
+        error: String::new(),
     }
 }
 
@@ -1379,13 +1611,12 @@ fn inspect_chatgpt_dom_state(
         headed,
         Some(timeout_ms),
     )?;
-    // agent-browser eval sometimes wraps the result in double quotes
-    let raw = stdout.trim();
-    let raw = raw
-        .strip_prefix('"')
-        .and_then(|s| s.strip_suffix('"'))
-        .unwrap_or(raw);
-    parse_chatgpt_dom_state(raw)
+    let raw = match parse_stdout_json(&stdout) {
+        Some(Value::String(payload)) => payload,
+        Some(other) => other.to_string(),
+        None => stdout.trim().to_string(),
+    };
+    parse_chatgpt_dom_state(raw.trim())
 }
 
 fn read_latest_chatgpt_response(
@@ -3179,10 +3410,11 @@ fn compare_running_chrome_targets(
 ) -> std::cmp::Ordering {
     let sticky_left = sticky_source.is_some_and(|path| path == left.source_path.as_path());
     let sticky_right = sticky_source.is_some_and(|path| path == right.source_path.as_path());
-    sticky_right
-        .cmp(&sticky_left)
-        .then_with(|| right.has_chatgpt_tab().cmp(&left.has_chatgpt_tab()))
+    right
+        .has_chatgpt_tab()
+        .cmp(&left.has_chatgpt_tab())
         .then_with(|| right.chatgpt_tab_count.cmp(&left.chatgpt_tab_count))
+        .then_with(|| sticky_right.cmp(&sticky_left))
         .then_with(|| {
             browser_family_priority(&right.browser_name)
                 .cmp(&browser_family_priority(&left.browser_name))
@@ -3855,9 +4087,12 @@ fn select_live_attach_profile_tab<'a>(
         );
     }
 
-    if let Some(active) = matches.iter().copied().find(|tab| tab.active) {
-        return Ok(active);
+    if matches.len() > 1 {
+        bail!(
+            "profile_email `{requested_email}` matched multiple live auto-connect tabs; refine the target before falling back to agent-browser"
+        );
     }
+
     Ok(matches[0])
 }
 
@@ -3969,7 +4204,26 @@ fn parse_stdout_json(stdout: &str) -> Option<Value> {
     if trimmed.is_empty() {
         return None;
     }
-    serde_json::from_str(trimmed).ok()
+    let mut parsed: Value = serde_json::from_str(trimmed).ok()?;
+    for _ in 0..4 {
+        let Value::String(inner) = &parsed else {
+            break;
+        };
+        let inner = inner.trim();
+        // Unwrap only when the payload is itself another JSON container or
+        // quoted JSON string; keep plain string scalars like "1" as strings.
+        if !matches!(
+            inner.as_bytes().first().copied(),
+            Some(b'{') | Some(b'[') | Some(b'"')
+        ) {
+            break;
+        }
+        let Ok(next) = serde_json::from_str(inner) else {
+            break;
+        };
+        parsed = next;
+    }
+    Some(parsed)
 }
 
 fn expand_step(
@@ -4650,7 +4904,7 @@ browser_cdp = "http://evil.example.com:9222"
     }
 
     #[test]
-    fn select_preferred_running_chrome_target_prefers_sticky_before_chatgpt() {
+    fn select_preferred_running_chrome_target_prefers_chatgpt_before_sticky() {
         let sticky_path = PathBuf::from("/tmp/chrome-sticky/DevToolsActivePort");
         let older = SystemTime::UNIX_EPOCH + Duration::from_secs(10);
         let newer = SystemTime::UNIX_EPOCH + Duration::from_secs(20);
@@ -4680,7 +4934,7 @@ browser_cdp = "http://evil.example.com:9222"
                 .unwrap();
         assert_eq!(
             sticky_choice.ws_endpoint,
-            "ws://127.0.0.1:9333/devtools/browser/sticky"
+            "ws://127.0.0.1:9222/devtools/browser/chatgpt"
         );
 
         let chatgpt_choice = select_preferred_running_chrome_target(&mut targets, None).unwrap();
@@ -5158,6 +5412,81 @@ browser_cdp = "http://evil.example.com:9222"
         assert!(err
             .to_string()
             .contains("profile_email `avivsinai@gmail.com` was not visible"));
+    }
+
+    #[test]
+    fn select_live_attach_profile_tab_errors_when_email_is_ambiguous() {
+        let tabs = vec![
+            AgentBrowserTab {
+                index: 1,
+                active: true,
+                title: "Inbox (43,617) - avivsinai@gmail.com - Gmail".to_string(),
+                url: "https://mail.google.com/mail/u/0/#inbox".to_string(),
+            },
+            AgentBrowserTab {
+                index: 2,
+                active: false,
+                title: "Drafts - avivsinai@gmail.com - Gmail".to_string(),
+                url: "https://mail.google.com/mail/u/1/#drafts".to_string(),
+            },
+        ];
+
+        let err = select_live_attach_profile_tab(&tabs, "avivsinai@gmail.com").unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("matched multiple live auto-connect tabs"));
+    }
+
+    #[test]
+    fn is_chatgpt_tab_matches_url_or_title() {
+        assert!(is_chatgpt_tab(&AgentBrowserTab {
+            index: 1,
+            active: false,
+            title: "Workspace".to_string(),
+            url: "https://chatgpt.com/c/abc".to_string(),
+        }));
+        assert!(is_chatgpt_tab(&AgentBrowserTab {
+            index: 2,
+            active: false,
+            title: "ChatGPT".to_string(),
+            url: "https://example.com/".to_string(),
+        }));
+        assert!(!is_chatgpt_tab(&AgentBrowserTab {
+            index: 3,
+            active: true,
+            title: "Workspace".to_string(),
+            url: "https://example.com/".to_string(),
+        }));
+    }
+
+    #[test]
+    fn chatgpt_run_tab_candidates_prioritize_active_chatgpt_tabs() {
+        let tabs = vec![
+            AgentBrowserTab {
+                index: 9,
+                active: true,
+                title: "Workspace".to_string(),
+                url: "https://example.com/".to_string(),
+            },
+            AgentBrowserTab {
+                index: 7,
+                active: false,
+                title: "ChatGPT".to_string(),
+                url: "https://chatgpt.com/c/older".to_string(),
+            },
+            AgentBrowserTab {
+                index: 5,
+                active: true,
+                title: "ChatGPT".to_string(),
+                url: "https://chatgpt.com/c/current".to_string(),
+            },
+        ];
+
+        let indices = chatgpt_run_tab_candidates(&tabs)
+            .into_iter()
+            .map(|tab| tab.index)
+            .collect::<Vec<_>>();
+        assert_eq!(indices, vec![5, 7]);
     }
 
     #[test]
@@ -6028,6 +6357,57 @@ browser_cdp = "http://evil.example.com:9222"
                 || err.to_string().contains("copy count")
                 || err.to_string().contains("invalid"),
             "expected parse error for quoted output, got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_stdout_json_unwraps_stringified_json_payloads() {
+        let parsed =
+            parse_stdout_json(r#""{\"status\":\"already-selected\",\"modelUsed\":\"Pro\"}""#)
+                .expect("stringified json payload");
+        assert_eq!(parsed["status"], "already-selected");
+        assert_eq!(parsed["modelUsed"], "Pro");
+    }
+
+    #[test]
+    fn parse_stdout_json_unwraps_nested_json_strings() {
+        let payload = "send=missing|stop=0|thinking=0|copy=1|msgs=1|lastlen=5|err=";
+        let nested = serde_json::to_string(&serde_json::to_string(payload).unwrap()).unwrap();
+        let parsed = parse_stdout_json(&nested).expect("nested json string");
+        assert_eq!(parsed, Value::String(payload.into()));
+    }
+
+    #[test]
+    fn parse_stdout_json_keeps_plain_string_scalars_as_strings() {
+        let parsed = parse_stdout_json(r#""1""#).expect("string scalar");
+        assert_eq!(parsed, Value::String("1".into()));
+    }
+
+    #[test]
+    fn parse_chatgpt_send_baseline_from_stdout_extracts_counts() {
+        let baseline = parse_chatgpt_send_baseline_from_stdout(
+            r#"{"status":"ok","assistantCountBeforeSend":1,"assistantLastLenBeforeSend":42}"#,
+        )
+        .expect("baseline");
+        assert_eq!(
+            baseline,
+            ChatgptResponseBaseline {
+                assistant_msg_count: 1,
+                assistant_last_len: 42,
+            }
+        );
+    }
+
+    #[test]
+    fn chatgpt_wait_probe_delay_is_immediate_on_first_attempt() {
+        assert_eq!(chatgpt_wait_probe_delay(1, 30_000, 30_000), None);
+        assert_eq!(
+            chatgpt_wait_probe_delay(2, 30_000, 30_000),
+            Some(Duration::from_millis(30_000))
+        );
+        assert_eq!(
+            chatgpt_wait_probe_delay(3, 30_000, 5_000),
+            Some(Duration::from_millis(5_000))
         );
     }
 

--- a/crates/yoetz-cli/src/chatgpt_web.rs
+++ b/crates/yoetz-cli/src/chatgpt_web.rs
@@ -181,11 +181,16 @@ pub fn select_reported_chatgpt_model(
     }
 
     let requested_model = requested_model.trim();
-    if requested_model.is_empty() || requested_model.eq_ignore_ascii_case("auto") {
+    if should_keep_current_chatgpt_model(requested_model) {
         None
     } else {
         canonical_chatgpt_model_slug(requested_model)
     }
+}
+
+pub fn should_keep_current_chatgpt_model(requested_model: &str) -> bool {
+    let requested_model = requested_model.trim();
+    requested_model.is_empty() || requested_model.eq_ignore_ascii_case("auto")
 }
 
 pub fn model_selector_button_selector_json() -> String {
@@ -993,26 +998,33 @@ pub fn build_chatgpt_dom_probe_function() -> String {
     format!(
         r##"
 () => {{
-  const send = Array.from(document.querySelectorAll({send_button_selector_json})).find((button) => {{
+  const isVisible = (button) => {{
     const rect = button.getBoundingClientRect();
     const style = window.getComputedStyle(button);
     return rect.width > 0 &&
       rect.height > 0 &&
       style.visibility !== "hidden" &&
       style.display !== "none";
-  }}) || null;
-  const stop = document.querySelector({stop_button_selector_json});
+  }};
+  const send = Array.from(document.querySelectorAll({send_button_selector_json})).find((button) => isVisible(button)) || null;
+  const stopButton = Array.from(document.querySelectorAll({stop_button_selector_json})).find((button) => isVisible(button)) || null;
+  const stopGenerating = !!stopButton && !stopButton.disabled;
   const thinking = document.querySelector(".result-thinking, [data-testid*='thinking'], [class*='thinking']");
   const msgs = document.querySelectorAll("[data-message-author-role='assistant']");
   const lastMsg = msgs.length > 0 ? msgs[msgs.length - 1] : null;
-  const copyButtons = lastMsg ? lastMsg.querySelectorAll("button[aria-label*='Copy'], button[data-testid*='copy']").length : 0;
+  const turnRoot =
+    lastMsg?.closest(".agent-turn, [class*='agent-turn'], [class*='turn-messages']") ||
+    lastMsg?.parentElement?.parentElement ||
+    lastMsg?.parentElement ||
+    document;
+  const copyButtons = lastMsg ? turnRoot.querySelectorAll("button[aria-label*='Copy'], button[data-testid*='copy']").length : 0;
   const lastLen = msgs.length > 0 ? msgs[msgs.length - 1].innerText.length : 0;
   const sendState = !send ? "missing" : send.disabled ? "disabled" : "enabled";
   const errEl = document.querySelector("[class*='error-toast'], [data-testid*='error'], [role='alert']");
   const errText = errEl ? errEl.innerText.substring(0, 100).toLowerCase() : "";
   const markers = ["network error","something went wrong","error generating","attachment failed","upload failed","too many requests"];
   const err = markers.find((marker) => errText.includes(marker)) || "";
-  return `send=${{sendState}}|stop=${{stop ? 1 : 0}}|thinking=${{thinking ? 1 : 0}}|copy=${{copyButtons}}|msgs=${{msgs.length}}|lastlen=${{lastLen}}|err=${{err}}`;
+  return `send=${{sendState}}|stop=${{stopGenerating ? 1 : 0}}|thinking=${{thinking ? 1 : 0}}|copy=${{copyButtons}}|msgs=${{msgs.length}}|lastlen=${{lastLen}}|err=${{err}}`;
 }}
 "##,
         send_button_selector_json = send_button_selector_json,
@@ -1151,6 +1163,14 @@ mod tests {
             select_reported_chatgpt_model(&selection, "pro"),
             Some("gpt-5-4-pro".to_string())
         );
+    }
+
+    #[test]
+    fn keep_current_chatgpt_model_detects_auto_and_empty_requests() {
+        assert!(should_keep_current_chatgpt_model(""));
+        assert!(should_keep_current_chatgpt_model("auto"));
+        assert!(should_keep_current_chatgpt_model(" AUTO "));
+        assert!(!should_keep_current_chatgpt_model("pro"));
     }
 
     #[test]
@@ -1311,6 +1331,8 @@ mod tests {
         let dom_probe = build_chatgpt_dom_probe_function();
         assert!(dom_probe.contains("send="));
         assert!(dom_probe.contains("copyButtons"));
+        assert!(dom_probe.contains("stopGenerating = !!stopButton && !stopButton.disabled"));
+        assert!(dom_probe.contains("turnRoot.querySelectorAll"));
 
         let latest_response = build_latest_response_probe_function();
         assert!(latest_response.contains("data-message-author-role"));

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
@@ -526,6 +526,9 @@ pub async fn ensure_chatgpt_control_tab_ready(
     }
     let result = wait_for_composer_ready(client, /* focus_composer */ false).await;
     if reused_existing_page && result.is_err() {
+        if should_retire_failed_reused_control_tab(control_run_id, &result) {
+            let _ = client.close_selected_page(true);
+        }
         open_chatgpt_auth_probe_page(client, browser_context_id, control_run_id, 30_000).await?;
         let retry = wait_for_composer_ready(client, /* focus_composer */ false).await;
         if control_run_id.is_none() {
@@ -537,6 +540,13 @@ pub async fn ensure_chatgpt_control_tab_ready(
         let _ = client.close_selected_page(true);
     }
     result
+}
+
+fn should_retire_failed_reused_control_tab(
+    control_run_id: Option<&str>,
+    result: &Result<()>,
+) -> bool {
+    control_run_id.is_some() && result.is_err()
 }
 
 async fn wait_for_composer_ready(client: &CdpMcpClient, focus_composer: bool) -> Result<()> {
@@ -623,6 +633,7 @@ async fn maybe_select_model(
     client: &CdpMcpClient,
     requested_model: &str,
 ) -> Result<Option<String>> {
+    let keep_current_model = chatgpt_web::should_keep_current_chatgpt_model(requested_model);
     let script = build_model_selection_script(requested_model);
     let selection = client
         .evaluate_script(&script, vec![])
@@ -638,6 +649,7 @@ async fn maybe_select_model(
     let model_used = chatgpt_web::select_reported_chatgpt_model(&selection, requested_model);
     match status {
         "selected" | "already-selected" => Ok(model_used),
+        "missing-selector" | "not-found" if keep_current_model => Ok(model_used),
         "missing-selector" => Err(anyhow!(
             "ChatGPT model selector button not found. {}",
             format_page_probe_summary(&selection)
@@ -1787,6 +1799,20 @@ mod tests {
         )
         .await
         .unwrap();
+    }
+
+    #[test]
+    fn retire_failed_reused_control_tab_only_for_persistent_control_tabs() {
+        let err = Err(anyhow!("composer did not mount"));
+        assert!(should_retire_failed_reused_control_tab(
+            Some("control-run"),
+            &err
+        ));
+        assert!(!should_retire_failed_reused_control_tab(None, &err));
+        assert!(!should_retire_failed_reused_control_tab(
+            Some("control-run"),
+            &Ok(())
+        ));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
@@ -483,10 +483,17 @@ impl CdpMcpClient {
                     .await
                 {
                     Ok(tab) => tab,
-                    Err(open_err) => self
-                        .reuse_page_target(&anchor, url, background, timeout_ms)
-                        .await
-                        .context(open_err)?,
+                    Err(open_err) => {
+                        if context_tab_navigation_reuse_rank(&anchor.url).is_some() {
+                            self.reuse_page_target(&anchor, url, background, timeout_ms)
+                                .await
+                                .context(open_err)?
+                        } else {
+                            return Err(open_err.context(
+                                "refusing to navigate an existing yoetz-owned ChatGPT tab as a recovery fallback",
+                            ));
+                        }
+                    }
                 }
             }
             ChatgptRecoveryStrategy::AnyUserPageAnchor => {
@@ -560,6 +567,13 @@ impl CdpMcpClient {
         }
 
         let tab = self.select_chatgpt_probe_target(candidates, timeout_ms)?;
+        if let Some(preferred_run_id) = preferred_run_id {
+            self.retire_duplicate_chatgpt_probe_tabs(
+                browser_context_id,
+                preferred_run_id,
+                tab.get_target_id(),
+            );
+        }
         configure_tab_timeout(&tab, timeout_ms);
         self.set_selected_tab(tab.clone());
 
@@ -864,6 +878,20 @@ impl CdpMcpClient {
             .map(|(_, target)| target))
     }
 
+    fn select_navigable_optional_context_target(
+        &self,
+        browser_context_id: Option<&str>,
+    ) -> Result<Option<TargetInfo>> {
+        Ok(self
+            .page_targets_in_optional_browser_context(browser_context_id)?
+            .into_iter()
+            .filter_map(|target| {
+                context_tab_navigation_reuse_rank(&target.url).map(|rank| (rank, target))
+            })
+            .min_by_key(|(rank, _)| *rank)
+            .map(|(_, target)| target))
+    }
+
     fn attach_page_target(&self, target_id: &str) -> Result<Arc<Tab>> {
         self.browser
             .attach_to_page_target(target_id)?
@@ -1033,6 +1061,27 @@ impl CdpMcpClient {
         self.attach_page_target(&candidates[index].target_id)
     }
 
+    fn retire_duplicate_chatgpt_probe_tabs(
+        &self,
+        browser_context_id: Option<&str>,
+        preferred_run_id: &str,
+        keep_target_id: &str,
+    ) {
+        let page_targets = self
+            .chatgpt_page_targets(browser_context_id)
+            .unwrap_or_default();
+        let duplicate_targets = duplicate_chatgpt_probe_target_ids_to_retire(
+            &page_targets,
+            preferred_run_id,
+            keep_target_id,
+        );
+        for target in duplicate_targets {
+            if let Ok(tab) = self.attach_page_target(&target) {
+                let _ = tab.close(true);
+            }
+        }
+    }
+
     fn probe_chatgpt_target(&self, target: &TargetInfo, timeout_ms: u64) -> ChatgptTabProbe {
         self.attach_page_target(&target.target_id)
             .map(|tab| probe_chatgpt_tab(&tab, timeout_ms))
@@ -1118,14 +1167,14 @@ fn choose_chatgpt_recovery_strategy(
     browser_context_id: Option<&str>,
     url: &str,
 ) -> Result<ChatgptRecoveryStrategy> {
-    if has_chatgpt_anchor {
-        if mutate_existing_chatgpt_tab_allowed() {
-            return Ok(ChatgptRecoveryStrategy::ReuseExistingChatgptTab);
-        }
-        return Ok(ChatgptRecoveryStrategy::ExistingChatgptAnchor);
+    if has_chatgpt_anchor && mutate_existing_chatgpt_tab_allowed() {
+        return Ok(ChatgptRecoveryStrategy::ReuseExistingChatgptTab);
     }
     if safe_anchor_url.is_some_and(|value| context_tab_reuse_rank(value).is_some()) {
         return Ok(ChatgptRecoveryStrategy::ExistingSafeAnchor);
+    }
+    if has_chatgpt_anchor && user_tab_anchor_allowed() {
+        return Ok(ChatgptRecoveryStrategy::ExistingChatgptAnchor);
     }
     if user_tab_anchor_allowed() {
         // Caller opted in via YOETZ_ALLOW_USER_TAB_ANCHOR=1. Use any existing
@@ -1163,10 +1212,10 @@ impl CdpMcpClient {
         browser_context_id: Option<&str>,
     ) -> Result<Arc<Tab>> {
         let target = self
-            .select_reusable_optional_context_target(browser_context_id)?
+            .select_navigable_optional_context_target(browser_context_id)?
             .with_context(|| {
                 format!(
-                    "there is no reusable blank or yoetz-owned tab in {} to navigate to `{url}`",
+                    "there is no reusable blank or new-tab page in {} to navigate to `{url}`",
                     browser_context_label(browser_context_id)
                 )
             })?;
@@ -1350,6 +1399,21 @@ fn choose_chatgpt_probe_index(probes: &[ChatgptTabProbe]) -> usize {
     }
 
     0
+}
+
+fn duplicate_chatgpt_probe_target_ids_to_retire(
+    targets: &[TargetInfo],
+    preferred_run_id: &str,
+    keep_target_id: &str,
+) -> Vec<String> {
+    targets
+        .iter()
+        .filter(|target| {
+            yoetz_run_id_from_url(&target.url).as_deref() == Some(preferred_run_id)
+                && target.target_id != keep_target_id
+        })
+        .map(|target| target.target_id.clone())
+        .collect()
 }
 
 pub(crate) fn infer_email_hints(title: &str, url: &str) -> Vec<String> {
@@ -2139,25 +2203,31 @@ fn is_yoetz_owned_url(url: &str) -> bool {
 
 fn context_tab_reuse_rank(url: &str) -> Option<u8> {
     let normalized = url.trim().to_ascii_lowercase();
-    // Only reuse a ChatGPT tab if it is yoetz-owned (stamped with the
-    // `?_yoetz=<run-id>` or `&_yoetz=<run-id>` marker we apply to every
-    // fresh tab). Non-yoetz ChatGPT tabs are almost certainly an active
-    // user conversation and must not be hijacked by the reuse fallback
-    // (review finding #8 — fresh-tab contract).
-    if is_chatgpt_url(&normalized) {
-        if is_yoetz_owned_url(&normalized) {
-            Some(0)
-        } else {
-            None
-        }
-    } else if normalized.is_empty() || normalized == "about:blank" {
-        Some(1)
+    if normalized.is_empty() || normalized == "about:blank" {
+        Some(0)
     } else if normalized.starts_with("chrome://newtab")
         || normalized.starts_with("chrome://new-tab-page")
     {
-        Some(2)
+        Some(1)
+    } else if is_chatgpt_url(&normalized) {
+        // Yoetz-owned ChatGPT tabs are safe for `window.open(...)` anchors,
+        // but they are deliberately ranked behind disposable blank/new-tab
+        // pages so recovery preserves per-run tab isolation when possible.
+        if is_yoetz_owned_url(&normalized) {
+            Some(2)
+        } else {
+            None
+        }
     } else {
         None
+    }
+}
+
+fn context_tab_navigation_reuse_rank(url: &str) -> Option<u8> {
+    if is_chatgpt_url(url) {
+        None
+    } else {
+        context_tab_reuse_rank(url)
     }
 }
 
@@ -2935,27 +3005,89 @@ mod tests {
     }
 
     #[test]
-    fn context_tab_reuse_rank_prefers_yoetz_owned_then_blank_tabs() {
-        // yoetz-owned ChatGPT tabs (`?_yoetz=` marker) are the only ChatGPT
-        // tabs we may reuse — any other ChatGPT tab may be a live user
-        // conversation and must be left alone (review finding #8).
+    fn context_tab_reuse_rank_prefers_disposable_tabs_before_yoetz_owned_chatgpt() {
+        // Default recovery should prefer disposable pages before touching an
+        // existing yoetz-owned ChatGPT tab from another run. Non-yoetz ChatGPT
+        // tabs remain completely ineligible.
         assert_eq!(
             context_tab_reuse_rank("https://chatgpt.com/?_yoetz=20260418T073330Z_abc"),
-            Some(0)
+            Some(2)
         );
         assert_eq!(
             context_tab_reuse_rank("https://chatgpt.com/c/xyz?foo=bar&_yoetz=run-abc"),
-            Some(0)
+            Some(2)
         );
         assert_eq!(context_tab_reuse_rank("https://chatgpt.com/c/abc"), None);
         assert_eq!(context_tab_reuse_rank("https://chatgpt.com/"), None);
-        assert_eq!(context_tab_reuse_rank("about:blank"), Some(1));
-        assert_eq!(context_tab_reuse_rank("chrome://newtab/"), Some(2));
+        assert_eq!(context_tab_reuse_rank("about:blank"), Some(0));
+        assert_eq!(context_tab_reuse_rank("chrome://newtab/"), Some(1));
         assert_eq!(context_tab_reuse_rank("https://calendar.google.com"), None);
     }
 
     #[test]
-    fn recovery_opens_fresh_tab_via_existing_chatgpt_anchor_when_create_target_blocked() {
+    fn context_tab_navigation_reuse_rank_rejects_chatgpt_tabs() {
+        assert_eq!(
+            context_tab_navigation_reuse_rank("https://chatgpt.com/?_yoetz=run-abc"),
+            None
+        );
+        assert_eq!(context_tab_navigation_reuse_rank("about:blank"), Some(0));
+        assert_eq!(
+            context_tab_navigation_reuse_rank("chrome://newtab/"),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn duplicate_chatgpt_probe_target_ids_to_retire_keeps_only_selected_run_tab() {
+        let targets = vec![
+            TargetInfo {
+                target_id: "target-1".to_string(),
+                Type: "page".to_string(),
+                title: "ChatGPT".to_string(),
+                url: "https://chatgpt.com/?_yoetz=run-abc".to_string(),
+                attached: false,
+                opener_id: None,
+                can_access_opener: false,
+                opener_frame_id: None,
+                parent_frame_id: None,
+                browser_context_id: Some("ctx-personal".to_string()),
+                subtype: None,
+            },
+            TargetInfo {
+                target_id: "target-2".to_string(),
+                Type: "page".to_string(),
+                title: "ChatGPT".to_string(),
+                url: "https://chatgpt.com/c/xyz?_yoetz=run-abc".to_string(),
+                attached: false,
+                opener_id: None,
+                can_access_opener: false,
+                opener_frame_id: None,
+                parent_frame_id: None,
+                browser_context_id: Some("ctx-personal".to_string()),
+                subtype: None,
+            },
+            TargetInfo {
+                target_id: "target-3".to_string(),
+                Type: "page".to_string(),
+                title: "ChatGPT".to_string(),
+                url: "https://chatgpt.com/?_yoetz=run-other".to_string(),
+                attached: false,
+                opener_id: None,
+                can_access_opener: false,
+                opener_frame_id: None,
+                parent_frame_id: None,
+                browser_context_id: Some("ctx-personal".to_string()),
+                subtype: None,
+            },
+        ];
+        assert_eq!(
+            duplicate_chatgpt_probe_target_ids_to_retire(&targets, "run-abc", "target-2"),
+            vec!["target-1".to_string()]
+        );
+    }
+
+    #[test]
+    fn recovery_prefers_safe_anchor_before_existing_chatgpt_tab() {
         assert_eq!(
             choose_chatgpt_recovery_strategy(
                 true,
@@ -2964,7 +3096,7 @@ mod tests {
                 "https://chatgpt.com/?_yoetz=test"
             )
             .unwrap(),
-            ChatgptRecoveryStrategy::ExistingChatgptAnchor
+            ChatgptRecoveryStrategy::ExistingSafeAnchor
         );
     }
 
@@ -2998,6 +3130,34 @@ mod tests {
             }
         }
         assert_eq!(strategy, ChatgptRecoveryStrategy::ReuseExistingChatgptTab);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn recovery_uses_existing_chatgpt_anchor_only_with_user_tab_opt_in() {
+        let previous = std::env::var(YOETZ_ALLOW_USER_TAB_ANCHOR_ENV).ok();
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::set_var(YOETZ_ALLOW_USER_TAB_ANCHOR_ENV, "1");
+        }
+        let strategy =
+            choose_chatgpt_recovery_strategy(true, None, None, "https://chatgpt.com/?_yoetz=test")
+                .unwrap();
+        match previous {
+            Some(value) => {
+                #[allow(unsafe_code)]
+                unsafe {
+                    std::env::set_var(YOETZ_ALLOW_USER_TAB_ANCHOR_ENV, value);
+                }
+            }
+            None => {
+                #[allow(unsafe_code)]
+                unsafe {
+                    std::env::remove_var(YOETZ_ALLOW_USER_TAB_ANCHOR_ENV);
+                }
+            }
+        }
+        assert_eq!(strategy, ChatgptRecoveryStrategy::ExistingChatgptAnchor);
     }
 
     #[test]

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -856,6 +856,7 @@ fn build_chatgpt_prepare_script(page_name: &str, model: &str, run_id: &str) -> S
         r##"
 const PAGE_NAME = {page_name_json};
 const MODEL = {model_json};
+const AUTO_MODEL = !String(MODEL || "").trim() || String(MODEL || "").trim().toLowerCase() === "auto";
 const MARKED_URL = {marked_url_json};
 const WINDOW_NAME = {window_name_json};
 const MODEL_SELECTION_FUNCTION_SOURCE = {model_selection_function_json};
@@ -924,7 +925,8 @@ if (loggedIn && composerReady) {{
     return fn();
   }}, MODEL_SELECTION_FUNCTION_SOURCE);
   const selectionStatus = selection?.status || "unknown";
-  if (!["selected", "already-selected"].includes(selectionStatus)) {{
+  const keepCurrentModel = AUTO_MODEL && ["missing-selector", "not-found"].includes(selectionStatus);
+  if (!["selected", "already-selected"].includes(selectionStatus) && !keepCurrentModel) {{
     const diagnostics = JSON.stringify({{
       status: selectionStatus,
       requested: selection?.requested || MODEL || "",
@@ -944,7 +946,12 @@ if (loggedIn && composerReady) {{
     }}
     throw new Error("unexpected model selection status '" + selectionStatus + "' (" + diagnostics + ")");
   }}
-  selectedModel = selection?.targetTestId || selection?.modelUsed || selection?.selectedLabel || null;
+  selectedModel =
+    selection?.targetTestId ||
+    selection?.modelUsed ||
+    selection?.selectedLabel ||
+    selection?.currentLabel ||
+    null;
   await page.waitForTimeout(500);
 }}
 console.log(JSON.stringify({{
@@ -1703,6 +1710,9 @@ mod tests {
 
         assert!(script.contains("const PAGE_NAME = \"yoetz-chatgpt-test\";"));
         assert!(script.contains("const MODEL = \"gpt-5-4-pro\";"));
+        assert!(script.contains(
+            "const AUTO_MODEL = !String(MODEL || \"\").trim() || String(MODEL || \"\").trim().toLowerCase() === \"auto\";"
+        ));
         assert!(script.contains("const MARKED_URL = \"https://chatgpt.com/?_yoetz=run-123\";"));
         assert!(script.contains("const WINDOW_NAME = \"yoetz:run-123\";"));
         assert!(
@@ -1725,8 +1735,10 @@ mod tests {
         ));
         assert!(script.contains("let selectedModel = null;"));
         assert!(script.contains(
-            "selectedModel = selection?.targetTestId || selection?.modelUsed || selection?.selectedLabel || null;"
+            "const keepCurrentModel = AUTO_MODEL && [\"missing-selector\", \"not-found\"].includes(selectionStatus);"
         ));
+        assert!(script.contains("selectedModel ="));
+        assert!(script.contains("selection?.currentLabel ||"));
         assert!(script.contains("modelUsed: selectedModel,"));
         assert!(script.contains("bodyText"));
         assert!(script.contains(

--- a/crates/yoetz-cli/src/live_attach.rs
+++ b/crates/yoetz-cli/src/live_attach.rs
@@ -169,7 +169,6 @@ enum DaemonResponse {
 struct DaemonSession {
     target: LiveAttachTarget,
     client: CdpMcpClient,
-    selector_cache: BTreeMap<String, Option<String>>,
 }
 
 struct LiveAttachDaemon {
@@ -377,11 +376,7 @@ impl LiveAttachDaemon {
         target.browser_id = browser_id_from_ws_endpoint(&actual_endpoint).or(target.browser_id);
         target.endpoint = Some(actual_endpoint);
 
-        Ok(DaemonSession {
-            target,
-            client,
-            selector_cache: BTreeMap::new(),
-        })
+        Ok(DaemonSession { target, client })
     }
 
     async fn reconnect_session_in_place(&mut self, session: &mut DaemonSession) -> Result<()> {
@@ -395,8 +390,9 @@ impl LiveAttachDaemon {
         explicit_context_id: Option<&str>,
         profile_email: Option<&str>,
     ) -> Result<(Option<String>, String)> {
-        let browser_context_id =
-            resolve_cached_browser_context_id(session, explicit_context_id, profile_email)?;
+        let browser_context_id = session
+            .client
+            .resolve_browser_context_id(explicit_context_id, profile_email)?;
         let control_run_id =
             self.control_run_id_for(&session.target.key, browser_context_id.as_deref());
         chatgpt::ensure_chatgpt_control_tab_ready(
@@ -632,24 +628,6 @@ fn daemon_rpc_timeout_error(addr: &str, timeout: Duration) -> anyhow::Error {
         "yoetz live-attach daemon at {addr} timed out after {}ms waiting for a response",
         timeout.as_millis()
     )
-}
-
-fn resolve_cached_browser_context_id(
-    session: &mut DaemonSession,
-    explicit_context_id: Option<&str>,
-    profile_email: Option<&str>,
-) -> Result<Option<String>> {
-    let selector_key = selector_cache_key(explicit_context_id, profile_email);
-    if let Some(cached) = session.selector_cache.get(&selector_key) {
-        return Ok(cached.clone());
-    }
-    let resolved = session
-        .client
-        .resolve_browser_context_id(explicit_context_id, profile_email)?;
-    session
-        .selector_cache
-        .insert(selector_key, resolved.clone());
-    Ok(resolved)
 }
 
 fn resolve_connect_endpoint(target: &LiveAttachTarget) -> Option<String> {
@@ -1181,14 +1159,6 @@ fn remove_if_exists(path: &Path) -> Result<()> {
     }
 }
 
-fn selector_cache_key(explicit_context_id: Option<&str>, profile_email: Option<&str>) -> String {
-    format!(
-        "ctx={}|email={}",
-        explicit_context_id.unwrap_or_default(),
-        profile_email.unwrap_or_default()
-    )
-}
-
 fn context_storage_key(browser_context_id: Option<&str>) -> String {
     browser_context_id
         .unwrap_or(DEFAULT_CONTEXT_KEY)
@@ -1300,15 +1270,6 @@ mod tests {
         assert!(target.implicit_default);
         assert_eq!(target.source_path, None);
         assert_eq!(target.browser_id, None);
-    }
-
-    #[test]
-    fn selector_cache_key_distinguishes_context_and_email() {
-        assert_eq!(
-            selector_cache_key(Some("ctx-1"), Some("user@example.com")),
-            "ctx=ctx-1|email=user@example.com"
-        );
-        assert_eq!(selector_cache_key(None, None), "ctx=|email=");
     }
 
     #[test]

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -66,7 +66,7 @@ struct Cli {
     #[arg(long = "config-profile", global = true)]
     config_profile: Option<String>,
 
-    #[arg(long, global = true, default_value = "60")]
+    #[arg(long, global = true, default_value = "180")]
     timeout_secs: u64,
 
     /// Allow unrecognized model IDs (for self-hosted models not in the registry)
@@ -1185,13 +1185,24 @@ fn running_profile_recipe_transport_priority(transport: browser::RecipeTransport
 }
 
 fn prioritize_chatgpt_transports_for_running_profile_auto_connect(
-    mut transports: Vec<browser::RecipeTransport>,
+    transports: Vec<browser::RecipeTransport>,
     prefer_auto_connect: bool,
 ) -> Vec<browser::RecipeTransport> {
     if !prefer_auto_connect {
         return transports;
     }
 
+    let has_agent_browser = transports.contains(&browser::RecipeTransport::AgentBrowser);
+    let has_manual = transports.contains(&browser::RecipeTransport::Manual);
+    if has_agent_browser {
+        let mut constrained = vec![browser::RecipeTransport::AgentBrowser];
+        if has_manual {
+            constrained.push(browser::RecipeTransport::Manual);
+        }
+        return constrained;
+    }
+
+    let mut transports = transports;
     transports.sort_by_key(|transport| running_profile_recipe_transport_priority(*transport));
     transports
 }
@@ -1213,12 +1224,8 @@ fn browser_check_transports(
     }
 
     if prefer_auto_connect {
-        let mut transports = vec![BrowserCheckTransport::AgentBrowser];
-        if dev_browser_available {
-            transports.push(BrowserCheckTransport::DevBrowser);
-        }
-        transports.push(BrowserCheckTransport::ChromeDevtoolsMcp);
-        return transports;
+        let _ = dev_browser_available;
+        return vec![BrowserCheckTransport::AgentBrowser];
     }
 
     let mut transports = vec![BrowserCheckTransport::ChromeDevtoolsMcp];
@@ -1686,6 +1693,7 @@ fn run_recipe_via_agent_browser(
     profile_dir: PathBuf,
     format: OutputFormat,
     is_chatgpt: bool,
+    prefer_auto_connect: bool,
     selected_cdp_target: &mut Option<browser::ResolvedCdpTarget>,
 ) -> Result<Value> {
     let needs_auth = is_chatgpt;
@@ -1751,6 +1759,10 @@ fn run_recipe_via_agent_browser(
                             return Err(err);
                         } else if let Some(recovery) = default_daemon_recovery_error(Some(&err)) {
                             return Err(recovery);
+                        } else if prefer_auto_connect {
+                            return Err(anyhow!(
+                                "running-profile auto-connect was unavailable ({err}). yoetz will not fall back to a managed profile for this run."
+                            ));
                         } else {
                             eprintln!("info: auto-connect unavailable, falling back to profile");
                             None
@@ -2164,6 +2176,19 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                     BrowserCheckTransport::AgentBrowser => {
                         let connection = if managed_profile_only {
                             browser::resolve_auth(&profile_dir, /* headed */ false)?
+                        } else if prefer_auto_connect {
+                            browser::try_auto_connect("https://chatgpt.com/").map_err(|e| {
+                                if let Some(recovery) = default_daemon_recovery_error(Some(&e)) {
+                                    return recovery;
+                                }
+                                maybe_prefer_browser_check_live_attach_failure(
+                                    anyhow!(
+                                        "running-profile auto-connect was unavailable ({e}). yoetz will not fall back to a managed profile for this check."
+                                    ),
+                                    prior_live_attach_failure.as_deref(),
+                                )
+                            })?;
+                            browser::BrowserConnection::AutoConnect
                         } else {
                             let fallback_cdp = resolved_cdp_target
                                 .as_ref()
@@ -2387,6 +2412,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         profile_dir.clone(),
                         format,
                         is_chatgpt,
+                        prefer_auto_connect,
                         &mut resolved_cdp_target,
                     ),
                     browser::RecipeTransport::ChromeDevtoolsMcp => {
@@ -3607,7 +3633,7 @@ mod tests {
     }
 
     #[test]
-    fn prioritize_chatgpt_transports_for_running_profile_moves_raw_cdp_last() {
+    fn prioritize_chatgpt_transports_for_running_profile_constrains_to_agent_browser_and_manual() {
         let transports = prioritize_chatgpt_transports_for_running_profile_auto_connect(
             vec![
                 browser::RecipeTransport::ChromeDevtoolsMcp,
@@ -3621,8 +3647,6 @@ mod tests {
             transports,
             vec![
                 browser::RecipeTransport::AgentBrowser,
-                browser::RecipeTransport::DevBrowser,
-                browser::RecipeTransport::ChromeDevtoolsMcp,
                 browser::RecipeTransport::Manual
             ]
         );
@@ -3681,11 +3705,7 @@ mod tests {
         );
         assert_eq!(
             browser_check_transports(true, false, true),
-            vec![
-                BrowserCheckTransport::AgentBrowser,
-                BrowserCheckTransport::DevBrowser,
-                BrowserCheckTransport::ChromeDevtoolsMcp,
-            ]
+            vec![BrowserCheckTransport::AgentBrowser]
         );
     }
 

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -1016,15 +1016,36 @@ fn recipe_should_stop_live_transport_fallback(
         return true;
     }
     if browser::is_chatgpt_auth_issue_error(err) {
-        return true;
+        if recipe_uses_exact_browser_context_selector(recipe_vars) {
+            return true;
+        }
+        if selected_cdp_target.is_some_and(browser::ResolvedCdpTarget::is_authoritative) {
+            return true;
+        }
+        return !is_live_cdp_only_transport(transport);
     }
-    if recipe_uses_chatgpt_browser_context_selector(recipe_vars)
-        && browser::is_chatgpt_profile_selector_visibility_error(err)
-    {
-        return true;
+    if browser::is_chatgpt_profile_selector_visibility_error(err) {
+        if recipe_uses_exact_browser_context_selector(recipe_vars) {
+            return true;
+        }
+        if recipe_uses_profile_email_selector(recipe_vars) {
+            if selected_cdp_target.is_some_and(browser::ResolvedCdpTarget::is_authoritative) {
+                return true;
+            }
+            return !matches!(
+                transport,
+                browser::RecipeTransport::ChromeDevtoolsMcp | browser::RecipeTransport::DevBrowser
+            );
+        }
     }
     if browser::is_chatgpt_attached_page_error(err) {
-        return true;
+        if recipe_uses_exact_browser_context_selector(recipe_vars) {
+            return true;
+        }
+        if selected_cdp_target.is_some_and(browser::ResolvedCdpTarget::is_authoritative) {
+            return true;
+        }
+        return matches!(transport, browser::RecipeTransport::AgentBrowser);
     }
 
     // Once the user has explicitly pinned a specific live Chrome target, do not
@@ -1058,16 +1079,34 @@ fn recipe_should_skip_remaining_live_cdp_transports(err: &anyhow::Error) -> bool
     browser::is_chrome_cdp_unreachable_error(err)
 }
 
+fn recipe_var_present(
+    recipe_vars: &std::collections::BTreeMap<String, String>,
+) -> impl Fn(&str) -> bool + '_ {
+    move |key| {
+        recipe_vars
+            .get(key)
+            .is_some_and(|value| !value.trim().is_empty())
+    }
+}
+
+fn recipe_uses_exact_browser_context_selector(
+    recipe_vars: &std::collections::BTreeMap<String, String>,
+) -> bool {
+    recipe_var_present(recipe_vars)("browser_context_id")
+}
+
+fn recipe_uses_profile_email_selector(
+    recipe_vars: &std::collections::BTreeMap<String, String>,
+) -> bool {
+    recipe_var_present(recipe_vars)("profile_email")
+}
+
+#[cfg(test)]
 fn recipe_uses_chatgpt_browser_context_selector(
     recipe_vars: &std::collections::BTreeMap<String, String>,
 ) -> bool {
-    ["browser_context_id", "profile_email"]
-        .into_iter()
-        .any(|key| {
-            recipe_vars
-                .get(key)
-                .is_some_and(|value| !value.trim().is_empty())
-        })
+    recipe_uses_exact_browser_context_selector(recipe_vars)
+        || recipe_uses_profile_email_selector(recipe_vars)
 }
 
 fn constrain_chatgpt_transports_for_browser_context_selector(
@@ -1075,19 +1114,86 @@ fn constrain_chatgpt_transports_for_browser_context_selector(
     recipe_vars: &std::collections::BTreeMap<String, String>,
     is_chatgpt: bool,
 ) -> Vec<browser::RecipeTransport> {
-    if !is_chatgpt || !recipe_uses_chatgpt_browser_context_selector(recipe_vars) {
+    if !is_chatgpt {
         return transports;
     }
 
+    if recipe_uses_exact_browser_context_selector(recipe_vars) {
+        return transports
+            .into_iter()
+            .filter(|transport| {
+                matches!(
+                    transport,
+                    browser::RecipeTransport::ChromeDevtoolsMcp | browser::RecipeTransport::Manual
+                )
+            })
+            .collect();
+    }
+
+    if recipe_uses_profile_email_selector(recipe_vars) {
+        return transports
+            .into_iter()
+            .filter(|transport| {
+                matches!(
+                    transport,
+                    browser::RecipeTransport::ChromeDevtoolsMcp
+                        | browser::RecipeTransport::AgentBrowser
+                        | browser::RecipeTransport::Manual
+                )
+            })
+            .collect();
+    }
+
     transports
-        .into_iter()
-        .filter(|transport| {
-            matches!(
-                transport,
-                browser::RecipeTransport::ChromeDevtoolsMcp | browser::RecipeTransport::Manual
-            )
-        })
-        .collect()
+}
+
+fn live_attach_owner_present(summary: &live_attach::DaemonSummary) -> bool {
+    matches!(
+        summary.health,
+        live_attach::DaemonHealth::Healthy | live_attach::DaemonHealth::Busy
+    )
+}
+
+fn should_prefer_running_profile_auto_connect(
+    selected_cdp_target: Option<&browser::ResolvedCdpTarget>,
+    live_attach_owner_is_present: bool,
+) -> bool {
+    // No healthy raw CDP target was selected, so prefer the running-profile
+    // transports before asking Chrome for a fresh live attach, unless yoetz
+    // already has a live-attach owner for the implicit/default path.
+    selected_cdp_target.is_none() && !live_attach_owner_is_present
+}
+
+fn maybe_print_running_profile_auto_connect_preference(
+    prefer_auto_connect: bool,
+    format: OutputFormat,
+) {
+    if prefer_auto_connect && matches!(format, OutputFormat::Text | OutputFormat::Markdown) {
+        eprintln!(
+            "info: no healthy raw Chrome DevTools target was discovered; reusing the running-profile auto-connect path instead of requesting a new raw CDP attach"
+        );
+    }
+}
+
+fn running_profile_recipe_transport_priority(transport: browser::RecipeTransport) -> u8 {
+    match transport {
+        browser::RecipeTransport::AgentBrowser => 0,
+        browser::RecipeTransport::DevBrowser => 1,
+        browser::RecipeTransport::ChromeDevtoolsMcp => 2,
+        browser::RecipeTransport::Manual => 3,
+    }
+}
+
+fn prioritize_chatgpt_transports_for_running_profile_auto_connect(
+    mut transports: Vec<browser::RecipeTransport>,
+    prefer_auto_connect: bool,
+) -> Vec<browser::RecipeTransport> {
+    if !prefer_auto_connect {
+        return transports;
+    }
+
+    transports.sort_by_key(|transport| running_profile_recipe_transport_priority(*transport));
+    transports
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1100,9 +1206,19 @@ enum BrowserCheckTransport {
 fn browser_check_transports(
     dev_browser_available: bool,
     managed_profile_only: bool,
+    prefer_auto_connect: bool,
 ) -> Vec<BrowserCheckTransport> {
     if managed_profile_only {
         return vec![BrowserCheckTransport::AgentBrowser];
+    }
+
+    if prefer_auto_connect {
+        let mut transports = vec![BrowserCheckTransport::AgentBrowser];
+        if dev_browser_available {
+            transports.push(BrowserCheckTransport::DevBrowser);
+        }
+        transports.push(BrowserCheckTransport::ChromeDevtoolsMcp);
+        return transports;
     }
 
     let mut transports = vec![BrowserCheckTransport::ChromeDevtoolsMcp];
@@ -1257,7 +1373,13 @@ fn should_demote_auto_selected_cdp_target(err: &anyhow::Error) -> bool {
         return false;
     }
     if browser::is_chatgpt_auth_issue_error(err) {
-        return false;
+        return true;
+    }
+    if browser::is_chatgpt_profile_selector_visibility_error(err) {
+        return true;
+    }
+    if browser::is_chatgpt_attached_page_error(err) {
+        return true;
     }
     if browser::is_chrome_cdp_unreachable_error(err) {
         return true;
@@ -1886,8 +2008,19 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
 
             let profile_dir =
                 browser::resolve_profile_dir(&ctx.browser_defaults, check_args.profile.as_ref())?;
-            let transports =
-                browser_check_transports(browser::use_dev_browser(), managed_profile_only);
+            let live_attach_owner_is_present =
+                live_attach_owner_present(&live_attach::inspect_daemon_sync());
+            let prefer_auto_connect = !managed_profile_only
+                && should_prefer_running_profile_auto_connect(
+                    resolved_cdp_target.as_ref(),
+                    live_attach_owner_is_present,
+                );
+            maybe_print_running_profile_auto_connect_preference(prefer_auto_connect, format);
+            let transports = browser_check_transports(
+                browser::use_dev_browser(),
+                managed_profile_only,
+                prefer_auto_connect,
+            );
             let mut prior_live_attach_failure: Option<String> = None;
 
             for transport in transports {
@@ -2177,6 +2310,11 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             let profile_dir =
                 browser::resolve_profile_dir(&ctx.browser_defaults, recipe_args.profile.as_ref())?;
             let is_chatgpt = is_chatgpt_recipe(&recipe, &recipe_path);
+            let managed_profile_only = profile_forces_managed_browser(
+                recipe_args.profile.as_deref(),
+                recipe_args.cdp.as_deref(),
+                recipe_args.browser_id.as_deref(),
+            );
             if is_chatgpt {
                 chatgpt_web::validate_thread_mode(recipe_vars.get("thread").map(String::as_str))?;
                 recipe_vars
@@ -2187,17 +2325,27 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 recipe_args.cdp.as_deref(),
                 recipe_args.browser_id.as_deref(),
                 &ctx.browser_defaults,
-                !profile_forces_managed_browser(
-                    recipe_args.profile.as_deref(),
-                    recipe_args.cdp.as_deref(),
-                    recipe_args.browser_id.as_deref(),
-                ),
+                !managed_profile_only,
             )?;
             maybe_print_auto_selected_cdp_target(resolved_cdp_target.as_ref(), format);
             let transports = constrain_chatgpt_transports_for_browser_context_selector(
                 browser::recipe_transports(&recipe, is_chatgpt),
                 &recipe_vars,
                 is_chatgpt,
+            );
+            let live_attach_owner_is_present =
+                live_attach_owner_present(&live_attach::inspect_daemon_sync());
+            let prefer_auto_connect = is_chatgpt
+                && !managed_profile_only
+                && !recipe_uses_exact_browser_context_selector(&recipe_vars)
+                && should_prefer_running_profile_auto_connect(
+                    resolved_cdp_target.as_ref(),
+                    live_attach_owner_is_present,
+                );
+            maybe_print_running_profile_auto_connect_preference(prefer_auto_connect, format);
+            let transports = prioritize_chatgpt_transports_for_running_profile_auto_connect(
+                transports,
+                prefer_auto_connect,
             );
             let manual_fallback =
                 manual_browser_recipe_fallback(&recipe_path, recipe_args.bundle.as_deref());
@@ -2325,7 +2473,6 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 .map(|target| target.endpoint.clone());
             let show_approval_guidance =
                 matches!(format, OutputFormat::Text | OutputFormat::Markdown);
-
             if resolved_cdp_target.is_some() {
                 match live_attach::ensure_chatgpt_session(
                     resolved_cdp_target.as_ref(),
@@ -2441,6 +2588,11 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                             || browser::is_chatgpt_auth_issue_error(&err)
                         {
                             return Err(err);
+                        }
+                        if matches!(format, OutputFormat::Text | OutputFormat::Markdown) {
+                            eprintln!(
+                                "info: live-attach owner setup failed ({err}); falling back to running-profile auto-connect"
+                            );
                         }
                     }
                 }
@@ -3091,13 +3243,19 @@ mod tests {
             "chatgpt login required in the attached Chrome session. Log in there and try again."
         );
         let vars = std::collections::BTreeMap::new();
-        assert!(recipe_should_stop_live_transport_fallback(
+        assert!(!recipe_should_stop_live_transport_fallback(
             &model_mismatch,
             None,
             browser::RecipeTransport::ChromeDevtoolsMcp,
             &vars,
         ));
         assert!(recipe_should_stop_live_transport_fallback(
+            &model_mismatch,
+            None,
+            browser::RecipeTransport::AgentBrowser,
+            &vars,
+        ));
+        assert!(!recipe_should_stop_live_transport_fallback(
             &auth_issue,
             None,
             browser::RecipeTransport::ChromeDevtoolsMcp,
@@ -3150,18 +3308,65 @@ mod tests {
     }
 
     #[test]
-    fn recipe_should_stop_profile_email_fallback_on_visibility_errors() {
+    fn recipe_should_stop_auth_issue_for_authoritative_target() {
         let err = anyhow!(
-            "profile_email `aviv.s@taboola.com` did not match any live Chrome browser context"
+            "chatgpt login required in the attached Chrome session. Log in there and try again."
         );
-        let vars = std::collections::BTreeMap::from([(
-            "profile_email".to_string(),
-            "aviv.s@taboola.com".to_string(),
+        let target = browser::resolve_cdp_target(
+            Some("ws://127.0.0.1:9222/devtools/browser/example"),
+            &browser::BrowserDefaults::default(),
+        )
+        .unwrap()
+        .unwrap();
+        let vars = std::collections::BTreeMap::new();
+        assert!(recipe_should_stop_live_transport_fallback(
+            &err,
+            Some(&target),
+            browser::RecipeTransport::ChromeDevtoolsMcp,
+            &vars,
+        ));
+    }
+
+    #[test]
+    fn recipe_should_stop_attached_page_errors_for_authoritative_target_or_exact_context() {
+        let err = anyhow!(
+            "requested ChatGPT model `pro` was not actually selected. Current page: url=https://chatgpt.com/, title=\"ChatGPT\""
+        );
+        let target = browser::resolve_cdp_target(
+            Some("ws://127.0.0.1:9222/devtools/browser/example"),
+            &browser::BrowserDefaults::default(),
+        )
+        .unwrap()
+        .unwrap();
+        let exact_context_vars = std::collections::BTreeMap::from([(
+            "browser_context_id".to_string(),
+            "ctx-123".to_string(),
         )]);
+        assert!(recipe_should_stop_live_transport_fallback(
+            &err,
+            Some(&target),
+            browser::RecipeTransport::ChromeDevtoolsMcp,
+            &std::collections::BTreeMap::new(),
+        ));
         assert!(recipe_should_stop_live_transport_fallback(
             &err,
             None,
             browser::RecipeTransport::ChromeDevtoolsMcp,
+            &exact_context_vars,
+        ));
+    }
+
+    #[test]
+    fn recipe_should_not_stop_dev_browser_page_errors_before_agent_browser() {
+        let err = anyhow!(
+            "{}",
+            r#"ChatGPT send button never became enabled after typing. {"send":"missing"}"#
+        );
+        let vars = std::collections::BTreeMap::new();
+        assert!(!recipe_should_stop_live_transport_fallback(
+            &err,
+            None,
+            browser::RecipeTransport::DevBrowser,
             &vars,
         ));
     }
@@ -3272,20 +3477,26 @@ mod tests {
     fn recipe_uses_chatgpt_browser_context_selector_detects_email_and_context_id() {
         let mut vars = std::collections::BTreeMap::new();
         assert!(!recipe_uses_chatgpt_browser_context_selector(&vars));
+        assert!(!recipe_uses_profile_email_selector(&vars));
+        assert!(!recipe_uses_exact_browser_context_selector(&vars));
 
         vars.insert(
             "profile_email".to_string(),
             "avivsinai@gmail.com".to_string(),
         );
         assert!(recipe_uses_chatgpt_browser_context_selector(&vars));
+        assert!(recipe_uses_profile_email_selector(&vars));
+        assert!(!recipe_uses_exact_browser_context_selector(&vars));
 
         vars.clear();
         vars.insert("browser_context_id".to_string(), "ctx-123".to_string());
         assert!(recipe_uses_chatgpt_browser_context_selector(&vars));
+        assert!(!recipe_uses_profile_email_selector(&vars));
+        assert!(recipe_uses_exact_browser_context_selector(&vars));
     }
 
     #[test]
-    fn constrain_chatgpt_transports_for_browser_context_selector_keeps_only_mcp_and_manual() {
+    fn constrain_chatgpt_transports_for_profile_email_keeps_agent_browser_available() {
         let mut vars = std::collections::BTreeMap::new();
         vars.insert(
             "profile_email".to_string(),
@@ -3305,6 +3516,7 @@ mod tests {
             transports,
             vec![
                 browser::RecipeTransport::ChromeDevtoolsMcp,
+                browser::RecipeTransport::AgentBrowser,
                 browser::RecipeTransport::Manual
             ]
         );
@@ -3336,16 +3548,127 @@ mod tests {
     }
 
     #[test]
-    fn browser_check_prefers_cdp_before_other_transports() {
+    fn recipe_should_not_stop_profile_email_fallback_on_advisory_live_target_visibility_errors() {
+        let err = anyhow!(
+            "profile_email `aviv.s@taboola.com` did not match any live Chrome browser context"
+        );
+        let vars = std::collections::BTreeMap::from([(
+            "profile_email".to_string(),
+            "aviv.s@taboola.com".to_string(),
+        )]);
+        assert!(!recipe_should_stop_live_transport_fallback(
+            &err,
+            None,
+            browser::RecipeTransport::ChromeDevtoolsMcp,
+            &vars,
+        ));
+    }
+
+    #[test]
+    fn prefer_running_profile_auto_connect_requires_implicit_target_and_no_live_owner() {
+        assert!(should_prefer_running_profile_auto_connect(None, false));
+        assert!(!should_prefer_running_profile_auto_connect(None, true));
+
+        let browser_defaults = browser::BrowserDefaults {
+            cdp: Some("ws://127.0.0.1:9222/devtools/browser/config".into()),
+            ..Default::default()
+        };
+        let configured = browser::resolve_cdp_target(None, &browser_defaults)
+            .unwrap()
+            .expect("configured target");
+        assert!(!should_prefer_running_profile_auto_connect(
+            Some(&configured),
+            false,
+        ));
+    }
+
+    #[test]
+    fn live_attach_owner_present_requires_healthy_or_busy_daemon() {
+        assert!(live_attach_owner_present(&live_attach::DaemonSummary {
+            health: live_attach::DaemonHealth::Healthy,
+            pid: Some(1),
+            session_count: 0,
+        }));
+        assert!(live_attach_owner_present(&live_attach::DaemonSummary {
+            health: live_attach::DaemonHealth::Healthy,
+            pid: Some(1),
+            session_count: 1,
+        }));
+        assert!(live_attach_owner_present(&live_attach::DaemonSummary {
+            health: live_attach::DaemonHealth::Busy,
+            pid: Some(1),
+            session_count: 0,
+        }));
+        assert!(!live_attach_owner_present(&live_attach::DaemonSummary {
+            health: live_attach::DaemonHealth::NotRunning,
+            pid: None,
+            session_count: 0,
+        }));
+    }
+
+    #[test]
+    fn prioritize_chatgpt_transports_for_running_profile_moves_raw_cdp_last() {
+        let transports = prioritize_chatgpt_transports_for_running_profile_auto_connect(
+            vec![
+                browser::RecipeTransport::ChromeDevtoolsMcp,
+                browser::RecipeTransport::DevBrowser,
+                browser::RecipeTransport::AgentBrowser,
+                browser::RecipeTransport::Manual,
+            ],
+            true,
+        );
         assert_eq!(
-            browser_check_transports(false, false),
+            transports,
+            vec![
+                browser::RecipeTransport::AgentBrowser,
+                browser::RecipeTransport::DevBrowser,
+                browser::RecipeTransport::ChromeDevtoolsMcp,
+                browser::RecipeTransport::Manual
+            ]
+        );
+    }
+
+    #[test]
+    fn prioritize_chatgpt_transports_for_running_profile_preserves_explicit_single_transport() {
+        let transports = prioritize_chatgpt_transports_for_running_profile_auto_connect(
+            vec![browser::RecipeTransport::ChromeDevtoolsMcp],
+            true,
+        );
+        assert_eq!(
+            transports,
+            vec![browser::RecipeTransport::ChromeDevtoolsMcp]
+        );
+    }
+
+    #[test]
+    fn prioritize_chatgpt_transports_for_running_profile_preserves_cdp_only_manual_fallback() {
+        let transports = prioritize_chatgpt_transports_for_running_profile_auto_connect(
+            vec![
+                browser::RecipeTransport::ChromeDevtoolsMcp,
+                browser::RecipeTransport::Manual,
+            ],
+            true,
+        );
+        assert_eq!(
+            transports,
+            vec![
+                browser::RecipeTransport::ChromeDevtoolsMcp,
+                browser::RecipeTransport::Manual
+            ]
+        );
+    }
+
+    #[test]
+    fn browser_check_orders_transports_by_mode() {
+        assert_eq!(
+            browser_check_transports(false, false, false),
             vec![
                 BrowserCheckTransport::ChromeDevtoolsMcp,
                 BrowserCheckTransport::AgentBrowser,
             ]
         );
         assert_eq!(
-            browser_check_transports(true, false),
+            browser_check_transports(true, false, false),
             vec![
                 BrowserCheckTransport::ChromeDevtoolsMcp,
                 BrowserCheckTransport::DevBrowser,
@@ -3353,8 +3676,16 @@ mod tests {
             ]
         );
         assert_eq!(
-            browser_check_transports(true, true),
+            browser_check_transports(true, true, false),
             vec![BrowserCheckTransport::AgentBrowser]
+        );
+        assert_eq!(
+            browser_check_transports(true, false, true),
+            vec![
+                BrowserCheckTransport::AgentBrowser,
+                BrowserCheckTransport::DevBrowser,
+                BrowserCheckTransport::ChromeDevtoolsMcp,
+            ]
         );
     }
 
@@ -3400,15 +3731,15 @@ mod tests {
     }
 
     #[test]
-    fn auto_selected_cdp_target_is_not_demoted_for_chatgpt_ui_auth_issues() {
+    fn auto_selected_cdp_target_is_demoted_for_chatgpt_ui_auth_issues() {
         let login_err = anyhow!(
             "chatgpt login required in the attached Chrome session. Log in there and try again."
         );
         let challenge_err = anyhow!(
             "cloudflare challenge detected in the attached Chrome session. Solve it in your browser window and try again."
         );
-        assert!(!should_demote_auto_selected_cdp_target(&login_err));
-        assert!(!should_demote_auto_selected_cdp_target(&challenge_err));
+        assert!(should_demote_auto_selected_cdp_target(&login_err));
+        assert!(should_demote_auto_selected_cdp_target(&challenge_err));
     }
 
     #[test]
@@ -3418,8 +3749,19 @@ mod tests {
         );
         let dev_browser_err =
             anyhow!("browser.newPage: Timeout 30000ms exceeded while waiting for connectOverCDP");
+        let profile_selector_err = anyhow!(
+            "profile_email `aviv.s@taboola.com` did not match any live Chrome browser context"
+        );
+        let page_err = anyhow!(
+            "{}",
+            r#"ChatGPT send button never became enabled after typing. {"send":"missing"}"#
+        );
         assert!(should_demote_auto_selected_cdp_target(&cdp_err));
         assert!(should_demote_auto_selected_cdp_target(&dev_browser_err));
+        assert!(should_demote_auto_selected_cdp_target(
+            &profile_selector_err
+        ));
+        assert!(should_demote_auto_selected_cdp_target(&page_err));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- fail closed on implicit running-profile auto-connect instead of cascading into other transports or a managed profile
- raise the default model timeout to 180 seconds for long reasoning reviews
- pin litellm-rust to the released v0.1.2 tag with the OpenRouter/Kimi timeout and reasoning fallback fixes

## Verification
- cargo test -p yoetz
- cargo clippy -p yoetz --all-targets -- -D warnings
- cargo build -p yoetz
- env YOETZ_AGENT=1 ./target/debug/yoetz ask ... --provider openrouter --model moonshotai/kimi-k2.6 --format json