### PR TITLE
fix(browser): Reuse ChatGPT live approval

### DIFF
--- a/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
@@ -14,7 +14,7 @@ use serde_json::Value;
 use std::{
     collections::{BTreeMap, BTreeSet},
     io::{Read, Write},
-    net::TcpStream,
+    net::{TcpStream, ToSocketAddrs},
     path::{Path, PathBuf},
     process::Command,
     sync::{Arc, Mutex},
@@ -1286,23 +1286,9 @@ pub fn discover_running_chrome_targets() -> Vec<RunningChromeTarget> {
 pub fn discover_devtools_active_port_files() -> Vec<DevtoolsActivePortFile> {
     let mut files = Vec::new();
     for path in devtools_active_port_candidates() {
-        let Ok(contents) = std::fs::read_to_string(&path) else {
-            continue;
-        };
-        let modified_at = std::fs::metadata(&path)
-            .ok()
-            .and_then(|metadata| metadata.modified().ok());
-        let ws_endpoint = parse_devtools_active_port(&contents, None);
-        let healthy = ws_endpoint
-            .as_deref()
-            .and_then(|endpoint| describe_running_chrome_target(endpoint, &path, modified_at))
-            .is_some();
-        files.push(DevtoolsActivePortFile {
-            path,
-            ws_endpoint,
-            modified_at,
-            healthy,
-        });
+        if let Some(file) = devtools_active_port_file_from_path(&path) {
+            files.push(file);
+        }
     }
     files
 }
@@ -1768,17 +1754,64 @@ fn resolve_devtools_active_port_ws(endpoint: &Url) -> Option<String> {
 }
 
 fn resolve_any_devtools_active_port_ws() -> Option<String> {
-    devtools_active_port_candidates()
-        .into_iter()
-        .find_map(|path| {
-            let contents = std::fs::read_to_string(&path).ok()?;
-            let ws_endpoint = parse_devtools_active_port(&contents, None)?;
-            let modified_at = std::fs::metadata(&path)
-                .ok()
-                .and_then(|metadata| metadata.modified().ok());
-            describe_running_chrome_target(&ws_endpoint, &path, modified_at)
-                .map(|target| target.ws_endpoint)
+    resolve_any_devtools_active_port_ws_from_candidates(&devtools_active_port_candidates())
+}
+
+fn resolve_any_devtools_active_port_ws_from_candidates(candidates: &[PathBuf]) -> Option<String> {
+    resolve_any_devtools_active_port_ws_from_candidates_with_approval_probe(
+        candidates,
+        &devtools_approval_mode_endpoint_is_reachable,
+    )
+}
+
+fn resolve_any_devtools_active_port_ws_from_candidates_with_approval_probe(
+    candidates: &[PathBuf],
+    approval_mode_probe: &dyn Fn(&Path, &str) -> bool,
+) -> Option<String> {
+    let mut entries = candidates
+        .iter()
+        .filter_map(|path| {
+            devtools_active_port_file_from_path_with_approval_probe(path, approval_mode_probe)
         })
+        .filter(|file| file.healthy)
+        .collect::<Vec<_>>();
+    entries.sort_by(|left, right| {
+        browser_family_priority(&right.path)
+            .cmp(&browser_family_priority(&left.path))
+            .then_with(|| {
+                modified_sort_key(right.modified_at).cmp(&modified_sort_key(left.modified_at))
+            })
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    entries.into_iter().find_map(|file| file.ws_endpoint)
+}
+
+fn devtools_active_port_file_from_path(path: &Path) -> Option<DevtoolsActivePortFile> {
+    devtools_active_port_file_from_path_with_approval_probe(
+        path,
+        &devtools_approval_mode_endpoint_is_reachable,
+    )
+}
+
+fn devtools_active_port_file_from_path_with_approval_probe(
+    path: &Path,
+    approval_mode_probe: &dyn Fn(&Path, &str) -> bool,
+) -> Option<DevtoolsActivePortFile> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    let modified_at = std::fs::metadata(path)
+        .ok()
+        .and_then(|metadata| metadata.modified().ok());
+    let ws_endpoint = parse_devtools_active_port(&contents, None);
+    let healthy = ws_endpoint.as_deref().is_some_and(|endpoint| {
+        describe_running_chrome_target(endpoint, path, modified_at).is_some()
+            || approval_mode_probe(path, endpoint)
+    });
+    Some(DevtoolsActivePortFile {
+        path: path.to_path_buf(),
+        ws_endpoint,
+        modified_at,
+        healthy,
+    })
 }
 
 fn describe_running_chrome_target(
@@ -1836,6 +1869,113 @@ fn fetch_target_list_summary(ws_endpoint: &str) -> Option<TargetListSummary> {
         page_target_count: page_entries.len(),
         page_samples,
     })
+}
+
+fn devtools_approval_mode_endpoint_is_reachable(source_path: &Path, ws_endpoint: &str) -> bool {
+    let Some((host, port)) = local_devtools_ws_endpoint_parts(ws_endpoint) else {
+        return false;
+    };
+    if !devtools_port_has_chromium_listener(source_path, port) {
+        return false;
+    }
+    let Ok(addrs) = (host.as_str(), port).to_socket_addrs() else {
+        return false;
+    };
+    addrs.into_iter().any(|addr| {
+        TcpStream::connect_timeout(&addr, Duration::from_millis(DISCOVERY_HTTP_TIMEOUT_MS)).is_ok()
+    })
+}
+
+fn local_devtools_ws_endpoint_parts(ws_endpoint: &str) -> Option<(String, u16)> {
+    let Ok(url) = Url::parse(ws_endpoint) else {
+        return None;
+    };
+    if !matches!(url.scheme(), "ws" | "wss") || !is_localhost_host(&url) {
+        return None;
+    }
+    let host = url.host_str()?.to_string();
+    let port = url.port_or_known_default()?;
+    Some((host, port))
+}
+
+fn devtools_port_has_chromium_listener(source_path: &Path, port: u16) -> bool {
+    let owner_pids = local_tcp_listener_pids(port);
+    if owner_pids.is_empty() {
+        return false;
+    }
+
+    discover_local_chromium_processes()
+        .into_iter()
+        .any(|process| {
+            owner_pids.contains(&process.pid)
+                && chromium_process_matches_active_port_path(&process, source_path)
+        })
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn local_tcp_listener_pids(port: u16) -> BTreeSet<u32> {
+    let Ok(output) = Command::new("lsof")
+        .args(["-nP", &format!("-iTCP:{port}"), "-sTCP:LISTEN", "-Fp"])
+        .output()
+    else {
+        return BTreeSet::new();
+    };
+    if !output.status.success() {
+        return BTreeSet::new();
+    }
+    parse_lsof_pid_output(&String::from_utf8_lossy(&output.stdout))
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn local_tcp_listener_pids(_port: u16) -> BTreeSet<u32> {
+    BTreeSet::new()
+}
+
+fn parse_lsof_pid_output(output: &str) -> BTreeSet<u32> {
+    output
+        .lines()
+        .filter_map(|line| line.strip_prefix('p'))
+        .filter_map(|pid| pid.trim().parse::<u32>().ok())
+        .collect()
+}
+
+fn chromium_process_matches_active_port_path(
+    process: &ChromiumProcessSummary,
+    source_path: &Path,
+) -> bool {
+    let Some(user_data_dir) = process.user_data_dir.as_deref() else {
+        return true;
+    };
+    let Some(active_port_dir) = source_path.parent() else {
+        return false;
+    };
+    paths_equivalent(active_port_dir, Path::new(user_data_dir))
+}
+
+fn paths_equivalent(left: &Path, right: &Path) -> bool {
+    if left == right {
+        return true;
+    }
+    let left = std::fs::canonicalize(left).unwrap_or_else(|_| left.to_path_buf());
+    let right = std::fs::canonicalize(right).unwrap_or_else(|_| right.to_path_buf());
+    left == right
+}
+
+fn browser_family_priority(source_path: &Path) -> u8 {
+    match browser_name_from_source_path(source_path).as_str() {
+        "Chrome" | "Chrome for Testing" => 4,
+        "Chrome Beta" => 3,
+        "Chrome Canary" => 2,
+        "Chromium" => 1,
+        _ => 0,
+    }
+}
+
+fn modified_sort_key(modified_at: Option<SystemTime>) -> u128 {
+    modified_at
+        .and_then(|time| time.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0)
 }
 
 fn summarize_page_target(entry: &DevtoolsTargetListEntry) -> Option<String> {
@@ -2601,6 +2741,16 @@ mod tests {
     }
 
     fn spawn_fake_devtools_server() -> (u16, Arc<AtomicBool>, thread::JoinHandle<()>) {
+        spawn_http_devtools_server(true)
+    }
+
+    fn spawn_approval_mode_devtools_server() -> (u16, Arc<AtomicBool>, thread::JoinHandle<()>) {
+        spawn_http_devtools_server(false)
+    }
+
+    fn spawn_http_devtools_server(
+        expose_json: bool,
+    ) -> (u16, Arc<AtomicBool>, thread::JoinHandle<()>) {
         let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
         listener
             .set_nonblocking(true)
@@ -2615,9 +2765,9 @@ mod tests {
                         let mut request = [0_u8; 2048];
                         let _ = stream.read(&mut request);
                         let request = String::from_utf8_lossy(&request);
-                        let body = if request.starts_with("GET /json/version ") {
+                        let body = if expose_json && request.starts_with("GET /json/version ") {
                             r#"{"Browser":"Chrome/147.0.0.0"}"#
-                        } else if request.starts_with("GET /json/list ") {
+                        } else if expose_json && request.starts_with("GET /json/list ") {
                             r#"[{"type":"page","url":"https://chatgpt.com/c/123","title":"ChatGPT - New chat"}]"#
                         } else {
                             ""
@@ -3423,6 +3573,68 @@ mod tests {
             parsed.as_deref(),
             Some("ws://127.0.0.1:9333/devtools/browser/from-active-port")
         );
+    }
+
+    #[test]
+    fn devtools_active_port_file_is_healthy_when_approval_mode_hides_json() {
+        let dir = tempdir().unwrap();
+        let active_port = dir.path().join("Google/Chrome/DevToolsActivePort");
+        let (port, shutdown, handle) = spawn_approval_mode_devtools_server();
+        write_devtools_active_port(&active_port, port, "approval-mode");
+
+        let file =
+            devtools_active_port_file_from_path_with_approval_probe(&active_port, &|_, _| true)
+                .unwrap();
+
+        shutdown.store(true, Ordering::Relaxed);
+        let _ = handle.join();
+
+        let expected = format!("ws://127.0.0.1:{port}/devtools/browser/approval-mode");
+        assert_eq!(file.ws_endpoint.as_deref(), Some(expected.as_str()));
+        assert!(
+            file.healthy,
+            "approval-mode Chrome hides /json endpoints but the browser websocket is still attachable after user approval"
+        );
+    }
+
+    #[test]
+    fn devtools_active_port_file_rejects_non_chromium_tcp_listener() {
+        let dir = tempdir().unwrap();
+        let active_port = dir.path().join("Google/Chrome/DevToolsActivePort");
+        let (port, shutdown, handle) = spawn_approval_mode_devtools_server();
+        write_devtools_active_port(&active_port, port, "not-chrome");
+
+        let file = devtools_active_port_file_from_path(&active_port).unwrap();
+
+        shutdown.store(true, Ordering::Relaxed);
+        let _ = handle.join();
+
+        let expected = format!("ws://127.0.0.1:{port}/devtools/browser/not-chrome");
+        assert_eq!(file.ws_endpoint.as_deref(), Some(expected.as_str()));
+        assert!(
+            !file.healthy,
+            "a stale DevToolsActivePort file must not become healthy just because another localhost process reused the port"
+        );
+    }
+
+    #[test]
+    fn resolve_any_devtools_active_port_ws_accepts_approval_mode_endpoint() {
+        let home = tempdir().unwrap();
+        let (stale_path, healthy_path) = devtools_active_port_test_paths(home.path());
+        let (port, shutdown, handle) = spawn_approval_mode_devtools_server();
+        write_devtools_active_port(&stale_path, port + 1, "stale");
+        write_devtools_active_port(&healthy_path, port, "approval-mode");
+
+        let resolved = resolve_any_devtools_active_port_ws_from_candidates_with_approval_probe(
+            &[stale_path.clone(), healthy_path.clone()],
+            &|_, endpoint| endpoint.ends_with("/approval-mode"),
+        );
+
+        shutdown.store(true, Ordering::Relaxed);
+        let _ = handle.join();
+
+        let expected = format!("ws://127.0.0.1:{port}/devtools/browser/approval-mode");
+        assert_eq!(resolved.as_deref(), Some(expected.as_str()));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/live_attach.rs
+++ b/crates/yoetz-cli/src/live_attach.rs
@@ -8,9 +8,11 @@ use std::io::{self, BufRead, BufReader, Write};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader as AsyncBufReader};
 use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{Mutex as AsyncMutex, Notify};
 
 use crate::browser::ResolvedCdpTarget;
 use crate::chatgpt_web;
@@ -34,7 +36,10 @@ const DEFAULT_CONTEXT_KEY: &str = "__default__";
 const DAEMON_START_TIMEOUT: Duration = Duration::from_secs(10);
 const DAEMON_START_POLL_MS: u64 = 100;
 const DAEMON_HEALTH_RPC_TIMEOUT: Duration = Duration::from_secs(5);
-const DAEMON_ENSURE_SESSION_TIMEOUT: Duration = Duration::from_secs(75);
+// The first live attach can block on Chrome's native "Allow remote debugging?"
+// dialog. Give an operator several minutes to approve it; after that the daemon
+// keeps the approved websocket open and later recipe runs should not prompt.
+const DAEMON_ENSURE_SESSION_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 const DAEMON_RECIPE_RPC_GRACE: Duration = Duration::from_secs(120);
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -305,10 +310,11 @@ impl LiveAttachDaemon {
             )
             .await?;
         recipe_ctx.cdp_endpoint = Some(session.client.ws_endpoint().to_string());
-        let result = match chatgpt::run_with_client(
+        let result = match chatgpt::run_with_client_using_page_open_mode(
             &mut session.client,
             recipe_ctx,
             browser_context_id.clone(),
+            live_attach_recipe_page_open_mode(),
         )
         .await
         {
@@ -480,6 +486,15 @@ impl LiveAttachDaemon {
     }
 }
 
+fn live_attach_recipe_page_open_mode() -> chatgpt::InitialPageOpenMode {
+    // The daemon has already created or reused a stable yoetz-owned ChatGPT
+    // control tab in this browser context. Open recipe tabs from that anchor
+    // instead of issuing Target.createTarget for each run, because current
+    // default-profile Chrome builds can close the approved CDP websocket on
+    // external new-target creation and force another consent dialog.
+    chatgpt::retry_initial_page_open_mode()
+}
+
 pub async fn ensure_chatgpt_session(
     cdp_target: Option<&ResolvedCdpTarget>,
     browser_context_id: Option<&str>,
@@ -559,15 +574,23 @@ pub async fn serve_daemon() -> Result<()> {
     };
     save_daemon_metadata(&metadata)?;
     let _metadata_guard = DaemonMetadataGuard;
-    let mut daemon = LiveAttachDaemon::load()?;
+    let daemon = Arc::new(AsyncMutex::new(LiveAttachDaemon::load()?));
+    let shutdown = Arc::new(Notify::new());
 
     loop {
-        let (socket, _) = listener
-            .accept()
-            .await
-            .context("accept yoetz live-attach client")?;
-        if handle_daemon_connection(socket, &metadata.token, &mut daemon).await? {
-            break;
+        tokio::select! {
+            _ = shutdown.notified() => break,
+            accepted = listener.accept() => {
+                let (socket, _) = accepted.context("accept yoetz live-attach client")?;
+                let token = metadata.token.clone();
+                let daemon = Arc::clone(&daemon);
+                let shutdown = Arc::clone(&shutdown);
+                tokio::spawn(async move {
+                    if let Err(err) = handle_daemon_connection(socket, &token, daemon, shutdown).await {
+                        eprintln!("warn: yoetz live-attach daemon connection failed: {err:#}");
+                    }
+                });
+            }
         }
     }
 
@@ -775,8 +798,9 @@ async fn healthy_daemon_metadata_with_timeout(timeout: Duration) -> Result<Optio
 async fn handle_daemon_connection(
     socket: TcpStream,
     token: &str,
-    daemon: &mut LiveAttachDaemon,
-) -> Result<bool> {
+    daemon: Arc<AsyncMutex<LiveAttachDaemon>>,
+    shutdown: Arc<Notify>,
+) -> Result<()> {
     let mut reader = AsyncBufReader::new(socket);
     let mut line = String::new();
     reader
@@ -786,12 +810,15 @@ async fn handle_daemon_connection(
 
     let request = serde_json::from_str::<DaemonRequest>(line.trim_end())
         .context("parse yoetz live-attach request")?;
-    let shutdown = matches!(request, DaemonRequest::Shutdown { .. });
-    let response = match dispatch_daemon_request(request, token, daemon).await {
+    let (response, shutdown_requested) = match dispatch_daemon_request(request, token, daemon).await
+    {
         Ok(response) => response,
-        Err(err) => DaemonResponse::Error {
-            message: format!("{err:#}"),
-        },
+        Err(err) => (
+            DaemonResponse::Error {
+                message: format!("{err:#}"),
+            },
+            false,
+        ),
     };
 
     let socket = reader.get_mut();
@@ -804,10 +831,41 @@ async fn handle_daemon_connection(
         .await
         .context("flush yoetz live-attach response")?;
 
-    Ok(shutdown)
+    if shutdown_requested {
+        shutdown.notify_one();
+    }
+
+    Ok(())
 }
 
 async fn dispatch_daemon_request(
+    request: DaemonRequest,
+    token: &str,
+    daemon: Arc<AsyncMutex<LiveAttachDaemon>>,
+) -> Result<(DaemonResponse, bool)> {
+    match request {
+        DaemonRequest::Ping {
+            token: request_token,
+        } => {
+            ensure_token(token, &request_token)?;
+            Ok((DaemonResponse::Pong, false))
+        }
+        DaemonRequest::Shutdown {
+            token: request_token,
+        } => {
+            ensure_token(token, &request_token)?;
+            Ok((DaemonResponse::Pong, true))
+        }
+        request => {
+            let mut daemon = daemon.lock().await;
+            dispatch_daemon_request_locked(request, token, &mut daemon)
+                .await
+                .map(|response| (response, false))
+        }
+    }
+}
+
+async fn dispatch_daemon_request_locked(
     request: DaemonRequest,
     token: &str,
     daemon: &mut LiveAttachDaemon,
@@ -1279,6 +1337,14 @@ mod tests {
     }
 
     #[test]
+    fn live_attach_recipe_page_open_mode_reuses_existing_anchor() {
+        assert_eq!(
+            live_attach_recipe_page_open_mode(),
+            chatgpt::retry_initial_page_open_mode()
+        );
+    }
+
+    #[test]
     #[serial]
     fn reset_removes_state_and_daemon_metadata_files() {
         let _guard = lock_env();
@@ -1498,6 +1564,51 @@ mod tests {
 
         let _ = shutdown_tx.send(());
         let _ = handle.join();
+    }
+
+    #[test]
+    fn shutdown_request_bypasses_busy_daemon_lock() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let daemon = Arc::new(AsyncMutex::new(LiveAttachDaemon {
+                state: LiveAttachState::default(),
+                sessions: BTreeMap::new(),
+            }));
+            let _busy = daemon.lock().await;
+            let shutdown = Arc::new(Notify::new());
+            let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            let server_daemon = Arc::clone(&daemon);
+            let server_shutdown = Arc::clone(&shutdown);
+            let server = tokio::spawn(async move {
+                let (socket, _) = listener.accept().await.unwrap();
+                handle_daemon_connection(socket, "token", server_daemon, server_shutdown)
+                    .await
+                    .unwrap();
+            });
+
+            let mut stream = TcpStream::connect(addr).await.unwrap();
+            stream
+                .write_all(br#"{"type":"shutdown","token":"token"}"#)
+                .await
+                .unwrap();
+            stream.write_all(b"\n").await.unwrap();
+            let mut reader = AsyncBufReader::new(stream);
+            let mut line = String::new();
+            tokio::time::timeout(DAEMON_HEALTH_RPC_TIMEOUT, reader.read_line(&mut line))
+                .await
+                .expect("shutdown response should not wait for the daemon work lock")
+                .unwrap();
+
+            match serde_json::from_str::<DaemonResponse>(line.trim_end()).unwrap() {
+                DaemonResponse::Pong => {}
+                other => panic!("expected shutdown Pong, got {other:?}"),
+            }
+            tokio::time::timeout(DAEMON_HEALTH_RPC_TIMEOUT, shutdown.notified())
+                .await
+                .expect("shutdown notify should be sent after the response is flushed");
+            server.await.unwrap();
+        });
     }
 
     #[test]

--- a/docs/decisions/ADR-001-live-attach-owner.md
+++ b/docs/decisions/ADR-001-live-attach-owner.md
@@ -28,6 +28,14 @@ The concrete changes are:
 - reconnect from the logical target identity (`source-path`, `browser-id`, or implicit default discovery), not by blindly reusing the last websocket URL
 - preserve daemon metadata on bounded ping timeouts so a busy owner is not mistaken for a dead one, while `yoetz browser reset` still forcefully clears a wedged owner
 - keep `dev-browser` and `agent-browser` as fallback transports instead of peer live-session owners
+- treat Chrome's approval-only remote debugging mode as a browser-websocket-only
+  mode: `/json/*` endpoints may be unavailable before approval, so
+  `DevToolsActivePort` discovery must not require `/json/version` before the
+  first attach; it may accept the endpoint only when the listening localhost
+  port is owned by a local Chromium process
+- open ChatGPT recipe tabs from the durable yoetz-owned control tab after the
+  daemon is attached, rather than issuing a fresh browser-level
+  `Target.createTarget` for every recipe run
 
 ## Alternatives Considered
 
@@ -56,5 +64,9 @@ The concrete changes are:
 - `attach`, `check`, and the ChatGPT `recipe` share one yoetz-owned CDP owner
 - repeated auth checks and recipe launches reuse the same control-tab identity for a resolved browser context instead of creating throwaway probe tabs
 - reconnect recovery now keeps the old `CreateTarget -> reconnect -> recover via existing anchor` behavior on the daemonized recipe path
+- Chrome still requires the first native approval after Chrome starts. Yoetz
+  cannot persist or bypass that browser consent; the invariant is that the
+  daemon keeps one approved websocket alive so subsequent ChatGPT recipe runs
+  do not create new attach prompts until Chrome or the daemon is restarted
 - a busy daemon times out cleanly instead of wedging `doctor`, `reset`, or later attach/check calls forever
 - `dev-browser` and `agent-browser` remain available, but only as fallback executors when the primary live owner is unavailable or unsuitable


### PR DESCRIPTION
Make the ChatGPT Pro web recipe reuse one approved live Chrome CDP owner so agents can run repeated recipe requests after the first native Chrome "Allow remote debugging?" approval. Chrome still owns the first consent prompt, and approval resets when Chrome or the yoetz live-attach daemon restarts.

Chrome approval-only mode can hide `/json/*` endpoints before approval, so discovery now accepts `DevToolsActivePort` browser websocket endpoints without requiring `/json/version` first. To avoid selecting a stale active-port file whose port was reused by an unrelated localhost service, the approval-mode fallback requires the listening port to be owned by a local Chromium process and, when available, match the active-port file's user data directory.

The live-attach daemon now opens ChatGPT recipe tabs from the durable yoetz-owned control tab instead of creating a fresh browser-level target for each run. It also accepts daemon connections concurrently, with `Ping` and `Shutdown` bypassing long-running attach/recipe work, so `yoetz browser reset` does not queue behind a first approval wait. The first `EnsureSession` timeout is extended to 10 minutes to give the operator time to approve Chrome's native dialog.

ADR-001 is updated with the approval-only browser-websocket invariant and the new discovery guard.

Follow-ups intentionally left out of this PR: a mid-recipe transport close can still require a new approval if the approved websocket dies, endpoint-equivalent session dedup is not implemented, inner dispatch still does not use explicit `catch_unwind`, the approval lock only serializes attach attempts and cannot persist Chrome consent, and cached-client liveness after Chrome restart still needs a targeted probe.

Validated with `cargo test -p yoetz` and `git diff --check`.