### PR TITLE
ref(browser): Rename live attach owner concepts

### DIFF
--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -47,7 +47,9 @@ const CHATGPT_SEND_ENABLE_POLL_INTERVAL_MS: u64 = 250;
 const DAEMON_APPROVAL_GRACE_WINDOW: Duration = Duration::from_secs(30);
 const LIVE_ATTACH_COMMAND_TIMEOUT_MS: u64 = 30_000;
 const CDP_SESSION_NAME: &str = "yoetz-cdp";
-const CHROME_APPROVAL_LOCK_FILENAME: &str = "chrome-approval.lock";
+// Keep the legacy filename for local compatibility; the lock only serializes
+// attach attempts and does not represent persisted Chrome approval.
+const CHROME_ATTACH_ATTEMPT_LOCK_FILENAME: &str = "chrome-approval.lock";
 const BROWSER_TARGET_STATE_FILENAME: &str = "browser-target.json";
 pub const CHATGPT_URL: &str = "https://chatgpt.com/";
 const COOKIE_SYNC_NODE_MIN_VERSION: NodeVersion = NodeVersion {
@@ -177,7 +179,7 @@ impl ResolvedCdpTarget {
         matches!(self.source, ResolvedCdpTargetSource::Flag)
     }
 
-    pub fn live_attach_target_key(&self) -> String {
+    pub fn live_attach_target_alias(&self) -> String {
         if let Some(source_path) = &self.source_path {
             return format!("source-path:{}", source_path.display());
         }
@@ -2024,12 +2026,12 @@ pub enum DaemonState {
 }
 
 #[derive(Debug)]
-pub struct ChromeApprovalLock {
+pub struct AttachAttemptLock {
     _lock_file: File,
     waited: bool,
 }
 
-impl ChromeApprovalLock {
+impl AttachAttemptLock {
     pub fn waited(&self) -> bool {
         self.waited
     }
@@ -2069,11 +2071,11 @@ fn acquire_waitable_lock(lock_path: &Path, action: &str) -> Result<(File, bool)>
     Ok((file, waited))
 }
 
-pub fn acquire_chrome_approval_lock() -> Result<ChromeApprovalLock> {
-    let lock_path = yoetz_lock_path(CHROME_APPROVAL_LOCK_FILENAME);
-    let (file, waited) = acquire_waitable_lock(&lock_path, "browser approval lock")?;
+pub fn acquire_attach_attempt_lock() -> Result<AttachAttemptLock> {
+    let lock_path = yoetz_lock_path(CHROME_ATTACH_ATTEMPT_LOCK_FILENAME);
+    let (file, waited) = acquire_waitable_lock(&lock_path, "browser attach attempt lock")?;
 
-    Ok(ChromeApprovalLock {
+    Ok(AttachAttemptLock {
         _lock_file: file,
         waited,
     })

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
@@ -40,7 +40,7 @@ use serde::{Deserialize, Serialize};
 use std::io::IsTerminal;
 use std::time::Duration;
 
-use super::client::{is_external_create_target_block_error, CdpMcpClient};
+use super::client::{is_external_create_target_block_error, ChromeCdpClient};
 use super::DevtoolsMcpRecipeContext;
 use crate::chatgpt_web;
 
@@ -199,20 +199,21 @@ async fn run_attached_recipe_with_reconnect(
     }
 }
 
-async fn connect_client(ctx: &DevtoolsMcpRecipeContext) -> Result<CdpMcpClient> {
-    connect_client_with_approval_lock(ctx.cdp_endpoint.as_deref(), ctx.show_approval_guidance).await
+async fn connect_client(ctx: &DevtoolsMcpRecipeContext) -> Result<ChromeCdpClient> {
+    connect_client_with_attach_attempt_lock(ctx.cdp_endpoint.as_deref(), ctx.show_approval_guidance)
+        .await
 }
 
-pub async fn connect_client_with_approval_lock(
+pub async fn connect_client_with_attach_attempt_lock(
     cdp_endpoint: Option<&str>,
     show_approval_guidance: bool,
-) -> Result<CdpMcpClient> {
+) -> Result<ChromeCdpClient> {
     // Step 0: attach directly to the user's running Chrome session.
     // Chrome may show an "Allow remote debugging?" dialog here whenever it
     // treats this as a new external attach request. Serialize only the attach
     // itself so approval prompts do not race across yoetz processes.
-    let client = with_chrome_approval_lock(show_approval_guidance, || async {
-        CdpMcpClient::connect_to_running_chrome(cdp_endpoint)
+    let client = with_attach_attempt_lock(show_approval_guidance, || async {
+        ChromeCdpClient::connect_to_running_chrome(cdp_endpoint)
             .await
             .map_err(cdp_attach_hint)
     })
@@ -222,7 +223,7 @@ pub async fn connect_client_with_approval_lock(
 }
 
 async fn run_attached_recipe(
-    mut client: CdpMcpClient,
+    mut client: ChromeCdpClient,
     ctx: &DevtoolsMcpRecipeContext,
     page_open_mode: InitialPageOpenMode,
 ) -> Result<ChatgptRunResult> {
@@ -258,7 +259,7 @@ async fn run_attached_recipe(
 }
 
 pub async fn run_with_client(
-    client: &mut CdpMcpClient,
+    client: &mut ChromeCdpClient,
     ctx: &DevtoolsMcpRecipeContext,
     browser_context_id: Option<String>,
 ) -> Result<ChatgptRunResult> {
@@ -272,7 +273,7 @@ pub async fn run_with_client(
 }
 
 pub async fn run_with_client_using_page_open_mode(
-    client: &mut CdpMcpClient,
+    client: &mut ChromeCdpClient,
     ctx: &DevtoolsMcpRecipeContext,
     browser_context_id: Option<String>,
     page_open_mode: InitialPageOpenMode,
@@ -288,7 +289,7 @@ pub async fn run_with_client_using_page_open_mode(
 }
 
 pub async fn run_with_client_using_page_open_mode_and_reconnect_policy(
-    client: &mut CdpMcpClient,
+    client: &mut ChromeCdpClient,
     ctx: &DevtoolsMcpRecipeContext,
     browser_context_id: Option<String>,
     page_open_mode: InitialPageOpenMode,
@@ -305,7 +306,7 @@ pub async fn run_with_client_using_page_open_mode_and_reconnect_policy(
 }
 
 async fn run_attached_recipe_inner(
-    client: &mut CdpMcpClient,
+    client: &mut ChromeCdpClient,
     ctx: &DevtoolsMcpRecipeContext,
     browser_context_id: Option<String>,
     page_open_mode: InitialPageOpenMode,
@@ -426,7 +427,7 @@ async fn run_attached_recipe_inner(
 }
 
 async fn open_initial_chatgpt_page(
-    client: &CdpMcpClient,
+    client: &ChromeCdpClient,
     marked_url: &str,
     browser_context_id: Option<&str>,
     mode: InitialPageOpenMode,
@@ -463,7 +464,7 @@ async fn open_initial_chatgpt_page(
 }
 
 async fn open_page_via_blank_target(
-    client: &CdpMcpClient,
+    client: &ChromeCdpClient,
     url: &str,
     background: bool,
     timeout_ms: u64,
@@ -486,7 +487,7 @@ async fn open_page_via_blank_target(
 }
 
 async fn open_initial_chatgpt_probe_page(
-    client: &CdpMcpClient,
+    client: &ChromeCdpClient,
     url: &str,
     timeout_ms: u64,
     browser_context_id: Option<&str>,
@@ -539,7 +540,7 @@ pub async fn check_auth(cdp_endpoint: Option<&str>, show_approval_guidance: bool
 }
 
 async fn open_chatgpt_auth_probe_page(
-    client: &CdpMcpClient,
+    client: &ChromeCdpClient,
     browser_context_id: Option<&str>,
     control_run_id: Option<&str>,
     timeout_ms: u64,
@@ -566,12 +567,13 @@ pub async fn check_auth_with_control_run_id(
     show_approval_guidance: bool,
     control_run_id: Option<&str>,
 ) -> Result<()> {
-    let client = connect_client_with_approval_lock(cdp_endpoint, show_approval_guidance).await?;
+    let client =
+        connect_client_with_attach_attempt_lock(cdp_endpoint, show_approval_guidance).await?;
     ensure_chatgpt_control_tab_ready(&client, None, control_run_id).await
 }
 
 pub async fn ensure_chatgpt_control_tab_ready(
-    client: &CdpMcpClient,
+    client: &ChromeCdpClient,
     browser_context_id: Option<&str>,
     control_run_id: Option<&str>,
 ) -> Result<()> {
@@ -585,7 +587,7 @@ pub async fn ensure_chatgpt_control_tab_ready(
 }
 
 pub async fn ensure_chatgpt_control_tab_ready_with_open_mode(
-    client: &CdpMcpClient,
+    client: &ChromeCdpClient,
     browser_context_id: Option<&str>,
     control_run_id: Option<&str>,
     page_open_mode: InitialPageOpenMode,
@@ -637,7 +639,7 @@ fn should_retire_failed_reused_control_tab(
     control_run_id.is_some() && result.is_err()
 }
 
-async fn wait_for_composer_ready(client: &CdpMcpClient, focus_composer: bool) -> Result<()> {
+async fn wait_for_composer_ready(client: &ChromeCdpClient, focus_composer: bool) -> Result<()> {
     let composer_state = evaluate_wait_for_composer_state(client, focus_composer).await?;
     match composer_state
         .get("status")
@@ -682,7 +684,7 @@ async fn wait_for_composer_ready(client: &CdpMcpClient, focus_composer: bool) ->
 }
 
 async fn evaluate_wait_for_composer_state(
-    client: &CdpMcpClient,
+    client: &ChromeCdpClient,
     focus_composer: bool,
 ) -> Result<serde_json::Value> {
     let script = build_wait_for_composer_script(focus_composer);
@@ -718,7 +720,7 @@ fn should_retry_wait_for_composer_error(err: &anyhow::Error) -> bool {
 }
 
 async fn maybe_select_model(
-    client: &CdpMcpClient,
+    client: &ChromeCdpClient,
     requested_model: &str,
 ) -> Result<Option<String>> {
     let keep_current_model = chatgpt_web::should_keep_current_chatgpt_model(requested_model);
@@ -843,7 +845,7 @@ fn format_model_selection_diagnostics(selection: &serde_json::Value) -> String {
     )
 }
 
-async fn maybe_disable_extended(client: &CdpMcpClient) -> Result<()> {
+async fn maybe_disable_extended(client: &ChromeCdpClient) -> Result<()> {
     let script = r##"
 () => {
   const button = document.querySelector("button[aria-label*='click to remove'][aria-label*='Extended'], button[aria-label*='remove'][aria-label*='Extended']");
@@ -938,53 +940,53 @@ fn approval_wait_message() -> String {
     )
 }
 
-async fn with_chrome_approval_lock<T, F, Fut>(show_approval_guidance: bool, action: F) -> Result<T>
+async fn with_attach_attempt_lock<T, F, Fut>(show_approval_guidance: bool, action: F) -> Result<T>
 where
     F: FnOnce() -> Fut,
     Fut: std::future::Future<Output = Result<T>>,
 {
-    with_chrome_approval_lock_using(
+    with_attach_attempt_lock_using(
         show_approval_guidance,
-        crate::browser::acquire_chrome_approval_lock,
+        crate::browser::acquire_attach_attempt_lock,
         action,
     )
     .await
 }
 
-trait ApprovalLockState {
+trait AttachAttemptLockState {
     fn waited(&self) -> bool;
 }
 
-impl ApprovalLockState for crate::browser::ChromeApprovalLock {
+impl AttachAttemptLockState for crate::browser::AttachAttemptLock {
     fn waited(&self) -> bool {
         self.waited()
     }
 }
 
-async fn with_chrome_approval_lock_using<T, L, Acquire, F, Fut>(
+async fn with_attach_attempt_lock_using<T, L, Acquire, F, Fut>(
     show_approval_guidance: bool,
     acquire_lock: Acquire,
     action: F,
 ) -> Result<T>
 where
-    L: ApprovalLockState,
+    L: AttachAttemptLockState,
     Acquire: FnOnce() -> Result<L>,
     F: FnOnce() -> Fut,
     Fut: std::future::Future<Output = Result<T>>,
 {
-    let approval_lock = acquire_lock()?;
-    emit_chrome_approval_guidance(show_approval_guidance, approval_lock.waited());
-    let _approval_lock = approval_lock;
+    let attach_attempt_lock = acquire_lock()?;
+    emit_chrome_attach_attempt_guidance(show_approval_guidance, attach_attempt_lock.waited());
+    let _attach_attempt_lock = attach_attempt_lock;
     action().await
 }
 
-fn emit_chrome_approval_guidance(show_approval_guidance: bool, waited: bool) {
+fn emit_chrome_attach_attempt_guidance(show_approval_guidance: bool, waited: bool) {
     if !show_approval_guidance {
         return;
     }
     if waited {
         eprintln!(
-            "info: another yoetz process is already requesting Chrome approval; waiting for it to finish before trying the chrome-devtools-mcp transport"
+            "info: another yoetz process is already starting a Chrome attach attempt; waiting for it to finish before trying the chrome-devtools-mcp transport"
         );
     }
     eprintln!(
@@ -1032,7 +1034,7 @@ fn should_retry_initial_new_page_after_reconnect(err: &anyhow::Error) -> bool {
 fn emit_transport_retry_notice(ctx: &DevtoolsMcpRecipeContext) {
     if ctx.show_approval_guidance || std::io::stderr().is_terminal() {
         eprintln!(
-            "info: Chrome dropped the initial CDP session while opening the ChatGPT tab; reconnecting once and falling back to existing-anchor recovery. Chrome may prompt again."
+            "info: Chrome dropped the initial CDP session while opening the ChatGPT tab; this standalone flow reconnects once and falls back to existing-anchor recovery. Daemon-owned live attach is not reconnecting to preserve the single-approval invariant."
         );
     }
 }
@@ -1107,7 +1109,7 @@ fn format_page_probe_summary(state: &serde_json::Value) -> String {
 /// `upload_file`. `upload_file` accepts either the file input itself or the
 /// element that opens the file chooser, so prefer visible menu items/buttons
 /// over guessing a hidden input uid.
-async fn try_upload_bundle(client: &CdpMcpClient, bundle_path: &std::path::Path) -> Result<()> {
+async fn try_upload_bundle(client: &ChromeCdpClient, bundle_path: &std::path::Path) -> Result<()> {
     let file_name = bundle_path
         .file_name()
         .and_then(|value| value.to_str())
@@ -1191,7 +1193,7 @@ async fn try_upload_bundle(client: &CdpMcpClient, bundle_path: &std::path::Path)
 }
 
 async fn try_upload_via_file_input(
-    client: &CdpMcpClient,
+    client: &ChromeCdpClient,
     bundle_path: &std::path::Path,
     file_name: &str,
 ) -> Result<bool> {
@@ -1215,7 +1217,10 @@ async fn try_upload_via_file_input(
     Ok(true)
 }
 
-async fn wait_for_file_input_uid(client: &CdpMcpClient, timeout_ms: u64) -> Result<Option<String>> {
+async fn wait_for_file_input_uid(
+    client: &ChromeCdpClient,
+    timeout_ms: u64,
+) -> Result<Option<String>> {
     let deadline = std::time::Instant::now() + Duration::from_millis(timeout_ms);
     let scope_script = chatgpt_web::build_scope_composer_file_input_function();
 
@@ -1253,7 +1258,7 @@ async fn wait_for_file_input_uid(client: &CdpMcpClient, timeout_ms: u64) -> Resu
     }
 }
 
-async fn click_upload_candidate(client: &CdpMcpClient, candidate_id: &str) -> Result<bool> {
+async fn click_upload_candidate(client: &ChromeCdpClient, candidate_id: &str) -> Result<bool> {
     let candidate_json = serde_json::to_string(candidate_id)?;
     let script = format!(
         r#"() => {{
@@ -1266,7 +1271,7 @@ async fn click_upload_candidate(client: &CdpMcpClient, candidate_id: &str) -> Re
     Ok(client.evaluate_script(&script, vec![]).await? == serde_json::Value::Bool(true))
 }
 
-async fn click_upload_menu_item(client: &CdpMcpClient) -> Result<bool> {
+async fn click_upload_menu_item(client: &ChromeCdpClient) -> Result<bool> {
     let script = chatgpt_web::build_upload_menu_item_click_function();
     Ok(client
         .evaluate_script(&script, vec![])
@@ -1276,7 +1281,7 @@ async fn click_upload_menu_item(client: &CdpMcpClient) -> Result<bool> {
         == Some("clicked"))
 }
 
-async fn collect_upload_diagnostics(client: &CdpMcpClient) -> Result<serde_json::Value> {
+async fn collect_upload_diagnostics(client: &ChromeCdpClient) -> Result<serde_json::Value> {
     let script = build_collect_upload_diagnostics_script();
 
     client
@@ -1416,7 +1421,7 @@ fn format_upload_diagnostics(diagnostics: &serde_json::Value) -> String {
     serde_json::to_string_pretty(diagnostics).unwrap_or_else(|_| diagnostics.to_string())
 }
 
-async fn wait_for_attachment_visible(client: &CdpMcpClient, file_name: &str) -> Result<()> {
+async fn wait_for_attachment_visible(client: &ChromeCdpClient, file_name: &str) -> Result<()> {
     let script = build_wait_for_attachment_visible_script(file_name)?;
     let evidence = client
         .evaluate_script(&script, vec![])
@@ -1459,7 +1464,7 @@ async () => {{
 /// Returns the final assistant message text once a post-send assistant turn
 /// has been idle for the shared ChatGPT stable-idle threshold.
 async fn poll_for_stable_response(
-    client: &mut CdpMcpClient,
+    client: &mut ChromeCdpClient,
     ctx: &DevtoolsMcpRecipeContext,
     page_id: &str,
     baseline: ResponseBaseline,
@@ -1573,7 +1578,7 @@ async fn poll_for_stable_response(
 async fn reconnect_response_poll_client(
     ctx: &DevtoolsMcpRecipeContext,
     page_id: &str,
-) -> Result<CdpMcpClient> {
+) -> Result<ChromeCdpClient> {
     let client = connect_client(ctx)
         .await
         .context("reconnect Chrome websocket for stable-idle polling")?;
@@ -1753,7 +1758,7 @@ fn classify_response_completion(
     }
 }
 
-async fn read_latest_assistant_text(client: &CdpMcpClient) -> Result<String> {
+async fn read_latest_assistant_text(client: &ChromeCdpClient) -> Result<String> {
     let script = r##"
 () => {
   const nodes = Array.from(document.querySelectorAll("[data-message-author-role='assistant']"));
@@ -1860,11 +1865,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn with_chrome_approval_lock_acquires_before_running_action() {
+    async fn with_attach_attempt_lock_acquires_before_running_action() {
         #[derive(Clone, Copy)]
         struct FakeLock;
 
-        impl ApprovalLockState for FakeLock {
+        impl AttachAttemptLockState for FakeLock {
             fn waited(&self) -> bool {
                 false
             }
@@ -1873,7 +1878,7 @@ mod tests {
         let acquired = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let acquired_for_action = acquired.clone();
 
-        with_chrome_approval_lock_using(
+        with_attach_attempt_lock_using(
             false,
             || {
                 acquired.store(true, std::sync::atomic::Ordering::SeqCst);
@@ -1882,7 +1887,7 @@ mod tests {
             || async move {
                 assert!(
                     acquired_for_action.load(std::sync::atomic::Ordering::SeqCst),
-                    "approval lock should be acquired before the action runs"
+                    "attach attempt lock should be acquired before the action runs"
                 );
                 Ok::<(), anyhow::Error>(())
             },

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
@@ -90,7 +90,7 @@ const EMAIL_INFERENCE_TRUSTED_ORIGINS: &[&str] = &[
     "platform.openai.com",
 ];
 
-pub struct CdpMcpClient {
+pub struct ChromeCdpClient {
     browser: Browser,
     selected_tab: Mutex<Option<Arc<Tab>>>,
     ws_endpoint: String,
@@ -345,7 +345,7 @@ struct BrowserContextPage {
     url: String,
 }
 
-impl CdpMcpClient {
+impl ChromeCdpClient {
     pub async fn connect_to_running_chrome(cdp_endpoint: Option<&str>) -> Result<Self> {
         let ws_endpoint = resolve_canonical_ws_endpoint(cdp_endpoint)?;
         let browser = Browser::connect_with_timeout(
@@ -1323,7 +1323,7 @@ fn external_create_target_block_guidance(url: &str) -> String {
     )
 }
 
-impl CdpMcpClient {
+impl ChromeCdpClient {
     async fn reuse_existing_optional_context_tab(
         &self,
         url: &str,
@@ -3801,11 +3801,12 @@ mod tests {
             .build()
             .expect("tokio runtime");
         let started = Instant::now();
-        let err =
-            match runtime.block_on(CdpMcpClient::connect_to_running_chrome(Some(&ws_endpoint))) {
-                Ok(_) => panic!("stalled websocket handshake should time out"),
-                Err(err) => err,
-            };
+        let err = match runtime.block_on(ChromeCdpClient::connect_to_running_chrome(Some(
+            &ws_endpoint,
+        ))) {
+            Ok(_) => panic!("stalled websocket handshake should time out"),
+            Err(err) => err,
+        };
         let elapsed = started.elapsed();
 
         shutdown.store(true, Ordering::Relaxed);

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/mod.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/mod.rs
@@ -23,7 +23,7 @@
 //!
 //! ## Module layout
 //!
-//! - [`client`] — `CdpMcpClient`: direct `headless_chrome` browser/tab client
+//! - [`client`] — `ChromeCdpClient`: direct `headless_chrome` browser/tab client
 //!   with a small compatibility surface for the recipe layer.
 //! - [`chatgpt`] — seven-step ChatGPT Pro recipe: navigate → snapshot → upload
 //!   → snapshot → type → click → wait → evaluate.

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -1470,11 +1470,11 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<ChatgptRecipe
 
         let prepare_script = build_chatgpt_prepare_script(&page_name, &ctx.model, &ctx.run_id);
         let prepare_stdout = {
-            let approval_lock = browser::acquire_chrome_approval_lock()?;
+            let attach_attempt_lock = browser::acquire_attach_attempt_lock()?;
             if ctx.show_approval_guidance {
-                if approval_lock.waited() {
+                if attach_attempt_lock.waited() {
                     eprintln!(
-                        "info: another yoetz process is already requesting Chrome approval; waiting for it to finish before trying the dev-browser transport"
+                        "info: another yoetz process is already starting a Chrome attach attempt; waiting for it to finish before trying the dev-browser transport"
                     );
                 }
                 eprintln!(

--- a/crates/yoetz-cli/src/live_attach.rs
+++ b/crates/yoetz-cli/src/live_attach.rs
@@ -31,7 +31,7 @@ use crate::chrome_devtools_mcp::{
         browser_id_from_ws_endpoint, cdp_failure_from_error, classify_cdp_failure,
         discover_devtools_active_port_files, discover_running_chrome_targets,
         is_terminal_cdp_failure, resolve_canonical_ws_endpoint, BrowserFingerprint, CdpFailure,
-        CdpMcpClient, DevtoolsActivePortFile, RunningChromeTarget,
+        ChromeCdpClient, DevtoolsActivePortFile, RunningChromeTarget,
     },
 };
 use yoetz_core::paths::home_dir;
@@ -172,7 +172,8 @@ pub enum DaemonHealth {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct LiveAttachTarget {
-    pub key: String,
+    #[serde(rename = "key")]
+    pub target_alias: String,
     pub connect_endpoint: Option<String>,
     pub endpoint: Option<String>,
     pub source_path: Option<PathBuf>,
@@ -184,7 +185,7 @@ impl LiveAttachTarget {
     pub fn from_resolved(target: Option<&ResolvedCdpTarget>) -> Self {
         match target {
             Some(target) => Self {
-                key: target.live_attach_target_key(),
+                target_alias: target.live_attach_target_alias(),
                 connect_endpoint: Some(target.endpoint.clone()),
                 endpoint: Some(target.endpoint.clone()),
                 source_path: target.source_path().map(Path::to_path_buf),
@@ -192,7 +193,7 @@ impl LiveAttachTarget {
                 implicit_default: false,
             },
             None => Self {
-                key: IMPLICIT_TARGET_KEY.to_string(),
+                target_alias: IMPLICIT_TARGET_KEY.to_string(),
                 connect_endpoint: None,
                 endpoint: None,
                 source_path: None,
@@ -408,11 +409,11 @@ enum DaemonResponse {
     },
 }
 
-struct DaemonSession {
+struct EndpointSession {
     endpoint_key: EndpointKey,
     aliases: BTreeSet<TargetAlias>,
     target: LiveAttachTarget,
-    client: DaemonSessionClient,
+    client: EndpointSessionClient,
     fingerprint: BrowserFingerprint,
     state: SessionState,
     contexts: BTreeMap<String, PersistedContextState>,
@@ -420,11 +421,11 @@ struct DaemonSession {
 
 struct RuntimeSession {
     endpoint_key: EndpointKey,
-    inner: AsyncMutex<Option<DaemonSession>>,
+    inner: AsyncMutex<Option<EndpointSession>>,
 }
 
 impl RuntimeSession {
-    fn new(session: DaemonSession) -> Self {
+    fn new(session: EndpointSession) -> Self {
         Self {
             endpoint_key: session.endpoint_key.clone(),
             inner: AsyncMutex::new(Some(session)),
@@ -447,7 +448,7 @@ struct PendingInitialConnect {
     endpoint_key: EndpointKey,
     endpoint_connect: Arc<PendingEndpointConnect>,
     contexts: BTreeMap<String, PersistedContextState>,
-    client_factory: Arc<dyn CdpMcpClientFactory>,
+    client_factory: Arc<dyn ChromeCdpClientFactory>,
 }
 
 struct PendingEndpointConnect {
@@ -492,7 +493,7 @@ enum CheckoutDecision {
 }
 
 #[derive(Clone)]
-struct DaemonSessionSnapshot {
+struct EndpointSessionSnapshot {
     endpoint_key: EndpointKey,
     aliases: BTreeSet<TargetAlias>,
     target: LiveAttachTarget,
@@ -502,8 +503,8 @@ struct DaemonSessionSnapshot {
     contexts: BTreeMap<String, PersistedContextState>,
 }
 
-impl DaemonSessionSnapshot {
-    fn from_session(session: &DaemonSession) -> Self {
+impl EndpointSessionSnapshot {
+    fn from_session(session: &EndpointSession) -> Self {
         Self {
             endpoint_key: session.endpoint_key.clone(),
             aliases: session.aliases.clone(),
@@ -520,13 +521,13 @@ impl DaemonSessionSnapshot {
     }
 }
 
-enum DaemonSessionClient {
-    Real(CdpMcpClient),
+enum EndpointSessionClient {
+    Real(ChromeCdpClient),
     #[cfg(test)]
     Test(TestSessionClient),
 }
 
-impl DaemonSessionClient {
+impl EndpointSessionClient {
     fn ws_endpoint(&self) -> &str {
         match self {
             Self::Real(client) => client.ws_endpoint(),
@@ -604,9 +605,10 @@ impl DaemonSessionClient {
     }
 }
 
-type CdpFactoryFuture<'a> = Pin<Box<dyn Future<Output = Result<DaemonSessionClient>> + Send + 'a>>;
+type CdpFactoryFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<EndpointSessionClient>> + Send + 'a>>;
 
-trait CdpMcpClientFactory: Send + Sync {
+trait ChromeCdpClientFactory: Send + Sync {
     fn connect<'a>(
         &'a self,
         endpoint: Option<&'a str>,
@@ -614,18 +616,18 @@ trait CdpMcpClientFactory: Send + Sync {
     ) -> CdpFactoryFuture<'a>;
 }
 
-struct ProductionCdpMcpClientFactory;
+struct ProductionChromeCdpClientFactory;
 
-impl CdpMcpClientFactory for ProductionCdpMcpClientFactory {
+impl ChromeCdpClientFactory for ProductionChromeCdpClientFactory {
     fn connect<'a>(
         &'a self,
         endpoint: Option<&'a str>,
         show_approval_guidance: bool,
     ) -> CdpFactoryFuture<'a> {
         Box::pin(async move {
-            chatgpt::connect_client_with_approval_lock(endpoint, show_approval_guidance)
+            chatgpt::connect_client_with_attach_attempt_lock(endpoint, show_approval_guidance)
                 .await
-                .map(DaemonSessionClient::Real)
+                .map(EndpointSessionClient::Real)
         })
     }
 }
@@ -813,7 +815,7 @@ impl TestSessionClient {
 
 #[cfg(test)]
 #[derive(Clone)]
-struct TestCdpMcpClientFactory {
+struct TestChromeCdpClientFactory {
     connect_count: Arc<AtomicUsize>,
     recipe_behaviors: Arc<StdMutex<VecDeque<TestRecipeBehavior>>>,
     connect_gate: Arc<StdMutex<Option<TestConnectGate>>>,
@@ -827,7 +829,7 @@ struct TestConnectGate {
 }
 
 #[cfg(test)]
-impl Default for TestCdpMcpClientFactory {
+impl Default for TestChromeCdpClientFactory {
     fn default() -> Self {
         Self {
             connect_count: Arc::new(AtomicUsize::new(0)),
@@ -838,7 +840,7 @@ impl Default for TestCdpMcpClientFactory {
 }
 
 #[cfg(test)]
-impl TestCdpMcpClientFactory {
+impl TestChromeCdpClientFactory {
     fn push_recipe_behavior(&self, behavior: TestRecipeBehavior) {
         self.recipe_behaviors.lock().unwrap().push_back(behavior);
     }
@@ -853,7 +855,7 @@ impl TestCdpMcpClientFactory {
 }
 
 #[cfg(test)]
-impl CdpMcpClientFactory for TestCdpMcpClientFactory {
+impl ChromeCdpClientFactory for TestChromeCdpClientFactory {
     fn connect<'a>(
         &'a self,
         endpoint: Option<&'a str>,
@@ -875,7 +877,7 @@ impl CdpMcpClientFactory for TestCdpMcpClientFactory {
                 .unwrap()
                 .pop_front()
                 .unwrap_or(TestRecipeBehavior::Succeed);
-            Ok(DaemonSessionClient::Test(TestSessionClient::new(
+            Ok(EndpointSessionClient::Test(TestSessionClient::new(
                 ws_endpoint,
                 behavior,
             )))
@@ -918,20 +920,31 @@ impl CdpEndpointResolver for TestCdpEndpointResolver {
         &self,
         target: &LiveAttachTarget,
     ) -> Result<ResolvedEndpointIdentity> {
-        if let Some(fingerprint) = self.fingerprints.lock().unwrap().get(&target.key).cloned() {
+        if let Some(fingerprint) = self
+            .fingerprints
+            .lock()
+            .unwrap()
+            .get(&target.target_alias)
+            .cloned()
+        {
             return Ok(ResolvedEndpointIdentity {
                 ws_endpoint: fingerprint.ws_endpoint.clone(),
                 fingerprint,
             });
         }
-        let ws_endpoint =
-            if let Some(endpoint) = self.endpoints.lock().unwrap().get(&target.key).cloned() {
-                endpoint
-            } else if let Some(endpoint) = self.default_endpoint.lock().unwrap().clone() {
-                endpoint
-            } else {
-                resolve_canonical_ws_endpoint(resolve_connect_endpoint(target).as_deref())?
-            };
+        let ws_endpoint = if let Some(endpoint) = self
+            .endpoints
+            .lock()
+            .unwrap()
+            .get(&target.target_alias)
+            .cloned()
+        {
+            endpoint
+        } else if let Some(endpoint) = self.default_endpoint.lock().unwrap().clone() {
+            endpoint
+        } else {
+            resolve_canonical_ws_endpoint(resolve_connect_endpoint(target).as_deref())?
+        };
         Ok(ResolvedEndpointIdentity {
             fingerprint: browser_fingerprint_from_target_and_endpoint(target, &ws_endpoint),
             ws_endpoint,
@@ -950,7 +963,7 @@ struct LiveAttachDaemon {
     sessions_by_endpoint: BTreeMap<EndpointKey, Arc<RuntimeSession>>,
     endpoint_by_alias: BTreeMap<TargetAlias, EndpointKey>,
     connecting_by_endpoint: BTreeMap<EndpointKey, Arc<PendingEndpointConnect>>,
-    client_factory: Arc<dyn CdpMcpClientFactory>,
+    client_factory: Arc<dyn ChromeCdpClientFactory>,
     endpoint_resolver: Arc<dyn CdpEndpointResolver>,
 }
 
@@ -972,7 +985,7 @@ impl LiveAttachDaemon {
             sessions_by_endpoint: BTreeMap::new(),
             endpoint_by_alias,
             connecting_by_endpoint: BTreeMap::new(),
-            client_factory: Arc::new(ProductionCdpMcpClientFactory),
+            client_factory: Arc::new(ProductionChromeCdpClientFactory),
             endpoint_resolver: Arc::new(ProductionCdpEndpointResolver),
         })
     }
@@ -1031,7 +1044,7 @@ impl LiveAttachDaemon {
             self.bind_alias_to_runtime(&target_alias, &runtime);
             return Ok(CheckoutDecision::Ready(SessionLease {
                 target_alias,
-                target_key: target.key.clone(),
+                target_key: target.target_alias.clone(),
                 target,
                 runtime,
             }));
@@ -1063,7 +1076,7 @@ impl LiveAttachDaemon {
                 self.bind_alias_to_runtime(&target_alias, &runtime);
                 return Ok(CheckoutDecision::Ready(SessionLease {
                     target_alias,
-                    target_key: target.key.clone(),
+                    target_key: target.target_alias.clone(),
                     target,
                     runtime,
                 }));
@@ -1080,7 +1093,7 @@ impl LiveAttachDaemon {
             });
         }
 
-        let target_key = target.key.clone();
+        let target_key = target.target_alias.clone();
         let endpoint_connect = Arc::new(PendingEndpointConnect::new());
         self.connecting_by_endpoint
             .insert(endpoint_key.clone(), Arc::clone(&endpoint_connect));
@@ -1128,7 +1141,7 @@ impl LiveAttachDaemon {
         self.bind_alias_to_runtime(&target_alias, &runtime);
         Some(SessionLease {
             target_alias,
-            target_key: target.key.clone(),
+            target_key: target.target_alias.clone(),
             target: target.clone(),
             runtime,
         })
@@ -1161,7 +1174,7 @@ impl LiveAttachDaemon {
             current: Some(current.clone()),
             detected_at_unix_ms: unix_ms_now(),
         };
-        let snapshot = DaemonSessionSnapshot::from_session(session);
+        let snapshot = EndpointSessionSnapshot::from_session(session);
         *guard = None;
         drop(guard);
         let err = anyhow!(CdpFailure::ChromeRestarted {
@@ -1189,7 +1202,7 @@ impl LiveAttachDaemon {
     fn finish_initial_connect(
         &mut self,
         pending: PendingInitialConnect,
-        result: Result<DaemonSession>,
+        result: Result<EndpointSession>,
     ) -> Result<SessionLease> {
         match result {
             Ok(session) => {
@@ -1333,7 +1346,7 @@ impl LiveAttachDaemon {
 
     fn record_session_success(
         &mut self,
-        session: &DaemonSessionSnapshot,
+        session: &EndpointSessionSnapshot,
         target_alias: &TargetAlias,
         target_alias_contexts: &BTreeMap<String, PersistedContextState>,
     ) -> Result<()> {
@@ -1446,7 +1459,7 @@ impl LiveAttachDaemon {
     fn record_session_terminal_error(
         &mut self,
         target_alias: &TargetAlias,
-        session: &DaemonSessionSnapshot,
+        session: &EndpointSessionSnapshot,
         err: &anyhow::Error,
     ) -> Result<()> {
         let mut aliases = session.aliases.clone();
@@ -1479,7 +1492,7 @@ impl LiveAttachDaemon {
     fn record_session_poisoned(
         &mut self,
         target_alias: &TargetAlias,
-        session: &DaemonSessionSnapshot,
+        session: &EndpointSessionSnapshot,
         panic_message: &str,
     ) -> Result<()> {
         let now = unix_ms_now();
@@ -1543,7 +1556,7 @@ impl LiveAttachDaemon {
         &self,
         target: &LiveAttachTarget,
     ) -> Option<anyhow::Error> {
-        if let Some(err) = self.automatic_reattach_blocked_error(&target.key) {
+        if let Some(err) = self.automatic_reattach_blocked_error(&target.target_alias) {
             return Some(err);
         }
         let (alias, _, endpoint_state) = self.persisted_endpoint_state_for_target(target)?;
@@ -1612,7 +1625,7 @@ impl LiveAttachDaemon {
             {
                 return Some(anyhow!(
                     "no live approved Chrome websocket is available for live-attach target `{}`. Persisted target `{direct_alias}` was owned by a previous live-attach daemon, and yoetz will not create a new Chrome CDP websocket from a recipe because that can trigger another remote-debugging approval prompt. Run `yoetz browser attach` to reapprove explicitly, or run `yoetz browser reset` to clear the stale owner state.",
-                    target.key
+                    target.target_alias
                 ));
             }
         }
@@ -1622,7 +1635,7 @@ impl LiveAttachDaemon {
         }
         Some(anyhow!(
             "no live approved Chrome websocket is available for live-attach target `{}`. Persisted target `{alias}` was owned by a previous live-attach daemon, and yoetz will not create a new Chrome CDP websocket from a recipe because that can trigger another remote-debugging approval prompt. Run `yoetz browser attach` to reapprove explicitly, or run `yoetz browser reset` to clear the stale owner state.",
-            target.key
+            target.target_alias
         ))
     }
 
@@ -1659,7 +1672,7 @@ impl LiveAttachDaemon {
     }
 }
 
-async fn connect_initial_session(pending: &PendingInitialConnect) -> Result<DaemonSession> {
+async fn connect_initial_session(pending: &PendingInitialConnect) -> Result<EndpointSession> {
     let identity = pending.identity.clone();
     let mut target = pending.target.clone();
     let client = pending
@@ -1682,7 +1695,7 @@ async fn connect_initial_session(pending: &PendingInitialConnect) -> Result<Daem
         connected_at_unix_ms: unix_ms_now(),
     };
 
-    Ok(DaemonSession {
+    Ok(EndpointSession {
         endpoint_key,
         aliases: BTreeSet::from([alias]),
         target,
@@ -1724,7 +1737,7 @@ fn terminal_session_state_from_error(
 }
 
 fn target_alias_for_target(target: &LiveAttachTarget) -> TargetAlias {
-    TargetAlias(target.key.clone())
+    TargetAlias(target.target_alias.clone())
 }
 
 fn endpoint_key_for_target(target: &LiveAttachTarget) -> Option<EndpointKey> {
@@ -1783,7 +1796,7 @@ fn optional_fingerprint_field_matches<T: PartialEq>(
 
 fn session_target_for_alias(
     mut target: LiveAttachTarget,
-    session: &DaemonSession,
+    session: &EndpointSession,
 ) -> LiveAttachTarget {
     let endpoint = Some(session.client.ws_endpoint().to_string());
     target.endpoint = endpoint.clone();
@@ -2198,7 +2211,7 @@ enum SessionRequest {
 
 struct SessionExecutionSuccess {
     response: DaemonResponse,
-    snapshot: DaemonSessionSnapshot,
+    snapshot: EndpointSessionSnapshot,
     target_alias: TargetAlias,
     target_alias_contexts: BTreeMap<String, PersistedContextState>,
 }
@@ -2207,7 +2220,7 @@ enum SessionExecutionError {
     TransportClosed {
         err: anyhow::Error,
         target_alias: TargetAlias,
-        snapshot: Box<DaemonSessionSnapshot>,
+        snapshot: Box<EndpointSessionSnapshot>,
     },
     Other {
         err: anyhow::Error,
@@ -2301,7 +2314,7 @@ async fn run_session_request_locked(
         let err = single_approval_transport_closed_error(err);
         session.state =
             terminal_session_state_from_error(session.fingerprint.clone(), &err, unix_ms_now());
-        let snapshot = DaemonSessionSnapshot::from_session(session);
+        let snapshot = EndpointSessionSnapshot::from_session(session);
         *guard = None;
         return Err(SessionExecutionError::TransportClosed {
             err,
@@ -2373,7 +2386,7 @@ async fn run_session_request_locked(
                     &err,
                     unix_ms_now(),
                 );
-                let snapshot = DaemonSessionSnapshot::from_session(session);
+                let snapshot = EndpointSessionSnapshot::from_session(session);
                 *guard = None;
                 return Err(SessionExecutionError::TransportClosed {
                     err,
@@ -2387,7 +2400,7 @@ async fn run_session_request_locked(
             };
             Ok(SessionExecutionSuccess {
                 response,
-                snapshot: DaemonSessionSnapshot::from_session(session),
+                snapshot: EndpointSessionSnapshot::from_session(session),
                 target_alias: lease.target_alias.clone(),
                 target_alias_contexts,
             })
@@ -2401,7 +2414,7 @@ async fn run_session_request_locked(
                     &err,
                     unix_ms_now(),
                 );
-                let snapshot = DaemonSessionSnapshot::from_session(session);
+                let snapshot = EndpointSessionSnapshot::from_session(session);
                 *guard = None;
                 return Err(SessionExecutionError::TransportClosed {
                     err,
@@ -2409,7 +2422,7 @@ async fn run_session_request_locked(
                     snapshot: Box::new(snapshot),
                 });
             }
-            let snapshot = DaemonSessionSnapshot::from_session(session);
+            let snapshot = EndpointSessionSnapshot::from_session(session);
             session.state = SessionState::Approved {
                 fingerprint: session.fingerprint.clone(),
                 connected_at_unix_ms,
@@ -2426,7 +2439,7 @@ async fn run_session_request_locked(
 async fn poison_runtime_session(
     runtime: &RuntimeSession,
     panic_message: &str,
-) -> Option<DaemonSessionSnapshot> {
+) -> Option<EndpointSessionSnapshot> {
     let mut guard = runtime.inner.lock().await;
     let mut session = guard.take()?;
     session.state = SessionState::Poisoned {
@@ -2434,11 +2447,11 @@ async fn poison_runtime_session(
         poisoned_at_unix_ms: unix_ms_now(),
         last_error: panic_message.to_string(),
     };
-    Some(DaemonSessionSnapshot::from_session(&session))
+    Some(EndpointSessionSnapshot::from_session(&session))
 }
 
 async fn ensure_chatgpt_session_with_session(
-    session: &mut DaemonSession,
+    session: &mut EndpointSession,
     explicit_context_id: Option<&str>,
     profile_email: Option<&str>,
 ) -> Result<LiveAttachSession> {
@@ -2448,7 +2461,7 @@ async fn ensure_chatgpt_session_with_session(
     session.target.endpoint = Some(session.client.ws_endpoint().to_string());
 
     Ok(LiveAttachSession {
-        target_key: session.target.key.clone(),
+        target_key: session.target.target_alias.clone(),
         control_run_id,
         browser_context_id,
         status: LiveAttachStatus::Attached,
@@ -2457,7 +2470,7 @@ async fn ensure_chatgpt_session_with_session(
 }
 
 async fn run_chatgpt_recipe_with_session(
-    session: &mut DaemonSession,
+    session: &mut EndpointSession,
     recipe_ctx: &mut chrome_devtools_mcp::DevtoolsMcpRecipeContext,
 ) -> Result<(ChatgptRunResult, Option<String>)> {
     let (browser_context_id, _) = ensure_chatgpt_control_tab_for_selectors(
@@ -2476,7 +2489,7 @@ async fn run_chatgpt_recipe_with_session(
 }
 
 async fn ensure_chatgpt_control_tab_for_selectors(
-    session: &mut DaemonSession,
+    session: &mut EndpointSession,
     explicit_context_id: Option<&str>,
     profile_email: Option<&str>,
 ) -> Result<(Option<String>, String)> {
@@ -2492,7 +2505,7 @@ async fn ensure_chatgpt_control_tab_for_selectors(
 }
 
 fn control_run_id_for_session(
-    session: &mut DaemonSession,
+    session: &mut EndpointSession,
     browser_context_id: Option<&str>,
 ) -> String {
     let now = unix_ms_now();
@@ -2510,7 +2523,7 @@ fn control_run_id_for_session(
 }
 
 fn contexts_for_browser_context_id(
-    session: &DaemonSession,
+    session: &EndpointSession,
     browser_context_id: Option<&str>,
 ) -> BTreeMap<String, PersistedContextState> {
     let key = context_storage_key(browser_context_id);
@@ -3055,13 +3068,13 @@ mod tests {
             sessions_by_endpoint: BTreeMap::new(),
             endpoint_by_alias: BTreeMap::new(),
             connecting_by_endpoint: BTreeMap::new(),
-            client_factory: Arc::new(TestCdpMcpClientFactory::default()),
+            client_factory: Arc::new(TestChromeCdpClientFactory::default()),
             endpoint_resolver: Arc::new(TestCdpEndpointResolver::default()),
         }
     }
 
     fn daemon_with_test_factory(
-        factory: TestCdpMcpClientFactory,
+        factory: TestChromeCdpClientFactory,
         resolver: TestCdpEndpointResolver,
     ) -> LiveAttachDaemon {
         LiveAttachDaemon {
@@ -3101,7 +3114,7 @@ mod tests {
 
     fn test_target(alias: &str, endpoint: &str) -> LiveAttachTarget {
         LiveAttachTarget {
-            key: alias.to_string(),
+            target_alias: alias.to_string(),
             connect_endpoint: Some(endpoint.to_string()),
             endpoint: Some(endpoint.to_string()),
             source_path: None,
@@ -3137,11 +3150,11 @@ mod tests {
         let endpoint = target.endpoint.clone().unwrap();
         let endpoint_key = EndpointKey::from_ws_endpoint(&endpoint).unwrap();
         let alias = target_alias_for_target(&target);
-        let session = DaemonSession {
+        let session = EndpointSession {
             endpoint_key: endpoint_key.clone(),
             aliases: BTreeSet::from([alias.clone()]),
             target,
-            client: DaemonSessionClient::Test(TestSessionClient::new(endpoint, behavior)),
+            client: EndpointSessionClient::Test(TestSessionClient::new(endpoint, behavior)),
             fingerprint: fingerprint.clone(),
             state: SessionState::Approved {
                 fingerprint,
@@ -3230,8 +3243,8 @@ mod tests {
         let guard = runtime.inner.lock().await;
         let session = guard.as_ref().expect("test session should be live");
         match &session.client {
-            DaemonSessionClient::Test(client) => client.set_probe_behavior(behavior),
-            DaemonSessionClient::Real(_) => panic!("expected test session client"),
+            EndpointSessionClient::Test(client) => client.set_probe_behavior(behavior),
+            EndpointSessionClient::Real(_) => panic!("expected test session client"),
         }
     }
 
@@ -3251,8 +3264,8 @@ mod tests {
         let guard = runtime.inner.lock().await;
         let session = guard.as_ref().expect("test session should be live");
         match &session.client {
-            DaemonSessionClient::Test(client) => client.set_control_tab_behavior(behavior),
-            DaemonSessionClient::Real(_) => panic!("expected test session client"),
+            EndpointSessionClient::Test(client) => client.set_control_tab_behavior(behavior),
+            EndpointSessionClient::Real(_) => panic!("expected test session client"),
         }
     }
 
@@ -3271,19 +3284,19 @@ mod tests {
         let guard = runtime.inner.lock().await;
         let session = guard.as_ref().expect("test session should be live");
         match &session.client {
-            DaemonSessionClient::Test(client) => (
+            EndpointSessionClient::Test(client) => (
                 client.new_page_count(),
                 client.user_window_open_count(),
                 client.control_tab_open_modes(),
             ),
-            DaemonSessionClient::Real(_) => panic!("expected test session client"),
+            EndpointSessionClient::Real(_) => panic!("expected test session client"),
         }
     }
 
     #[test]
-    fn live_attach_target_uses_implicit_key_without_resolved_target() {
+    fn live_attach_target_uses_implicit_alias_without_resolved_target() {
         let target = LiveAttachTarget::from_resolved(None);
-        assert_eq!(target.key, IMPLICIT_TARGET_KEY);
+        assert_eq!(target.target_alias, IMPLICIT_TARGET_KEY);
         assert_eq!(target.connect_endpoint, None);
         assert_eq!(target.endpoint, None);
         assert!(target.implicit_default);
@@ -3626,7 +3639,7 @@ mod tests {
     #[test]
     fn endpoint_key_for_target_uses_canonical_ws_endpoint_not_alias() {
         let target = LiveAttachTarget {
-            key: "endpoint:http://127.0.0.1:9222".to_string(),
+            target_alias: "endpoint:http://127.0.0.1:9222".to_string(),
             connect_endpoint: Some("http://127.0.0.1:9222".to_string()),
             endpoint: Some("ws://127.0.0.1:9222/devtools/browser/test".to_string()),
             source_path: None,
@@ -3704,12 +3717,12 @@ mod tests {
         runtime.block_on(async {
             let endpoint = "ws://127.0.0.1:9222/devtools/browser/same";
             let target = test_target("browser-id:same", endpoint);
-            let factory = TestCdpMcpClientFactory::default();
+            let factory = TestChromeCdpClientFactory::default();
             factory.push_recipe_behavior(TestRecipeBehavior::Error(
                 "Unable to make method calls because underlying connection is closed".to_string(),
             ));
             let resolver = TestCdpEndpointResolver::default();
-            resolver.set_endpoint(&target.key, endpoint);
+            resolver.set_endpoint(&target.target_alias, endpoint);
             let daemon = Arc::new(AsyncMutex::new(daemon_with_test_factory(
                 factory.clone(),
                 resolver,
@@ -3755,10 +3768,10 @@ mod tests {
         runtime.block_on(async {
             let endpoint = "ws://127.0.0.1:9222/devtools/browser/create-denied";
             let target = test_target("browser-id:create-denied", endpoint);
-            let factory = TestCdpMcpClientFactory::default();
+            let factory = TestChromeCdpClientFactory::default();
             factory.push_recipe_behavior(TestRecipeBehavior::CdpTargetCreateDeniedClosed);
             let resolver = TestCdpEndpointResolver::default();
-            resolver.set_endpoint(&target.key, endpoint);
+            resolver.set_endpoint(&target.target_alias, endpoint);
             let daemon = Arc::new(AsyncMutex::new(daemon_with_test_factory(
                 factory.clone(),
                 resolver,
@@ -3891,13 +3904,13 @@ mod tests {
             let endpoint = "ws://127.0.0.1:9222/devtools/browser/race";
             let target_a = test_target("browser-id:race-a", endpoint);
             let target_b = test_target("browser-id:race-b", endpoint);
-            let factory = TestCdpMcpClientFactory::default();
+            let factory = TestChromeCdpClientFactory::default();
             let connect_started = Arc::new(Notify::new());
             let connect_release = Arc::new(Notify::new());
             factory.block_next_connect(Arc::clone(&connect_started), Arc::clone(&connect_release));
             let resolver = TestCdpEndpointResolver::default();
-            resolver.set_endpoint(&target_a.key, endpoint);
-            resolver.set_endpoint(&target_b.key, endpoint);
+            resolver.set_endpoint(&target_a.target_alias, endpoint);
+            resolver.set_endpoint(&target_b.target_alias, endpoint);
             let daemon = Arc::new(AsyncMutex::new(daemon_with_test_factory(
                 factory.clone(),
                 resolver,
@@ -3985,7 +3998,7 @@ mod tests {
             let endpoint = "ws://127.0.0.1:9222/devtools/browser/shared";
             let source_path = dir.path().join("DevToolsActivePort");
             let source_target = LiveAttachTarget {
-                key: format!("source-path:{}", source_path.display()),
+                target_alias: format!("source-path:{}", source_path.display()),
                 connect_endpoint: Some("http://127.0.0.1:9222".to_string()),
                 endpoint: None,
                 source_path: Some(source_path),
@@ -3994,11 +4007,11 @@ mod tests {
             };
             let browser_target = test_target("browser-id:shared", endpoint);
             let implicit_target = LiveAttachTarget::from_resolved(None);
-            let factory = TestCdpMcpClientFactory::default();
+            let factory = TestChromeCdpClientFactory::default();
             let resolver = TestCdpEndpointResolver::default();
-            resolver.set_endpoint(&source_target.key, endpoint);
-            resolver.set_endpoint(&browser_target.key, endpoint);
-            resolver.set_endpoint(&implicit_target.key, endpoint);
+            resolver.set_endpoint(&source_target.target_alias, endpoint);
+            resolver.set_endpoint(&browser_target.target_alias, endpoint);
+            resolver.set_endpoint(&implicit_target.target_alias, endpoint);
             let daemon = Arc::new(AsyncMutex::new(daemon_with_test_factory(
                 factory.clone(),
                 resolver,
@@ -4175,7 +4188,7 @@ mod tests {
             let old_endpoint = "ws://127.0.0.1:9222/devtools/browser/old";
             let new_endpoint = "ws://127.0.0.1:9333/devtools/browser/new";
             let mut target = test_target(alias, old_endpoint);
-            let factory = TestCdpMcpClientFactory::default();
+            let factory = TestChromeCdpClientFactory::default();
             let resolver = TestCdpEndpointResolver::default();
             resolver.set_endpoint(alias, old_endpoint);
             let daemon = Arc::new(AsyncMutex::new(daemon_with_test_factory(
@@ -4248,7 +4261,7 @@ mod tests {
             let alias = "browser-id:same-endpoint-restarted";
             let endpoint = "ws://127.0.0.1:9222/devtools/browser/same";
             let target = test_target(alias, endpoint);
-            let factory = TestCdpMcpClientFactory::default();
+            let factory = TestChromeCdpClientFactory::default();
             let resolver = TestCdpEndpointResolver::default();
             let mut old_fingerprint = test_fingerprint(endpoint);
             old_fingerprint.listener_pid = Some(1111);
@@ -4329,7 +4342,7 @@ mod tests {
             endpoint_key,
         );
         let target = LiveAttachTarget {
-            key: "browser-id:test".to_string(),
+            target_alias: "browser-id:test".to_string(),
             connect_endpoint: Some(endpoint.to_string()),
             endpoint: Some(endpoint.to_string()),
             source_path: None,
@@ -4807,7 +4820,7 @@ mod tests {
     fn resolve_connect_endpoint_prefers_fresh_source_path_over_stale_endpoint() {
         let source_path = PathBuf::from("/tmp/yoetz-profile");
         let target = LiveAttachTarget {
-            key: "source-path:/tmp/yoetz-profile".to_string(),
+            target_alias: "source-path:/tmp/yoetz-profile".to_string(),
             connect_endpoint: Some("http://127.0.0.1:9222".to_string()),
             endpoint: Some("ws://127.0.0.1:9222/devtools/browser/stale".to_string()),
             source_path: Some(source_path.clone()),
@@ -4833,7 +4846,7 @@ mod tests {
     #[test]
     fn resolve_connect_endpoint_prefers_fresh_browser_id_over_stale_endpoint() {
         let target = LiveAttachTarget {
-            key: "browser-id:browser-123".to_string(),
+            target_alias: "browser-id:browser-123".to_string(),
             connect_endpoint: Some("http://127.0.0.1:9222".to_string()),
             endpoint: Some("ws://127.0.0.1:9222/devtools/browser/browser-123".to_string()),
             source_path: None,
@@ -4859,7 +4872,7 @@ mod tests {
     #[test]
     fn resolve_connect_endpoint_implicit_default_ignores_persisted_endpoint() {
         let target = LiveAttachTarget {
-            key: IMPLICIT_TARGET_KEY.to_string(),
+            target_alias: IMPLICIT_TARGET_KEY.to_string(),
             connect_endpoint: Some("http://127.0.0.1:9222".to_string()),
             endpoint: Some("ws://127.0.0.1:9222/devtools/browser/stale".to_string()),
             source_path: None,
@@ -4876,7 +4889,7 @@ mod tests {
     #[test]
     fn resolve_connect_endpoint_prefers_original_http_connect_endpoint() {
         let target = LiveAttachTarget {
-            key: "endpoint:http://127.0.0.1:9222".to_string(),
+            target_alias: "endpoint:http://127.0.0.1:9222".to_string(),
             connect_endpoint: Some("http://127.0.0.1:9222".to_string()),
             endpoint: Some("ws://127.0.0.1:9222/devtools/browser/stale".to_string()),
             source_path: None,
@@ -4967,7 +4980,7 @@ mod tests {
                 sessions_by_endpoint: BTreeMap::new(),
                 endpoint_by_alias: BTreeMap::new(),
                 connecting_by_endpoint: BTreeMap::new(),
-                client_factory: Arc::new(TestCdpMcpClientFactory::default()),
+                client_factory: Arc::new(TestChromeCdpClientFactory::default()),
                 endpoint_resolver: Arc::new(TestCdpEndpointResolver::default()),
             }));
             let _busy = daemon.lock().await;

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -2659,7 +2659,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             // the real-browser CI lane (review finding #13) against a fresh
             // Chrome for Testing instance so the deeper `check` / `attach`
             // auth-probe path is not exercised.
-            let client = chrome_devtools_mcp::client::CdpMcpClient::connect_to_running_chrome(
+            let client = chrome_devtools_mcp::client::ChromeCdpClient::connect_to_running_chrome(
                 Some(&args.cdp),
             )
             .await

--- a/docs/decisions/ADR-001-live-attach-owner.md
+++ b/docs/decisions/ADR-001-live-attach-owner.md
@@ -97,7 +97,7 @@ explicit `yoetz browser attach` flow or by clearing the stale state with
 
 ## 2026-05-02 Amendment: Endpoint-Owned State
 
-`LiveAttachTarget.key` is a target alias, not the CDP session key. The daemon
+`LiveAttachTarget.target_alias` is a target alias, not the CDP session key. The daemon
 keys live sessions and persisted owner state by the approved canonical browser
 websocket endpoint, and keeps a separate alias map for selectors such as
 `source-path:*`, `browser-id:*`, and `implicit-default`.


### PR DESCRIPTION
Rename the browser live-attach owner concepts to match the endpoint-owned model introduced in the Stage B work.

This changes Rust-side names for the direct Chrome CDP client, attach-attempt lock, endpoint session, and live attach target alias. It also updates the standalone retry notice so daemon-owned live attach remains described as non-reconnecting to preserve the single-approval invariant.

Wire compatibility is intentionally preserved: `LiveAttachTarget` still serializes the alias field as `key`, persisted state structs are unchanged, and the lock continues to use the existing `chrome-approval.lock` filename while the code identifier now reflects attach-attempt serialization.