### PR TITLE
fix(browser): Recognize live-CDP daemon timeout strings

### DIFF
--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -2077,9 +2077,8 @@ pub fn acquire_chrome_approval_lock() -> Result<ChromeApprovalLock> {
 }
 
 pub fn is_chrome_approval_wait_error(err: &anyhow::Error) -> bool {
-    format!("{err:#}")
-        .to_lowercase()
-        .contains("allow remote debugging")
+    let message = format!("{err:#}").to_lowercase();
+    message.contains("allow remote debugging") || message.contains("remote-debugging consent")
 }
 
 /// Detect the actionable "Chrome CDP unreachable" error produced by
@@ -4010,7 +4009,8 @@ fn looks_like_timeout(err: &anyhow::Error) -> bool {
 }
 
 fn allow_dialog_error(err: &anyhow::Error) -> bool {
-    err.to_string().contains("Allow remote debugging")
+    let message = err.to_string();
+    message.contains("Allow remote debugging") || message.contains("remote-debugging consent")
 }
 
 fn live_attach_approval_wait_error(timeout_ms: u64) -> anyhow::Error {
@@ -5964,6 +5964,16 @@ browser_cdp = "http://evil.example.com:9222"
     fn is_chrome_approval_wait_error_rejects_non_approval_timeouts() {
         let err = anyhow!("ChatGPT response timed out after 900000ms");
         assert!(!is_chrome_approval_wait_error(&err));
+    }
+
+    #[test]
+    fn is_chrome_approval_wait_error_matches_live_cdp_consent_phrase() {
+        let err = anyhow!(
+            "Timed out after 5000ms initializing live CDP browser during Target.getTargets. \
+             Chrome may be waiting for remote-debugging consent or a target may be unresponsive."
+        );
+        assert!(is_chrome_approval_wait_error(&err));
+        assert!(allow_dialog_error(&err));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -2078,7 +2078,9 @@ pub fn acquire_chrome_approval_lock() -> Result<ChromeApprovalLock> {
 
 pub fn is_chrome_approval_wait_error(err: &anyhow::Error) -> bool {
     let message = format!("{err:#}").to_lowercase();
-    message.contains("allow remote debugging") || message.contains("remote-debugging consent")
+    message.contains("allow remote debugging")
+        || message.contains("remote-debugging consent")
+        || message.contains("remote debugging consent")
 }
 
 /// Detect the actionable "Chrome CDP unreachable" error produced by
@@ -4009,8 +4011,10 @@ fn looks_like_timeout(err: &anyhow::Error) -> bool {
 }
 
 fn allow_dialog_error(err: &anyhow::Error) -> bool {
-    let message = err.to_string();
-    message.contains("Allow remote debugging") || message.contains("remote-debugging consent")
+    let message = format!("{err:#}").to_lowercase();
+    message.contains("allow remote debugging")
+        || message.contains("remote-debugging consent")
+        || message.contains("remote debugging consent")
 }
 
 fn live_attach_approval_wait_error(timeout_ms: u64) -> anyhow::Error {
@@ -5974,6 +5978,26 @@ browser_cdp = "http://evil.example.com:9222"
         );
         assert!(is_chrome_approval_wait_error(&err));
         assert!(allow_dialog_error(&err));
+    }
+
+    #[test]
+    fn is_chrome_approval_wait_error_matches_consent_space_variant() {
+        let err = anyhow!("Chrome is waiting for remote debugging consent");
+        assert!(is_chrome_approval_wait_error(&err));
+        assert!(allow_dialog_error(&err));
+    }
+
+    #[test]
+    fn allow_dialog_error_is_case_insensitive_and_reads_full_chain() {
+        let err = anyhow!("waiting for Allow Remote Debugging consent dialog")
+            .context("connecting to Chrome");
+        assert!(
+            allow_dialog_error(&err),
+            "mixed-case dialog phrase in chain should still match"
+        );
+
+        let not_approval = anyhow!("connection refused");
+        assert!(!allow_dialog_error(&not_approval));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -1636,9 +1636,8 @@ mod tests {
         assert!(is_dev_browser_connect_failure(&get_targets));
         assert!(should_retry_dev_browser_connect_failure(&get_targets));
 
-        let target_init = anyhow!(
-            "Timed out after 5000ms initializing live CDP targets during Page.enable"
-        );
+        let target_init =
+            anyhow!("Timed out after 5000ms initializing live CDP targets during Page.enable");
         assert!(is_dev_browser_connect_failure(&target_init));
 
         let consent_wait = anyhow!(

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -728,8 +728,15 @@ fn is_dev_browser_target_auto_attach_failure(err: &anyhow::Error) -> bool {
         .contains("target.setautoattach")
 }
 
+fn is_dev_browser_remote_debugging_consent_wait(err: &anyhow::Error) -> bool {
+    let message = format!("{err:#}").to_lowercase();
+    message.contains("remote-debugging consent") || message.contains("remote debugging consent")
+}
+
 fn should_retry_dev_browser_connect_failure(err: &anyhow::Error) -> bool {
-    is_dev_browser_connect_failure(err) && !is_dev_browser_target_auto_attach_failure(err)
+    is_dev_browser_connect_failure(err)
+        && !is_dev_browser_target_auto_attach_failure(err)
+        && !is_dev_browser_remote_debugging_consent_wait(err)
 }
 
 fn maybe_add_dev_browser_connect_guidance(err: anyhow::Error) -> anyhow::Error {
@@ -1628,22 +1635,42 @@ mod tests {
     }
 
     #[test]
-    fn is_dev_browser_connect_failure_matches_live_cdp_daemon_timeouts() {
-        let get_targets = anyhow!(
-            "Timed out after 5000ms initializing live CDP browser during Target.getTargets. \
-             Chrome may be waiting for remote-debugging consent or a target may be unresponsive."
-        );
-        assert!(is_dev_browser_connect_failure(&get_targets));
-        assert!(should_retry_dev_browser_connect_failure(&get_targets));
+    fn is_dev_browser_connect_failure_matches_target_gettargets_token_alone() {
+        let err = anyhow!("Timed out after 5000ms during Target.getTargets");
+        assert!(is_dev_browser_connect_failure(&err));
+        assert!(should_retry_dev_browser_connect_failure(&err));
+    }
 
-        let target_init =
+    #[test]
+    fn is_dev_browser_connect_failure_matches_initializing_live_cdp_browser_token_alone() {
+        let err = anyhow!("Timed out after 5000ms initializing live CDP browser");
+        assert!(is_dev_browser_connect_failure(&err));
+        assert!(should_retry_dev_browser_connect_failure(&err));
+    }
+
+    #[test]
+    fn is_dev_browser_connect_failure_matches_initializing_live_cdp_targets_token_alone() {
+        let err =
             anyhow!("Timed out after 5000ms initializing live CDP targets during Page.enable");
-        assert!(is_dev_browser_connect_failure(&target_init));
+        assert!(is_dev_browser_connect_failure(&err));
+        assert!(should_retry_dev_browser_connect_failure(&err));
+    }
 
-        let consent_wait = anyhow!(
-            "Target.getTargets timed out; Chrome may be waiting for remote-debugging consent"
+    #[test]
+    fn is_dev_browser_connect_failure_matches_remote_debugging_consent_token_alone() {
+        let err =
+            anyhow!("Timed out after 5000ms; Chrome may be waiting for remote-debugging consent");
+        assert!(is_dev_browser_connect_failure(&err));
+        assert!(
+            !should_retry_dev_browser_connect_failure(&err),
+            "consent waits must not retry — would re-trigger the Allow popup"
         );
-        assert!(is_dev_browser_connect_failure(&consent_wait));
+    }
+
+    #[test]
+    fn is_dev_browser_connect_failure_requires_connection_failure_gate() {
+        let hint_without_timeout = anyhow!("Chrome may be waiting for remote-debugging consent");
+        assert!(!is_dev_browser_connect_failure(&hint_without_timeout));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -707,7 +707,11 @@ pub(crate) fn is_dev_browser_connect_failure(err: &anyhow::Error) -> bool {
         || message.contains("auto connect")
         || message.contains("could not connect to chrome")
         || message.contains("browser.getversion")
-        || message.contains("target.setautoattach");
+        || message.contains("target.setautoattach")
+        || message.contains("target.gettargets")
+        || message.contains("initializing live cdp browser")
+        || message.contains("initializing live cdp targets")
+        || message.contains("remote-debugging consent");
     let has_connection_failure = message.contains("timed out")
         || message.contains("timeout")
         || message.contains("connectionclosed")
@@ -1621,6 +1625,26 @@ mod tests {
         let other = anyhow!("ChatGPT response timed out after 900000ms");
         assert!(!is_dev_browser_connect_failure(&other));
         assert!(!should_retry_dev_browser_connect_failure(&other));
+    }
+
+    #[test]
+    fn is_dev_browser_connect_failure_matches_live_cdp_daemon_timeouts() {
+        let get_targets = anyhow!(
+            "Timed out after 5000ms initializing live CDP browser during Target.getTargets. \
+             Chrome may be waiting for remote-debugging consent or a target may be unresponsive."
+        );
+        assert!(is_dev_browser_connect_failure(&get_targets));
+        assert!(should_retry_dev_browser_connect_failure(&get_targets));
+
+        let target_init = anyhow!(
+            "Timed out after 5000ms initializing live CDP targets during Page.enable"
+        );
+        assert!(is_dev_browser_connect_failure(&target_init));
+
+        let consent_wait = anyhow!(
+            "Target.getTargets timed out; Chrome may be waiting for remote-debugging consent"
+        );
+        assert!(is_dev_browser_connect_failure(&consent_wait));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Prereq for the in-yoetz Chrome 147 dev-browser replacement. Widens the error classifiers so the upcoming yoetz-owned live-CDP daemon's error strings land in the correct code paths — approval-pending goes to the "click Allow" fallthrough, and live-CDP timeout errors get the dev-browser connect-failure guidance.

- `is_dev_browser_connect_failure` (`dev_browser.rs:703-722`) now matches `Target.getTargets`, `"initializing live CDP browser"`, `"initializing live CDP targets"`, and `"remote-debugging consent"` alongside the existing `connectOverCDP` / `Target.setAutoAttach` / `auto-connect` tokens.
- `is_chrome_approval_wait_error` (`browser.rs:2079`) and `allow_dialog_error` (`browser.rs:4012`) also match `"remote-debugging consent"`.
- Two new regression tests pin each phrase:
  - `is_dev_browser_connect_failure_matches_live_cdp_daemon_timeouts`
  - `is_chrome_approval_wait_error_matches_live_cdp_consent_phrase`

Matchers land independently so the in-yoetz daemon work can land cleanly behind them.

## Test plan

- [x] `cargo test -p yoetz` — 369 passed, 2 ignored
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)