### PR TITLE
fix(browser): Prevent hidden ChatGPT live reattach

### DIFF
--- a/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
@@ -142,6 +142,12 @@ pub enum InitialPageOpenMode {
     RecoverViaExistingAnchor,
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum ReconnectPolicy {
+    Never,
+    OneStandaloneRetry,
+}
+
 impl InitialPageOpenMode {
     fn debug_strategy(self) -> &'static str {
         match self {
@@ -241,7 +247,14 @@ async fn run_attached_recipe(
             (None, None) => "resolve Chrome browser context".to_string(),
         })?;
 
-    run_attached_recipe_inner(&mut client, ctx, browser_context_id, page_open_mode).await
+    run_attached_recipe_inner(
+        &mut client,
+        ctx,
+        browser_context_id,
+        page_open_mode,
+        ReconnectPolicy::OneStandaloneRetry,
+    )
+    .await
 }
 
 pub async fn run_with_client(
@@ -264,7 +277,31 @@ pub async fn run_with_client_using_page_open_mode(
     browser_context_id: Option<String>,
     page_open_mode: InitialPageOpenMode,
 ) -> Result<ChatgptRunResult> {
-    run_attached_recipe_inner(client, ctx, browser_context_id, page_open_mode).await
+    run_with_client_using_page_open_mode_and_reconnect_policy(
+        client,
+        ctx,
+        browser_context_id,
+        page_open_mode,
+        ReconnectPolicy::OneStandaloneRetry,
+    )
+    .await
+}
+
+pub async fn run_with_client_using_page_open_mode_and_reconnect_policy(
+    client: &mut CdpMcpClient,
+    ctx: &DevtoolsMcpRecipeContext,
+    browser_context_id: Option<String>,
+    page_open_mode: InitialPageOpenMode,
+    reconnect_policy: ReconnectPolicy,
+) -> Result<ChatgptRunResult> {
+    run_attached_recipe_inner(
+        client,
+        ctx,
+        browser_context_id,
+        page_open_mode,
+        reconnect_policy,
+    )
+    .await
 }
 
 async fn run_attached_recipe_inner(
@@ -272,6 +309,7 @@ async fn run_attached_recipe_inner(
     ctx: &DevtoolsMcpRecipeContext,
     browser_context_id: Option<String>,
     page_open_mode: InitialPageOpenMode,
+    reconnect_policy: ReconnectPolicy,
 ) -> Result<ChatgptRunResult> {
     let marked_url = chatgpt_web::mark_chatgpt_url(&ctx.run_id);
     let page_id = open_initial_chatgpt_page(
@@ -376,6 +414,7 @@ async fn run_attached_recipe_inner(
         response_baseline,
         ctx.response_timeout_ms,
         ctx.response_poll_interval_ms,
+        reconnect_policy,
     )
     .await
     .context("stable-idle polling for ChatGPT response")?;
@@ -1380,6 +1419,7 @@ async fn poll_for_stable_response(
     baseline: ResponseBaseline,
     overall_timeout_ms: u64,
     poll_interval_ms: u64,
+    reconnect_policy: ReconnectPolicy,
 ) -> Result<String> {
     let read_state_js = response_poll_state_script();
     let start = std::time::Instant::now();
@@ -1401,7 +1441,7 @@ async fn poll_for_stable_response(
         let state = match client.evaluate_script(&read_state_js, vec![]).await {
             Ok(state) => state,
             Err(err) => {
-                match classify_response_poll_eval_error(&err, reconnect_used) {
+                match classify_response_poll_eval_error(&err, reconnect_used, reconnect_policy) {
                     ResponsePollEvalFailureAction::ReconnectAndRetry => {
                         emit_stable_idle_warning(
                             "warn: stable-idle poll lost the Chrome websocket; reconnecting once to the existing ChatGPT tab",
@@ -1507,9 +1547,13 @@ enum ResponsePollEvalFailureAction {
 fn classify_response_poll_eval_error(
     err: &anyhow::Error,
     reconnect_used: bool,
+    reconnect_policy: ReconnectPolicy,
 ) -> ResponsePollEvalFailureAction {
     if !is_closed_cdp_transport_error(err) {
         return ResponsePollEvalFailureAction::RetrySameClient;
+    }
+    if reconnect_policy == ReconnectPolicy::Never {
+        return ResponsePollEvalFailureAction::Fail;
     }
     if reconnect_used {
         ResponsePollEvalFailureAction::Fail
@@ -1976,16 +2020,26 @@ mod tests {
         let other = anyhow!("Execution context was destroyed");
 
         assert_eq!(
-            classify_response_poll_eval_error(&closed, false),
+            classify_response_poll_eval_error(&closed, false, ReconnectPolicy::OneStandaloneRetry),
             ResponsePollEvalFailureAction::ReconnectAndRetry
         );
         assert_eq!(
-            classify_response_poll_eval_error(&closed, true),
+            classify_response_poll_eval_error(&closed, true, ReconnectPolicy::OneStandaloneRetry),
             ResponsePollEvalFailureAction::Fail
         );
         assert_eq!(
-            classify_response_poll_eval_error(&other, false),
+            classify_response_poll_eval_error(&other, false, ReconnectPolicy::OneStandaloneRetry),
             ResponsePollEvalFailureAction::RetrySameClient
+        );
+    }
+
+    #[test]
+    fn daemon_response_poll_closed_transport_fails_without_reconnect() {
+        let closed = anyhow!("Unable to make method calls because underlying connection is closed");
+
+        assert_eq!(
+            classify_response_poll_eval_error(&closed, false, ReconnectPolicy::Never),
+            ResponsePollEvalFailureAction::Fail
         );
     }
 

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
@@ -17,7 +17,8 @@ use std::{
     net::{TcpStream, ToSocketAddrs},
     path::{Path, PathBuf},
     process::Command,
-    sync::{Arc, Mutex},
+    sync::{mpsc, Arc, Mutex},
+    thread,
     time::{Duration, Instant, SystemTime},
 };
 
@@ -333,6 +334,24 @@ impl CdpMcpClient {
 
     pub fn ws_endpoint(&self) -> &str {
         &self.ws_endpoint
+    }
+
+    pub fn probe_liveness(&self, timeout_ms: u64) -> Result<()> {
+        let browser = self.browser.clone();
+        let timeout = Duration::from_millis(timeout_ms.max(1));
+        let (tx, rx) = mpsc::sync_channel(1);
+        thread::Builder::new()
+            .name("yoetz-cdp-liveness-probe".to_string())
+            .spawn(move || {
+                let result = browser
+                    .get_page_targets()
+                    .map(|_| ())
+                    .context("probe Chrome CDP session liveness");
+                let _ = tx.send(result);
+            })
+            .context("spawn Chrome CDP session liveness probe")?;
+
+        receive_liveness_probe_result(rx, timeout)
     }
 
     pub async fn new_page(
@@ -1227,6 +1246,19 @@ impl CdpMcpClient {
                     browser_context_label(browser_context_id)
                 )
             })
+    }
+}
+
+fn receive_liveness_probe_result(rx: mpsc::Receiver<Result<()>>, timeout: Duration) -> Result<()> {
+    match rx.recv_timeout(timeout) {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Timeout) => Err(anyhow!(
+            "probe Chrome CDP session liveness timed out after {}ms",
+            timeout.as_millis()
+        )),
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            Err(anyhow!("probe Chrome CDP session liveness worker exited"))
+        }
     }
 }
 
@@ -2897,6 +2929,16 @@ mod tests {
         ];
 
         assert_eq!(choose_chatgpt_probe_index(&probes), 0);
+    }
+
+    #[test]
+    fn liveness_probe_receiver_honors_timeout() {
+        let (_tx, rx) = std::sync::mpsc::sync_channel(1);
+
+        let err = receive_liveness_probe_result(rx, Duration::from_millis(1))
+            .expect_err("empty liveness probe channel should time out");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("timed out after 1ms"), "{msg}");
     }
 
     #[test]

--- a/crates/yoetz-cli/src/live_attach.rs
+++ b/crates/yoetz-cli/src/live_attach.rs
@@ -120,6 +120,8 @@ struct PersistedTargetState {
     status: Option<LiveAttachStatus>,
     updated_at_unix_ms: Option<u64>,
     last_error: Option<String>,
+    #[serde(default)]
+    automatic_reattach_blocked: bool,
     contexts: BTreeMap<String, PersistedContextState>,
 }
 
@@ -176,9 +178,16 @@ struct DaemonSession {
     client: CdpMcpClient,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum InitialAttachPolicy {
+    Allow,
+    RequireLiveSessionIfPersisted,
+}
+
 struct LiveAttachDaemon {
     state: LiveAttachState,
     sessions: BTreeMap<String, DaemonSession>,
+    session_key_by_alias: BTreeMap<String, String>,
 }
 
 impl LiveAttachDaemon {
@@ -186,6 +195,7 @@ impl LiveAttachDaemon {
         Ok(Self {
             state: load_state()?,
             sessions: BTreeMap::new(),
+            session_key_by_alias: BTreeMap::new(),
         })
     }
 
@@ -196,36 +206,27 @@ impl LiveAttachDaemon {
         profile_email: Option<&str>,
     ) -> Result<LiveAttachSession> {
         let target_key = target.key.clone();
-        let mut session = self.take_or_connect_session(target).await?;
-        let mut reconnect_used = false;
+        let mut session = self
+            .take_or_connect_session(target, InitialAttachPolicy::Allow)
+            .await?;
 
-        loop {
-            let result = self
-                .ensure_chatgpt_session_with_session(
-                    &mut session,
-                    explicit_context_id,
-                    profile_email,
-                )
-                .await;
-
-            match result {
-                Ok(session_info) => {
-                    self.sessions.insert(target_key.clone(), session);
-                    return Ok(session_info);
-                }
-                Err(err) if !reconnect_used && is_closed_cdp_transport_error(&err) => {
-                    reconnect_used = true;
-                    self.reconnect_session_in_place(&mut session).await?;
-                }
-                Err(err) => {
-                    self.record_target_error(
-                        &target_key,
-                        session.target.endpoint.as_deref(),
-                        &err,
-                    )?;
-                    self.sessions.insert(target_key.clone(), session);
-                    return Err(err);
-                }
+        match self
+            .ensure_chatgpt_session_with_session(&mut session, explicit_context_id, profile_email)
+            .await
+        {
+            Ok(session_info) => {
+                self.store_session(target_key.clone(), session);
+                Ok(session_info)
+            }
+            Err(err) if is_closed_cdp_transport_error(&err) => {
+                let err = single_approval_transport_closed_error(err);
+                self.record_session_terminal_error(&target_key, &session, &err)?;
+                Err(err)
+            }
+            Err(err) => {
+                self.record_target_error(&target_key, session.target.endpoint.as_deref(), &err)?;
+                self.store_session(target_key.clone(), session);
+                Err(err)
             }
         }
     }
@@ -263,36 +264,31 @@ impl LiveAttachDaemon {
         mut recipe_ctx: chrome_devtools_mcp::DevtoolsMcpRecipeContext,
     ) -> Result<ChatgptRunResult> {
         let target_key = target.key.clone();
-        let mut session = self.take_or_connect_session(target).await?;
-        let mut reconnect_used = false;
+        let mut session = self
+            .take_or_connect_session(target, InitialAttachPolicy::RequireLiveSessionIfPersisted)
+            .await?;
 
         if recipe_ctx.run_id.trim().is_empty() {
             recipe_ctx.run_id = chatgpt_web::generate_run_id();
         }
 
-        loop {
-            let result = self
-                .run_chatgpt_recipe_with_session(&mut session, &mut recipe_ctx)
-                .await;
-
-            match result {
-                Ok(result) => {
-                    self.sessions.insert(target_key.clone(), session);
-                    return Ok(result);
-                }
-                Err(err) if !reconnect_used && is_closed_cdp_transport_error(&err) => {
-                    reconnect_used = true;
-                    self.reconnect_session_in_place(&mut session).await?;
-                }
-                Err(err) => {
-                    self.record_target_error(
-                        &target_key,
-                        session.target.endpoint.as_deref(),
-                        &err,
-                    )?;
-                    self.sessions.insert(target_key.clone(), session);
-                    return Err(err);
-                }
+        match self
+            .run_chatgpt_recipe_with_session(&mut session, &mut recipe_ctx)
+            .await
+        {
+            Ok(result) => {
+                self.store_session(target_key.clone(), session);
+                Ok(result)
+            }
+            Err(err) if is_closed_cdp_transport_error(&err) => {
+                let err = single_approval_transport_closed_error(err);
+                self.record_session_terminal_error(&target_key, &session, &err)?;
+                Err(err)
+            }
+            Err(err) => {
+                self.record_target_error(&target_key, session.target.endpoint.as_deref(), &err)?;
+                self.store_session(target_key.clone(), session);
+                Err(err)
             }
         }
     }
@@ -310,50 +306,14 @@ impl LiveAttachDaemon {
             )
             .await?;
         recipe_ctx.cdp_endpoint = Some(session.client.ws_endpoint().to_string());
-        let result = match chatgpt::run_with_client_using_page_open_mode(
+        let result = chatgpt::run_with_client_using_page_open_mode_and_reconnect_policy(
             &mut session.client,
             recipe_ctx,
             browser_context_id.clone(),
             live_attach_recipe_page_open_mode(),
+            live_attach_recipe_reconnect_policy(),
         )
-        .await
-        {
-            Ok(result) => result,
-            Err(err) if chatgpt::should_recover_initial_page_open_after_reconnect(&err) => {
-                if recipe_ctx.show_approval_guidance {
-                    eprintln!(
-                        "info: chrome-devtools-mcp lost the first ChatGPT page open; reconnecting once and retrying via an existing yoetz-owned anchor"
-                    );
-                }
-                self.reconnect_session_in_place(session).await?;
-                let (retry_browser_context_id, retry_control_run_id) = self
-                    .ensure_chatgpt_control_tab_for_selectors(
-                        session,
-                        recipe_ctx.browser_context_id.as_deref(),
-                        recipe_ctx.profile_email.as_deref(),
-                    )
-                    .await?;
-                recipe_ctx.cdp_endpoint = Some(session.client.ws_endpoint().to_string());
-                let retry_result = chatgpt::run_with_client_using_page_open_mode(
-                    &mut session.client,
-                    recipe_ctx,
-                    retry_browser_context_id.clone(),
-                    chatgpt::retry_initial_page_open_mode(),
-                )
-                .await
-                .context("retrying ChatGPT page open after reconnect")
-                .context(err)?;
-                self.record_target_success(
-                    &session.target.key,
-                    Some(session.client.ws_endpoint()),
-                    retry_browser_context_id.as_deref(),
-                    &retry_control_run_id,
-                )?;
-                session.target.endpoint = Some(session.client.ws_endpoint().to_string());
-                return Ok(retry_result);
-            }
-            Err(err) => return Err(err),
-        };
+        .await?;
 
         self.record_target_success(
             &session.target.key,
@@ -366,12 +326,63 @@ impl LiveAttachDaemon {
         Ok(result)
     }
 
-    async fn take_or_connect_session(&mut self, target: LiveAttachTarget) -> Result<DaemonSession> {
-        if let Some(session) = self.sessions.remove(&target.key) {
+    async fn take_or_connect_session(
+        &mut self,
+        target: LiveAttachTarget,
+        initial_attach_policy: InitialAttachPolicy,
+    ) -> Result<DaemonSession> {
+        let target_key = target.key.clone();
+        for session_key in self.session_lookup_keys(&target) {
+            let Some(mut session) = self.sessions.remove(&session_key) else {
+                continue;
+            };
+            if let Err(err) = session.client.probe_liveness(750) {
+                let err = single_approval_transport_closed_error(err);
+                self.record_session_terminal_error(&target_key, &session, &err)?;
+                return Err(err);
+            }
+            session.target = session_target_for_alias(target, &session);
             return Ok(session);
         }
 
+        if let Some(err) = self.automatic_reattach_blocked_error_for_target(&target) {
+            return Err(err);
+        }
+
+        if let Some(err) = self.hidden_initial_attach_blocked_error(&target, initial_attach_policy)
+        {
+            return Err(err);
+        }
+
         self.connect_session(target).await
+    }
+
+    fn session_lookup_keys(&self, target: &LiveAttachTarget) -> Vec<String> {
+        let mut keys = Vec::new();
+        push_unique(
+            &mut keys,
+            self.session_key_by_alias.get(&target.key).cloned(),
+        );
+        push_unique(&mut keys, session_key_for_target(target));
+        push_unique(
+            &mut keys,
+            self.state
+                .sessions
+                .get(&target.key)
+                .and_then(|state| state.endpoint.as_deref())
+                .map(endpoint_session_key),
+        );
+        push_unique(&mut keys, Some(target.key.clone()));
+        keys
+    }
+
+    fn store_session(&mut self, alias_key: String, session: DaemonSession) {
+        let session_key = session_key_for_session(&session);
+        self.session_key_by_alias
+            .insert(alias_key, session_key.clone());
+        self.session_key_by_alias
+            .insert(session.target.key.clone(), session_key.clone());
+        self.sessions.insert(session_key, session);
     }
 
     async fn connect_session(&mut self, mut target: LiveAttachTarget) -> Result<DaemonSession> {
@@ -383,11 +394,6 @@ impl LiveAttachDaemon {
         target.endpoint = Some(actual_endpoint);
 
         Ok(DaemonSession { target, client })
-    }
-
-    async fn reconnect_session_in_place(&mut self, session: &mut DaemonSession) -> Result<()> {
-        *session = self.connect_session(session.target.clone()).await?;
-        Ok(())
     }
 
     async fn ensure_chatgpt_control_tab_for_selectors(
@@ -449,6 +455,7 @@ impl LiveAttachDaemon {
         target.status = Some(LiveAttachStatus::Attached);
         target.updated_at_unix_ms = Some(now);
         target.last_error = None;
+        target.automatic_reattach_blocked = false;
         target
             .contexts
             .entry(context_storage_key(browser_context_id))
@@ -484,6 +491,198 @@ impl LiveAttachDaemon {
         target.last_error = Some(format!("{err:#}"));
         save_state(&self.state)
     }
+
+    fn record_target_terminal_error(
+        &mut self,
+        target_key: &str,
+        endpoint: Option<&str>,
+        err: &anyhow::Error,
+    ) -> Result<()> {
+        let target = self.ensure_target_record(target_key);
+        target.endpoint = endpoint
+            .map(str::to_owned)
+            .or_else(|| target.endpoint.clone());
+        target.status = Some(LiveAttachStatus::Degraded);
+        target.updated_at_unix_ms = Some(unix_ms_now());
+        target.last_error = Some(format!("{err:#}"));
+        target.automatic_reattach_blocked = true;
+        save_state(&self.state)
+    }
+
+    fn record_session_terminal_error(
+        &mut self,
+        target_key: &str,
+        session: &DaemonSession,
+        err: &anyhow::Error,
+    ) -> Result<()> {
+        let session_key = session_key_for_session(session);
+        let endpoint = session
+            .target
+            .endpoint
+            .clone()
+            .unwrap_or_else(|| session.client.ws_endpoint().to_string());
+        let mut aliases = vec![target_key.to_string(), session.target.key.clone()];
+        aliases.extend(
+            self.session_key_by_alias
+                .iter()
+                .filter(|(_, key)| *key == &session_key)
+                .map(|(alias, _)| alias.clone()),
+        );
+        aliases.sort();
+        aliases.dedup();
+        for alias in aliases {
+            self.record_target_terminal_error(&alias, Some(&endpoint), err)?;
+        }
+        Ok(())
+    }
+
+    fn automatic_reattach_blocked_error(&self, target_key: &str) -> Option<anyhow::Error> {
+        if let Some(err) = self.automatic_reattach_blocked_error_for_alias(target_key) {
+            return Some(err);
+        }
+        let session_key = self.session_key_by_alias.get(target_key)?;
+        self.session_key_by_alias
+            .iter()
+            .filter(|(_, key)| *key == session_key)
+            .find_map(|(alias, _)| self.automatic_reattach_blocked_error_for_alias(alias))
+    }
+
+    fn automatic_reattach_blocked_error_for_target(
+        &self,
+        target: &LiveAttachTarget,
+    ) -> Option<anyhow::Error> {
+        if let Some(err) = self.automatic_reattach_blocked_error(&target.key) {
+            return Some(err);
+        }
+        let (alias, state) = self.persisted_state_for_target(target)?;
+        if state.automatic_reattach_blocked {
+            return self.automatic_reattach_blocked_error_for_alias(alias);
+        }
+        None
+    }
+
+    fn automatic_reattach_blocked_error_for_alias(
+        &self,
+        target_key: &str,
+    ) -> Option<anyhow::Error> {
+        let target = self.state.sessions.get(target_key)?;
+        if !target.automatic_reattach_blocked {
+            return None;
+        }
+        let last_error = target
+            .last_error
+            .as_deref()
+            .unwrap_or("the approved Chrome websocket is no longer usable");
+        Some(anyhow!(
+            "automatic Chrome reattach is disabled for live-attach target `{target_key}` because the previously approved websocket failed: {last_error}\nRun `yoetz browser reset` before reattaching so any new Chrome remote-debugging approval is explicit."
+        ))
+    }
+
+    fn hidden_initial_attach_blocked_error(
+        &self,
+        target: &LiveAttachTarget,
+        initial_attach_policy: InitialAttachPolicy,
+    ) -> Option<anyhow::Error> {
+        if initial_attach_policy == InitialAttachPolicy::Allow {
+            return None;
+        }
+        let (alias, state) = self.persisted_state_for_target(target)?;
+        if state.endpoint.is_none() && state.status != Some(LiveAttachStatus::Attached) {
+            return None;
+        }
+        Some(anyhow!(
+            "no live approved Chrome websocket is available for live-attach target `{}`. Persisted target `{alias}` was owned by a previous live-attach daemon, and yoetz will not create a new Chrome CDP websocket from a recipe because that can trigger another remote-debugging approval prompt. Run `yoetz browser attach` to reapprove explicitly, or run `yoetz browser reset` to clear the stale owner state.",
+            target.key
+        ))
+    }
+
+    fn persisted_state_for_target(
+        &self,
+        target: &LiveAttachTarget,
+    ) -> Option<(&str, &PersistedTargetState)> {
+        if let Some((alias, state)) = self.state.sessions.get_key_value(&target.key) {
+            return Some((alias.as_str(), state));
+        }
+        let session_key = session_key_for_target(target)?;
+        self.state
+            .sessions
+            .iter()
+            .find(|(_, state)| {
+                state
+                    .endpoint
+                    .as_deref()
+                    .map(endpoint_session_key)
+                    .as_deref()
+                    == Some(session_key.as_str())
+            })
+            .map(|(alias, state)| (alias.as_str(), state))
+    }
+}
+
+fn single_approval_transport_closed_error(err: anyhow::Error) -> anyhow::Error {
+    err.context(
+        "approved Chrome CDP websocket closed; yoetz live-attach will not reconnect automatically because that can trigger another Chrome remote-debugging approval prompt. Run `yoetz browser reset` before reattaching",
+    )
+}
+
+fn endpoint_session_key(endpoint: &str) -> String {
+    format!("endpoint:{endpoint}")
+}
+
+fn session_key_for_target(target: &LiveAttachTarget) -> Option<String> {
+    resolve_connect_endpoint(target)
+        .as_deref()
+        .and_then(canonical_endpoint_session_key)
+        .or_else(|| {
+            target
+                .endpoint
+                .as_deref()
+                .and_then(canonical_endpoint_session_key)
+        })
+}
+
+fn session_key_for_session(session: &DaemonSession) -> String {
+    canonical_endpoint_session_key(session.client.ws_endpoint())
+        .or_else(|| {
+            session
+                .target
+                .endpoint
+                .as_deref()
+                .and_then(canonical_endpoint_session_key)
+        })
+        .unwrap_or_else(|| session.target.key.clone())
+}
+
+fn canonical_endpoint_session_key(endpoint: &str) -> Option<String> {
+    if endpoint.starts_with("ws://") || endpoint.starts_with("wss://") {
+        Some(endpoint_session_key(endpoint))
+    } else {
+        None
+    }
+}
+
+fn session_target_for_alias(
+    mut target: LiveAttachTarget,
+    session: &DaemonSession,
+) -> LiveAttachTarget {
+    let endpoint = Some(session.client.ws_endpoint().to_string());
+    target.endpoint = endpoint.clone();
+    target.browser_id =
+        browser_id_from_ws_endpoint(session.client.ws_endpoint()).or(target.browser_id);
+    target.connect_endpoint = target
+        .connect_endpoint
+        .or_else(|| session.target.connect_endpoint.clone())
+        .or(endpoint);
+    target
+}
+
+fn push_unique(values: &mut Vec<String>, value: Option<String>) {
+    let Some(value) = value else {
+        return;
+    };
+    if !values.contains(&value) {
+        values.push(value);
+    }
 }
 
 fn live_attach_recipe_page_open_mode() -> chatgpt::InitialPageOpenMode {
@@ -493,6 +692,10 @@ fn live_attach_recipe_page_open_mode() -> chatgpt::InitialPageOpenMode {
     // default-profile Chrome builds can close the approved CDP websocket on
     // external new-target creation and force another consent dialog.
     chatgpt::retry_initial_page_open_mode()
+}
+
+fn live_attach_recipe_reconnect_policy() -> chatgpt::ReconnectPolicy {
+    chatgpt::ReconnectPolicy::Never
 }
 
 pub async fn ensure_chatgpt_session(
@@ -1345,6 +1548,192 @@ mod tests {
     }
 
     #[test]
+    fn live_attach_recipe_disables_hidden_reconnects() {
+        assert_eq!(
+            live_attach_recipe_reconnect_policy(),
+            chatgpt::ReconnectPolicy::Never
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn terminal_transport_error_blocks_automatic_reattach_until_success() {
+        let _guard = lock_env();
+        let dir = tempdir().unwrap();
+        let state_path = dir.path().join("live-attach.json");
+        let _state = EnvVarGuard::set("YOETZ_LIVE_ATTACH_STATE_PATH", &state_path);
+        let mut daemon = LiveAttachDaemon {
+            state: LiveAttachState::default(),
+            sessions: BTreeMap::new(),
+            session_key_by_alias: BTreeMap::new(),
+        };
+        let target_key = "implicit-default";
+        let endpoint = "ws://127.0.0.1:9222/devtools/browser/test";
+        let err = single_approval_transport_closed_error(anyhow!(
+            "Unable to make method calls because underlying connection is closed"
+        ));
+
+        daemon
+            .record_target_terminal_error(target_key, Some(endpoint), &err)
+            .unwrap();
+        let blocked = daemon
+            .automatic_reattach_blocked_error(target_key)
+            .expect("terminal transport error should block automatic reattach");
+        let blocked = format!("{blocked:#}");
+        assert!(blocked.contains("automatic Chrome reattach is disabled"));
+        assert!(blocked.contains("yoetz browser reset"));
+
+        daemon
+            .record_target_success(target_key, Some(endpoint), None, "control-run")
+            .unwrap();
+        assert!(
+            daemon
+                .automatic_reattach_blocked_error(target_key)
+                .is_none(),
+            "successful explicit attach should clear the reattach block"
+        );
+    }
+
+    #[test]
+    fn persisted_target_state_defaults_reattach_block_to_false() {
+        let state: PersistedTargetState = serde_json::from_str(
+            r#"{
+                "endpoint": "ws://127.0.0.1:9222/devtools/browser/test",
+                "status": "attached",
+                "updated_at_unix_ms": 1,
+                "last_error": null,
+                "contexts": {}
+            }"#,
+        )
+        .unwrap();
+
+        assert!(!state.automatic_reattach_blocked);
+    }
+
+    #[test]
+    fn session_lookup_prefers_alias_binding_to_endpoint_key() {
+        let mut daemon = LiveAttachDaemon {
+            state: LiveAttachState::default(),
+            sessions: BTreeMap::new(),
+            session_key_by_alias: BTreeMap::from([(
+                IMPLICIT_TARGET_KEY.to_string(),
+                "endpoint:ws://127.0.0.1:9222/devtools/browser/test".to_string(),
+            )]),
+        };
+        daemon.state.sessions.insert(
+            IMPLICIT_TARGET_KEY.to_string(),
+            PersistedTargetState {
+                endpoint: Some("ws://127.0.0.1:9222/devtools/browser/test".to_string()),
+                status: Some(LiveAttachStatus::Attached),
+                updated_at_unix_ms: Some(1),
+                last_error: None,
+                automatic_reattach_blocked: false,
+                contexts: BTreeMap::new(),
+            },
+        );
+
+        assert_eq!(
+            daemon.session_lookup_keys(&LiveAttachTarget::from_resolved(None)),
+            vec![
+                "endpoint:ws://127.0.0.1:9222/devtools/browser/test".to_string(),
+                IMPLICIT_TARGET_KEY.to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn session_key_for_target_uses_canonical_ws_endpoint_not_alias() {
+        let target = LiveAttachTarget {
+            key: "endpoint:http://127.0.0.1:9222".to_string(),
+            connect_endpoint: Some("http://127.0.0.1:9222".to_string()),
+            endpoint: Some("ws://127.0.0.1:9222/devtools/browser/test".to_string()),
+            source_path: None,
+            browser_id: None,
+            implicit_default: false,
+        };
+
+        assert_eq!(
+            session_key_for_target(&target),
+            Some("endpoint:ws://127.0.0.1:9222/devtools/browser/test".to_string())
+        );
+    }
+
+    #[test]
+    fn automatic_reattach_block_applies_to_endpoint_aliases() {
+        let endpoint_key = "endpoint:ws://127.0.0.1:9222/devtools/browser/test".to_string();
+        let mut daemon = LiveAttachDaemon {
+            state: LiveAttachState::default(),
+            sessions: BTreeMap::new(),
+            session_key_by_alias: BTreeMap::from([
+                ("source-path:/tmp/chrome".to_string(), endpoint_key.clone()),
+                ("browser-id:test".to_string(), endpoint_key),
+            ]),
+        };
+        daemon.state.sessions.insert(
+            "source-path:/tmp/chrome".to_string(),
+            PersistedTargetState {
+                endpoint: Some("ws://127.0.0.1:9222/devtools/browser/test".to_string()),
+                status: Some(LiveAttachStatus::Degraded),
+                updated_at_unix_ms: Some(1),
+                last_error: Some("closed transport".to_string()),
+                automatic_reattach_blocked: true,
+                contexts: BTreeMap::new(),
+            },
+        );
+
+        let err = daemon
+            .automatic_reattach_blocked_error("browser-id:test")
+            .expect("endpoint alias should inherit the terminal reattach block");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("source-path:/tmp/chrome"));
+        assert!(msg.contains("yoetz browser reset"));
+    }
+
+    #[test]
+    fn recipe_attach_policy_blocks_persisted_owner_after_daemon_restart() {
+        let mut daemon = LiveAttachDaemon {
+            state: LiveAttachState::default(),
+            sessions: BTreeMap::new(),
+            session_key_by_alias: BTreeMap::new(),
+        };
+        daemon.state.sessions.insert(
+            "source-path:/tmp/chrome".to_string(),
+            PersistedTargetState {
+                endpoint: Some("ws://127.0.0.1:9222/devtools/browser/test".to_string()),
+                status: Some(LiveAttachStatus::Attached),
+                updated_at_unix_ms: Some(1),
+                last_error: None,
+                automatic_reattach_blocked: false,
+                contexts: BTreeMap::new(),
+            },
+        );
+        let target = LiveAttachTarget {
+            key: "browser-id:test".to_string(),
+            connect_endpoint: Some("ws://127.0.0.1:9222/devtools/browser/test".to_string()),
+            endpoint: Some("ws://127.0.0.1:9222/devtools/browser/test".to_string()),
+            source_path: None,
+            browser_id: Some("test".to_string()),
+            implicit_default: false,
+        };
+
+        let err = daemon
+            .hidden_initial_attach_blocked_error(
+                &target,
+                InitialAttachPolicy::RequireLiveSessionIfPersisted,
+            )
+            .expect("recipe should not auto-reattach after daemon restart");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("previous live-attach daemon"), "{msg}");
+        assert!(msg.contains("yoetz browser attach"), "{msg}");
+        assert!(
+            daemon
+                .hidden_initial_attach_blocked_error(&target, InitialAttachPolicy::Allow)
+                .is_none(),
+            "explicit attach flow may establish a new approved owner"
+        );
+    }
+
+    #[test]
     #[serial]
     fn reset_removes_state_and_daemon_metadata_files() {
         let _guard = lock_env();
@@ -1362,6 +1751,7 @@ mod tests {
                     status: Some(LiveAttachStatus::Attached),
                     updated_at_unix_ms: Some(unix_ms_now()),
                     last_error: None,
+                    automatic_reattach_blocked: false,
                     contexts: BTreeMap::new(),
                 },
             )]),
@@ -1573,6 +1963,7 @@ mod tests {
             let daemon = Arc::new(AsyncMutex::new(LiveAttachDaemon {
                 state: LiveAttachState::default(),
                 sessions: BTreeMap::new(),
+                session_key_by_alias: BTreeMap::new(),
             }));
             let _busy = daemon.lock().await;
             let shutdown = Arc::new(Notify::new());

--- a/docs/decisions/ADR-001-live-attach-owner.md
+++ b/docs/decisions/ADR-001-live-attach-owner.md
@@ -36,6 +36,10 @@ The concrete changes are:
 - open ChatGPT recipe tabs from the durable yoetz-owned control tab after the
   daemon is attached, rather than issuing a fresh browser-level
   `Target.createTarget` for every recipe run
+- forbid automatic CDP reconnect inside daemon-owned ChatGPT flows after the
+  first approved websocket exists. A closed websocket is terminal for the
+  current request and requires an explicit `yoetz browser reset` before any new
+  attach attempt.
 
 ## Alternatives Considered
 
@@ -63,10 +67,30 @@ The concrete changes are:
 
 - `attach`, `check`, and the ChatGPT `recipe` share one yoetz-owned CDP owner
 - repeated auth checks and recipe launches reuse the same control-tab identity for a resolved browser context instead of creating throwaway probe tabs
-- reconnect recovery now keeps the old `CreateTarget -> reconnect -> recover via existing anchor` behavior on the daemonized recipe path
+- daemonized ChatGPT requests fail closed on transport loss instead of creating
+  a second CDP websocket that could trigger another Chrome approval dialog
 - Chrome still requires the first native approval after Chrome starts. Yoetz
   cannot persist or bypass that browser consent; the invariant is that the
   daemon keeps one approved websocket alive so subsequent ChatGPT recipe runs
   do not create new attach prompts until Chrome or the daemon is restarted
 - a busy daemon times out cleanly instead of wedging `doctor`, `reset`, or later attach/check calls forever
 - `dev-browser` and `agent-browser` remain available, but only as fallback executors when the primary live owner is unavailable or unsuitable
+
+## 2026-05-02 Amendment: No Hidden Reattach
+
+The live-attach daemon is an owner, not a retry wrapper. Once Chrome has
+approved the daemon's websocket, daemon-owned code must not create another CDP
+websocket as hidden recovery for `ensure-session`, recipe page-open, or
+stable-idle polling failures.
+
+When the approved websocket closes, the daemon records the target as degraded,
+blocks automatic reattach for that target, and returns an error telling the
+operator to run `yoetz browser reset` before reattaching. Standalone
+non-daemon recipe code may keep its explicitly scoped one-retry fallback, but
+the daemon path always passes a no-reconnect policy to the recipe engine.
+
+If a daemon restarts while persisted live-attach state still says a target was
+previously attached, recipe requests also fail closed instead of creating a new
+websocket from that stale state. A new owner may be established only through an
+explicit `yoetz browser attach` flow or by clearing the stale state with
+`yoetz browser reset`.


### PR DESCRIPTION
Prevent daemon-owned ChatGPT live attach from creating a hidden second Chrome CDP websocket after the first approved websocket dies.

This is the follow-up fix for the v0.2.57 failure where Chrome dropped the websocket during stable-idle polling, Yoetz reconnected inside the recipe engine, and Chrome showed a second remote-debugging approval prompt. The daemon now treats websocket loss as terminal for the current request: failure is the recovery path that preserves the single-approval invariant.

The change has four behavioral pillars:

- `ReconnectPolicy::Never` is passed from the live-attach daemon into the ChatGPT recipe path, so response polling and page-open failures cannot secretly reconnect under daemon ownership.
- Cached daemon sessions are probed with `CdpMcpClient::probe_liveness` before reuse, with a bounded timeout around the existing websocket's `Target.getTargets` call.
- Closed transports record a degraded terminal state with `automatic_reattach_blocked`, preventing later aliases from creating a fresh CDP attach without an explicit reset.
- `InitialAttachPolicy::RequireLiveSessionIfPersisted` prevents recipe requests from silently reattaching after daemon restart when persisted state shows a prior live owner; explicit `yoetz browser attach` remains the reapproval path.

ADR-001 now records that automatic CDP reconnect is forbidden inside daemon-owned ChatGPT flows after approval, including the daemon-restart case.

Follow-ups for Stage B:

1. Persist `sessions_by_endpoint` and `endpoint_by_alias` instead of using an in-memory alias map.
2. Add a fake `CdpMcpClientFactory` and `connect_count == 1` invariant tests.
3. Add the explicit 8-variant `SessionState` enum.
4. Add a typed `BrowserFingerprint`.
5. Add panic isolation with `AssertUnwindSafe` and `catch_unwind` around session work.
6. Move long recipes out of the global daemon lock behind per-session `Arc<AsyncMutex<_>>` ownership.
7. Replace string-matched transport classifiers with typed `CdpFailure` variants.
8. Rename the Chrome approval lock to an attach-attempt lock, simplify the policy API, use one save for terminal alias state, and finish the small cleanup items from review.

Verified locally with `cargo fmt --check`, `cargo test --workspace`, and `cargo clippy --workspace --all-targets -- -D warnings`.