### PR TITLE
chore(release): v0.2.59

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.2.58",
+  "version": "0.2.59",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.2.58",
+  "version": "0.2.59",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.2.59] - 2026-05-03
+
 ## [0.2.58] - 2026-05-02
 
 ## [0.2.57] - 2026-05-02

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3190,7 +3190,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoetz"
-version = "0.2.58"
+version = "0.2.59"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "yoetz-core"
-version = "0.2.58"
+version = "0.2.59"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/yoetz-core", "crates/yoetz-cli"]
 
 [workspace.package]
-version = "0.2.58"
+version = "0.2.59"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yoetz
-version: 0.2.58
+version: 0.2.59
 description: >
   Fast CLI-first LLM council, bundler, and multimodal gateway. Use ONLY when user
   explicitly mentions "yoetz", "yoetz ask", "yoetz council", "yoetz review",


### PR DESCRIPTION
## Release

- updates `CHANGELOG.md` for `v0.2.59`
- bumps workspace version to `0.2.59`
- aligns skill/plugin metadata to `0.2.59`
- merge triggers .github/workflows/release.yml, which creates the tag and
  publishes the release
- GitHub release notes come from the committed `CHANGELOG.md` entry