### PR TITLE
chore(release): v0.2.56

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.2.55",
+  "version": "0.2.56",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.2.55",
+  "version": "0.2.56",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.56] - 2026-04-24
 ### Added
 
 - Yoetz-owned live-CDP Node daemon bundled into the yoetz binary as
@@ -53,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `remote-debugging consent` timeouts — retrying a human-consent wait
   was re-triggering the Chrome "Allow remote debugging?" popup while
   the original dialog was still open.
+
 
 ## [0.2.55] - 2026-04-24
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3190,7 +3190,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoetz"
-version = "0.2.55"
+version = "0.2.56"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "yoetz-core"
-version = "0.2.55"
+version = "0.2.56"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/yoetz-core", "crates/yoetz-cli"]
 
 [workspace.package]
-version = "0.2.55"
+version = "0.2.56"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yoetz
-version: 0.2.55
+version: 0.2.56
 description: >
   Fast CLI-first LLM council, bundler, and multimodal gateway. Use ONLY when user
   explicitly mentions "yoetz", "yoetz ask", "yoetz council", "yoetz review",


### PR DESCRIPTION
## Release

- updates `CHANGELOG.md` for `v0.2.56`
- bumps workspace version to `0.2.56`
- aligns skill/plugin metadata to `0.2.56`
- merge triggers .github/workflows/release.yml, which creates the tag and
  publishes the release
- GitHub release notes come from the committed `CHANGELOG.md` entry