### PR TITLE
fix(browser): Reduce running-profile approval churn and prefer MCP on Chrome 147

### DIFF
--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -5,7 +5,7 @@ use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use std::env;
 use std::fs::{self, File, OpenOptions};
-use std::io::{self, IsTerminal, Read};
+use std::io::{self, IsTerminal};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
@@ -3597,98 +3597,6 @@ pub fn try_auto_connect(target_url: &str) -> Result<()> {
     verify_auth_cdp(target_url, &connection)
 }
 
-pub fn try_cdp_attach_lite(endpoint: &str) -> Result<()> {
-    let connection = BrowserConnection::Cdp {
-        endpoint: endpoint.to_string(),
-    };
-    probe_live_attach_connection(&connection).map_err(|e| {
-        if allow_dialog_error(&e) {
-            e
-        } else if should_attach_chrome136_warning(endpoint, &e) {
-            e.context(chrome136_cdp_warning(endpoint))
-        } else {
-            e
-        }
-    })
-}
-
-/// Lightweight auto-connect check: verifies Chrome is reachable via
-/// auto-connect without opening new tabs. Used by the recipe path where
-/// the recipe itself handles navigation and auth detection.
-///
-/// Returns immediately if an existing daemon is healthy. Otherwise spawns
-/// a bounded probe so the CLI does not hang indefinitely on approval-gated
-/// CDP connections.
-pub fn try_auto_connect_lite() -> Result<()> {
-    if is_daemon_healthy() {
-        return Ok(());
-    }
-    let connection = BrowserConnection::AutoConnect;
-    probe_live_attach_connection(&connection)
-}
-
-fn probe_live_attach_connection(connection: &BrowserConnection) -> Result<()> {
-    if !connection.is_live_attach() {
-        return Err(anyhow!(
-            "probe_live_attach_connection requires a live browser connection"
-        ));
-    }
-    let (bin, prefix_args) = resolve_agent_browser()?;
-    let args = build_agent_browser_args(
-        vec!["snapshot".to_string(), "-c".to_string()],
-        OutputFormat::Text,
-        Some(connection),
-        /* use_stealth */ false,
-        /* headed */ false,
-    );
-    let mut all_args = prefix_args;
-    all_args.extend(args);
-
-    let mut child = Command::new(&bin)
-        .args(&all_args)
-        .env("AGENT_BROWSER_DEFAULT_TIMEOUT", "10000")
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .with_context(|| format!("failed to spawn agent-browser (via {bin})"))?;
-
-    let timeout = Duration::from_secs(15);
-    let start = Instant::now();
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                if status.success() {
-                    return Ok(());
-                }
-                let stderr = child
-                    .stderr
-                    .as_mut()
-                    .map(|stream| {
-                        let mut buf = String::new();
-                        let _ = stream.read_to_string(&mut buf);
-                        buf
-                    })
-                    .unwrap_or_default();
-                return Err(anyhow!("live browser reachability probe failed: {stderr}"));
-            }
-            Ok(None) => {
-                if start.elapsed() > timeout {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return Err(anyhow!(
-                        "live browser reachability probe timed out ({}s). \
-                         Chrome may be showing an \"Allow remote debugging?\" dialog — \
-                         please click Allow in Chrome to authorize the connection",
-                        timeout.as_secs()
-                    ));
-                }
-                thread::sleep(Duration::from_millis(200));
-            }
-            Err(err) => return Err(anyhow!("live browser reachability probe error: {err}")),
-        }
-    }
-}
-
 fn clear_browser_target_state() -> Result<()> {
     let path = browser_target_state_path();
     match fs::remove_file(&path) {
@@ -4105,14 +4013,18 @@ fn allow_dialog_error(err: &anyhow::Error) -> bool {
     err.to_string().contains("Allow remote debugging")
 }
 
+fn live_attach_approval_wait_error(timeout_ms: u64) -> anyhow::Error {
+    anyhow!(
+        "live browser attach timed out ({}s). Chrome may be showing an \"Allow remote debugging?\" dialog — please click Allow in Chrome, then retry.",
+        timeout_ms / 1000
+    )
+}
+
 fn rewrite_live_attach_timeout(err: anyhow::Error) -> anyhow::Error {
     if !looks_like_timeout(&err) {
         return err;
     }
-    anyhow!(
-        "live browser attach timed out ({}s). Chrome may be showing an \"Allow remote debugging?\" dialog — please click Allow in Chrome, then retry.",
-        LIVE_ATTACH_COMMAND_TIMEOUT_MS / 1000
-    )
+    live_attach_approval_wait_error(LIVE_ATTACH_COMMAND_TIMEOUT_MS)
 }
 
 fn auth_check_timeout_ms(connection: &BrowserConnection) -> u64 {

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -518,12 +518,10 @@ console.log("ok:" + pages.length);
         Ok(stdout) if stdout.trim().starts_with("ok:") => Ok(()),
         Ok(stdout) => Err(anyhow!("dev-browser connection check failed: {stdout}")),
         Err(first_err) => {
-            let msg = format!("{first_err:#}");
-            let is_timeout = msg.contains("Timeout") || msg.contains("timed out");
-            if !is_timeout {
+            if !is_dev_browser_connect_failure(&first_err) {
                 return Err(first_err.context("dev-browser connection check failed"));
             }
-            eprintln!("info: dev-browser connection timed out, retrying with longer timeout");
+            eprintln!("info: dev-browser connection check failed, retrying with longer timeout");
             std::thread::sleep(std::time::Duration::from_secs(2));
             let stdout = run_script_connect_with_browser_and_endpoint(
                 script,
@@ -549,13 +547,7 @@ fn build_chatgpt_auth_probe_script(page_name: &str) -> String {
 const PAGE_NAME = {page_name_json};
 const CHATGPT_URL = {chatgpt_url_json};
 const normalize = (value) => String(value || "").replace(/\s+/g, " ").trim();
-const pages = await browser.listPages();
-const chatgptPage =
-  pages.find((entry) => entry.name === PAGE_NAME) ||
-  pages.find((entry) => normalize(entry.url).toLowerCase().includes("chatgpt.com"));
-const page = chatgptPage
-  ? await browser.getPage(chatgptPage.name || chatgptPage.id)
-  : await browser.getPage(PAGE_NAME);
+const page = await browser.getPage(PAGE_NAME);
 const currentUrl = normalize(page.url()).toLowerCase();
 if (!currentUrl.includes("chatgpt.com")) {{
   await page.goto(CHATGPT_URL, {{ waitUntil: "domcontentloaded" }});
@@ -710,12 +702,20 @@ fn parse_positive_u64_var(vars: &BTreeMap<String, String>, key: &str) -> Result<
 
 pub(crate) fn is_dev_browser_connect_failure(err: &anyhow::Error) -> bool {
     let message = format!("{err:#}").to_lowercase();
-    (message.contains("connectovercdp")
+    let has_connect_hint = message.contains("connectovercdp")
         || message.contains("auto-connect")
         || message.contains("auto connect")
         || message.contains("could not connect to chrome")
-        || message.contains("browser.getversion"))
-        && (message.contains("timed out") || message.contains("timeout"))
+        || message.contains("browser.getversion")
+        || message.contains("target.setautoattach");
+    let has_connection_failure = message.contains("timed out")
+        || message.contains("timeout")
+        || message.contains("connectionclosed")
+        || message.contains("underlying connection is closed")
+        || message.contains("connection refused")
+        || message.contains("socket hang up")
+        || message.contains("closed");
+    has_connect_hint && has_connection_failure
 }
 
 fn maybe_add_dev_browser_connect_guidance(err: anyhow::Error) -> anyhow::Error {
@@ -1596,6 +1596,11 @@ mod tests {
             anyhow!("browser.newPage: Timeout 30000ms exceeded while waiting for connectOverCDP");
         assert!(is_dev_browser_connect_failure(&err));
 
+        let without_timeout = anyhow!(
+            "browserType.connectOverCDP: connection closed while waiting for connectOverCDP"
+        );
+        assert!(is_dev_browser_connect_failure(&without_timeout));
+
         let other = anyhow!("ChatGPT response timed out after 900000ms");
         assert!(!is_dev_browser_connect_failure(&other));
     }
@@ -1758,19 +1763,19 @@ mod tests {
     }
 
     #[test]
-    fn chatgpt_auth_probe_script_reuses_named_page_and_existing_tabs() {
+    fn chatgpt_auth_probe_script_uses_exact_named_page_only() {
         let script = build_chatgpt_auth_probe_script("yoetz-chatgpt-test");
 
         assert!(script.contains("const PAGE_NAME = \"yoetz-chatgpt-test\";"));
-        assert!(script.contains("const pages = await browser.listPages();"));
-        assert!(script.contains("pages.find((entry) => entry.name === PAGE_NAME)"));
-        assert!(script.contains("await browser.getPage(chatgptPage.name || chatgptPage.id)"));
         assert!(script.contains("await browser.getPage(PAGE_NAME)"));
         assert!(
             script.contains("await page.goto(CHATGPT_URL, { waitUntil: \"domcontentloaded\" });")
         );
         assert!(script.contains("bodyText"));
         assert!(!script.contains("browser.newPage()"));
+        assert!(!script.contains(
+            "pages.find((entry) => normalize(entry.url).toLowerCase().includes(\"chatgpt.com\"))"
+        ));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -518,7 +518,7 @@ console.log("ok:" + pages.length);
         Ok(stdout) if stdout.trim().starts_with("ok:") => Ok(()),
         Ok(stdout) => Err(anyhow!("dev-browser connection check failed: {stdout}")),
         Err(first_err) => {
-            if !is_dev_browser_connect_failure(&first_err) {
+            if !should_retry_dev_browser_connect_failure(&first_err) {
                 return Err(first_err.context("dev-browser connection check failed"));
             }
             eprintln!("info: dev-browser connection check failed, retrying with longer timeout");
@@ -716,6 +716,16 @@ pub(crate) fn is_dev_browser_connect_failure(err: &anyhow::Error) -> bool {
         || message.contains("socket hang up")
         || message.contains("closed");
     has_connect_hint && has_connection_failure
+}
+
+fn is_dev_browser_target_auto_attach_failure(err: &anyhow::Error) -> bool {
+    format!("{err:#}")
+        .to_lowercase()
+        .contains("target.setautoattach")
+}
+
+fn should_retry_dev_browser_connect_failure(err: &anyhow::Error) -> bool {
+    is_dev_browser_connect_failure(err) && !is_dev_browser_target_auto_attach_failure(err)
 }
 
 fn maybe_add_dev_browser_connect_guidance(err: anyhow::Error) -> anyhow::Error {
@@ -1595,14 +1605,22 @@ mod tests {
         let err =
             anyhow!("browser.newPage: Timeout 30000ms exceeded while waiting for connectOverCDP");
         assert!(is_dev_browser_connect_failure(&err));
+        assert!(should_retry_dev_browser_connect_failure(&err));
 
         let without_timeout = anyhow!(
             "browserType.connectOverCDP: connection closed while waiting for connectOverCDP"
         );
         assert!(is_dev_browser_connect_failure(&without_timeout));
+        assert!(should_retry_dev_browser_connect_failure(&without_timeout));
+
+        let auto_attach_hang =
+            anyhow!("browserType.connectOverCDP: Target.setAutoAttach timed out after 30000ms");
+        assert!(is_dev_browser_connect_failure(&auto_attach_hang));
+        assert!(!should_retry_dev_browser_connect_failure(&auto_attach_hang));
 
         let other = anyhow!("ChatGPT response timed out after 900000ms");
         assert!(!is_dev_browser_connect_failure(&other));
+        assert!(!should_retry_dev_browser_connect_failure(&other));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -1271,6 +1271,36 @@ fn maybe_prefer_browser_check_live_attach_failure(
     err
 }
 
+fn browser_check_exhausted_error(
+    errors: &[(BrowserCheckTransport, String)],
+    prior_live_attach_failure: Option<&str>,
+) -> anyhow::Error {
+    let attempted = errors
+        .iter()
+        .map(|(transport, detail)| {
+            format!("{}: {detail}", browser_check_transport_name(*transport))
+        })
+        .collect::<Vec<_>>();
+    let attempted = if attempted.is_empty() {
+        "none".to_string()
+    } else {
+        attempted.join("\n- ")
+    };
+
+    if let Some(prior) = prior_live_attach_failure {
+        return anyhow!(
+            "browser check failed; no browser check transport succeeded.\n\n\
+             Live-attach error: {prior}\n\n\
+             Attempted transports:\n- {attempted}"
+        );
+    }
+
+    anyhow!(
+        "browser check failed; no browser check transport succeeded.\n\n\
+         Attempted transports:\n- {attempted}"
+    )
+}
+
 fn maybe_print_auto_selected_cdp_target(
     target: Option<&browser::ResolvedCdpTarget>,
     format: OutputFormat,
@@ -1972,6 +2002,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 prefer_auto_connect,
             );
             let mut prior_live_attach_failure: Option<String> = None;
+            let mut check_errors: Vec<(BrowserCheckTransport, String)> = Vec::new();
 
             for transport in transports {
                 match transport {
@@ -2043,6 +2074,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                                     "info: {} auth check failed ({e}), trying next transport",
                                     browser_check_transport_name(transport)
                                 );
+                                check_errors.push((transport, format!("{e:#}")));
                             }
                         }
                     }
@@ -2108,6 +2140,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                                     "info: {} auth check failed ({e}), trying next transport",
                                     browser_check_transport_name(transport)
                                 );
+                                check_errors.push((transport, format!("{e:#}")));
                             }
                         }
                     }
@@ -2182,7 +2215,10 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 }
             }
 
-            unreachable!("browser check transport list must include a fallback transport")
+            Err(browser_check_exhausted_error(
+                &check_errors,
+                prior_live_attach_failure.as_deref(),
+            ))
         }
         BrowserCommand::Doctor(args) => {
             let report = browser::browser_doctor_report(args.live);
@@ -3718,6 +3754,24 @@ mod tests {
             err.to_string(),
             "chatgpt login required. Run `yoetz browser login` and try again."
         );
+    }
+
+    #[test]
+    fn browser_check_exhaustion_reports_dev_browser_failure() {
+        let errors = vec![(
+            BrowserCheckTransport::DevBrowser,
+            "dev-browser connection check failed: Target.setAutoAttach connection closed"
+                .to_string(),
+        )];
+        let err = browser_check_exhausted_error(
+            &errors,
+            Some("dev-browser could not connect to Chrome before managed fallback"),
+        );
+        let message = format!("{err:#}");
+        assert!(message.contains("browser check failed"));
+        assert!(message.contains("dev-browser"));
+        assert!(message.contains("Target.setAutoAttach connection closed"));
+        assert!(message.contains("dev-browser could not connect to Chrome"));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -979,20 +979,6 @@ fn recipe_transport_error_detail(err: &anyhow::Error) -> String {
     format!("{err:#}")
 }
 
-fn print_recipe_chrome_approval_message(transport: browser::RecipeTransport) {
-    eprintln!(
-        "info: connecting to Chrome via {} — if prompted, click Allow in Chrome's remote debugging dialog",
-        recipe_transport_name(transport)
-    );
-}
-
-fn print_recipe_chrome_approval_lock_wait_message(transport: browser::RecipeTransport) {
-    eprintln!(
-        "info: another yoetz process is already requesting Chrome approval; waiting for it to finish before trying the {} transport",
-        recipe_transport_name(transport)
-    );
-}
-
 fn recipe_has_remaining_manual_fallback(
     transports: &[browser::RecipeTransport],
     current_index: usize,
@@ -1148,10 +1134,8 @@ fn constrain_chatgpt_transports_for_browser_context_selector(
 }
 
 fn live_attach_owner_present(summary: &live_attach::DaemonSummary) -> bool {
-    matches!(
-        summary.health,
-        live_attach::DaemonHealth::Healthy | live_attach::DaemonHealth::Busy
-    )
+    matches!(summary.health, live_attach::DaemonHealth::Busy)
+        || matches!(summary.health, live_attach::DaemonHealth::Healthy) && summary.session_count > 0
 }
 
 fn should_prefer_running_profile_auto_connect(
@@ -1192,8 +1176,16 @@ fn prioritize_chatgpt_transports_for_running_profile_auto_connect(
         return transports;
     }
 
+    let has_dev_browser = transports.contains(&browser::RecipeTransport::DevBrowser);
     let has_agent_browser = transports.contains(&browser::RecipeTransport::AgentBrowser);
     let has_manual = transports.contains(&browser::RecipeTransport::Manual);
+    if has_dev_browser {
+        let mut constrained = vec![browser::RecipeTransport::DevBrowser];
+        if has_manual {
+            constrained.push(browser::RecipeTransport::Manual);
+        }
+        return constrained;
+    }
     if has_agent_browser {
         let mut constrained = vec![browser::RecipeTransport::AgentBrowser];
         if has_manual {
@@ -1224,7 +1216,9 @@ fn browser_check_transports(
     }
 
     if prefer_auto_connect {
-        let _ = dev_browser_available;
+        if dev_browser_available {
+            return vec![BrowserCheckTransport::DevBrowser];
+        }
         return vec![BrowserCheckTransport::AgentBrowser];
     }
 
@@ -1704,72 +1698,16 @@ fn run_recipe_via_agent_browser(
             recipe_args.browser_id.as_deref(),
         ) {
             None
+        } else if let Some(target) = selected_cdp_target.as_ref().cloned() {
+            Some(browser::BrowserConnection::Cdp {
+                endpoint: target.endpoint,
+            })
+        } else if prefer_auto_connect {
+            // Avoid a separate auto-connect probe here. The recipe run should
+            // establish the single running-profile live session we keep.
+            Some(browser::BrowserConnection::AutoConnect)
         } else {
-            let mut selected_live_connection = None;
-            if let Some(target) = selected_cdp_target.as_ref().cloned() {
-                let endpoint = target.endpoint.clone();
-                let approval_lock = browser::acquire_chrome_approval_lock()?;
-                if matches!(format, OutputFormat::Text | OutputFormat::Markdown) {
-                    if approval_lock.waited() {
-                        print_recipe_chrome_approval_lock_wait_message(
-                            browser::RecipeTransport::AgentBrowser,
-                        );
-                    }
-                    print_recipe_chrome_approval_message(browser::RecipeTransport::AgentBrowser);
-                }
-                match browser::try_cdp_attach_lite(&endpoint) {
-                    Ok(()) => {
-                        selected_live_connection =
-                            Some(browser::BrowserConnection::Cdp { endpoint });
-                    }
-                    Err(e) => {
-                        if browser::is_chrome_approval_wait_error(&e) {
-                            return Err(anyhow!(
-                                "Chrome may be showing an \"Allow remote debugging?\" dialog. Click Allow, then retry."
-                            ));
-                        } else if target.is_authoritative() {
-                            return Err(resolved_cdp_attach_failure(e, &target));
-                        }
-                        maybe_demote_auto_selected_cdp_target(selected_cdp_target, format, &e);
-                    }
-                }
-            }
-
-            if let Some(connection) = selected_live_connection {
-                Some(connection)
-            } else {
-                let approval_lock = browser::acquire_chrome_approval_lock()?;
-                let should_warn_about_approval = !browser::is_daemon_healthy();
-                if matches!(format, OutputFormat::Text | OutputFormat::Markdown) {
-                    if approval_lock.waited() {
-                        print_recipe_chrome_approval_lock_wait_message(
-                            browser::RecipeTransport::AgentBrowser,
-                        );
-                    }
-                    if should_warn_about_approval {
-                        print_recipe_chrome_approval_message(
-                            browser::RecipeTransport::AgentBrowser,
-                        );
-                    }
-                }
-                match browser::try_auto_connect_lite() {
-                    Ok(()) => Some(browser::BrowserConnection::AutoConnect),
-                    Err(err) => {
-                        if browser::is_chrome_approval_wait_error(&err) {
-                            return Err(err);
-                        } else if let Some(recovery) = default_daemon_recovery_error(Some(&err)) {
-                            return Err(recovery);
-                        } else if prefer_auto_connect {
-                            return Err(anyhow!(
-                                "running-profile auto-connect was unavailable ({err}). yoetz will not fall back to a managed profile for this run."
-                            ));
-                        } else {
-                            eprintln!("info: auto-connect unavailable, falling back to profile");
-                            None
-                        }
-                    }
-                }
-            }
+            None
         }
     } else {
         None
@@ -2499,6 +2437,13 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 .map(|target| target.endpoint.clone());
             let show_approval_guidance =
                 matches!(format, OutputFormat::Text | OutputFormat::Markdown);
+            let live_attach_owner_is_present =
+                live_attach_owner_present(&live_attach::inspect_daemon_sync());
+            let prefer_auto_connect = should_prefer_running_profile_auto_connect(
+                resolved_cdp_target.as_ref(),
+                live_attach_owner_is_present,
+            );
+            maybe_print_running_profile_auto_connect_preference(prefer_auto_connect, format);
             if resolved_cdp_target.is_some() {
                 match live_attach::ensure_chatgpt_session(
                     resolved_cdp_target.as_ref(),
@@ -2581,7 +2526,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 }
             }
 
-            if resolved_cdp_target.is_none() {
+            if resolved_cdp_target.is_none() && !prefer_auto_connect {
                 match live_attach::ensure_chatgpt_session(None, None, None, show_approval_guidance)
                     .await
                 {
@@ -3609,8 +3554,8 @@ mod tests {
     }
 
     #[test]
-    fn live_attach_owner_present_requires_healthy_or_busy_daemon() {
-        assert!(live_attach_owner_present(&live_attach::DaemonSummary {
+    fn live_attach_owner_present_requires_attached_session_or_busy_daemon() {
+        assert!(!live_attach_owner_present(&live_attach::DaemonSummary {
             health: live_attach::DaemonHealth::Healthy,
             pid: Some(1),
             session_count: 0,
@@ -3633,7 +3578,8 @@ mod tests {
     }
 
     #[test]
-    fn prioritize_chatgpt_transports_for_running_profile_constrains_to_agent_browser_and_manual() {
+    fn prioritize_chatgpt_transports_for_running_profile_prefers_dev_browser_and_drops_other_live_owners(
+    ) {
         let transports = prioritize_chatgpt_transports_for_running_profile_auto_connect(
             vec![
                 browser::RecipeTransport::ChromeDevtoolsMcp,
@@ -3646,7 +3592,27 @@ mod tests {
         assert_eq!(
             transports,
             vec![
-                browser::RecipeTransport::AgentBrowser,
+                browser::RecipeTransport::DevBrowser,
+                browser::RecipeTransport::Manual
+            ]
+        );
+    }
+
+    #[test]
+    fn prioritize_chatgpt_transports_for_running_profile_falls_back_to_dev_browser_when_agent_browser_is_unavailable(
+    ) {
+        let transports = prioritize_chatgpt_transports_for_running_profile_auto_connect(
+            vec![
+                browser::RecipeTransport::ChromeDevtoolsMcp,
+                browser::RecipeTransport::DevBrowser,
+                browser::RecipeTransport::Manual,
+            ],
+            true,
+        );
+        assert_eq!(
+            transports,
+            vec![
+                browser::RecipeTransport::DevBrowser,
                 browser::RecipeTransport::Manual
             ]
         );
@@ -3705,6 +3671,10 @@ mod tests {
         );
         assert_eq!(
             browser_check_transports(true, false, true),
+            vec![BrowserCheckTransport::DevBrowser]
+        );
+        assert_eq!(
+            browser_check_transports(false, false, true),
             vec![BrowserCheckTransport::AgentBrowser]
         );
     }

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -1161,9 +1161,9 @@ fn maybe_print_running_profile_auto_connect_preference(
 
 fn running_profile_recipe_transport_priority(transport: browser::RecipeTransport) -> u8 {
     match transport {
-        browser::RecipeTransport::AgentBrowser => 0,
+        browser::RecipeTransport::ChromeDevtoolsMcp => 0,
         browser::RecipeTransport::DevBrowser => 1,
-        browser::RecipeTransport::ChromeDevtoolsMcp => 2,
+        browser::RecipeTransport::AgentBrowser => 2,
         browser::RecipeTransport::Manual => 3,
     }
 }
@@ -1177,8 +1177,19 @@ fn prioritize_chatgpt_transports_for_running_profile_auto_connect(
     }
 
     let has_dev_browser = transports.contains(&browser::RecipeTransport::DevBrowser);
+    let has_chrome_devtools_mcp = transports.contains(&browser::RecipeTransport::ChromeDevtoolsMcp);
     let has_agent_browser = transports.contains(&browser::RecipeTransport::AgentBrowser);
     let has_manual = transports.contains(&browser::RecipeTransport::Manual);
+    if has_chrome_devtools_mcp {
+        let mut constrained = vec![browser::RecipeTransport::ChromeDevtoolsMcp];
+        if has_dev_browser {
+            constrained.push(browser::RecipeTransport::DevBrowser);
+        }
+        if has_manual {
+            constrained.push(browser::RecipeTransport::Manual);
+        }
+        return constrained;
+    }
     if has_dev_browser {
         let mut constrained = vec![browser::RecipeTransport::DevBrowser];
         if has_manual {
@@ -1216,10 +1227,11 @@ fn browser_check_transports(
     }
 
     if prefer_auto_connect {
+        let mut transports = vec![BrowserCheckTransport::ChromeDevtoolsMcp];
         if dev_browser_available {
-            return vec![BrowserCheckTransport::DevBrowser];
+            transports.push(BrowserCheckTransport::DevBrowser);
         }
-        return vec![BrowserCheckTransport::AgentBrowser];
+        return transports;
     }
 
     let mut transports = vec![BrowserCheckTransport::ChromeDevtoolsMcp];
@@ -3614,7 +3626,7 @@ mod tests {
     }
 
     #[test]
-    fn prioritize_chatgpt_transports_for_running_profile_prefers_dev_browser_and_drops_other_live_owners(
+    fn prioritize_chatgpt_transports_for_running_profile_prefers_mcp_then_dev_browser_and_drops_agent_browser(
     ) {
         let transports = prioritize_chatgpt_transports_for_running_profile_auto_connect(
             vec![
@@ -3628,6 +3640,7 @@ mod tests {
         assert_eq!(
             transports,
             vec![
+                browser::RecipeTransport::ChromeDevtoolsMcp,
                 browser::RecipeTransport::DevBrowser,
                 browser::RecipeTransport::Manual
             ]
@@ -3635,7 +3648,7 @@ mod tests {
     }
 
     #[test]
-    fn prioritize_chatgpt_transports_for_running_profile_falls_back_to_dev_browser_when_agent_browser_is_unavailable(
+    fn prioritize_chatgpt_transports_for_running_profile_keeps_mcp_before_dev_browser_when_agent_browser_is_unavailable(
     ) {
         let transports = prioritize_chatgpt_transports_for_running_profile_auto_connect(
             vec![
@@ -3648,6 +3661,7 @@ mod tests {
         assert_eq!(
             transports,
             vec![
+                browser::RecipeTransport::ChromeDevtoolsMcp,
                 browser::RecipeTransport::DevBrowser,
                 browser::RecipeTransport::Manual
             ]
@@ -3707,11 +3721,14 @@ mod tests {
         );
         assert_eq!(
             browser_check_transports(true, false, true),
-            vec![BrowserCheckTransport::DevBrowser]
+            vec![
+                BrowserCheckTransport::ChromeDevtoolsMcp,
+                BrowserCheckTransport::DevBrowser
+            ]
         );
         assert_eq!(
             browser_check_transports(false, false, true),
-            vec![BrowserCheckTransport::AgentBrowser]
+            vec![BrowserCheckTransport::ChromeDevtoolsMcp]
         );
     }
 


### PR DESCRIPTION
## Summary

Running-profile ChatGPT recipe/check path was firing multiple Chrome remote-debugging approval popups and cascading across transports. This branch reworks the live-attach supervisor so a single consent grant carries one session through MCP, with no duplicate popups and no silent daemon recycling.

Three commits:
- `d53847d` — reduce running-profile approval churn. Remove the agent-browser recipe path's `try_cdp_attach_lite` / `try_auto_connect_lite` probe subprocesses, approval locks, and per-recipe approval prints. Tighten `live_attach_owner_present` so a Healthy + 0-session daemon no longer masquerades as an owner. Guard `BrowserCommand::Attach`'s implicit `ensure_chatgpt_session(None, ...)` behind `!prefer_auto_connect` so it only refreshes an existing daemon session. Narrow the ChatGPT auth probe script to the exact named page.
- `7e32ff3` — return a structured error when `browser check` exhausts its transport list (`browser_check_exhausted_error`), replacing an `unreachable!` that would panic when the new single-transport list failed.
- `a93646e` — prefer `chrome-devtools-mcp` first in both `prioritize_chatgpt_transports_for_running_profile_auto_connect` and `browser_check_transports` when `prefer_auto_connect=true`. MCP is the only transport that works against Chrome 147 default profile (vendored direct CDP client; never calls root `Target.setAutoAttach`). DevBrowser stays as fallback for Chrome ≤146 / Chrome for Testing. Classify `Target.setAutoAttach` timeouts as non-retryable connect failures so we do not fire a second `connectOverCDP` and trigger a second approval popup.

## Live verification

Against Chrome 147.0.7727.102 default profile with `chrome://inspect` remote debugging enabled:

```
$ yoetz --format json browser check
{
  \"method\": \"auto_connect\",
  \"status\": \"ok\",
  \"transport\": \"chrome-devtools-mcp\"
}
```

One Allow prompt, clean success. Also smoke-tested end-to-end by running \`yoetz browser recipe --recipe chatgpt\` — the recipe connected via MCP, submitted a prompt, and ChatGPT Pro responded in full. No duplicate popups, no transport fanout.

Automated gates:
- \`cargo test -p yoetz\` — 367 passed, 2 ignored
- \`cargo test\` (full workspace) — green
- \`cargo clippy --all-targets -- -D warnings\` — clean

## Follow-ups (not in this PR)

- \`agent-browser 0.25.4\` is Rust-native and does not call root \`Target.setAutoAttach\` per code inspection at \`vercel/agent-browser/cli/src/native/browser.rs:325\`, but a live probe against the same Chrome 147 default profile still hangs inside \`discover_and_attach_targets\`. Separate investigation.
- dev-browser's Playwright \`connectOverCDP\` cannot be made to work against Chrome 147 default profile via a one-line root-\`setAutoAttach\` skip — Playwright's page/context graph depends on the resulting \`attachedToTarget\` events. The right fix is a small vendored Node CDP client for the live-attach backend only (keep Playwright for managed profiles). Tracked as a follow-up issue.

## Test plan

- [x] \`yoetz browser check\` against Chrome 147 default profile returns transport \"chrome-devtools-mcp\"
- [x] \`yoetz browser recipe --recipe chatgpt\` end-to-end submit + response against Chrome 147 default profile
- [x] \`cargo test -p yoetz\` / full test suite green
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] Codex peer-reviewed all three commits

Co-authored with codex on root-cause finding for the transport-priority inversion and the structured \`browser_check_exhausted_error\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)