### PR TITLE
fix(chatgpt): harden Pro recipe across daemon, DOM, and transport layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Hardened the ChatGPT Pro browser recipe across live transports: each run now
+  opens and refocuses a run-marked ChatGPT tab, reports
+  `model_selection_status` separately from `model_used`, and avoids automatic
+  fallback after upload/send/wait phases that may already have side effects.
+
+### Fixed
+
+- Replaced the macOS clipboard upload path with composer-scoped file input
+  attachment handling, including stable attachment readiness checks and
+  recipe-controlled `upload_timeout_ms` for both dev-browser and
+  chrome-devtools-mcp transports.
+- Added run-id/manual recovery details to terminal ChatGPT transport errors so
+  interrupted runs can be continued from the yoetz-owned tab without blindly
+  submitting a duplicate request.
+- Tightened ChatGPT model selection verification to require checked/current
+  menu state instead of accepting selector-label text alone, scoped response
+  polling indicators to the active assistant turn, and scales upload timeouts
+  with bundle size for large attachments.
+
+### Security
+
+- Fixed a critical same-machine live-CDP daemon exposure by requiring a private
+  runtime directory, same-user peer credentials, and token-protected RPCs before
+  accepting browser JavaScript execution requests.
+- Prefer `XDG_RUNTIME_DIR` for the live-CDP daemon on Unix and automatically
+  tighten existing owner-matched `~/.yoetz` directories to `0700` during
+  upgrade so the hardened socket and token checks do not reject normal users.
+
 ## [0.3.0] - 2026-05-03
 
 ## [0.2.59] - 2026-05-03

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3202,6 +3202,7 @@ dependencies = [
  "headless_chrome",
  "hex",
  "jsonschema",
+ "libc",
  "litellm-rust",
  "predicates",
  "rand",

--- a/crates/yoetz-cli/Cargo.toml
+++ b/crates/yoetz-cli/Cargo.toml
@@ -49,6 +49,7 @@ jsonschema = "0.45"
 fs2 = "0.4"
 headless_chrome = "1.0.21"
 futures-util = "0.3"
+libc = "0.2"
 
 [dev-dependencies]
 serial_test = "3.4"

--- a/crates/yoetz-cli/assets/live-cdp-daemon-src/live-cdp-browser.ts
+++ b/crates/yoetz-cli/assets/live-cdp-daemon-src/live-cdp-browser.ts
@@ -71,8 +71,23 @@ interface KeyDefinition {
   text?: string;
 }
 
+interface CdpDomNode {
+  nodeId?: unknown;
+  backendNodeId?: unknown;
+  nodeName?: unknown;
+  localName?: unknown;
+  attributes?: unknown;
+}
+
+interface ScopedMarkerRequirement {
+  attributeName: string;
+  value: string;
+  description: string;
+}
+
 const LIVE_CDP_BROWSER_INIT_TIMEOUT_MS = 5_000;
 const LIVE_CDP_TARGET_INIT_TIMEOUT_MS = 5_000;
+const INPUT_FILE_DIAGNOSTIC_LIMIT = 10;
 
 export interface LiveCdpTransport {
   send(message: string): void;
@@ -91,6 +106,47 @@ export interface LiveCdpLocatorDescriptor {
   selector: string;
   index?: number | null;
   hasText?: string | null;
+}
+
+export interface LiveCdpInputFileNodeDiagnostic {
+  nodeId: number;
+  backendNodeId?: number;
+  nodeName?: string;
+  localName?: string;
+  attributes: Record<string, string>;
+  selectorHint: string;
+}
+
+export interface LiveCdpSetInputFilesResult {
+  selector: string;
+  fileCount: number;
+  matchCount: number;
+  targetId: string;
+  url: string;
+  selectedNode: LiveCdpInputFileNodeDiagnostic;
+  selectedViaScopedMarker: boolean;
+  scopedMarkers: string[];
+}
+
+export interface LiveCdpSetInputFilesErrorDetails {
+  selector: string;
+  fileCount: number;
+  matchCount: number;
+  targetId: string;
+  url: string;
+  scopedMarkers: string[];
+  diagnostics: LiveCdpInputFileNodeDiagnostic[];
+  diagnosticsTruncated: boolean;
+}
+
+export class LiveCdpSetInputFilesError extends Error {
+  constructor(
+    message: string,
+    readonly details: LiveCdpSetInputFilesErrorDetails
+  ) {
+    super(`${message} ${formatSetInputFilesErrorDetails(details)}`);
+    this.name = "LiveCdpSetInputFilesError";
+  }
 }
 
 export type SerializedEvaluation =
@@ -1042,12 +1098,17 @@ export class LiveCdpPage extends EventEmitter {
     });
   }
 
-  async setInputFiles(selector: string, files: string | string[]): Promise<void> {
+  async setInputFiles(
+    selector: string,
+    files: string | string[]
+  ): Promise<LiveCdpSetInputFilesResult> {
     const fileList = Array.isArray(files) ? files : [files];
+    const scopedMarkerRequirements = findScopedMarkerRequirements(selector);
+    const scopedMarkers = scopedMarkerRequirements.map((marker) => marker.description);
     await this.sendSession("DOM.enable", {}).catch(() => {});
     const documentResult = await this.sendSession("DOM.getDocument", {
-      depth: -1,
-      pierce: true,
+      depth: 0,
+      pierce: false,
     });
     const root = documentResult.root as { nodeId?: unknown } | undefined;
     const nodeId = typeof root?.nodeId === "number" ? root.nodeId : undefined;
@@ -1055,19 +1116,82 @@ export class LiveCdpPage extends EventEmitter {
       throw new Error("DOM.getDocument did not return a root node");
     }
 
-    const queryResult = await this.sendSession("DOM.querySelector", {
+    const queryResult = await this.sendSession("DOM.querySelectorAll", {
       nodeId,
       selector,
     });
-    const inputNodeId = typeof queryResult.nodeId === "number" ? queryResult.nodeId : undefined;
-    if (!inputNodeId) {
-      throw new Error(`No file input found for selector "${selector}"`);
+    const inputNodeIds = Array.isArray(queryResult.nodeIds)
+      ? queryResult.nodeIds.filter((candidate): candidate is number => typeof candidate === "number")
+      : [];
+    const baseDetails = (
+      diagnostics: LiveCdpInputFileNodeDiagnostic[],
+      diagnosticsTruncated = false
+    ): LiveCdpSetInputFilesErrorDetails => ({
+      selector,
+      fileCount: fileList.length,
+      matchCount: inputNodeIds.length,
+      targetId: this.targetId,
+      url: this.#url,
+      scopedMarkers,
+      diagnostics,
+      diagnosticsTruncated,
+    });
+
+    if (inputNodeIds.length === 0) {
+      throw new LiveCdpSetInputFilesError(
+        `No file input found for selector "${selector}"`,
+        baseDetails([])
+      );
+    }
+
+    let selectedNode: LiveCdpInputFileNodeDiagnostic;
+    let selectedViaScopedMarker = false;
+    if (inputNodeIds.length === 1) {
+      selectedNode = await describeInputFileCandidate(this, inputNodeIds[0]);
+    } else {
+      const shouldInspectAllMatches = scopedMarkerRequirements.length > 0;
+      const inspectedNodeIds = shouldInspectAllMatches
+        ? inputNodeIds
+        : inputNodeIds.slice(0, INPUT_FILE_DIAGNOSTIC_LIMIT);
+      const diagnostics = await Promise.all(
+        inspectedNodeIds.map((candidateNodeId) => describeInputFileCandidate(this, candidateNodeId))
+      );
+      const scopedMarkerMatches = diagnostics.filter((diagnostic) =>
+        matchesAnyScopedMarker(diagnostic, scopedMarkerRequirements)
+      );
+      if (scopedMarkerMatches.length === 1) {
+        selectedNode = scopedMarkerMatches[0];
+        selectedViaScopedMarker = true;
+      } else {
+        throw new LiveCdpSetInputFilesError(
+          `Ambiguous file input selector "${selector}" matched ${inputNodeIds.length} nodes`,
+          baseDetails(diagnostics, inspectedNodeIds.length < inputNodeIds.length)
+        );
+      }
+    }
+
+    if (!isFileInputDiagnostic(selectedNode)) {
+      throw new LiveCdpSetInputFilesError(
+        `Selector "${selector}" resolved to ${selectedNode.selectorHint}, not an input[type=file]`,
+        baseDetails([selectedNode])
+      );
     }
 
     await this.sendSession("DOM.setFileInputFiles", {
-      nodeId: inputNodeId,
+      nodeId: selectedNode.nodeId,
       files: fileList,
     });
+
+    return {
+      selector,
+      fileCount: fileList.length,
+      matchCount: inputNodeIds.length,
+      targetId: this.targetId,
+      url: this.#url,
+      selectedNode,
+      selectedViaScopedMarker,
+      scopedMarkers,
+    };
   }
 
   async screenshot(
@@ -1532,6 +1656,168 @@ function normalizeLocatorDescriptor(
     index: descriptor.index ?? null,
     hasText: descriptor.hasText ?? null,
   };
+}
+
+async function describeInputFileCandidate(
+  page: LiveCdpPage,
+  nodeId: number
+): Promise<LiveCdpInputFileNodeDiagnostic> {
+  const describeResult = await page.sendSession("DOM.describeNode", {
+    nodeId,
+    depth: 0,
+    pierce: false,
+  });
+  const node =
+    typeof describeResult.node === "object" && describeResult.node !== null
+      ? (describeResult.node as CdpDomNode)
+      : undefined;
+  const attributes = readDomAttributes(node?.attributes);
+  const nodeName = typeof node?.nodeName === "string" ? node.nodeName : undefined;
+  const localName = typeof node?.localName === "string" ? node.localName : undefined;
+
+  return {
+    nodeId: typeof node?.nodeId === "number" ? node.nodeId : nodeId,
+    backendNodeId: typeof node?.backendNodeId === "number" ? node.backendNodeId : undefined,
+    nodeName,
+    localName,
+    attributes,
+    selectorHint: buildInputFileSelectorHint(localName ?? nodeName, attributes),
+  };
+}
+
+function readDomAttributes(attributes: unknown): Record<string, string> {
+  if (!Array.isArray(attributes)) {
+    return {};
+  }
+
+  const result: Record<string, string> = {};
+  for (let index = 0; index + 1 < attributes.length; index += 2) {
+    const name = attributes[index];
+    const value = attributes[index + 1];
+    if (typeof name === "string" && typeof value === "string") {
+      result[name.toLowerCase()] = value;
+    }
+  }
+  return result;
+}
+
+function buildInputFileSelectorHint(
+  rawName: string | undefined,
+  attributes: Record<string, string>
+): string {
+  const tagName = rawName ? rawName.toLowerCase() : "node";
+  const parts = [tagName];
+  if (attributes.id) {
+    parts.push(`#${truncateDiagnosticValue(attributes.id, 60)}`);
+  }
+
+  const interestingAttributes = [
+    "type",
+    "name",
+    "title",
+    "accept",
+    "multiple",
+    "aria-label",
+    "data-testid",
+    ...Object.keys(attributes)
+      .filter((attributeName) => attributeName.startsWith("data-yoetz-"))
+      .sort(),
+  ];
+  const seen = new Set<string>();
+  for (const attributeName of interestingAttributes) {
+    if (seen.has(attributeName) || !(attributeName in attributes)) {
+      continue;
+    }
+    seen.add(attributeName);
+    const value = attributes[attributeName];
+    if (value === "") {
+      parts.push(`[${attributeName}]`);
+    } else {
+      parts.push(`[${attributeName}=${JSON.stringify(truncateDiagnosticValue(value, 80))}]`);
+    }
+  }
+
+  return parts.join("");
+}
+
+function isFileInputDiagnostic(diagnostic: LiveCdpInputFileNodeDiagnostic): boolean {
+  const tagName = (diagnostic.localName ?? diagnostic.nodeName ?? "").toLowerCase();
+  return tagName === "input" && diagnostic.attributes.type?.toLowerCase() === "file";
+}
+
+function findScopedMarkerRequirements(selector: string): ScopedMarkerRequirement[] {
+  const markers: ScopedMarkerRequirement[] = [];
+  const attributePattern =
+    /\[\s*([a-zA-Z_][-\w:.]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\]\s]+))\s*\]/g;
+  for (const match of selector.matchAll(attributePattern)) {
+    const attributeName = match[1].toLowerCase();
+    const value = match[2] ?? match[3] ?? match[4] ?? "";
+    if (!isScopedMarkerAttribute(attributeName, value)) {
+      continue;
+    }
+    markers.push({
+      attributeName,
+      value,
+      description: `${attributeName}=${JSON.stringify(value)}`,
+    });
+  }
+
+  return markers;
+}
+
+function isScopedMarkerAttribute(attributeName: string, value: string): boolean {
+  if (attributeName.startsWith("data-yoetz-")) {
+    return value.length > 0;
+  }
+
+  return attributeName === "title" && value.startsWith("yoetz-");
+}
+
+function matchesAnyScopedMarker(
+  diagnostic: LiveCdpInputFileNodeDiagnostic,
+  requirements: ScopedMarkerRequirement[]
+): boolean {
+  return requirements.some(
+    (requirement) => diagnostic.attributes[requirement.attributeName] === requirement.value
+  );
+}
+
+function formatSetInputFilesErrorDetails(details: LiveCdpSetInputFilesErrorDetails): string {
+  const parts = [
+    `matches=${details.matchCount}`,
+    `files=${details.fileCount}`,
+    `target=${details.targetId}`,
+  ];
+  if (details.url) {
+    parts.push(`url=${JSON.stringify(truncateDiagnosticValue(details.url, 120))}`);
+  }
+  if (details.scopedMarkers.length > 0) {
+    parts.push(`scopedMarkers=[${details.scopedMarkers.join(", ")}]`);
+  }
+  if (details.diagnostics.length > 0) {
+    const candidates = details.diagnostics.map(formatInputFileCandidateDiagnostic).join("; ");
+    parts.push(
+      `candidates=[${candidates}${details.diagnosticsTruncated ? "; ..." : ""}]`
+    );
+  }
+
+  return `(${parts.join(", ")})`;
+}
+
+function formatInputFileCandidateDiagnostic(
+  diagnostic: LiveCdpInputFileNodeDiagnostic
+): string {
+  const backend =
+    diagnostic.backendNodeId === undefined ? "" : ` backendNodeId=${diagnostic.backendNodeId}`;
+  return `nodeId=${diagnostic.nodeId}${backend} ${diagnostic.selectorHint}`;
+}
+
+function truncateDiagnosticValue(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  return `${value.slice(0, Math.max(0, maxLength - 3))}...`;
 }
 
 function compareTargetAttachPriority(left: TargetInfo, right: TargetInfo): number {

--- a/crates/yoetz-cli/assets/live-cdp-daemon.mjs
+++ b/crates/yoetz-cli/assets/live-cdp-daemon.mjs
@@ -21,6 +21,14 @@ import vm from "node:vm";
 import { EventEmitter } from "node:events";
 var LIVE_CDP_BROWSER_INIT_TIMEOUT_MS = 5e3;
 var LIVE_CDP_TARGET_INIT_TIMEOUT_MS = 5e3;
+var INPUT_FILE_DIAGNOSTIC_LIMIT = 10;
+var LiveCdpSetInputFilesError = class extends Error {
+  constructor(message, details) {
+    super(`${message} ${formatSetInputFilesErrorDetails(details)}`);
+    this.details = details;
+    this.name = "LiveCdpSetInputFilesError";
+  }
+};
 var WebSocketLiveCdpTransport = class _WebSocketLiveCdpTransport {
   constructor(socket) {
     this.socket = socket;
@@ -735,29 +743,83 @@ var LiveCdpPage = class extends EventEmitter {
   }
   async setInputFiles(selector, files) {
     const fileList = Array.isArray(files) ? files : [files];
+    const scopedMarkerRequirements = findScopedMarkerRequirements(selector);
+    const scopedMarkers = scopedMarkerRequirements.map((marker) => marker.description);
     await this.sendSession("DOM.enable", {}).catch(() => {
     });
     const documentResult = await this.sendSession("DOM.getDocument", {
-      depth: -1,
-      pierce: true
+      depth: 0,
+      pierce: false
     });
     const root = documentResult.root;
     const nodeId = typeof root?.nodeId === "number" ? root.nodeId : void 0;
     if (nodeId === void 0) {
       throw new Error("DOM.getDocument did not return a root node");
     }
-    const queryResult = await this.sendSession("DOM.querySelector", {
+    const queryResult = await this.sendSession("DOM.querySelectorAll", {
       nodeId,
       selector
     });
-    const inputNodeId = typeof queryResult.nodeId === "number" ? queryResult.nodeId : void 0;
-    if (!inputNodeId) {
-      throw new Error(`No file input found for selector "${selector}"`);
+    const inputNodeIds = Array.isArray(queryResult.nodeIds) ? queryResult.nodeIds.filter((candidate) => typeof candidate === "number") : [];
+    const baseDetails = (diagnostics, diagnosticsTruncated = false) => ({
+      selector,
+      fileCount: fileList.length,
+      matchCount: inputNodeIds.length,
+      targetId: this.targetId,
+      url: this.#url,
+      scopedMarkers,
+      diagnostics,
+      diagnosticsTruncated
+    });
+    if (inputNodeIds.length === 0) {
+      throw new LiveCdpSetInputFilesError(
+        `No file input found for selector "${selector}"`,
+        baseDetails([])
+      );
+    }
+    let selectedNode;
+    let selectedViaScopedMarker = false;
+    if (inputNodeIds.length === 1) {
+      selectedNode = await describeInputFileCandidate(this, inputNodeIds[0]);
+    } else {
+      const shouldInspectAllMatches = scopedMarkerRequirements.length > 0;
+      const inspectedNodeIds = shouldInspectAllMatches ? inputNodeIds : inputNodeIds.slice(0, INPUT_FILE_DIAGNOSTIC_LIMIT);
+      const diagnostics = await Promise.all(
+        inspectedNodeIds.map((candidateNodeId) => describeInputFileCandidate(this, candidateNodeId))
+      );
+      const scopedMarkerMatches = diagnostics.filter(
+        (diagnostic) => matchesAnyScopedMarker(diagnostic, scopedMarkerRequirements)
+      );
+      if (scopedMarkerMatches.length === 1) {
+        selectedNode = scopedMarkerMatches[0];
+        selectedViaScopedMarker = true;
+      } else {
+        throw new LiveCdpSetInputFilesError(
+          `Ambiguous file input selector "${selector}" matched ${inputNodeIds.length} nodes`,
+          baseDetails(diagnostics, inspectedNodeIds.length < inputNodeIds.length)
+        );
+      }
+    }
+    if (!isFileInputDiagnostic(selectedNode)) {
+      throw new LiveCdpSetInputFilesError(
+        `Selector "${selector}" resolved to ${selectedNode.selectorHint}, not an input[type=file]`,
+        baseDetails([selectedNode])
+      );
     }
     await this.sendSession("DOM.setFileInputFiles", {
-      nodeId: inputNodeId,
+      nodeId: selectedNode.nodeId,
       files: fileList
     });
+    return {
+      selector,
+      fileCount: fileList.length,
+      matchCount: inputNodeIds.length,
+      targetId: this.targetId,
+      url: this.#url,
+      selectedNode,
+      selectedViaScopedMarker,
+      scopedMarkers
+    };
   }
   async screenshot(options = {}) {
     const params = {
@@ -1102,6 +1164,132 @@ function normalizeLocatorDescriptor(descriptor) {
     index: descriptor.index ?? null,
     hasText: descriptor.hasText ?? null
   };
+}
+async function describeInputFileCandidate(page, nodeId) {
+  const describeResult = await page.sendSession("DOM.describeNode", {
+    nodeId,
+    depth: 0,
+    pierce: false
+  });
+  const node = typeof describeResult.node === "object" && describeResult.node !== null ? describeResult.node : void 0;
+  const attributes = readDomAttributes(node?.attributes);
+  const nodeName = typeof node?.nodeName === "string" ? node.nodeName : void 0;
+  const localName = typeof node?.localName === "string" ? node.localName : void 0;
+  return {
+    nodeId: typeof node?.nodeId === "number" ? node.nodeId : nodeId,
+    backendNodeId: typeof node?.backendNodeId === "number" ? node.backendNodeId : void 0,
+    nodeName,
+    localName,
+    attributes,
+    selectorHint: buildInputFileSelectorHint(localName ?? nodeName, attributes)
+  };
+}
+function readDomAttributes(attributes) {
+  if (!Array.isArray(attributes)) {
+    return {};
+  }
+  const result = {};
+  for (let index = 0; index + 1 < attributes.length; index += 2) {
+    const name = attributes[index];
+    const value = attributes[index + 1];
+    if (typeof name === "string" && typeof value === "string") {
+      result[name.toLowerCase()] = value;
+    }
+  }
+  return result;
+}
+function buildInputFileSelectorHint(rawName, attributes) {
+  const tagName = rawName ? rawName.toLowerCase() : "node";
+  const parts = [tagName];
+  if (attributes.id) {
+    parts.push(`#${truncateDiagnosticValue(attributes.id, 60)}`);
+  }
+  const interestingAttributes = [
+    "type",
+    "name",
+    "title",
+    "accept",
+    "multiple",
+    "aria-label",
+    "data-testid",
+    ...Object.keys(attributes).filter((attributeName) => attributeName.startsWith("data-yoetz-")).sort()
+  ];
+  const seen = /* @__PURE__ */ new Set();
+  for (const attributeName of interestingAttributes) {
+    if (seen.has(attributeName) || !(attributeName in attributes)) {
+      continue;
+    }
+    seen.add(attributeName);
+    const value = attributes[attributeName];
+    if (value === "") {
+      parts.push(`[${attributeName}]`);
+    } else {
+      parts.push(`[${attributeName}=${JSON.stringify(truncateDiagnosticValue(value, 80))}]`);
+    }
+  }
+  return parts.join("");
+}
+function isFileInputDiagnostic(diagnostic) {
+  const tagName = (diagnostic.localName ?? diagnostic.nodeName ?? "").toLowerCase();
+  return tagName === "input" && diagnostic.attributes.type?.toLowerCase() === "file";
+}
+function findScopedMarkerRequirements(selector) {
+  const markers = [];
+  const attributePattern = /\[\s*([a-zA-Z_][-\w:.]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\]\s]+))\s*\]/g;
+  for (const match of selector.matchAll(attributePattern)) {
+    const attributeName = match[1].toLowerCase();
+    const value = match[2] ?? match[3] ?? match[4] ?? "";
+    if (!isScopedMarkerAttribute(attributeName, value)) {
+      continue;
+    }
+    markers.push({
+      attributeName,
+      value,
+      description: `${attributeName}=${JSON.stringify(value)}`
+    });
+  }
+  return markers;
+}
+function isScopedMarkerAttribute(attributeName, value) {
+  if (attributeName.startsWith("data-yoetz-")) {
+    return value.length > 0;
+  }
+  return attributeName === "title" && value.startsWith("yoetz-");
+}
+function matchesAnyScopedMarker(diagnostic, requirements) {
+  return requirements.some(
+    (requirement) => diagnostic.attributes[requirement.attributeName] === requirement.value
+  );
+}
+function formatSetInputFilesErrorDetails(details) {
+  const parts = [
+    `matches=${details.matchCount}`,
+    `files=${details.fileCount}`,
+    `target=${details.targetId}`
+  ];
+  if (details.url) {
+    parts.push(`url=${JSON.stringify(truncateDiagnosticValue(details.url, 120))}`);
+  }
+  if (details.scopedMarkers.length > 0) {
+    parts.push(`scopedMarkers=[${details.scopedMarkers.join(", ")}]`);
+  }
+  if (details.diagnostics.length > 0) {
+    const candidates = details.diagnostics.map(formatInputFileCandidateDiagnostic).join("; ");
+    parts.push(
+      `candidates=[${candidates}${details.diagnosticsTruncated ? "; ..." : ""}]`
+    );
+  }
+  return `(${parts.join(", ")})`;
+}
+function formatInputFileCandidateDiagnostic(diagnostic) {
+  const backend = diagnostic.backendNodeId === void 0 ? "" : ` backendNodeId=${diagnostic.backendNodeId}`;
+  return `nodeId=${diagnostic.nodeId}${backend} ${diagnostic.selectorHint}`;
+}
+function truncateDiagnosticValue(value, maxLength) {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, Math.max(0, maxLength - 3))}...`;
 }
 function compareTargetAttachPriority(left, right) {
   const leftIsYoetz = isYoetzTarget(left);

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -12,7 +12,7 @@ use std::sync::OnceLock;
 use std::thread;
 use std::time::{Duration, Instant, SystemTime};
 
-use crate::chatgpt_recipe;
+use crate::chatgpt_recipe::{self, AnyhowResultExt};
 use crate::chatgpt_web;
 use crate::chrome_devtools_mcp::client::{
     browser_id_from_ws_endpoint, discover_devtools_active_port_files,
@@ -35,13 +35,14 @@ const CHATGPT_WAIT_ACTION: &str = "chatgpt_wait_response";
 const CHATGPT_WAIT_UPLOAD_ACTION: &str = "chatgpt_wait_upload";
 const CHATGPT_SELECT_MODEL_ACTION: &str = "chatgpt_select_model";
 const CHATGPT_OPEN_ATTACHMENT_UI_ACTION: &str = "chatgpt_open_attachment_ui";
+const CHATGPT_UPLOAD_BUNDLE_ACTION: &str = "chatgpt_upload_bundle";
 const CHATGPT_SEND_ACTION: &str = "chatgpt_send";
 const CHATGPT_POLL_ATTEMPTS_DEFAULT: usize = 60;
 const CHATGPT_POLL_INTERVAL_MS_DEFAULT: u64 = 30_000;
 const CHATGPT_POLL_TOTAL_TIMEOUT_MS_DEFAULT: u64 = 1_800_000;
 const CHATGPT_POLL_COMMAND_TIMEOUT_MS_DEFAULT: u64 = 10_000;
-const CHATGPT_UPLOAD_POLL_ATTEMPTS_DEFAULT: usize = 30;
-const CHATGPT_UPLOAD_POLL_INTERVAL_MS_DEFAULT: u64 = 1_000;
+const CHATGPT_UPLOAD_POLL_ATTEMPTS_DEFAULT: usize = 60;
+const CHATGPT_UPLOAD_POLL_INTERVAL_MS_DEFAULT: u64 = 2_000;
 const CHATGPT_SEND_ENABLE_TIMEOUT_MS: u64 = 10_000;
 const CHATGPT_SEND_ENABLE_POLL_INTERVAL_MS: u64 = 250;
 const DAEMON_APPROVAL_GRACE_WINDOW: Duration = Duration::from_secs(30);
@@ -103,6 +104,7 @@ pub struct RecipeContext {
     pub bundle_text: Option<String>,
     pub profile_dir: Option<PathBuf>,
     pub profile_mode: BrowserProfileMode,
+    pub fallback_used: bool,
     pub use_stealth: bool,
     pub headed: bool,
     pub vars: BTreeMap<String, String>,
@@ -137,7 +139,10 @@ pub enum BrowserProfileMode {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum BrowserConnection {
     /// Connected to a live Chrome instance via CDP with explicit endpoint.
-    Cdp { endpoint: String },
+    Cdp {
+        endpoint: String,
+        run_id: Option<String>,
+    },
     /// Connected via agent-browser auto-discovery to a live Chrome instance.
     AutoConnect,
     /// Cookie-extracted Playwright storageState file.
@@ -314,12 +319,16 @@ fn build_agent_browser_args(
     }
 
     match connection {
-        Some(BrowserConnection::Cdp { endpoint }) => {
+        Some(BrowserConnection::Cdp { endpoint, run_id }) => {
             if !args
                 .iter()
                 .any(|a| a == "--session" || a.starts_with("--session="))
             {
-                args.insert(0, CDP_SESSION_NAME.to_string());
+                let session_name = run_id
+                    .as_deref()
+                    .map(live_cdp_session_name_for_run)
+                    .unwrap_or_else(|| CDP_SESSION_NAME.to_string());
+                args.insert(0, session_name);
                 args.insert(0, "--session".to_string());
             }
             if !args.iter().any(|a| a == "--cdp" || a.starts_with("--cdp=")) {
@@ -504,6 +513,8 @@ fn run_recipe_with_connection(
     let mut events: Vec<Value> = Vec::new();
     let mut headed = ctx.headed;
     let mut pending_chatgpt_send_baseline: Option<ChatgptResponseBaseline> = None;
+    let mut chatgpt_stage = ChatgptRecipeStage::Idle;
+    let mut chatgpt_focus_cache = ChatgptRunTabFocusCache::default();
 
     if let Some(connection) = connection {
         if connection.is_live_attach() {
@@ -524,13 +535,38 @@ fn run_recipe_with_connection(
     for (idx, step) in recipe.steps.iter().enumerate() {
         // Evaluate skip_if before anything else (including sleep).
         if let Some(expr) = &step.skip_if {
+            if let Some(action) = step.action.as_deref() {
+                focus_chatgpt_run_tab_before_recipe_action(
+                    is_chatgpt_recipe,
+                    action,
+                    connection,
+                    &ctx,
+                    headed,
+                    step.timeout_ms
+                        .unwrap_or(CHATGPT_POLL_COMMAND_TIMEOUT_MS_DEFAULT),
+                    Some(&mut chatgpt_focus_cache),
+                )
+                .map_err(|err| {
+                    mark_chatgpt_error_after_side_effect(err, chatgpt_stage.terminal_phase(action))
+                })
+                .with_context(|| {
+                    format!("recipe step {idx} ({action}) target focus before skip_if failed")
+                })?;
+            }
             let result = run_agent_browser_with_connection(
                 vec!["eval".to_string(), expr.clone()],
                 OutputFormat::Text,
                 connection,
                 ctx.use_stealth,
                 headed,
-            )?;
+            )
+            .map_err(|err| {
+                let phase = step
+                    .action
+                    .as_deref()
+                    .and_then(|action| chatgpt_stage.terminal_phase(action));
+                mark_chatgpt_error_after_side_effect(err, phase)
+            })?;
             let trimmed = result.trim().trim_matches('"');
             if !trimmed.is_empty()
                 && trimmed != "false"
@@ -553,6 +589,21 @@ fn run_recipe_with_connection(
             return Err(anyhow!("recipe step {idx} missing action"));
         };
 
+        focus_chatgpt_run_tab_before_recipe_action(
+            is_chatgpt_recipe,
+            action,
+            connection,
+            &ctx,
+            headed,
+            step.timeout_ms
+                .unwrap_or(CHATGPT_POLL_COMMAND_TIMEOUT_MS_DEFAULT),
+            Some(&mut chatgpt_focus_cache),
+        )
+        .map_err(|err| {
+            mark_chatgpt_error_after_side_effect(err, chatgpt_stage.terminal_phase(action))
+        })
+        .with_context(|| format!("recipe step {idx} ({action}) target focus failed"))?;
+
         if action == CHATGPT_WAIT_ACTION {
             // Interpolate recipe vars (e.g. {{wait_timeout_ms}}) in args before parsing.
             let interpolated_args: Option<Vec<String>> = step
@@ -564,6 +615,7 @@ fn run_recipe_with_connection(
                         .collect::<Result<Vec<_>>>()
                 })
                 .transpose()
+                .with_chatgpt_phase(chatgpt_recipe::ChatgptTransportPhase::WaitResponse)
                 .with_context(|| format!("recipe step {idx} ({action}) var interpolation"))?;
             let stdout = run_chatgpt_wait_response(
                 interpolated_args.as_deref(),
@@ -574,6 +626,7 @@ fn run_recipe_with_connection(
                 ctx.use_stealth,
                 headed,
             )
+            .with_chatgpt_phase(chatgpt_recipe::ChatgptTransportPhase::WaitResponse)
             .with_context(|| format!("recipe step {idx} ({action}) failed"))?;
 
             if wants_json || wants_jsonl {
@@ -600,6 +653,9 @@ fn run_recipe_with_connection(
 
         if action == CHATGPT_SELECT_MODEL_ACTION {
             let stdout = run_chatgpt_select_model(&ctx, connection, ctx.use_stealth, headed)
+                .map_err(|err| {
+                    mark_chatgpt_error_after_side_effect(err, chatgpt_stage.terminal_phase(action))
+                })
                 .with_context(|| format!("recipe step {idx} ({action}) failed"))?;
 
             if wants_json || wants_jsonl {
@@ -626,6 +682,37 @@ fn run_recipe_with_connection(
 
         if action == CHATGPT_OPEN_ATTACHMENT_UI_ACTION {
             let stdout = run_chatgpt_open_attachment_ui(connection, ctx.use_stealth, headed)
+                .map_err(|err| {
+                    mark_chatgpt_error_after_side_effect(err, chatgpt_stage.terminal_phase(action))
+                })
+                .with_context(|| format!("recipe step {idx} ({action}) failed"))?;
+
+            if wants_json || wants_jsonl {
+                let stdout_value =
+                    parse_stdout_json(&stdout).unwrap_or(Value::String(stdout.clone()));
+                let event = json!({
+                    "type": "browser_step",
+                    "index": idx,
+                    "action": action,
+                    "args": step.args,
+                    "stdout": stdout_value,
+                });
+                if wants_jsonl {
+                    write_jsonl_event(&event)?;
+                }
+                if collect_step_events {
+                    events.push(event);
+                }
+            } else {
+                print!("{stdout}");
+            }
+            continue;
+        }
+
+        if action == CHATGPT_UPLOAD_BUNDLE_ACTION {
+            chatgpt_stage.mark_upload_started();
+            let stdout = run_chatgpt_upload_bundle(&ctx, connection, ctx.use_stealth, headed)
+                .with_chatgpt_phase(chatgpt_recipe::ChatgptTransportPhase::Upload)
                 .with_context(|| format!("recipe step {idx} ({action}) failed"))?;
 
             if wants_json || wants_jsonl {
@@ -652,8 +739,10 @@ fn run_recipe_with_connection(
 
         if action == CHATGPT_SEND_ACTION {
             let stdout = run_chatgpt_send(connection, ctx.use_stealth, headed)
+                .with_chatgpt_phase(chatgpt_recipe::ChatgptTransportPhase::Send)
                 .with_context(|| format!("recipe step {idx} ({action}) failed"))?;
             pending_chatgpt_send_baseline = parse_chatgpt_send_baseline_from_stdout(&stdout);
+            chatgpt_stage.mark_send_succeeded();
 
             if wants_json || wants_jsonl {
                 let stdout_value =
@@ -678,6 +767,7 @@ fn run_recipe_with_connection(
         }
 
         if action == CHATGPT_WAIT_UPLOAD_ACTION {
+            chatgpt_stage.mark_upload_started();
             let stdout = run_chatgpt_wait_upload(
                 &ctx,
                 step.args.as_deref(),
@@ -685,6 +775,7 @@ fn run_recipe_with_connection(
                 ctx.use_stealth,
                 headed,
             )
+            .with_chatgpt_phase(chatgpt_recipe::ChatgptTransportPhase::Upload)
             .with_context(|| format!("recipe step {idx} ({action}) failed"))?;
 
             if wants_json || wants_jsonl {
@@ -709,7 +800,17 @@ fn run_recipe_with_connection(
             continue;
         }
 
-        let commands = expand_step(action, step.args.as_deref(), &ctx)?;
+        if is_chatgpt_recipe && action == "upload" {
+            chatgpt_stage.mark_upload_started();
+        }
+        let action_terminal_phase = if is_chatgpt_recipe {
+            chatgpt_stage.terminal_phase(action)
+        } else {
+            None
+        };
+        let commands = expand_step(action, step.args.as_deref(), &ctx)
+            .map_err(|err| mark_chatgpt_error_after_side_effect(err, action_terminal_phase))
+            .with_context(|| format!("recipe step {idx} ({action}) expand failed"))?;
 
         for args in commands {
             let stdout = match run_agent_browser_with_connection_timeout(
@@ -740,7 +841,10 @@ fn run_recipe_with_connection(
                         &ctx.target_url,
                         headed,
                         snapshot.as_deref(),
-                    )? {
+                    )
+                    .map_err(|err| {
+                        mark_chatgpt_error_after_side_effect(err, action_terminal_phase)
+                    })? {
                         headed = true;
                         run_agent_browser_with_connection_timeout(
                             args.clone(),
@@ -749,9 +853,15 @@ fn run_recipe_with_connection(
                             ctx.use_stealth,
                             headed,
                             step.timeout_ms,
-                        )?
+                        )
+                        .map_err(|err| {
+                            mark_chatgpt_error_after_side_effect(err, action_terminal_phase)
+                        })?
                     } else {
-                        return Err(err.context(format!("recipe step {idx} ({action}) failed")));
+                        return Err(mark_chatgpt_error_after_side_effect(
+                            err.context(format!("recipe step {idx} ({action}) failed")),
+                            action_terminal_phase,
+                        ));
                     }
                 }
             };
@@ -779,7 +889,7 @@ fn run_recipe_with_connection(
     }
 
     let payload = if is_chatgpt_recipe {
-        chatgpt_recipe_payload_from_steps(&events)
+        chatgpt_recipe_payload_from_steps(&events, ctx.fallback_used)
     } else {
         json!({
             "name": recipe.name,
@@ -799,11 +909,15 @@ fn run_recipe_with_connection(
             "backend": "agent-browser",
             "response": payload.get("response").cloned().unwrap_or(Value::Null),
             "model_used": payload.get("model_used").cloned().unwrap_or(Value::Null),
+            "model_selection_status": payload
+                .get("model_selection_status")
+                .cloned()
+                .unwrap_or(Value::Null),
             "warnings": payload
                 .get("warnings")
                 .cloned()
                 .unwrap_or_else(|| Value::Array(Vec::new())),
-            "fallback_used": true,
+            "fallback_used": ctx.fallback_used,
             "delivery_mode": payload.get("delivery_mode").cloned().unwrap_or(Value::Null),
             "auto_paste_fallback": payload
                 .get("auto_paste_fallback")
@@ -816,9 +930,10 @@ fn run_recipe_with_connection(
     Ok(payload)
 }
 
-fn chatgpt_recipe_payload_from_steps(steps: &[Value]) -> Value {
+fn chatgpt_recipe_payload_from_steps(steps: &[Value], fallback_used: bool) -> Value {
     let mut response = Value::Null;
     let mut model_used = Value::Null;
+    let mut model_selection_status = chatgpt_recipe::ChatgptModelSelectionStatus::Unavailable;
     let mut warnings: Vec<String> = Vec::new();
 
     for step in steps {
@@ -830,6 +945,11 @@ fn chatgpt_recipe_payload_from_steps(steps: &[Value]) -> Value {
         if action == CHATGPT_SELECT_MODEL_ACTION {
             if let Some(value) = stdout.get("model_used").cloned() {
                 model_used = value;
+            }
+            if let Some(value) = stdout.get("model_selection_status").cloned() {
+                if let Ok(status) = serde_json::from_value(value) {
+                    model_selection_status = status;
+                }
             }
         }
         if action == CHATGPT_WAIT_ACTION {
@@ -853,8 +973,9 @@ fn chatgpt_recipe_payload_from_steps(steps: &[Value]) -> Value {
         backend: "agent-browser".to_string(),
         response: response.as_str().unwrap_or_default().to_string(),
         model_used: model_used.as_str().map(str::to_owned),
+        model_selection_status,
         warnings,
-        fallback_used: true,
+        fallback_used,
         delivery_mode: chatgpt_recipe::ChatgptDeliveryMode::FileUpload,
         auto_paste_fallback: false,
     };
@@ -863,6 +984,77 @@ fn chatgpt_recipe_payload_from_steps(steps: &[Value]) -> Value {
         object.insert("steps".to_string(), json!(steps));
     }
     payload
+}
+
+fn focus_chatgpt_run_tab_before_recipe_action(
+    is_chatgpt_recipe: bool,
+    action: &str,
+    connection: Option<&BrowserConnection>,
+    ctx: &RecipeContext,
+    headed: bool,
+    timeout_ms: u64,
+    focus_cache: Option<&mut ChatgptRunTabFocusCache>,
+) -> Result<()> {
+    if !is_chatgpt_recipe || action == "open" {
+        return Ok(());
+    }
+    let Some(connection) = connection.filter(|connection| connection.is_live_attach()) else {
+        return Ok(());
+    };
+
+    focus_chatgpt_run_tab_for_live_attach_cached(
+        Some(connection),
+        ctx.vars.get("run_id").map(String::as_str),
+        ctx.use_stealth,
+        headed,
+        timeout_ms,
+        focus_cache,
+    )
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ChatgptRecipeStage {
+    Idle,
+    UploadStarted,
+    SendSucceeded,
+}
+
+impl ChatgptRecipeStage {
+    fn mark_upload_started(&mut self) {
+        if *self == Self::Idle {
+            *self = Self::UploadStarted;
+        }
+    }
+
+    fn mark_send_succeeded(&mut self) {
+        *self = Self::SendSucceeded;
+    }
+
+    fn terminal_phase(self, action: &str) -> Option<chatgpt_recipe::ChatgptTransportPhase> {
+        if self == Self::SendSucceeded {
+            return Some(chatgpt_recipe::ChatgptTransportPhase::WaitResponse);
+        }
+
+        match action {
+            CHATGPT_WAIT_ACTION => Some(chatgpt_recipe::ChatgptTransportPhase::WaitResponse),
+            CHATGPT_SEND_ACTION => Some(chatgpt_recipe::ChatgptTransportPhase::Send),
+            CHATGPT_WAIT_UPLOAD_ACTION | CHATGPT_UPLOAD_BUNDLE_ACTION | "upload" => {
+                Some(chatgpt_recipe::ChatgptTransportPhase::Upload)
+            }
+            _ if self == Self::UploadStarted => Some(chatgpt_recipe::ChatgptTransportPhase::Upload),
+            _ => None,
+        }
+    }
+}
+
+fn mark_chatgpt_error_after_side_effect(
+    err: anyhow::Error,
+    phase: Option<chatgpt_recipe::ChatgptTransportPhase>,
+) -> anyhow::Error {
+    match phase {
+        Some(phase) => chatgpt_recipe::mark_terminal_fallback_phase(err, phase),
+        None => err,
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -993,18 +1185,20 @@ fn run_chatgpt_wait_response(
     use_stealth: bool,
     headed: bool,
 ) -> Result<String> {
-    let options = parse_chatgpt_poll_args(args)?;
+    let options = parse_chatgpt_poll_args(CHATGPT_WAIT_ACTION, args)?;
     let command_timeout_ms = timeout_ms.unwrap_or(CHATGPT_POLL_COMMAND_TIMEOUT_MS_DEFAULT);
     let started_at = Instant::now();
     let deadline = started_at + Duration::from_millis(options.timeout_ms);
+    let mut focus_cache = ChatgptRunTabFocusCache::default();
     // Prefer the exact pre-send assistant counters returned by
     // `chatgpt_send`; otherwise fall back to a fresh DOM baseline.
-    focus_chatgpt_run_tab_for_auto_connect(
+    focus_chatgpt_run_tab_for_live_attach_cached(
         connection,
         run_id,
         use_stealth,
         headed,
         command_timeout_ms,
+        Some(&mut focus_cache),
     )?;
     let baseline_dom = match baseline {
         Some(baseline) => baseline_dom_state(baseline),
@@ -1045,12 +1239,13 @@ fn run_chatgpt_wait_response(
 
         completed_polls = attempt;
 
-        focus_chatgpt_run_tab_for_auto_connect(
+        focus_chatgpt_run_tab_for_live_attach_cached(
             connection,
             run_id,
             use_stealth,
             headed,
             command_timeout_ms,
+            Some(&mut focus_cache),
         )?;
         let dom = inspect_chatgpt_dom_state(connection, use_stealth, headed, command_timeout_ms)?;
         if !dom.error.is_empty() {
@@ -1061,12 +1256,13 @@ fn run_chatgpt_wait_response(
         match classify_chatgpt_completion(&dom, &baseline_dom) {
             CompletionVerdict::CopyButton => {
                 let elapsed_ms = started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
-                focus_chatgpt_run_tab_for_auto_connect(
+                focus_chatgpt_run_tab_for_live_attach_cached(
                     connection,
                     run_id,
                     use_stealth,
                     headed,
                     command_timeout_ms,
+                    Some(&mut focus_cache),
                 )?;
                 let response = read_latest_chatgpt_response(
                     connection,
@@ -1112,12 +1308,13 @@ fn run_chatgpt_wait_response(
                 if stable_for_ms >= stable_idle_threshold_ms {
                     let elapsed_ms =
                         started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
-                    focus_chatgpt_run_tab_for_auto_connect(
+                    focus_chatgpt_run_tab_for_live_attach_cached(
                         connection,
                         run_id,
                         use_stealth,
                         headed,
                         command_timeout_ms,
+                        Some(&mut focus_cache),
                     )?;
                     let response = read_latest_chatgpt_response(
                         connection,
@@ -1190,40 +1387,86 @@ fn chatgpt_wait_probe_delay(
     }
 }
 
-fn focus_chatgpt_run_tab_for_auto_connect(
+#[derive(Debug, Default)]
+struct ChatgptRunTabFocusCache {
+    run_id: Option<String>,
+    tab_index: Option<usize>,
+}
+
+fn focus_chatgpt_run_tab_for_live_attach_cached(
     connection: Option<&BrowserConnection>,
     run_id: Option<&str>,
     use_stealth: bool,
     headed: bool,
     timeout_ms: u64,
+    mut cache: Option<&mut ChatgptRunTabFocusCache>,
 ) -> Result<()> {
-    let Some(connection @ BrowserConnection::AutoConnect) = connection else {
+    let Some(connection) = connection.filter(|connection| connection.is_live_attach()) else {
         return Ok(());
     };
     let Some(run_id) = run_id.map(str::trim).filter(|run_id| !run_id.is_empty()) else {
         return Ok(());
     };
+    let encoded_marker_param = chatgpt_web::chatgpt_run_url_marker(run_id);
+    let raw_marker_param = format!("_yoetz={run_id}");
+    let url_has_run_marker =
+        |url: &str| url.contains(&encoded_marker_param) || url.contains(&raw_marker_param);
+    let run_marker = format!("yoetz:{run_id}");
+
+    if let Some(cache_ref) = cache.as_deref_mut() {
+        if cache_ref.run_id.as_deref() == Some(run_id) {
+            if let Some(index) = cache_ref.tab_index {
+                if select_live_attach_tab(connection, index, use_stealth, headed, timeout_ms)
+                    .is_ok()
+                {
+                    let identity = inspect_current_live_attach_tab_identity(
+                        connection,
+                        use_stealth,
+                        headed,
+                        timeout_ms,
+                    )?;
+                    if identity.window_name == run_marker || url_has_run_marker(&identity.url) {
+                        return Ok(());
+                    }
+                }
+                cache_ref.tab_index = None;
+            }
+        } else {
+            cache_ref.run_id = Some(run_id.to_string());
+            cache_ref.tab_index = None;
+        }
+    }
 
     let tabs = list_live_attach_tabs(connection, use_stealth, headed, Some(timeout_ms))
         .with_context(|| format!("list Chrome tabs while tracking yoetz run `{run_id}`"))?;
-    let marker_param = format!("_yoetz={run_id}");
-    if tabs
+    if let Some(tab) = tabs
         .iter()
-        .any(|tab| tab.active && tab.url.contains(&marker_param))
+        .find(|tab| tab.active && url_has_run_marker(&tab.url))
     {
+        if let Some(cache_ref) = cache.as_deref_mut() {
+            cache_ref.run_id = Some(run_id.to_string());
+            cache_ref.tab_index = Some(tab.index);
+        }
         return Ok(());
     }
-    if let Some(tab) = tabs.iter().find(|tab| tab.url.contains(&marker_param)) {
+    if let Some(tab) = tabs.iter().find(|tab| url_has_run_marker(&tab.url)) {
         select_live_attach_tab(connection, tab.index, use_stealth, headed, timeout_ms)?;
+        if let Some(cache_ref) = cache.as_deref_mut() {
+            cache_ref.run_id = Some(run_id.to_string());
+            cache_ref.tab_index = Some(tab.index);
+        }
         return Ok(());
     }
 
-    let run_marker = format!("yoetz:{run_id}");
     for tab in chatgpt_run_tab_candidates(&tabs) {
         select_live_attach_tab(connection, tab.index, use_stealth, headed, timeout_ms)?;
         let identity =
             inspect_current_live_attach_tab_identity(connection, use_stealth, headed, timeout_ms)?;
-        if identity.window_name == run_marker || identity.url.contains(&marker_param) {
+        if identity.window_name == run_marker || url_has_run_marker(&identity.url) {
+            if let Some(cache_ref) = cache.as_deref_mut() {
+                cache_ref.run_id = Some(run_id.to_string());
+                cache_ref.tab_index = Some(tab.index);
+            }
             return Ok(());
         }
     }
@@ -1307,7 +1550,7 @@ fn inspect_current_live_attach_tab_identity(
 /// `display: none` when done) has disappeared inside the file tile.
 fn parse_upload_poll_options(args: Option<&[String]>) -> Result<ChatgptPollOptions> {
     match args {
-        Some(a) if !a.is_empty() => parse_chatgpt_poll_args(Some(a)),
+        Some(a) if !a.is_empty() => parse_chatgpt_poll_args(CHATGPT_WAIT_UPLOAD_ACTION, Some(a)),
         _ => Ok(ChatgptPollOptions {
             attempts: CHATGPT_UPLOAD_POLL_ATTEMPTS_DEFAULT,
             interval_ms: CHATGPT_UPLOAD_POLL_INTERVAL_MS_DEFAULT,
@@ -1346,11 +1589,14 @@ fn run_chatgpt_select_model(
         .and_then(Value::as_str)
         .unwrap_or("unknown");
     let model_used = chatgpt_web::select_reported_chatgpt_model(&selection, requested_model);
+    let model_selection_status =
+        chatgpt_web::chatgpt_model_selection_status(&selection, requested_model);
     match status {
         "selected" | "already-selected" => {
             Ok(json!({
                 "status": "ok",
                 "model_used": model_used,
+                "model_selection_status": model_selection_status,
             })
             .to_string())
         }
@@ -1358,6 +1604,7 @@ fn run_chatgpt_select_model(
             Ok(json!({
                 "status": "ok",
                 "model_used": model_used,
+                "model_selection_status": model_selection_status,
             })
             .to_string())
         }
@@ -1442,6 +1689,102 @@ fn run_chatgpt_open_attachment_ui(
     }
 }
 
+fn run_chatgpt_upload_bundle(
+    ctx: &RecipeContext,
+    connection: Option<&BrowserConnection>,
+    use_stealth: bool,
+    headed: bool,
+) -> Result<String> {
+    let bundle_path = ctx
+        .bundle_path
+        .as_deref()
+        .context("ChatGPT upload requires `bundle_path` in the recipe context")?;
+    let marker_selector = format!(
+        "input[type='file'][title='{}']",
+        chatgpt_web::COMPOSER_FILE_INPUT_MARKER
+    );
+    let scope_expression = build_chatgpt_upload_scope_with_nudges_expression()?;
+
+    let scope_result = eval_chatgpt_upload_scope(
+        &scope_expression,
+        connection,
+        use_stealth,
+        headed,
+        CHATGPT_POLL_COMMAND_TIMEOUT_MS_DEFAULT,
+    )?;
+    if !chatgpt_upload_scope_is_marked(&scope_result) {
+        return Err(anyhow!(
+            "composer-scoped ChatGPT file input was not available for upload: {}",
+            scope_result
+        ));
+    }
+
+    run_agent_browser_with_connection_timeout(
+        vec![
+            "upload".to_string(),
+            marker_selector.clone(),
+            bundle_path.to_string(),
+        ],
+        OutputFormat::Text,
+        connection,
+        use_stealth,
+        headed,
+        Some(CHATGPT_POLL_COMMAND_TIMEOUT_MS_DEFAULT),
+    )
+    .with_context(|| format!("upload `{bundle_path}` through {marker_selector}"))?;
+
+    Ok(json!({"status": "ok", "selector": marker_selector}).to_string())
+}
+
+fn build_chatgpt_upload_scope_with_nudges_expression() -> Result<String> {
+    let scope_function_json =
+        serde_json::to_string(&chatgpt_web::build_scope_composer_file_input_function())?;
+    let open_function_json =
+        serde_json::to_string(&chatgpt_web::build_open_attachment_ui_function())?;
+    let menu_function_json =
+        serde_json::to_string(&chatgpt_web::build_upload_menu_item_click_function())?;
+    chatgpt_web::wrap_function_source_for_json_eval(&format!(
+        r#"
+async () => {{
+  const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  const run = (source) => eval("(" + source + ")")();
+  let state = await run({scope_function_json});
+  if (state?.status === "marked") return state;
+  await run({open_function_json}).catch(() => null);
+  await wait(300);
+  state = await run({scope_function_json});
+  if (state?.status === "marked") return state;
+  await run({menu_function_json}).catch(() => null);
+  await wait(300);
+  return await run({scope_function_json});
+}}
+"#
+    ))
+}
+
+fn eval_chatgpt_upload_scope(
+    scope_expression: &str,
+    connection: Option<&BrowserConnection>,
+    use_stealth: bool,
+    headed: bool,
+    timeout_ms: u64,
+) -> Result<Value> {
+    let stdout = run_agent_browser_with_connection_timeout(
+        vec!["eval".to_string(), scope_expression.to_string()],
+        OutputFormat::Text,
+        connection,
+        use_stealth,
+        headed,
+        Some(timeout_ms),
+    )?;
+    parse_stdout_json(&stdout)
+        .with_context(|| format!("parse ChatGPT upload scope result: {stdout}"))
+}
+
+fn chatgpt_upload_scope_is_marked(result: &Value) -> bool {
+    result.get("status").and_then(Value::as_str) == Some("marked")
+}
+
 fn run_chatgpt_wait_upload(
     ctx: &RecipeContext,
     args: Option<&[String]>,
@@ -1490,7 +1833,19 @@ fn run_chatgpt_wait_upload(
 
         match status {
             "done" => {
-                return Ok(json!({"status": "ok", "polls": attempt}).to_string());
+                let stable_ready_count = probe
+                    .get("stableReadyCount")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0);
+                if stable_ready_count >= chatgpt_web::CHATGPT_UPLOAD_STABLE_POLLS {
+                    return Ok(json!({"status": "ok", "polls": attempt}).to_string());
+                }
+            }
+            "failed" => {
+                return Err(anyhow!(
+                    "attachment upload for `{file_name}` failed: {}",
+                    probe
+                ));
             }
             "no_tile" if attempt > 5 => {
                 return Err(anyhow!(
@@ -1650,7 +2005,10 @@ fn read_latest_chatgpt_response(
         .to_string())
 }
 
-fn parse_chatgpt_poll_args(args: Option<&[String]>) -> Result<ChatgptPollOptions> {
+fn parse_chatgpt_poll_args(
+    action_name: &str,
+    args: Option<&[String]>,
+) -> Result<ChatgptPollOptions> {
     let mut options = ChatgptPollOptions {
         attempts: CHATGPT_POLL_ATTEMPTS_DEFAULT,
         interval_ms: CHATGPT_POLL_INTERVAL_MS_DEFAULT,
@@ -1685,7 +2043,7 @@ fn parse_chatgpt_poll_args(args: Option<&[String]>) -> Result<ChatgptPollOptions
                     .parse()
                     .with_context(|| format!("invalid --timeout-ms value `{raw}`"))?;
             }
-            other => return Err(anyhow!("unsupported {CHATGPT_WAIT_ACTION} arg `{other}`")),
+            other => return Err(anyhow!("unsupported {action_name} arg `{other}`")),
         }
     }
     if options.interval_ms == 0 {
@@ -1988,10 +2346,14 @@ pub fn close_browser() -> Result<()> {
 }
 
 pub fn close_live_attach_session() -> Result<()> {
+    close_live_attach_session_name(CDP_SESSION_NAME)
+}
+
+fn close_live_attach_session_name(session_name: &str) -> Result<()> {
     let (bin, prefix_args) = resolve_agent_browser()?;
     let mut cmd = Command::new(bin);
     cmd.args(prefix_args);
-    match cmd.args(["--session", CDP_SESSION_NAME, "close"]).output() {
+    match cmd.args(["--session", session_name, "close"]).output() {
         Ok(output) if !output.status.success() => {
             let stderr = String::from_utf8_lossy(&output.stderr);
             eprintln!("warning: session close failed: {stderr}");
@@ -2003,10 +2365,38 @@ pub fn close_live_attach_session() -> Result<()> {
 }
 
 pub fn close_browser_for_connection(connection: &BrowserConnection) -> Result<()> {
-    if connection.is_live_attach() {
-        return close_live_attach_session();
+    match connection {
+        BrowserConnection::AutoConnect => return close_live_attach_session(),
+        BrowserConnection::Cdp { run_id, .. } => {
+            let session_name = run_id
+                .as_deref()
+                .map(live_cdp_session_name_for_run)
+                .unwrap_or_else(|| CDP_SESSION_NAME.to_string());
+            return close_live_attach_session_name(&session_name);
+        }
+        BrowserConnection::CookieState { .. } | BrowserConnection::Profile { .. } => {}
     }
     close_browser_daemon()
+}
+
+pub fn live_cdp_session_name_for_run(run_id: &str) -> String {
+    let mut suffix = run_id
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+    suffix.truncate(50);
+    let suffix = suffix.trim_matches('-');
+    if suffix.is_empty() {
+        CDP_SESSION_NAME.to_string()
+    } else {
+        format!("{CDP_SESSION_NAME}-{suffix}")
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -3533,7 +3923,12 @@ pub fn resolve_browser_connection(
 ) -> Result<BrowserConnection> {
     if let Some(endpoint) = resolve_cdp_endpoint(cdp_override, browser_defaults) {
         match try_cdp_attach(&endpoint, target_url) {
-            Ok(()) => return Ok(BrowserConnection::Cdp { endpoint }),
+            Ok(()) => {
+                return Ok(BrowserConnection::Cdp {
+                    endpoint,
+                    run_id: None,
+                })
+            }
             Err(err) if should_stop_live_attach_fallback(&err) => {
                 return Err(err);
             }
@@ -3555,6 +3950,7 @@ pub fn resolve_browser_connection(
 pub fn try_cdp_attach(endpoint: &str, target_url: &str) -> Result<()> {
     let connection = BrowserConnection::Cdp {
         endpoint: endpoint.to_string(),
+        run_id: None,
     };
     verify_auth_cdp(target_url, &connection).map_err(|e| {
         if allow_dialog_error(&e) {
@@ -4519,6 +4915,7 @@ mod tests {
             bundle_text: Some("hello world".to_string()),
             profile_dir: None,
             profile_mode: BrowserProfileMode::ProfileOnly,
+            fallback_used: false,
             use_stealth: true,
             headed: false,
             target_url: CHATGPT_URL.to_string(),
@@ -4644,6 +5041,76 @@ mod tests {
         .clone()
     }
 
+    fn fake_agent_browser_focus_bin() -> PathBuf {
+        static BIN: TestOnceLock<PathBuf> = TestOnceLock::new();
+        BIN.get_or_init(|| {
+            let dir = unique_test_dir("fake_agent_browser_focus");
+            let bin = command_path(&dir, "fake-agent-browser-focus");
+            write_executable_script(
+                &bin,
+                r#"#!/bin/sh
+printf '%s\n' "$*" >> "$LOG_PATH"
+case "$*" in
+  *"tab list --json"*)
+    printf '{"success":true,"data":{"tabs":[{"active":true,"index":1,"title":"Docs","url":"https://docs.example.com/"},{"active":false,"index":4,"title":"ChatGPT","url":"https://chatgpt.com/?_yoetz=run-focus"}]}}'
+    ;;
+  *" eval "*)
+    case "$*" in
+      *"windowName"*)
+        printf '{"windowName":"yoetz:run-focus","url":"https://chatgpt.com/?_yoetz=run-focus"}'
+        exit 0
+        ;;
+    esac
+    count=0
+    if [ -f "$EVAL_COUNT_PATH" ]; then count=$(cat "$EVAL_COUNT_PATH"); fi
+    count=$((count + 1))
+    printf '%s' "$count" > "$EVAL_COUNT_PATH"
+    if [ "$count" = "1" ]; then
+      printf '{"status":"already-selected","currentLabel":"GPT-5 Pro"}'
+    elif [ "$count" = "2" ]; then
+      printf '{"status":"marked"}'
+    else
+      printf '{"status":"sent","assistantCountBeforeSend":0,"assistantLastLenBeforeSend":0}'
+    fi
+    ;;
+esac
+"#,
+                r#"@echo off
+setlocal enabledelayedexpansion
+echo %*>> "%LOG_PATH%"
+echo %* | findstr /c:"tab list --json" >nul
+if %errorlevel%==0 (
+  echo {"success":true,"data":{"tabs":[{"active":true,"index":1,"title":"Docs","url":"https://docs.example.com/"},{"active":false,"index":4,"title":"ChatGPT","url":"https://chatgpt.com/?_yoetz=run-focus"}]}}
+  exit /b 0
+)
+echo %* | findstr /c:" eval " >nul
+if %errorlevel%==0 (
+  echo %* | findstr /c:"windowName" >nul
+  if !errorlevel!==0 (
+    echo {"windowName":"yoetz:run-focus","url":"https://chatgpt.com/?_yoetz=run-focus"}
+    exit /b 0
+  )
+  set count=0
+  if exist "%EVAL_COUNT_PATH%" (
+    set /p count=<"%EVAL_COUNT_PATH%"
+  )
+  set /a count=count+1
+  > "%EVAL_COUNT_PATH%" echo !count!
+  if "!count!"=="1" (
+    echo {"status":"already-selected","currentLabel":"GPT-5 Pro"}
+  ) else if "!count!"=="2" (
+    echo {"status":"marked"}
+  ) else (
+    echo {"status":"sent","assistantCountBeforeSend":0,"assistantLastLenBeforeSend":0}
+  )
+)
+"#,
+            );
+            bin
+        })
+        .clone()
+    }
+
     #[test]
     fn detect_agent_browser_in_path_does_not_fall_back_to_npx() {
         let _guard = lock_env();
@@ -4746,6 +5213,7 @@ mod tests {
     fn browser_connection_live_attach_detection() {
         assert!(BrowserConnection::Cdp {
             endpoint: "http://127.0.0.1:9222".to_string(),
+            run_id: None,
         }
         .is_live_attach());
         assert!(BrowserConnection::AutoConnect.is_live_attach());
@@ -5622,6 +6090,7 @@ browser_cdp = "http://evil.example.com:9222"
             OutputFormat::Json,
             Some(&BrowserConnection::Cdp {
                 endpoint: "http://127.0.0.1:9222".to_string(),
+                run_id: None,
             }),
             /* use_stealth */ true,
             /* headed */ true,
@@ -5632,6 +6101,29 @@ browser_cdp = "http://evil.example.com:9222"
         assert!(args.iter().any(|arg| arg == "http://127.0.0.1:9222"));
         assert!(!args.iter().any(|arg| arg == "--headed"));
         assert!(!args.iter().any(|arg| arg == "--user-agent"));
+    }
+
+    #[test]
+    fn build_agent_browser_args_uses_run_scoped_cdp_session_name() {
+        let args = build_agent_browser_args(
+            vec!["snapshot".to_string()],
+            OutputFormat::Json,
+            Some(&BrowserConnection::Cdp {
+                endpoint: "http://127.0.0.1:9222".to_string(),
+                run_id: Some("run:abc/123".to_string()),
+            }),
+            /* use_stealth */ true,
+            /* headed */ true,
+        );
+
+        assert!(args.iter().any(|arg| arg == "yoetz-cdp-run-abc-123"));
+        assert!(!args.iter().any(|arg| arg == CDP_SESSION_NAME));
+    }
+
+    #[test]
+    fn live_cdp_session_name_leaves_agent_browser_length_headroom() {
+        let name = live_cdp_session_name_for_run(&"a".repeat(200));
+        assert_eq!(name.len(), "yoetz-cdp-".len() + 50);
     }
 
     #[test]
@@ -5646,6 +6138,105 @@ browser_cdp = "http://evil.example.com:9222"
         assert!(args.iter().any(|arg| arg == "--auto-connect"));
         assert!(!args.iter().any(|arg| arg == "--session"));
         assert!(!args.iter().any(|arg| arg == CDP_SESSION_NAME));
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn live_attach_chatgpt_steps_focus_run_tab_before_built_in_and_generic_actions() {
+        fn assert_action_was_focused(lines: &[&str], needle: &str) {
+            let action_idx = lines
+                .iter()
+                .position(|line| line.contains(needle))
+                .unwrap_or_else(|| panic!("expected `{needle}` in log:\n{}", lines.join("\n")));
+            assert!(
+                lines[..action_idx]
+                    .iter()
+                    .rev()
+                    .any(|line| line.contains(" tab 4")),
+                "expected tab 4 selection before `{needle}` in log:\n{}",
+                lines.join("\n")
+            );
+        }
+
+        fn run_case(label: &str, connection: BrowserConnection, expected_connection_arg: &str) {
+            let log_dir = unique_test_dir(label);
+            let log_path = log_dir.join("agent-browser.log");
+            let eval_count_path = log_dir.join("eval-count");
+            let bin = fake_agent_browser_focus_bin();
+            let _bin_env = EnvVarGuard::set("YOETZ_AGENT_BROWSER_BIN", &bin);
+            let _log_env = EnvVarGuard::set("LOG_PATH", &log_path);
+            let _eval_env = EnvVarGuard::set("EVAL_COUNT_PATH", &eval_count_path);
+            let mut ctx = recipe_context();
+            ctx.use_stealth = false;
+            ctx.vars.insert("model".to_string(), "auto".to_string());
+            ctx.vars.insert("prompt".to_string(), "Review".to_string());
+            ctx.vars
+                .insert("run_id".to_string(), "run-focus".to_string());
+            let recipe = serde_yaml_ng::from_str::<Recipe>(
+                r##"
+name: chatgpt
+steps:
+  - action: open
+    args: ["https://chatgpt.com/?_yoetz={{run_id}}"]
+  - action: chatgpt_select_model
+  - action: chatgpt_upload_bundle
+  - action: type
+    args: ["#prompt-textarea", "{{prompt}}"]
+  - action: chatgpt_send
+"##,
+            )
+            .unwrap();
+
+            run_recipe_with_connection(recipe, ctx, Some(&connection), OutputFormat::Text).unwrap();
+
+            let logged = fs::read_to_string(&log_path).unwrap_or_default();
+            assert!(
+                logged.contains(expected_connection_arg),
+                "expected `{expected_connection_arg}` in log:\n{logged}"
+            );
+            let lines = logged.lines().collect::<Vec<_>>();
+            let eval_indices = lines
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, line)| {
+                    (line.contains(" eval ") && !line.contains("windowName")).then_some(idx)
+                })
+                .collect::<Vec<_>>();
+            assert!(
+                eval_indices.len() >= 3,
+                "expected model-selection, upload-scope, and send evals:\n{logged}"
+            );
+            for idx in eval_indices {
+                assert!(
+                    lines[..idx]
+                        .iter()
+                        .rev()
+                        .any(|line| line.contains(" tab 4")),
+                    "expected run-tab focus before eval line `{}`:\n{logged}",
+                    lines[idx]
+                );
+            }
+            assert_action_was_focused(
+                &lines,
+                " upload input[type='file'][title='yoetz-upload-target'] /tmp/bundle.md",
+            );
+            assert_action_was_focused(&lines, " type #prompt-textarea Review");
+        }
+
+        let _guard = lock_env();
+        run_case(
+            "focus_auto_connect",
+            BrowserConnection::AutoConnect,
+            "--auto-connect",
+        );
+        run_case(
+            "focus_cdp",
+            BrowserConnection::Cdp {
+                endpoint: "http://127.0.0.1:9222".to_string(),
+                run_id: Some("run-focus".to_string()),
+            },
+            "--cdp http://127.0.0.1:9222 --session yoetz-cdp-run-focus",
+        );
     }
 
     #[test]
@@ -5680,6 +6271,7 @@ browser_cdp = "http://evil.example.com:9222"
         assert_eq!(
             auth_check_timeout_ms(&BrowserConnection::Cdp {
                 endpoint: "http://127.0.0.1:9222".to_string(),
+                run_id: None,
             }),
             LIVE_ATTACH_AUTH_CHECK_TIMEOUT_MS
         );
@@ -5734,6 +6326,7 @@ browser_cdp = "http://evil.example.com:9222"
             r#"{"text":"Verify you are human"}"#,
             Some(&BrowserConnection::Cdp {
                 endpoint: "http://127.0.0.1:9222".to_string(),
+                run_id: None,
             }),
         );
         assert_eq!(
@@ -5800,6 +6393,7 @@ browser_cdp = "http://evil.example.com:9222"
             BrowserConnection::AutoConnect,
             BrowserConnection::Cdp {
                 endpoint: "http://127.0.0.1:9222".to_string(),
+                run_id: None,
             },
         ];
         for connection in live_cases {
@@ -6209,7 +6803,7 @@ browser_cdp = "http://evil.example.com:9222"
 
     #[test]
     fn parse_chatgpt_poll_args_defaults() {
-        let options = parse_chatgpt_poll_args(None).unwrap();
+        let options = parse_chatgpt_poll_args(CHATGPT_WAIT_ACTION, None).unwrap();
         assert_eq!(options.interval_ms, CHATGPT_POLL_INTERVAL_MS_DEFAULT);
         assert_eq!(options.timeout_ms, CHATGPT_POLL_TOTAL_TIMEOUT_MS_DEFAULT);
         // attempts derived from ceil(timeout / interval) when not explicit.
@@ -6226,7 +6820,7 @@ browser_cdp = "http://evil.example.com:9222"
             "--interval-ms".to_string(),
             "10000".to_string(),
         ];
-        let options = parse_chatgpt_poll_args(Some(&args)).unwrap();
+        let options = parse_chatgpt_poll_args(CHATGPT_WAIT_ACTION, Some(&args)).unwrap();
         // ceil(600000 / 10000) = 60
         assert_eq!(options.attempts, 60);
     }
@@ -6241,7 +6835,7 @@ browser_cdp = "http://evil.example.com:9222"
             "--interval-ms".to_string(),
             "10000".to_string(),
         ];
-        let options = parse_chatgpt_poll_args(Some(&args)).unwrap();
+        let options = parse_chatgpt_poll_args(CHATGPT_WAIT_ACTION, Some(&args)).unwrap();
         // Explicit --attempts should be preserved, not derived.
         assert_eq!(options.attempts, 5);
     }
@@ -6256,7 +6850,7 @@ browser_cdp = "http://evil.example.com:9222"
             "--timeout-ms".to_string(),
             "42000".to_string(),
         ];
-        let options = parse_chatgpt_poll_args(Some(&args)).unwrap();
+        let options = parse_chatgpt_poll_args(CHATGPT_WAIT_ACTION, Some(&args)).unwrap();
         assert_eq!(
             options,
             ChatgptPollOptions {
@@ -6270,14 +6864,22 @@ browser_cdp = "http://evil.example.com:9222"
     #[test]
     fn parse_chatgpt_poll_args_rejects_unknown_flag() {
         let args = vec!["--nope".to_string()];
-        let err = parse_chatgpt_poll_args(Some(&args)).unwrap_err();
+        let err = parse_chatgpt_poll_args(CHATGPT_WAIT_ACTION, Some(&args)).unwrap_err();
         assert!(err.to_string().contains("unsupported"));
+    }
+
+    #[test]
+    fn parse_upload_poll_options_labels_unknown_args_as_upload_wait() {
+        let args = vec!["--nope".to_string()];
+        let err = parse_upload_poll_options(Some(&args)).unwrap_err();
+        assert!(err.to_string().contains(CHATGPT_WAIT_UPLOAD_ACTION));
+        assert!(!err.to_string().contains(CHATGPT_WAIT_ACTION));
     }
 
     #[test]
     fn parse_chatgpt_poll_args_rejects_zero_timeout() {
         let args = vec!["--timeout-ms".to_string(), "0".to_string()];
-        let err = parse_chatgpt_poll_args(Some(&args)).unwrap_err();
+        let err = parse_chatgpt_poll_args(CHATGPT_WAIT_ACTION, Some(&args)).unwrap_err();
         assert!(err.to_string().contains("--timeout-ms"));
     }
 
@@ -6289,7 +6891,8 @@ browser_cdp = "http://evil.example.com:9222"
                 "action": CHATGPT_SELECT_MODEL_ACTION,
                 "stdout": {
                     "status": "ok",
-                    "model_used": "gpt-5-4-pro"
+                    "model_used": "gpt-5-4-pro",
+                    "model_selection_status": "selected"
                 }
             }),
             json!({
@@ -6303,16 +6906,20 @@ browser_cdp = "http://evil.example.com:9222"
             }),
         ];
 
-        let payload = chatgpt_recipe_payload_from_steps(&steps);
+        let payload = chatgpt_recipe_payload_from_steps(&steps, true);
         assert_eq!(payload["transport"], "agent-browser");
         assert_eq!(payload["backend"], "agent-browser");
         assert_eq!(payload["response"], "final answer");
         assert_eq!(payload["model_used"], "gpt-5-4-pro");
+        assert_eq!(payload["model_selection_status"], "selected");
         assert_eq!(payload["fallback_used"], true);
         assert_eq!(payload["warnings"], json!(["used paste fallback"]));
         assert_eq!(payload["delivery_mode"], "file_upload");
         assert_eq!(payload["auto_paste_fallback"], false);
         assert_eq!(payload["steps"], json!(steps));
+
+        let primary_payload = chatgpt_recipe_payload_from_steps(&steps, false);
+        assert_eq!(primary_payload["fallback_used"], false);
     }
 
     fn dom(send: ChatgptSendState, stop: bool, thinking: bool, copy: usize) -> ChatgptDomState {

--- a/crates/yoetz-cli/src/chatgpt_recipe.rs
+++ b/crates/yoetz-cli/src/chatgpt_recipe.rs
@@ -1,10 +1,142 @@
+//! ChatGPT recipe output types and terminal-fallback phase markers.
+
+use anyhow::Error as AnyhowError;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::fmt;
 use std::path::PathBuf;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ChatgptTransportPhase {
+    Upload,
+    Send,
+    WaitResponse,
+}
+
+pub(crate) trait AnyhowResultExt<T> {
+    fn with_chatgpt_phase(self, phase: ChatgptTransportPhase) -> Result<T, AnyhowError>;
+}
+
+impl<T> AnyhowResultExt<T> for Result<T, AnyhowError> {
+    fn with_chatgpt_phase(self, phase: ChatgptTransportPhase) -> Result<T, AnyhowError> {
+        self.map_err(|err| mark_terminal_fallback_phase(err, phase))
+    }
+}
+
+impl fmt::Display for ChatgptTransportPhase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Upload => "upload",
+            Self::Send => "send",
+            Self::WaitResponse => "wait_response",
+        })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "ChatGPT {phase} phase failed after browser side effects; automatic transport fallback is disabled"
+)]
+pub struct ChatgptTerminalFallbackError {
+    phase: ChatgptTransportPhase,
+}
+
+impl ChatgptTerminalFallbackError {
+    pub fn phase(&self) -> ChatgptTransportPhase {
+        self.phase
+    }
+}
+
+pub fn mark_terminal_fallback_phase(err: AnyhowError, phase: ChatgptTransportPhase) -> AnyhowError {
+    err.context(ChatgptTerminalFallbackError { phase })
+}
+
+pub fn terminal_fallback_phase(err: &AnyhowError) -> Option<ChatgptTransportPhase> {
+    if let Some(marker) = err.downcast_ref::<ChatgptTerminalFallbackError>() {
+        return Some(marker.phase());
+    }
+
+    for cause in err.chain() {
+        if let Some(marker) = cause.downcast_ref::<ChatgptTerminalFallbackError>() {
+            return Some(marker.phase());
+        }
+    }
+
+    classify_terminal_fallback_phase_message(&format!("{err:#}"))
+}
+
+pub(crate) fn classify_terminal_fallback_phase_message(
+    message: &str,
+) -> Option<ChatgptTransportPhase> {
+    let message = message.to_ascii_lowercase();
+    const PHASE_NEEDLES: &[(&[&str], ChatgptTransportPhase)] = &[
+        (
+            &["chatgpt_wait_response"],
+            ChatgptTransportPhase::WaitResponse,
+        ),
+        (
+            &["timed out waiting for chatgpt response"],
+            ChatgptTransportPhase::WaitResponse,
+        ),
+        (
+            &["chatgpt response timed out"],
+            ChatgptTransportPhase::WaitResponse,
+        ),
+        (
+            &["response timed out after", "chatgpt"],
+            ChatgptTransportPhase::WaitResponse,
+        ),
+        (&["chatgpt_wait_upload"], ChatgptTransportPhase::Upload),
+        (&["recipe step", "(upload)"], ChatgptTransportPhase::Upload),
+        (&["attachment chip for `"], ChatgptTransportPhase::Upload),
+        (
+            &["file attachment did not finish uploading"],
+            ChatgptTransportPhase::Upload,
+        ),
+        (
+            &["could not set chatgpt upload input files"],
+            ChatgptTransportPhase::Upload,
+        ),
+        (
+            &["parse attachment upload probe"],
+            ChatgptTransportPhase::Upload,
+        ),
+        (&["upload for `"], ChatgptTransportPhase::Upload),
+        (&["chatgpt_send"], ChatgptTransportPhase::Send),
+        (&["chatgpt send button"], ChatgptTransportPhase::Send),
+        (&["chatgpt send click"], ChatgptTransportPhase::Send),
+        (
+            &["missing assistant baseline in chatgpt send payload"],
+            ChatgptTransportPhase::Send,
+        ),
+        (
+            &["unexpected chatgpt send status"],
+            ChatgptTransportPhase::Send,
+        ),
+    ];
+
+    for (needles, phase) in PHASE_NEEDLES {
+        if needles.iter().all(|needle| message.contains(needle)) {
+            return Some(*phase);
+        }
+    }
+
+    None
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ChatgptDeliveryMode {
     FileUpload,
     Paste,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChatgptModelSelectionStatus {
+    Selected,
+    KeptCurrent,
+    Unavailable,
+    Mismatch,
 }
 
 impl ChatgptDeliveryMode {
@@ -26,6 +158,7 @@ pub struct ChatgptRecipeSpec {
     pub run_id: String,
     pub wait_timeout_ms: u64,
     pub wait_interval_ms: u64,
+    pub upload_timeout_ms: u64,
     pub disable_extended: bool,
 }
 
@@ -35,6 +168,7 @@ pub struct ChatgptRecipeOutput {
     pub backend: String,
     pub response: String,
     pub model_used: Option<String>,
+    pub model_selection_status: ChatgptModelSelectionStatus,
     pub warnings: Vec<String>,
     pub fallback_used: bool,
     pub delivery_mode: ChatgptDeliveryMode,
@@ -49,6 +183,7 @@ impl ChatgptRecipeOutput {
             "backend": self.backend,
             "response": self.response,
             "model_used": self.model_used,
+            "model_selection_status": self.model_selection_status,
             "warnings": self.warnings,
             "fallback_used": self.fallback_used,
             "delivery_mode": self.delivery_mode.as_str(),
@@ -63,6 +198,7 @@ impl ChatgptRecipeOutput {
             "backend": self.backend,
             "response": self.response,
             "model_used": self.model_used,
+            "model_selection_status": self.model_selection_status,
             "warnings": self.warnings,
             "fallback_used": self.fallback_used,
             "delivery_mode": self.delivery_mode.as_str(),
@@ -74,6 +210,7 @@ impl ChatgptRecipeOutput {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anyhow::anyhow;
 
     #[test]
     fn chatgpt_recipe_output_serializes_standard_contract() {
@@ -82,6 +219,7 @@ mod tests {
             backend: "dev-browser".to_string(),
             response: "ok".to_string(),
             model_used: Some("gpt-5-4-pro".to_string()),
+            model_selection_status: ChatgptModelSelectionStatus::Selected,
             warnings: vec!["fallback".to_string()],
             fallback_used: true,
             delivery_mode: ChatgptDeliveryMode::Paste,
@@ -94,9 +232,49 @@ mod tests {
         assert_eq!(payload["backend"], "dev-browser");
         assert_eq!(payload["response"], "ok");
         assert_eq!(payload["model_used"], "gpt-5-4-pro");
+        assert_eq!(payload["model_selection_status"], "selected");
         assert_eq!(payload["warnings"], json!(["fallback"]));
         assert_eq!(payload["fallback_used"], true);
         assert_eq!(payload["delivery_mode"], "paste");
         assert_eq!(payload["auto_paste_fallback"], true);
+    }
+
+    #[test]
+    fn terminal_fallback_phase_reads_typed_marker() {
+        let err = mark_terminal_fallback_phase(anyhow!("send failed"), ChatgptTransportPhase::Send);
+
+        assert_eq!(
+            terminal_fallback_phase(&err),
+            Some(ChatgptTransportPhase::Send)
+        );
+    }
+
+    #[test]
+    fn terminal_fallback_phase_classifies_upload_send_and_wait_messages() {
+        let cases = [
+            (
+                anyhow!("recipe step 7 (upload) failed: agent-browser failed"),
+                ChatgptTransportPhase::Upload,
+            ),
+            (
+                anyhow!("recipe step 8 (chatgpt_send) failed: ChatGPT send button never became enabled after typing"),
+                ChatgptTransportPhase::Send,
+            ),
+            (
+                anyhow!("recipe step 9 (chatgpt_wait_response) failed: timed out waiting for ChatGPT response"),
+                ChatgptTransportPhase::WaitResponse,
+            ),
+        ];
+
+        for (err, expected) in cases {
+            assert_eq!(terminal_fallback_phase(&err), Some(expected));
+        }
+    }
+
+    #[test]
+    fn terminal_fallback_phase_does_not_classify_pre_delivery_errors() {
+        let err = anyhow!("recipe step 3 (chatgpt_select_model) failed: model selector not found");
+
+        assert_eq!(terminal_fallback_phase(&err), None);
     }
 }

--- a/crates/yoetz-cli/src/chatgpt_web.rs
+++ b/crates/yoetz-cli/src/chatgpt_web.rs
@@ -1,8 +1,12 @@
+//! Shared ChatGPT web contracts and DOM-script builders used by browser transports.
+
 use anyhow::{anyhow, Result};
 use rand::random;
 use std::collections::BTreeMap;
 use std::path::Path;
 use time::{format_description::FormatItem, macros::format_description, OffsetDateTime};
+
+use crate::chatgpt_recipe::ChatgptModelSelectionStatus;
 
 pub const CHATGPT_URL: &str = "https://chatgpt.com/";
 pub const COMPOSER_SELECTOR: &str =
@@ -18,6 +22,46 @@ pub const UPLOAD_MENU_TEXT_PATTERN: &str =
     "upload from computer|from computer|upload files|choose files|browse";
 pub const STABLE_IDLE_FLOOR_MS: u64 = 90_000;
 pub const STABLE_IDLE_INTERVAL_MULTIPLIER: u64 = 3;
+pub(crate) const CHATGPT_UPLOAD_STABLE_POLLS: u64 = 2;
+pub(crate) const JS_VISIBILITY_HELPERS: &str = r#"
+  const isVisible = (el) => {
+    if (!el) return false;
+    const rect = el.getBoundingClientRect();
+    const style = window.getComputedStyle(el);
+    return rect.width > 0 &&
+      rect.height > 0 &&
+      style.visibility !== "hidden" &&
+      style.display !== "none";
+  };
+  const findVisible = (root, selector) =>
+    Array.from((root || document).querySelectorAll(selector)).find((el) => isVisible(el)) || null;
+"#;
+pub(crate) const JS_COMPOSER_SCOPE_HELPERS: &str = r#"
+  const COMPOSER_ROOT_SELECTOR = "[data-testid*='composer'], [class*='composer'], main, [role='main']";
+  const getComposerScope = (composerEl = document.querySelector(COMPOSER_SELECTOR)) => {
+    const composerForm = composerEl?.closest("form") || null;
+    const composerRoot = composerForm ||
+      composerEl?.closest(COMPOSER_ROOT_SELECTOR) ||
+      composerEl?.parentElement ||
+      null;
+    const seenRoots = new Set();
+    const roots = [];
+    [composerForm, composerRoot, document].forEach((root) => {
+      if (root && !seenRoots.has(root)) {
+        seenRoots.add(root);
+        roots.push(root);
+      }
+    });
+    return { composerEl, composerForm, composerRoot, roots };
+  };
+"#;
+pub(crate) const JS_TURN_ROOT_HELPERS: &str = r#"
+  const latestAssistantTurn = (msg) =>
+    msg?.closest(".agent-turn, [class*='agent-turn'], [class*='turn-messages']") ||
+    msg?.parentElement?.parentElement ||
+    msg?.parentElement ||
+    null;
+"#;
 static RUN_ID_TS_FORMAT: &[FormatItem<'static>] =
     format_description!("[year][month][day]T[hour][minute][second]Z");
 const AUTH_MARKERS: &[&str] = &[
@@ -66,6 +110,21 @@ pub fn generate_run_id() -> String {
     format!("{ts}_{suffix}")
 }
 
+pub fn validate_run_id(run_id: &str) -> Result<()> {
+    let valid = !run_id.is_empty()
+        && run_id.len() <= 128
+        && run_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b':' | b'.' | b'-'));
+    if valid {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "invalid `run_id`: expected 1-128 ASCII letters, digits, `_`, `:`, `.`, or `-`"
+        ))
+    }
+}
+
 pub fn validate_thread_mode(raw: Option<&str>) -> Result<()> {
     match raw.unwrap_or("fresh").trim().to_ascii_lowercase().as_str() {
         "" | "fresh" => Ok(()),
@@ -79,7 +138,23 @@ pub fn validate_thread_mode(raw: Option<&str>) -> Result<()> {
 }
 
 pub fn mark_chatgpt_url(run_id: &str) -> String {
-    format!("{CHATGPT_URL}?_yoetz={run_id}")
+    format!("{CHATGPT_URL}?{}", chatgpt_run_url_marker(run_id))
+}
+
+pub(crate) fn chatgpt_run_url_marker(run_id: &str) -> String {
+    format!("_yoetz={}", percent_encode_query_component(run_id))
+}
+
+fn percent_encode_query_component(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
 }
 
 pub fn build_set_window_name_js(run_id: &str) -> String {
@@ -190,7 +265,28 @@ pub fn select_reported_chatgpt_model(
 
 pub fn should_keep_current_chatgpt_model(requested_model: &str) -> bool {
     let requested_model = requested_model.trim();
-    requested_model.is_empty() || requested_model.eq_ignore_ascii_case("auto")
+    requested_model.is_empty()
+        || requested_model.eq_ignore_ascii_case("current")
+        || requested_model.eq_ignore_ascii_case("keep-current")
+}
+
+pub(crate) fn chatgpt_model_selection_status(
+    selection: &serde_json::Value,
+    requested_model: &str,
+) -> ChatgptModelSelectionStatus {
+    let status = selection
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("unknown");
+    let keep_current_model = should_keep_current_chatgpt_model(requested_model);
+    match status {
+        "selected" => ChatgptModelSelectionStatus::Selected,
+        "already-selected" if keep_current_model => ChatgptModelSelectionStatus::KeptCurrent,
+        "already-selected" => ChatgptModelSelectionStatus::Selected,
+        "missing-selector" | "not-found" => ChatgptModelSelectionStatus::Unavailable,
+        "selection-mismatch" => ChatgptModelSelectionStatus::Mismatch,
+        _ => ChatgptModelSelectionStatus::Unavailable,
+    }
 }
 
 pub fn model_selector_button_selector_json() -> String {
@@ -253,14 +349,45 @@ async () => {{
   const normalize = (value) => String(value || "").replace(/\s+/g, " ").trim();
   const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
   const isCheckedState = (ariaChecked, dataState) => ariaChecked === "true" || dataState === "checked";
-  const isVisible = (el) => {{
-    if (!el) return false;
-    const rect = el.getBoundingClientRect();
-    const style = window.getComputedStyle(el);
-    return rect.width > 0 &&
-      rect.height > 0 &&
-      style.visibility !== "hidden" &&
-      style.display !== "none";
+  const hasSelectedCurrentMarker = (ariaSelected, ariaCurrent, dataSelected, dataCurrent) =>
+    ariaSelected === "true" ||
+    dataSelected === "true" ||
+    (!!ariaCurrent && ariaCurrent !== "false") ||
+    (!!dataCurrent && dataCurrent !== "false");
+    const itemIsSelected = (item) => !!item && (
+      isCheckedState(item.ariaChecked || "", item.dataState || "") ||
+      hasSelectedCurrentMarker(item.ariaSelected || "", item.ariaCurrent || "", item.dataSelected || "", item.dataCurrent || "")
+    );
+{visibility_helpers}
+    const slugify = (value) => normalize(value).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  const isLowSignalSelectorLabel = (value) => {{
+    const key = slugify(value);
+    return !key || key === "chatgpt" || key === "chat-gpt" || key === "openai" || key === "model-selector" || key === "selected-model";
+  }};
+  const selectorLabelMatchesTarget = (label, item, tierSlug, targetTestId, candidateTestIds) => {{
+    const labelText = normalize(label).toLowerCase();
+    const labelSlug = slugify(labelText);
+    if (isLowSignalSelectorLabel(labelText)) return false;
+    const candidates = [];
+    const add = (value) => {{
+      const raw = normalize(value || "");
+      const key = slugify(raw);
+      if (!key || isLowSignalSelectorLabel(raw)) return;
+      candidates.push({{ raw: raw.toLowerCase(), key }});
+    }};
+    add(tierSlug);
+    add(item?.text || "");
+    add((item?.testId || "").replace(/^model-switcher-/, ""));
+    add((targetTestId || "").replace(/^model-switcher-/, ""));
+    (candidateTestIds || []).forEach((value) => add(value));
+    return candidates.some((candidate) => {{
+      if (candidate.key === labelSlug) return true;
+      if (tierSlug && candidate.key === slugify(tierSlug)) {{
+        const escaped = candidate.raw.replace(/[.*+?^$()|[\]\\]/g, "\\$&");
+        return new RegExp(`(^|[^a-z0-9])${{escaped}}([^a-z0-9]|$)`).test(labelText);
+      }}
+      return candidate.key.length >= 4 && labelSlug.includes(candidate.key);
+    }});
   }};
   const realClick = (el) => {{
     el.dispatchEvent(new PointerEvent("pointerdown", {{ bubbles: true, cancelable: true, pointerId: 1 }}));
@@ -402,8 +529,18 @@ async () => {{
   }};
   const requestedTrimmed = normalize(requested);
   const requestedLower = requestedTrimmed.toLowerCase();
-  const autoMode = !requestedTrimmed || requestedLower === "auto";
+  const keepCurrentMode = !requestedTrimmed || requestedLower === "current" || requestedLower === "keep-current";
+  const autoMode = requestedLower === "auto";
   const requestedGenericTier = deriveRequestedTier(requestedLower);
+
+  if (keepCurrentMode) {{
+    return {{
+      ...responseBase,
+      status: "already-selected",
+      modelUsed: currentLabel || null,
+      keepCurrent: true,
+    }};
+  }}
 
   if (!selectorButton) {{
     return {{
@@ -455,6 +592,10 @@ async () => {{
           haystack,
           ariaChecked: normalize(el.getAttribute?.("aria-checked") || "").toLowerCase(),
           dataState: normalize(el.getAttribute?.("data-state") || "").toLowerCase(),
+          ariaSelected: normalize(el.getAttribute?.("aria-selected") || "").toLowerCase(),
+          ariaCurrent: normalize(el.getAttribute?.("aria-current") || "").toLowerCase(),
+          dataSelected: normalize(el.getAttribute?.("data-selected") || "").toLowerCase(),
+          dataCurrent: normalize(el.getAttribute?.("data-current") || "").toLowerCase(),
         }};
       }})
       .filter((item) => item && (item.text || item.testId));
@@ -518,6 +659,7 @@ async () => {{
 
   let target = null;
   let selectionNeedles = [];
+  let requestedTestIds = [];
   if (autoMode) {{
     target =
       findExactTierLabelItem(items, "pro") ||
@@ -545,7 +687,7 @@ async () => {{
     }}
     selectionNeedles.push(target.testId.toLowerCase(), target.text.toLowerCase());
   }} else {{
-    const requestedTestIds = Array.from(new Set(
+    requestedTestIds = Array.from(new Set(
       (MODEL_TESTID_CANDIDATES[requestedLower] || [MODEL_TESTID_ALIASES[requestedLower] || requestedLower])
         .map((value) => normalize(value).toLowerCase())
         .filter(Boolean)
@@ -581,7 +723,7 @@ async () => {{
   }}
 
   const targetTestId = target.testId || null;
-  if (target.ariaChecked === "true" || target.dataState === "checked") {{
+  if (itemIsSelected(target)) {{
     return {{
       ...responseBase,
       status: "already-selected",
@@ -641,19 +783,21 @@ async () => {{
           ? findPreferredTestIdItem(updatedItems, [targetTestId.toLowerCase()]) || null
           : findGenericNeedleItem(updatedItems, selectionNeedles) || null;
       const targetNode = targetTestId
-        ? document.querySelector(`[data-testid="${{targetTestId}}"]`)
-          : null;
+        ? Array.from(document.querySelectorAll(`[data-testid="${{targetTestId}}"]`)).find((el) => isVisible(el)) || null
+        : null;
       targetChecked = isCheckedState(
         normalize(targetNode?.getAttribute?.("aria-checked") || "").toLowerCase(),
         normalize(targetNode?.getAttribute?.("data-state") || "").toLowerCase(),
-      ) || isCheckedState(updatedTarget?.ariaChecked || "", updatedTarget?.dataState || "");
+      ) ||
+        hasSelectedCurrentMarker(
+          normalize(targetNode?.getAttribute?.("aria-selected") || "").toLowerCase(),
+          normalize(targetNode?.getAttribute?.("aria-current") || "").toLowerCase(),
+          normalize(targetNode?.getAttribute?.("data-selected") || "").toLowerCase(),
+          normalize(targetNode?.getAttribute?.("data-current") || "").toLowerCase(),
+        ) ||
+        itemIsSelected(updatedTarget);
       selectedLabel = readSelectorLabel();
-      const effectiveTierSlug = targetTierSlug || classifyTier(updatedTarget || target);
-      const trustedTierSelected = effectiveTierSlug && (
-        hasTrustedUserFacingTierLabel(updatedTarget || target, effectiveTierSlug) ||
-        updatedItems.some((item) => hasTrustedUserFacingTierLabel(item, effectiveTierSlug))
-      );
-      if (targetChecked || selectionNeedles.filter(Boolean).some((needle) => needle && selectedLabel.includes(needle)) || trustedTierSelected) {{
+      if (targetChecked) {{
         verifyConfirmed = true;
       }}
     }}
@@ -662,9 +806,7 @@ async () => {{
       return {{
         ...responseBase,
         status: "selected",
-        modelUsed: targetChecked
-          ? (updatedTarget?.text || target.text || requestedTrimmed || currentLabel || null)
-          : (selectedLabel || updatedTarget?.text || target.text || requestedTrimmed || currentLabel || null),
+        modelUsed: updatedTarget?.text || target.text || requestedTrimmed || currentLabel || null,
         selectedLabel: selectedLabel || null,
         targetTestId,
         targetChecked,
@@ -691,18 +833,9 @@ async () => {{
     const reopenedChecked = isCheckedState(
       reopenedTarget?.ariaChecked || "",
       reopenedTarget?.dataState || "",
-    );
+    ) || itemIsSelected(reopenedTarget);
     const reopenedLabel = readSelectorLabel();
-    const reopenedEffectiveTierSlug = targetTierSlug || classifyTier(reopenedTarget || target);
-    const reopenedTrustedTierSelected = reopenedEffectiveTierSlug && (
-      hasTrustedUserFacingTierLabel(reopenedTarget || target, reopenedEffectiveTierSlug) ||
-      reopenedItems.some((item) => hasTrustedUserFacingTierLabel(item, reopenedEffectiveTierSlug))
-    );
-    if (
-      reopenedChecked ||
-      selectionNeedles.filter(Boolean).some((needle) => needle && reopenedLabel.includes(needle)) ||
-      reopenedTrustedTierSelected
-    ) {{
+    if (reopenedChecked) {{
       selectionConfirmed = true;
       updatedItems = reopenedItems;
       updatedTarget = reopenedTarget;
@@ -711,9 +844,7 @@ async () => {{
       return {{
         ...responseBase,
         status: "selected",
-        modelUsed: reopenedChecked
-          ? (reopenedTarget?.text || target.text || requestedTrimmed || currentLabel || null)
-          : (reopenedLabel || reopenedTarget?.text || target.text || requestedTrimmed || currentLabel || null),
+        modelUsed: reopenedTarget?.text || target.text || requestedTrimmed || currentLabel || null,
         selectedLabel: reopenedLabel || null,
         targetTestId,
         targetChecked: reopenedChecked,
@@ -742,6 +873,7 @@ async () => {{
         model_item_selector = model_item_selector,
         model_testid_aliases = model_testid_aliases,
         model_testid_candidates = model_testid_candidates,
+        visibility_helpers = JS_VISIBILITY_HELPERS,
     )
 }
 
@@ -759,87 +891,180 @@ pub fn build_attachment_probe_function(file_name: &str) -> Result<String> {
   const fileName = {file_name_json};
   const fileStem = {file_stem_json};
   const ATTACHMENT_TILE_SELECTOR = {attachment_tile_selector_json};
-  const clip = (value, max = 120) => String(value || "").replace(/\s+/g, " ").trim().slice(0, max);
-  const composer = document.querySelector({composer_selector_json});
-  const composerForm = composer?.closest("form");
-  const root = composerForm || document;
-  const isBusy = (tile) => {{
-    const busyNode = tile.matches?.("[aria-busy='true'], [data-state='uploading'], [role='progressbar']")
-      ? tile
-      : tile.querySelector("[class*='animate-spin'], [role='progressbar'], [aria-busy='true'], [data-state='uploading']");
-    if (!busyNode) {{
-      const busyText = clip(tile.innerText || tile.textContent || "").toLowerCase();
-      return /\buploading\b|\bprocessing\b|\bscanning\b/.test(busyText);
-    }}
-    const visibilityTarget = busyNode.closest?.("[aria-busy='true'], [data-state='uploading'], [role='progressbar']") || busyNode.parentElement || busyNode;
-    return getComputedStyle(visibilityTarget).display !== "none";
+  const COMPOSER_SELECTOR = {composer_selector_json};
+  const clip = (value, max = 160) => String(value || "").replace(/\s+/g, " ").trim().slice(0, max);
+{visibility_helpers}
+{composer_scope_helpers}
+  const escapeRegExp = (value) => String(value || "").replace(/[.*+?^${{}}()|[\]\\]/g, "\\$&");
+  const stripExpectedName = (value) => {{
+    let text = String(value || "");
+    [fileName, fileStem].filter(Boolean).forEach((name) => {{
+      text = text.replace(new RegExp(escapeRegExp(name), "gi"), " ");
+    }});
+    return clip(text, 220);
   }};
-  const describeTile = (tile) => {{
-    const text = clip(tile.innerText || tile.textContent || "");
-    const ariaLabel = clip(tile.getAttribute?.("aria-label") || "");
-    const title = clip(tile.getAttribute?.("title") || "");
-    const busy = isBusy(tile);
+  const includesName = (value) => {{
+    const text = String(value || "");
+    return !!fileName && text.includes(fileName);
+  }};
+  const includesStem = (value) => {{
+    const text = String(value || "");
+    return !!fileStem && text.includes(fileStem);
+  }};
+  const failurePattern = /\b(upload failed|failed|failure|error uploading|upload error|attachment error|file error|something went wrong|could not|couldn't|cannot|can't|unsupported|too large|blocked|try again)\b/i;
+  const busyPattern = /\b(uploading|processing|scanning|attaching|preparing|loading)\b/i;
+  const busySelector = "[aria-busy='true'], [role='progressbar'], [data-state='uploading'], [data-state='loading'], [class*='progress'], [class*='spinner'], [class*='animate-spin']";
+  const {{ composerForm, composerRoot }} = getComposerScope();
+  const readFields = (tile) => [
+    clip(tile.innerText || tile.textContent || ""),
+    clip(tile.getAttribute?.("aria-label") || ""),
+    clip(tile.getAttribute?.("title") || ""),
+    clip(tile.getAttribute?.("data-testid") || "", 80),
+  ].filter(Boolean);
+  const childHasExactName = (tile) => Array.from(tile.querySelectorAll("*")).some((node) => {{
+    const text = clip(node.innerText || node.textContent || "", 220);
+    return text === fileName ||
+      clip(node.getAttribute?.("aria-label") || "", 220) === fileName ||
+      clip(node.getAttribute?.("title") || "", 220) === fileName;
+  }});
+  const busyInfo = (tile) => {{
+    const busyNodes = [
+      ...(tile.matches?.(busySelector) ? [tile] : []),
+      ...Array.from(tile.querySelectorAll(busySelector)),
+    ].filter((node) => isVisible(node));
+    const text = stripExpectedName(tile.innerText || tile.textContent || "");
     return {{
-      text,
-      ariaLabel,
-      title,
-      ready: !busy,
+      busy: busyNodes.length > 0 || busyPattern.test(text),
+      busyMarkerCount: busyNodes.length,
+      busyText: busyPattern.test(text) ? text : "",
     }};
   }};
-  const visibleEvidence = Array.from(root.querySelectorAll(ATTACHMENT_TILE_SELECTOR))
-    .map((tile) => describeTile(tile))
-    .filter((entry) => {{
-      const combined = `${{entry.text}} ${{entry.ariaLabel}} ${{entry.title}}`;
-      return combined.includes(fileName) || (fileStem && combined.includes(fileStem));
-    }})
-    .slice(0, 6);
+  const describeTile = (tile, scope, index) => {{
+    const fields = readFields(tile);
+    const combined = fields.join(" ");
+    const failureText = fields.map(stripExpectedName).join(" ");
+    const combinedNameMatched = includesName(combined) || includesStem(combined);
+    const exactNameMatched = fields.some((field) => field === fileName) ||
+      (!combinedNameMatched && childHasExactName(tile));
+    const nameMatched = exactNameMatched || combinedNameMatched;
+    const busy = busyInfo(tile);
+    const failed = failurePattern.test(failureText);
+    return {{
+      scope,
+      index,
+      text: fields[0] || "",
+      ariaLabel: fields[1] || "",
+      title: fields[2] || "",
+      testId: fields[3] || "",
+      nameMatched,
+      exactNameMatched,
+      stemMatched: !exactNameMatched && includesStem(combined),
+      busy: busy.busy,
+      busyMarkerCount: busy.busyMarkerCount,
+      busyText: busy.busyText,
+      failure: failed,
+      failureText: failed ? clip(failureText, 180) : "",
+      ready: nameMatched && !busy.busy && !failed,
+    }};
+  }};
+  const collectTiles = (root, scope) => root
+    ? Array.from(root.querySelectorAll(ATTACHMENT_TILE_SELECTOR))
+      .filter((tile) => isVisible(tile))
+      .map((tile, index) => describeTile(tile, scope, index))
+    : [];
+  const scopedTiles = collectTiles(composerRoot, composerForm ? "form" : "composer-root");
+  const documentTiles = collectTiles(document, "document");
+  const scopedMatches = scopedTiles.filter((entry) => entry.nameMatched);
+  const documentMatches = documentTiles.filter((entry) => entry.nameMatched);
+  const matchedTiles = scopedMatches.some((entry) => entry.exactNameMatched)
+    ? scopedMatches.filter((entry) => entry.exactNameMatched)
+    : scopedMatches.length > 0
+      ? scopedMatches
+      : documentMatches.some((entry) => entry.exactNameMatched)
+        ? documentMatches.filter((entry) => entry.exactNameMatched)
+        : documentMatches;
+  const alertEvidence = Array.from(document.querySelectorAll("[role='alert'], [aria-live], [class*='error'], [data-testid*='error']"))
+    .filter((el) => isVisible(el))
+    .map((el) => clip(el.innerText || el.textContent || el.getAttribute?.("aria-label") || "", 180))
+    .filter((text) => failurePattern.test(text) && (includesName(text) || includesStem(text) || /\bupload|attachment|file\b/i.test(text)))
+    .slice(0, 4);
+  const failureEvidence = [
+    ...matchedTiles.filter((entry) => entry.failure),
+    ...alertEvidence.map((text) => ({{ scope: "alert", text, failure: true }})),
+  ].slice(0, 6);
+  const busyEvidence = matchedTiles.filter((entry) => entry.busy).slice(0, 6);
+  const readinessEvidence = matchedTiles.filter((entry) => entry.ready).slice(0, 6);
   const inputs = Array.from(document.querySelectorAll("input[type='file']")).map((input) => ({{
     fileNames: Array.from(input.files || []).map((file) => file.name),
     multiple: !!input.multiple,
+    inComposer: !!(composerRoot && composerRoot.contains(input)),
   }}));
   const inputMatched = inputs.some((input) => input.fileNames.some((name) => name === fileName));
-  if (visibleEvidence.some((entry) => entry.ready)) {{
+  const attachmentFailure = failureEvidence.length > 0;
+  const exactNameMatched = matchedTiles.some((entry) => entry.exactNameMatched);
+  const readyNow = readinessEvidence.length > 0 && busyEvidence.length === 0 && !attachmentFailure;
+  const readyCounts = window.__yoetzAttachmentReadyCounts || (window.__yoetzAttachmentReadyCounts = Object.create(null));
+  const readyKey = `file:${{fileName}}`;
+  readyCounts[readyKey] = readyNow ? (Number(readyCounts[readyKey] || 0) + 1) : 0;
+  const status = attachmentFailure
+    ? "failed"
+    : readyNow
+      ? "done"
+      : matchedTiles.length > 0 || inputMatched
+        ? "uploading"
+        : (scopedTiles.length > 0 || documentTiles.length > 0 ? "no_match" : "no_tile");
+  if (readyNow) {{
     return {{
       ok: true,
-      status: "done",
-      visibleEvidence,
+      status,
+      visibleEvidence: matchedTiles.slice(0, 6),
+      readinessEvidence,
+      busyEvidence,
+      failureEvidence,
       inputMatched,
-      composerScoped: !!composerForm,
+      exactNameMatched,
+      stableReadyCount: readyCounts[readyKey],
+      composerScoped: !!composerRoot,
+      scopeUsed: matchedTiles[0]?.scope || null,
+      tileCount: scopedTiles.length || documentTiles.length,
     }};
   }}
   return {{
     ok: false,
-    status: visibleEvidence.length > 0 || inputMatched ? "uploading" : "no_match",
-    visibleEvidence,
+    status,
+    visibleEvidence: matchedTiles.slice(0, 6),
+    readinessEvidence,
+    busyEvidence,
+    failureEvidence,
+    attachmentFailure,
+    exactNameMatched,
+    stableReadyCount: readyCounts[readyKey],
     inputMatched,
     inputs,
-    composerScoped: !!composerForm,
+    composerScoped: !!composerRoot,
+    scopeUsed: matchedTiles[0]?.scope || null,
+    tileCount: scopedTiles.length || documentTiles.length,
+    matchedTileCount: matchedTiles.length,
+    fallbackMatches: scopedMatches.length > 0 ? [] : documentMatches.slice(0, 4),
   }};
 }}
 "##,
         attachment_tile_selector_json = attachment_tile_selector_json,
         composer_selector_json = composer_selector_json(),
+        visibility_helpers = JS_VISIBILITY_HELPERS,
+        composer_scope_helpers = JS_COMPOSER_SCOPE_HELPERS,
     ))
 }
 
-pub fn build_open_attachment_ui_function() -> String {
+pub(crate) fn build_open_attachment_ui_function() -> String {
     let attachment_trigger_selector_json = attachment_trigger_selector_json();
     format!(
         r##"
 () => {{
-  const ATTACHMENT_TRIGGER_SELECTOR = {attachment_trigger_selector_json};
-  const clip = (value, max = 120) => String(value || "").replace(/\s+/g, " ").trim().slice(0, max);
-  const isVisible = (el) => {{
-    if (!el) return false;
-    const rect = el.getBoundingClientRect();
-    const style = window.getComputedStyle(el);
-    return rect.width > 0 &&
-      rect.height > 0 &&
-      style.visibility !== "hidden" &&
-      style.display !== "none" &&
-      style.pointerEvents !== "none";
-  }};
-  const button = Array.from(document.querySelectorAll(ATTACHMENT_TRIGGER_SELECTOR)).find((el) => isVisible(el))
+    const ATTACHMENT_TRIGGER_SELECTOR = {attachment_trigger_selector_json};
+    const clip = (value, max = 120) => String(value || "").replace(/\s+/g, " ").trim().slice(0, max);
+{visibility_helpers}
+    const button = Array.from(document.querySelectorAll(ATTACHMENT_TRIGGER_SELECTOR)).find((el) => isVisible(el))
     || document.querySelector(ATTACHMENT_TRIGGER_SELECTOR);
   if (!button) {{
     return {{
@@ -857,26 +1082,18 @@ pub fn build_open_attachment_ui_function() -> String {
 }}
 "##,
         attachment_trigger_selector_json = attachment_trigger_selector_json,
+        visibility_helpers = JS_VISIBILITY_HELPERS,
     )
 }
 
-pub fn build_upload_menu_item_click_function() -> String {
+pub(crate) fn build_upload_menu_item_click_function() -> String {
     let upload_menu_text_pattern_json = upload_menu_text_pattern_json();
     format!(
         r##"
 () => {{
-  const TEXT_PATTERN = new RegExp({upload_menu_text_pattern_json}, "i");
-  const clip = (value, max = 120) => String(value || "").replace(/\s+/g, " ").trim().slice(0, max);
-  const isVisible = (el) => {{
-    if (!el) return false;
-    const rect = el.getBoundingClientRect();
-    const style = window.getComputedStyle(el);
-    return rect.width > 0 &&
-      rect.height > 0 &&
-      style.visibility !== "hidden" &&
-      style.display !== "none" &&
-      style.pointerEvents !== "none";
-  }};
+    const TEXT_PATTERN = new RegExp({upload_menu_text_pattern_json}, "i");
+    const clip = (value, max = 120) => String(value || "").replace(/\s+/g, " ").trim().slice(0, max);
+{visibility_helpers}
   const selectors = ["[role='menuitem']", "button", "[role='button']", "label", "li"];
   const nodes = Array.from(document.querySelectorAll(selectors.join(",")));
   const target = nodes.find((el) => {{
@@ -896,6 +1113,7 @@ pub fn build_upload_menu_item_click_function() -> String {
 }}
 "##,
         upload_menu_text_pattern_json = upload_menu_text_pattern_json,
+        visibility_helpers = JS_VISIBILITY_HELPERS,
     )
 }
 
@@ -903,9 +1121,9 @@ pub fn build_upload_menu_item_click_function() -> String {
 /// snapshot walker (and `upload_file`'s fallback) can identify the correct
 /// target. Using the composer form's own file input — never a page-wide
 /// first-match — keeps the bundle from landing on unrelated hidden inputs.
-pub const COMPOSER_FILE_INPUT_MARKER: &str = "yoetz-upload-target";
+pub(crate) const COMPOSER_FILE_INPUT_MARKER: &str = "yoetz-upload-target";
 
-pub fn build_scope_composer_file_input_function() -> String {
+pub(crate) fn build_scope_composer_file_input_function() -> String {
     let composer_selector_json = composer_selector_json();
     let marker_json = serde_json::to_string(COMPOSER_FILE_INPUT_MARKER)
         .expect("serialize composer-file-input marker");
@@ -940,46 +1158,53 @@ pub fn build_send_button_click_function() -> String {
         r##"
 () => {{
   const SEND_BUTTON_SELECTOR = {send_button_selector_json};
-  const COMPOSER_SELECTOR = {composer_selector_json};
-  const ATTACHMENT_TILE_SELECTOR = {attachment_tile_selector_json};
-  const clip = (value, max = 120) => String(value || "").replace(/\s+/g, " ").trim().slice(0, max);
-  const isVisible = (el) => {{
-    if (!el) return false;
-    const rect = el.getBoundingClientRect();
-    const style = window.getComputedStyle(el);
-    return rect.width > 0 &&
-      rect.height > 0 &&
-      style.visibility !== "hidden" &&
-      style.display !== "none" &&
-      style.pointerEvents !== "none";
-  }};
-  const buttons = Array.from(document.querySelectorAll(SEND_BUTTON_SELECTOR)).filter((el) => isVisible(el));
-  const enabledButton = buttons.find((button) => !button.disabled) || null;
+    const COMPOSER_SELECTOR = {composer_selector_json};
+    const ATTACHMENT_TILE_SELECTOR = {attachment_tile_selector_json};
+    const clip = (value, max = 120) => String(value || "").replace(/\s+/g, " ").trim().slice(0, max);
+{visibility_helpers}
+{composer_scope_helpers}
+    const {{ composerEl, composerForm, composerRoot, roots: searchRoots }} = getComposerScope();
+  const seenButtons = new Set();
+  const buttonEntries = [];
+  searchRoots.forEach((root) => {{
+    const scope = root === composerForm ? "form" : root === composerRoot ? "composer-root" : "document";
+    Array.from(root.querySelectorAll(SEND_BUTTON_SELECTOR)).forEach((button) => {{
+      if (!seenButtons.has(button) && isVisible(button)) {{
+        seenButtons.add(button);
+        buttonEntries.push({{ button, scope }});
+      }}
+    }});
+  }});
+  const enabledEntry = buttonEntries.find((entry) => !entry.button.disabled) || null;
   const assistantMessages = Array.from(document.querySelectorAll("[data-message-author-role='assistant']"));
   const lastAssistant = assistantMessages.length > 0 ? assistantMessages[assistantMessages.length - 1] : null;
-  const composerEl = document.querySelector(COMPOSER_SELECTOR);
+  const attachmentRoot = composerRoot || document;
   const diagnostics = {{
     url: window.location.href || "",
     title: document.title || "",
-    attachmentPresent: !!document.querySelector(ATTACHMENT_TILE_SELECTOR),
+    attachmentPresent: !!attachmentRoot.querySelector(ATTACHMENT_TILE_SELECTOR),
     composerTextLength: ((composerEl?.innerText || composerEl?.textContent || "").trim()).length,
-    buttonCount: buttons.length,
-    buttons: buttons.slice(0, 4).map((button) => ({{
-      text: clip(button.innerText || button.textContent || ""),
-      testId: clip(button.getAttribute?.("data-testid") || "", 80),
-      disabled: !!button.disabled,
-      ariaLabel: clip(button.getAttribute?.("aria-label") || ""),
+    composerScoped: !!composerRoot,
+    buttonCount: buttonEntries.length,
+    buttons: buttonEntries.slice(0, 6).map((entry) => ({{
+      scope: entry.scope,
+      text: clip(entry.button.innerText || entry.button.textContent || ""),
+      testId: clip(entry.button.getAttribute?.("data-testid") || "", 80),
+      disabled: !!entry.button.disabled,
+      ariaLabel: clip(entry.button.getAttribute?.("aria-label") || ""),
     }})),
   }};
-  if (!enabledButton) {{
+  if (!enabledEntry) {{
     return {{
       status: "not-ready",
       diagnostics,
     }};
   }}
+  const enabledButton = enabledEntry.button;
   enabledButton.click();
   return {{
     status: "sent",
+    sendScope: enabledEntry.scope,
     selectorLabel: clip(enabledButton.getAttribute?.("data-testid") || enabledButton.getAttribute?.("aria-label") || enabledButton.innerText || enabledButton.textContent || "", 80),
     assistantCountBeforeSend: assistantMessages.length,
     assistantLastLenBeforeSend: (lastAssistant?.innerText || "").length,
@@ -989,63 +1214,89 @@ pub fn build_send_button_click_function() -> String {
         send_button_selector_json = send_button_selector_json,
         composer_selector_json = composer_selector_json,
         attachment_tile_selector_json = attachment_tile_selector_json,
+        visibility_helpers = JS_VISIBILITY_HELPERS,
+        composer_scope_helpers = JS_COMPOSER_SCOPE_HELPERS,
     )
 }
 
 pub fn build_chatgpt_dom_probe_function() -> String {
     let send_button_selector_json = send_button_selector_json();
     let stop_button_selector_json = stop_button_selector_json();
+    let composer_selector_json = composer_selector_json();
     format!(
         r##"
 () => {{
-  const isVisible = (button) => {{
-    const rect = button.getBoundingClientRect();
-    const style = window.getComputedStyle(button);
-    return rect.width > 0 &&
-      rect.height > 0 &&
-      style.visibility !== "hidden" &&
-      style.display !== "none";
-  }};
-  const send = Array.from(document.querySelectorAll({send_button_selector_json})).find((button) => isVisible(button)) || null;
-  const stopButton = Array.from(document.querySelectorAll({stop_button_selector_json})).find((button) => isVisible(button)) || null;
-  const stopGenerating = !!stopButton && !stopButton.disabled;
-  const thinking = document.querySelector(".result-thinking, [data-testid*='thinking'], [class*='thinking']");
-  const msgs = document.querySelectorAll("[data-message-author-role='assistant']");
+  const COMPOSER_SELECTOR = {composer_selector_json};
+{visibility_helpers}
+{composer_scope_helpers}
+{turn_root_helpers}
+  const {{ roots }} = getComposerScope();
+  const send = roots.flatMap((root) => Array.from(root.querySelectorAll({send_button_selector_json}))).find((button) => isVisible(button)) || null;
+  const msgs = Array.from(document.querySelectorAll("[data-message-author-role='assistant']")).filter((msg) => isVisible(msg));
   const lastMsg = msgs.length > 0 ? msgs[msgs.length - 1] : null;
-  const turnRoot =
-    lastMsg?.closest(".agent-turn, [class*='agent-turn'], [class*='turn-messages']") ||
-    lastMsg?.parentElement?.parentElement ||
-    lastMsg?.parentElement ||
-    document;
-  const copyButtons = lastMsg ? turnRoot.querySelectorAll("button[aria-label*='Copy'], button[data-testid*='copy']").length : 0;
-  const lastLen = msgs.length > 0 ? msgs[msgs.length - 1].innerText.length : 0;
+  const turnRoot = latestAssistantTurn(lastMsg);
+  const globalStopButton = findVisible(document, {stop_button_selector_json});
+  const stopButton = (turnRoot ? findVisible(turnRoot, {stop_button_selector_json}) : null) ||
+    ((send?.disabled || !lastMsg) ? globalStopButton : null);
+  const stopGenerating = !!stopButton && !stopButton.disabled;
+  const thinkingSelector = ".result-thinking, [data-testid*='thinking'], [class*='thinking']";
+  const visibleThinking = !!((turnRoot ? findVisible(turnRoot, thinkingSelector) : null) ||
+    (!turnRoot ? findVisible(document, thinkingSelector) : null));
+  const copyButtons = lastMsg
+    ? Array.from((turnRoot || lastMsg).querySelectorAll("button[aria-label*='Copy'], button[data-testid*='copy']")).filter((button) => isVisible(button)).length
+    : 0;
+  const lastLen = lastMsg ? (lastMsg.innerText || "").length : 0;
   const sendState = !send ? "missing" : send.disabled ? "disabled" : "enabled";
-  const errEl = document.querySelector("[class*='error-toast'], [data-testid*='error'], [role='alert']");
+  const errEl = findVisible(document, "[class*='error-toast'], [data-testid*='error'], [role='alert']");
   const errText = errEl ? errEl.innerText.substring(0, 100).toLowerCase() : "";
   const markers = ["network error","something went wrong","error generating","attachment failed","upload failed","too many requests"];
   const err = markers.find((marker) => errText.includes(marker)) || "";
-  return `send=${{sendState}}|stop=${{stopGenerating ? 1 : 0}}|thinking=${{thinking ? 1 : 0}}|copy=${{copyButtons}}|msgs=${{msgs.length}}|lastlen=${{lastLen}}|err=${{err}}`;
+  return `send=${{sendState}}|stop=${{stopGenerating ? 1 : 0}}|thinking=${{visibleThinking ? 1 : 0}}|copy=${{copyButtons}}|msgs=${{msgs.length}}|lastlen=${{lastLen}}|err=${{err}}`;
 }}
 "##,
         send_button_selector_json = send_button_selector_json,
         stop_button_selector_json = stop_button_selector_json,
+        composer_selector_json = composer_selector_json,
+        visibility_helpers = JS_VISIBILITY_HELPERS,
+        composer_scope_helpers = JS_COMPOSER_SCOPE_HELPERS,
+        turn_root_helpers = JS_TURN_ROOT_HELPERS,
     )
 }
 
 pub fn build_latest_response_probe_function() -> String {
-    r#"
+    let mut source = String::from(
+        r#"
 () => {
-  const msgs = Array.from(document.querySelectorAll("[data-message-author-role='assistant']"));
+"#,
+    );
+    source.push_str(JS_VISIBILITY_HELPERS);
+    source.push_str(JS_TURN_ROOT_HELPERS);
+    source.push_str(
+        r#"
+  const cleanMessageText = (msg) => {
+    if (!msg) return "";
+    const clone = msg.cloneNode(true);
+    clone.querySelectorAll("button, [role='button'], input, textarea").forEach((node) => node.remove());
+    return String(clone.textContent || "").replace(/\s+/g, " ").trim();
+  };
+  const msgs = Array.from(document.querySelectorAll("[data-message-author-role='assistant']")).filter((msg) => isVisible(msg));
   const lastMsg = msgs.length > 0 ? msgs[msgs.length - 1] : null;
+  const turnRoot = latestAssistantTurn(lastMsg);
+  const visibleCopyButtons = lastMsg
+    ? Array.from((turnRoot || lastMsg).querySelectorAll("button[aria-label*='Copy'], button[data-testid*='copy']")).filter((button) => isVisible(button)).length
+    : 0;
   return {
-    response: String(lastMsg?.innerText || "").trim(),
+    response: cleanMessageText(lastMsg),
+    assistantCount: msgs.length,
+    visibleCopyButtons,
   };
 }
-"#
-    .to_string()
+"#,
+    );
+    source
 }
 
-pub fn wrap_function_source_for_json_eval(function_source: &str) -> Result<String> {
+pub(crate) fn wrap_function_source_for_json_eval(function_source: &str) -> Result<String> {
     let function_json = serde_json::to_string(function_source)?;
     Ok(format!(
         r#"(async () => {{
@@ -1166,11 +1417,41 @@ mod tests {
     }
 
     #[test]
-    fn keep_current_chatgpt_model_detects_auto_and_empty_requests() {
+    fn keep_current_chatgpt_model_detects_current_and_empty_requests() {
         assert!(should_keep_current_chatgpt_model(""));
-        assert!(should_keep_current_chatgpt_model("auto"));
-        assert!(should_keep_current_chatgpt_model(" AUTO "));
+        assert!(should_keep_current_chatgpt_model("current"));
+        assert!(should_keep_current_chatgpt_model(" KEEP-CURRENT "));
+        assert!(!should_keep_current_chatgpt_model("auto"));
         assert!(!should_keep_current_chatgpt_model("pro"));
+    }
+
+    #[test]
+    fn chatgpt_model_selection_status_reports_contract_values() {
+        assert_eq!(
+            chatgpt_model_selection_status(&serde_json::json!({"status": "selected"}), "pro"),
+            ChatgptModelSelectionStatus::Selected
+        );
+        assert_eq!(
+            chatgpt_model_selection_status(
+                &serde_json::json!({"status": "already-selected"}),
+                "current"
+            ),
+            ChatgptModelSelectionStatus::KeptCurrent
+        );
+        assert_eq!(
+            chatgpt_model_selection_status(
+                &serde_json::json!({"status": "missing-selector"}),
+                "current"
+            ),
+            ChatgptModelSelectionStatus::Unavailable
+        );
+        assert_eq!(
+            chatgpt_model_selection_status(
+                &serde_json::json!({"status": "selection-mismatch"}),
+                "pro"
+            ),
+            ChatgptModelSelectionStatus::Mismatch
+        );
     }
 
     #[test]
@@ -1289,6 +1570,42 @@ mod tests {
     }
 
     #[test]
+    fn model_selection_function_does_not_confirm_visible_unchecked_pro_with_generic_label() {
+        let visible_unchecked_pro_fixture = r#"
+<button data-testid="model-switcher-dropdown-button">
+  <span data-testid="model-switcher-selected-model">ChatGPT</span>
+</button>
+<div role="menuitemradio" data-testid="model-switcher-gpt-5-4-pro" aria-checked="false">
+  Pro Research-grade intelligence
+</div>
+"#;
+        assert!(visible_unchecked_pro_fixture.contains("aria-checked=\"false\""));
+        assert!(visible_unchecked_pro_fixture.contains(">ChatGPT<"));
+
+        let script = build_model_selection_function("pro");
+        assert!(
+            script.contains("if (targetChecked)"),
+            "model selection must require checked/current menu state, not only selector label text"
+        );
+        assert!(
+            !script.contains("targetChecked || selectorLabelConfirmed"),
+            "selector label text must not confirm model selection without checked/current state"
+        );
+        assert!(
+            !script.contains("reopenedChecked ||"),
+            "reopened selector label text must not confirm model selection without checked/current state"
+        );
+        assert!(
+            !script.contains("trustedTierSelected"),
+            "visible trusted tier menu text must not confirm selection by itself"
+        );
+        assert!(
+            !script.contains("reopenedTrustedTierSelected"),
+            "visible trusted tier menu text must not confirm selection after reopen"
+        );
+    }
+
+    #[test]
     fn model_selection_function_supports_auto_and_explicit_modes() {
         let auto_script = build_model_selection_function("auto");
         assert!(auto_script.contains(r#"const requested = "auto";"#));
@@ -1308,9 +1625,23 @@ mod tests {
         let script = build_attachment_probe_function("bundle.txt").unwrap();
         assert!(script.contains(r#"const fileName = "bundle.txt";"#));
         assert!(script.contains(r#"const fileStem = "bundle";"#));
-        assert!(script.contains(
-            r#"status: visibleEvidence.length > 0 || inputMatched ? "uploading" : "no_match""#
-        ));
+        assert!(script.contains("readinessEvidence"));
+        assert!(script.contains("stableReadyCount"));
+        assert!(script.contains("attachmentFailure"));
+        assert!(script.contains("exactNameMatched"));
+        assert!(script.contains("busyEvidence"));
+    }
+
+    #[test]
+    fn attachment_probe_function_ignores_failure_words_inside_filename() {
+        let script = build_attachment_probe_function("review-failed-cases.md").unwrap();
+        assert!(script.contains(r#"const fileName = "review-failed-cases.md";"#));
+        assert!(script.contains("stripExpectedName"));
+        assert!(script.contains("const failed = failurePattern.test(failureText);"));
+        assert!(
+            !script.contains("failurePattern.test(combined)"),
+            "tile failure matching must not run against text that still includes the filename"
+        );
     }
 
     #[test]
@@ -1327,16 +1658,21 @@ mod tests {
         assert!(send_click.contains("SEND_BUTTON_SELECTOR"));
         assert!(send_click.contains("status: \"sent\""));
         assert!(send_click.contains("status: \"not-ready\""));
+        assert!(send_click.contains("roots: searchRoots"));
+        assert!(send_click.contains("const scope = root === composerForm ? \"form\""));
 
         let dom_probe = build_chatgpt_dom_probe_function();
         assert!(dom_probe.contains("send="));
         assert!(dom_probe.contains("copyButtons"));
         assert!(dom_probe.contains("stopGenerating = !!stopButton && !stopButton.disabled"));
-        assert!(dom_probe.contains("turnRoot.querySelectorAll"));
+        assert!(dom_probe.contains("latestAssistantTurn"));
+        assert!(dom_probe.contains("copyButtons"));
+        assert!(dom_probe.contains("visibleThinking"));
 
         let latest_response = build_latest_response_probe_function();
         assert!(latest_response.contains("data-message-author-role"));
-        assert!(latest_response.contains("response: String"));
+        assert!(latest_response.contains("response: cleanMessageText(lastMsg)"));
+        assert!(latest_response.contains("visibleCopyButtons"));
     }
 
     #[test]
@@ -1370,6 +1706,16 @@ mod tests {
         assert!(timestamp.ends_with('Z'));
         assert_eq!(suffix.len(), 6);
         assert!(suffix.chars().all(|ch| ch.is_ascii_hexdigit()));
+        validate_run_id(&run_id).unwrap();
+    }
+
+    #[test]
+    fn validate_run_id_rejects_url_and_log_injection_characters() {
+        validate_run_id("run:abc.123_ok-9").unwrap();
+        assert!(validate_run_id("").is_err());
+        assert!(validate_run_id("run&evil=1").is_err());
+        assert!(validate_run_id("run\nnext").is_err());
+        assert!(validate_run_id(&"a".repeat(129)).is_err());
     }
 
     #[test]
@@ -1377,6 +1723,10 @@ mod tests {
         assert_eq!(
             mark_chatgpt_url("20260417T071228Z_ab12cd"),
             "https://chatgpt.com/?_yoetz=20260417T071228Z_ab12cd"
+        );
+        assert_eq!(
+            mark_chatgpt_url("run:abc.123"),
+            "https://chatgpt.com/?_yoetz=run%3Aabc.123"
         );
         let script = build_set_window_name_js("20260417T071228Z_ab12cd");
         assert!(script.contains(r#"window.name = "yoetz:20260417T071228Z_ab12cd""#));
@@ -1391,7 +1741,6 @@ mod tests {
     <style>
       body { font-family: sans-serif; }
       .file-tile { border: 1px solid #ccc; padding: 8px; margin-top: 8px; }
-      .hidden-copy { display: none; }
     </style>
   </head>
   <body>
@@ -1418,7 +1767,6 @@ mod tests {
         message.textContent = "Fixture assistant response";
         const copy = document.createElement("button");
         copy.setAttribute("aria-label", "Copy");
-        copy.className = "hidden-copy";
         copy.textContent = "Copy";
         message.appendChild(copy);
         transcript.appendChild(message);

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
@@ -42,12 +42,12 @@ use std::time::Duration;
 
 use super::client::{is_external_create_target_block_error, ChromeCdpClient};
 use super::DevtoolsMcpRecipeContext;
-use crate::chatgpt_web;
+use crate::chatgpt_recipe::AnyhowResultExt;
+use crate::{chatgpt_recipe, chatgpt_web};
 
 /// Stable-idle polling parameters.
 const STABLE_IDLE_CONSECUTIVE_POLLS: u32 = 12;
-const UPLOAD_INPUT_WAIT_MS: u64 = 5_000;
-const ATTACHMENT_VERIFY_WAIT_MS: u64 = 15_000;
+const EAGER_FILE_INPUT_VERIFY_TIMEOUT_MS: u64 = 15_000;
 const WAIT_FOR_COMPOSER_JS_TEMPLATE: &str = r##"
 async () => {
   const focusComposer = __YOETZ_FOCUS_COMPOSER__;
@@ -101,6 +101,13 @@ fn build_wait_for_composer_script(focus_composer: bool) -> String {
 pub struct ChatgptRunResult {
     pub response: String,
     pub model_used: Option<String>,
+    pub model_selection_status: chatgpt_recipe::ChatgptModelSelectionStatus,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct ModelSelectionOutcome {
+    model_used: Option<String>,
+    model_selection_status: chatgpt_recipe::ChatgptModelSelectionStatus,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -328,11 +335,11 @@ async fn run_attached_recipe_inner(
         .context("mark yoetz-owned ChatGPT tab with window.name")?;
 
     // Step 2: wait for the composer to mount, then select the best model the
-    // user can actually access. When `model` is `auto` or empty, prefer the
-    // strongest available Pro/GPT-5 option and fall back to the current model
-    // if the selector UI is unavailable.
+    // user can actually access. `model=auto` actively selects the strongest
+    // visible Pro/GPT-5 option; an empty/current model keeps the current UI
+    // selection.
     wait_for_composer_ready(client, /* focus_composer */ true).await?;
-    let model_used = maybe_select_model(client, &ctx.model).await?;
+    let model_selection = maybe_select_model(client, &ctx.model).await?;
     if ctx.disable_extended {
         maybe_disable_extended(client).await?;
     }
@@ -350,8 +357,9 @@ async fn run_attached_recipe_inner(
         .bundle_path
         .as_ref()
         .context("ChatGPT recipe requires a bundle file path")?;
-    try_upload_bundle(client, bundle_path)
+    try_upload_bundle(client, bundle_path, ctx.upload_timeout_ms)
         .await
+        .with_chatgpt_phase(chatgpt_recipe::ChatgptTransportPhase::Upload)
         .context("upload bundle to ChatGPT")?;
 
     // Step 4: type the delivery text into the focused composer.
@@ -375,17 +383,20 @@ async fn run_attached_recipe_inner(
     let _ = client
         .evaluate_script(&refocus_js, vec![])
         .await
+        .with_chatgpt_phase(chatgpt_recipe::ChatgptTransportPhase::Send)
         .context("refocus composer after upload")?;
 
     client
         .type_text(&delivery_text, /* submit_key */ None)
         .await
+        .with_chatgpt_phase(chatgpt_recipe::ChatgptTransportPhase::Send)
         .context("type_text into ChatGPT composer")?;
 
     let click_send_js = chatgpt_web::build_send_button_click_function();
     let clicked = client
         .evaluate_script(&click_send_js, vec![])
         .await
+        .with_chatgpt_phase(chatgpt_recipe::ChatgptTransportPhase::Send)
         .context("evaluate_script click send button")?;
     if clicked.get("status").and_then(serde_json::Value::as_str) != Some("sent") {
         return Err(anyhow!(
@@ -394,10 +405,12 @@ async fn run_attached_recipe_inner(
                 .get("diagnostics")
                 .cloned()
                 .unwrap_or(serde_json::Value::Null)
-        ));
+        ))
+        .with_chatgpt_phase(chatgpt_recipe::ChatgptTransportPhase::Send);
     }
-    let response_baseline =
-        parse_response_baseline(&clicked).context("parse ChatGPT response baseline before send")?;
+    let response_baseline = parse_response_baseline(&clicked)
+        .with_chatgpt_phase(chatgpt_recipe::ChatgptTransportPhase::Send)
+        .context("parse ChatGPT response baseline before send")?;
 
     // Step 6: stable-idle polling for response completion.
     //
@@ -418,11 +431,13 @@ async fn run_attached_recipe_inner(
         reconnect_policy,
     )
     .await
+    .with_chatgpt_phase(chatgpt_recipe::ChatgptTransportPhase::WaitResponse)
     .context("stable-idle polling for ChatGPT response")?;
 
     Ok(ChatgptRunResult {
         response: response_text,
-        model_used,
+        model_used: model_selection.model_used,
+        model_selection_status: model_selection.model_selection_status,
     })
 }
 
@@ -722,7 +737,7 @@ fn should_retry_wait_for_composer_error(err: &anyhow::Error) -> bool {
 async fn maybe_select_model(
     client: &ChromeCdpClient,
     requested_model: &str,
-) -> Result<Option<String>> {
+) -> Result<ModelSelectionOutcome> {
     let keep_current_model = chatgpt_web::should_keep_current_chatgpt_model(requested_model);
     let script = build_model_selection_script(requested_model);
     let selection = client
@@ -737,9 +752,17 @@ async fn maybe_select_model(
         "phase=select-model status={status} payload={selection}"
     ));
     let model_used = chatgpt_web::select_reported_chatgpt_model(&selection, requested_model);
+    let model_selection_status =
+        chatgpt_web::chatgpt_model_selection_status(&selection, requested_model);
     match status {
-        "selected" | "already-selected" => Ok(model_used),
-        "missing-selector" | "not-found" if keep_current_model => Ok(model_used),
+        "selected" | "already-selected" => Ok(ModelSelectionOutcome {
+            model_used,
+            model_selection_status,
+        }),
+        "missing-selector" | "not-found" if keep_current_model => Ok(ModelSelectionOutcome {
+            model_used,
+            model_selection_status,
+        }),
         "missing-selector" => Err(anyhow!(
             "ChatGPT model selector button not found. {}",
             format_page_probe_summary(&selection)
@@ -1109,16 +1132,30 @@ fn format_page_probe_summary(state: &serde_json::Value) -> String {
 /// `upload_file`. `upload_file` accepts either the file input itself or the
 /// element that opens the file chooser, so prefer visible menu items/buttons
 /// over guessing a hidden input uid.
-async fn try_upload_bundle(client: &ChromeCdpClient, bundle_path: &std::path::Path) -> Result<()> {
+async fn try_upload_bundle(
+    client: &ChromeCdpClient,
+    bundle_path: &std::path::Path,
+    upload_timeout_ms: u64,
+) -> Result<()> {
+    let deadline = std::time::Instant::now() + Duration::from_millis(upload_timeout_ms);
     let file_name = bundle_path
         .file_name()
         .and_then(|value| value.to_str())
         .map(ToOwned::to_owned)
         .context("bundle path must end in a UTF-8 filename")?;
 
-    if try_upload_via_file_input(client, bundle_path, &file_name)
-        .await
-        .context("eager file input upload")?
+    // Fast path: 0ms input wait falls through to click flow if no input, but
+    // once an input is found and upload_file runs we still need real verify time.
+    let (input_wait_ms, verify_timeout_ms) = eager_file_input_upload_timeouts();
+    if try_upload_via_file_input(
+        client,
+        bundle_path,
+        &file_name,
+        input_wait_ms,
+        verify_timeout_ms,
+    )
+    .await
+    .context("eager file input upload")?
     {
         return Ok(());
     }
@@ -1159,7 +1196,12 @@ async fn try_upload_bundle(client: &ChromeCdpClient, bundle_path: &std::path::Pa
         attempts.push(format!("clicked candidate: {label}"));
         tokio::time::sleep(Duration::from_millis(300)).await;
 
-        if try_upload_via_file_input(client, bundle_path, &file_name)
+        let remaining_ms = remaining_upload_timeout_ms(deadline);
+        if remaining_ms == 0 {
+            attempts.push("upload deadline exhausted before file input wait".to_string());
+            break;
+        }
+        if try_upload_via_file_input(client, bundle_path, &file_name, remaining_ms, remaining_ms)
             .await
             .with_context(|| format!("upload after clicking {label}"))?
         {
@@ -1172,9 +1214,20 @@ async fn try_upload_bundle(client: &ChromeCdpClient, bundle_path: &std::path::Pa
         if menu_clicked {
             attempts.push(format!("clicked upload menu after: {label}"));
             tokio::time::sleep(Duration::from_millis(300)).await;
-            if try_upload_via_file_input(client, bundle_path, &file_name)
-                .await
-                .with_context(|| format!("upload after upload menu from {label}"))?
+            let remaining_ms = remaining_upload_timeout_ms(deadline);
+            if remaining_ms == 0 {
+                attempts.push("upload deadline exhausted before upload-menu wait".to_string());
+                break;
+            }
+            if try_upload_via_file_input(
+                client,
+                bundle_path,
+                &file_name,
+                remaining_ms,
+                remaining_ms,
+            )
+            .await
+            .with_context(|| format!("upload after upload menu from {label}"))?
             {
                 return Ok(());
             }
@@ -1192,12 +1245,25 @@ async fn try_upload_bundle(client: &ChromeCdpClient, bundle_path: &std::path::Pa
     ))
 }
 
+fn remaining_upload_timeout_ms(deadline: std::time::Instant) -> u64 {
+    deadline
+        .saturating_duration_since(std::time::Instant::now())
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64
+}
+
+fn eager_file_input_upload_timeouts() -> (u64, u64) {
+    (0, EAGER_FILE_INPUT_VERIFY_TIMEOUT_MS)
+}
+
 async fn try_upload_via_file_input(
     client: &ChromeCdpClient,
     bundle_path: &std::path::Path,
     file_name: &str,
+    input_wait_timeout_ms: u64,
+    attachment_verify_timeout_ms: u64,
 ) -> Result<bool> {
-    let input_uid = wait_for_file_input_uid(client, UPLOAD_INPUT_WAIT_MS)
+    let input_uid = wait_for_file_input_uid(client, input_wait_timeout_ms)
         .await
         .context("wait for file input")?;
 
@@ -1210,7 +1276,7 @@ async fn try_upload_via_file_input(
         .await
         .with_context(|| format!("upload_file via input `{input_uid}`"))?;
 
-    wait_for_attachment_visible(client, file_name)
+    wait_for_attachment_visible(client, file_name, attachment_verify_timeout_ms)
         .await
         .with_context(|| format!("verify attachment chip for `{file_name}`"))?;
 
@@ -1421,8 +1487,12 @@ fn format_upload_diagnostics(diagnostics: &serde_json::Value) -> String {
     serde_json::to_string_pretty(diagnostics).unwrap_or_else(|_| diagnostics.to_string())
 }
 
-async fn wait_for_attachment_visible(client: &ChromeCdpClient, file_name: &str) -> Result<()> {
-    let script = build_wait_for_attachment_visible_script(file_name)?;
+async fn wait_for_attachment_visible(
+    client: &ChromeCdpClient,
+    file_name: &str,
+    upload_timeout_ms: u64,
+) -> Result<()> {
+    let script = build_wait_for_attachment_visible_script(file_name, upload_timeout_ms)?;
     let evidence = client
         .evaluate_script(&script, vec![])
         .await
@@ -1437,25 +1507,35 @@ async fn wait_for_attachment_visible(client: &ChromeCdpClient, file_name: &str) 
     ))
 }
 
-fn build_wait_for_attachment_visible_script(file_name: &str) -> Result<String> {
+fn build_wait_for_attachment_visible_script(
+    file_name: &str,
+    upload_timeout_ms: u64,
+) -> Result<String> {
     let probe_function_json =
         serde_json::to_string(&chatgpt_web::build_attachment_probe_function(file_name)?)?;
     Ok(format!(
         r##"
 async () => {{
   const probe = eval("(" + {probe_function_json} + ")");
-  const deadline = Date.now() + {ATTACHMENT_VERIFY_WAIT_MS};
+  const stableEnough = (state) => state?.ok && Number(state?.stableReadyCount || 0) >= {upload_stable_polls};
+  const deadline = Date.now() + {upload_timeout_ms};
   while (Date.now() < deadline) {{
     const state = probe();
-    if (state?.ok) {{
+    if (stableEnough(state) || state?.status === "failed") {{
       return state;
     }}
     await new Promise((resolve) => setTimeout(resolve, 250));
   }}
-  return probe();
+  const finalState = probe();
+  if (finalState?.ok && !stableEnough(finalState)) {{
+    return {{ ...finalState, ok: false, status: "uploading", stableReady: false }};
+  }}
+  return finalState;
 }}
 "##,
         probe_function_json = probe_function_json,
+        upload_timeout_ms = upload_timeout_ms,
+        upload_stable_polls = chatgpt_web::CHATGPT_UPLOAD_STABLE_POLLS,
     ))
 }
 
@@ -1618,19 +1698,19 @@ fn response_poll_state_script() -> String {
     let stop_button_selector_json = chatgpt_web::stop_button_selector_json();
     format!(
         r##"
-() => {{
-  const nodes = Array.from(document.querySelectorAll("[data-message-author-role='assistant']"));
-  const send = Array.from(document.querySelectorAll({send_button_selector_json})).find((button) => {{
-    const rect = button.getBoundingClientRect();
-    const style = window.getComputedStyle(button);
-    return rect.width > 0 &&
-      rect.height > 0 &&
-      style.visibility !== "hidden" &&
-      style.display !== "none";
-  }}) || null;
-  const stopButton = document.querySelector({stop_button_selector_json});
+  () => {{
+{visibility_helpers}
+{turn_root_helpers}
+    const nodes = Array.from(document.querySelectorAll("[data-message-author-role='assistant']"));
+  const send = findVisible(document, {send_button_selector_json});
+  const last = nodes.length > 0 ? nodes[nodes.length - 1] : null;
+  const turnRoot = latestAssistantTurn(last);
+  const stopButton = (turnRoot ? findVisible(turnRoot, {stop_button_selector_json}) : null) ||
+    (!turnRoot ? findVisible(document, {stop_button_selector_json}) : null);
   const stopGenerating = !!stopButton && !stopButton.disabled;
-  const thinking = document.querySelector(".result-thinking, [data-testid*='thinking'], [class*='thinking']");
+  const thinkingSelector = ".result-thinking, [data-testid*='thinking'], [class*='thinking']";
+  const thinking = (turnRoot ? findVisible(turnRoot, thinkingSelector) : null) ||
+    (!turnRoot ? findVisible(document, thinkingSelector) : null);
   if (nodes.length === 0) {{
     return {{
       ready: false,
@@ -1645,13 +1725,8 @@ fn response_poll_state_script() -> String {
       error: "",
     }};
   }}
-  const last = nodes[nodes.length - 1];
-  const turnRoot =
-    last.closest(".agent-turn, [class*='agent-turn'], [class*='turn-messages']") ||
-    last.parentElement?.parentElement ||
-    last.parentElement ||
-    document;
-  const copyButtons = turnRoot.querySelectorAll("button[aria-label*='Copy'], button[data-testid*='copy']").length;
+  const copyRoot = turnRoot || last.parentElement || document;
+  const copyButtons = copyRoot.querySelectorAll("button[aria-label*='Copy'], button[data-testid*='copy']").length;
   const errEl = document.querySelector('[class*="error-toast"], [data-testid*="error"], [role="alert"]');
   const errText = errEl ? (errEl.innerText || "").substring(0, 100).toLowerCase() : "";
   const markers = ["network error","something went wrong","error generating","attachment failed","upload failed","too many requests"];
@@ -1673,9 +1748,11 @@ fn response_poll_state_script() -> String {
     error,
   }};
 }}
-"##,
+  "##,
         send_button_selector_json = send_button_selector_json,
         stop_button_selector_json = stop_button_selector_json,
+        visibility_helpers = chatgpt_web::JS_VISIBILITY_HELPERS,
+        turn_root_helpers = chatgpt_web::JS_TURN_ROOT_HELPERS,
     )
 }
 
@@ -1806,6 +1883,16 @@ mod tests {
         assert!(chatgpt_web::STABLE_IDLE_INTERVAL_MULTIPLIER >= 2);
         assert!(!chatgpt_web::CHATGPT_URL.is_empty());
     };
+
+    #[test]
+    fn eager_file_input_upload_keeps_verify_slack_after_zero_wait_probe() {
+        let (input_wait_ms, verify_timeout_ms) = eager_file_input_upload_timeouts();
+        assert_eq!(input_wait_ms, 0);
+        assert!(
+            verify_timeout_ms >= 5_000,
+            "finding an eager file input must not upload and then verify with a 0ms deadline"
+        );
+    }
 
     fn lock_env() -> MutexGuard<'static, ()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -2198,9 +2285,11 @@ mod tests {
 
     #[test]
     fn attachment_visibility_script_matches_file_name_variable() {
-        let script = build_wait_for_attachment_visible_script("bundle.txt").unwrap();
+        let script = build_wait_for_attachment_visible_script("bundle.txt", 180_000).unwrap();
         assert!(script.contains("name === fileName"));
-        assert!(!script.contains("exactName"));
+        assert!(script.contains("exactNameMatched"));
+        assert!(script.contains("stableReadyCount"));
+        assert!(script.contains("Date.now() + 180000"));
     }
 
     #[test]
@@ -2213,7 +2302,9 @@ mod tests {
     #[test]
     fn response_poll_script_looks_for_copy_buttons_on_turn_root() {
         let script = response_poll_state_script();
-        assert!(script.contains("last.closest(\".agent-turn"));
-        assert!(script.contains("turnRoot.querySelectorAll"));
+        assert!(script.contains("latestAssistantTurn"));
+        assert!(script.contains("const copyRoot = turnRoot || last.parentElement || document;"));
+        assert!(script.contains("copyRoot.querySelectorAll"));
+        assert!(script.contains("findVisible(turnRoot,"));
     }
 }

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/mod.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/mod.rs
@@ -105,6 +105,9 @@ pub struct DevtoolsMcpRecipeContext {
     /// Poll interval for stable-idle response detection, in ms.
     pub response_poll_interval_ms: u64,
 
+    /// Maximum time to wait for file input discovery and attachment readiness.
+    pub upload_timeout_ms: u64,
+
     /// Whether to disable Extended Pro before sending.
     pub disable_extended: bool,
 
@@ -125,6 +128,7 @@ impl Default for DevtoolsMcpRecipeContext {
             run_id: String::new(),
             response_timeout_ms: 1_800_000, // 30 min default for ChatGPT Pro Extended
             response_poll_interval_ms: 30_000,
+            upload_timeout_ms: 120_000,
             disable_extended: false,
             show_approval_guidance: true,
         }

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -18,7 +18,6 @@ use reqwest::Url;
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::env;
-#[cfg(test)]
 use std::fs;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
@@ -31,7 +30,8 @@ use std::time::{Duration, Instant};
 #[cfg(test)]
 use yoetz_core::paths::home_dir;
 
-use crate::{browser, chatgpt_web};
+use crate::chatgpt_recipe::AnyhowResultExt;
+use crate::{browser, chatgpt_recipe, chatgpt_web};
 
 /// Cached dev-browser resolution.
 static DEV_BROWSER: OnceLock<String> = OnceLock::new();
@@ -50,6 +50,7 @@ const DEV_BROWSER_WAIT_POLL_MS: u64 = 100;
 /// Extended timeout for ChatGPT response polling (30 minutes by default).
 const CHATGPT_POLL_TIMEOUT_MS_DEFAULT: u64 = 1_800_000;
 const CHATGPT_POLL_INTERVAL_MS_DEFAULT: u64 = 30_000;
+const CHATGPT_UPLOAD_TIMEOUT_MS_DEFAULT: u64 = 120_000;
 const CHATGPT_BROWSER_NAME: &str = "yoetz-chatgpt";
 const CHATGPT_AUTH_PROBE_PAGE_NAME: &str = "yoetz-chatgpt-main";
 const CHATGPT_RECIPE_PAGE_NAME_PREFIX: &str = "yoetz-chatgpt-run";
@@ -64,6 +65,7 @@ pub struct ChatgptPollSettings {
 pub struct ChatgptRecipeRunResult {
     pub response: String,
     pub model_used: Option<String>,
+    pub model_selection_status: chatgpt_recipe::ChatgptModelSelectionStatus,
     pub warnings: Vec<String>,
 }
 
@@ -672,7 +674,7 @@ pub fn ensure_chatgpt_auth_with_page_check_and_endpoint(cdp_endpoint: Option<&st
 /// split into micro-scripts with JSON stdout handoffs instead of generating one
 /// large helper-heavy script.
 pub struct DevBrowserRecipeContext {
-    /// Path to the bundle file on disk (used for macOS clipboard file upload).
+    /// Path to the bundle file on disk (used for composer-scoped file upload).
     pub bundle_path: Option<PathBuf>,
     /// Bundle text content (for paste mode).
     pub bundle_text: Option<String>,
@@ -688,6 +690,8 @@ pub struct DevBrowserRecipeContext {
     pub run_id: String,
     /// ChatGPT response polling settings.
     pub poll_settings: ChatgptPollSettings,
+    /// Maximum time to wait for a file attachment to finish uploading.
+    pub upload_timeout_ms: u64,
     /// Allow an empty assistant response to count as success.
     pub allow_empty_response: bool,
     /// Optional explicit CDP endpoint for selecting a specific Chrome instance.
@@ -707,6 +711,7 @@ impl Default for DevBrowserRecipeContext {
             disable_extended: false,
             paste_mode: false,
             poll_settings: ChatgptPollSettings::default(),
+            upload_timeout_ms: CHATGPT_UPLOAD_TIMEOUT_MS_DEFAULT,
             allow_empty_response: false,
             cdp_endpoint: None,
             show_approval_guidance: false,
@@ -725,6 +730,34 @@ pub fn resolve_chatgpt_poll_settings(
         settings.interval_ms = interval_ms;
     }
     Ok(settings)
+}
+
+pub fn resolve_chatgpt_upload_timeout_ms(
+    vars: &BTreeMap<String, String>,
+    bundle_path: Option<&Path>,
+) -> Result<u64> {
+    let base_timeout_ms = parse_positive_u64_var(vars, "upload_timeout_ms")?
+        .unwrap_or(CHATGPT_UPLOAD_TIMEOUT_MS_DEFAULT);
+    let Some(bundle_path) = bundle_path else {
+        return Ok(base_timeout_ms);
+    };
+    let Ok(metadata) = fs::metadata(bundle_path) else {
+        return Ok(base_timeout_ms);
+    };
+    Ok(scale_chatgpt_upload_timeout_ms(
+        base_timeout_ms,
+        metadata.len(),
+    ))
+}
+
+fn scale_chatgpt_upload_timeout_ms(base_timeout_ms: u64, file_size_bytes: u64) -> u64 {
+    const BYTES_PER_MIB: u64 = 1024 * 1024;
+    const EXTRA_MS_PER_MIB: u64 = 5_000;
+    const MAX_UPLOAD_TIMEOUT_MS: u64 = 3_600_000;
+
+    let mib = file_size_bytes.div_ceil(BYTES_PER_MIB);
+    let scaled = base_timeout_ms.saturating_add(mib.saturating_mul(EXTRA_MS_PER_MIB));
+    scaled.min(MAX_UPLOAD_TIMEOUT_MS)
 }
 
 fn parse_positive_u64_var(vars: &BTreeMap<String, String>, key: &str) -> Result<Option<u64>> {
@@ -873,6 +906,8 @@ struct ChatgptPrepareResult {
     composer_ready: bool,
     #[serde(rename = "modelUsed")]
     model_used: Option<String>,
+    #[serde(rename = "modelSelection")]
+    model_selection: Option<Value>,
     url: String,
     title: String,
     #[serde(rename = "bodyText")]
@@ -917,7 +952,9 @@ fn build_chatgpt_prepare_script(page_name: &str, model: &str, run_id: &str) -> S
         r##"
 const PAGE_NAME = {page_name_json};
 const MODEL = {model_json};
-const AUTO_MODEL = !String(MODEL || "").trim() || String(MODEL || "").trim().toLowerCase() === "auto";
+const MODEL_TRIMMED = String(MODEL || "").trim();
+const MODEL_LOWER = MODEL_TRIMMED.toLowerCase();
+const KEEP_CURRENT_MODEL = !MODEL_TRIMMED || MODEL_LOWER === "current" || MODEL_LOWER === "keep-current";
 const MARKED_URL = {marked_url_json};
 const WINDOW_NAME = {window_name_json};
 const MODEL_SELECTION_FUNCTION_SOURCE = {model_selection_function_json};
@@ -951,6 +988,7 @@ const readState = async () => await page.evaluate(() => {{
 let state = await readState();
 let composerReady = loggedIn && state.composerVisible;
 let selectedModel = null;
+let modelSelection = null;
 composerReady =
   composerReady &&
   state.assistantCount === 0 &&
@@ -986,7 +1024,8 @@ if (loggedIn && composerReady) {{
     return fn();
   }}, MODEL_SELECTION_FUNCTION_SOURCE);
   const selectionStatus = selection?.status || "unknown";
-  const keepCurrentModel = AUTO_MODEL && ["missing-selector", "not-found"].includes(selectionStatus);
+  modelSelection = selection || null;
+  const keepCurrentModel = KEEP_CURRENT_MODEL && ["missing-selector", "not-found"].includes(selectionStatus);
   if (!["selected", "already-selected"].includes(selectionStatus) && !keepCurrentModel) {{
     const diagnostics = JSON.stringify({{
       status: selectionStatus,
@@ -1020,6 +1059,7 @@ console.log(JSON.stringify({{
   loggedIn,
   composerReady,
   modelUsed: selectedModel,
+  modelSelection,
   url: state.url,
   title: state.title,
   bodyText: state.bodyText,
@@ -1038,12 +1078,13 @@ fn build_chatgpt_send_script(
     page_name: &str,
     prompt: &str,
     delivery_text: &str,
-    file_on_clipboard: bool,
+    file_upload_path: Option<&str>,
+    upload_timeout_ms: u64,
     disable_extended: bool,
     bundle_file_name: Option<&str>,
 ) -> String {
     let page_name_json = serde_json::to_string(page_name).unwrap();
-    let file_on_clipboard_json = serde_json::to_string(&file_on_clipboard).unwrap();
+    let file_upload_path_json = serde_json::to_string(&file_upload_path).unwrap();
     let delivery_text_json = serde_json::to_string(delivery_text).unwrap();
     let prompt_json = serde_json::to_string(prompt).unwrap();
     let bundle_file_name_json = serde_json::to_string(&bundle_file_name).unwrap();
@@ -1052,6 +1093,14 @@ fn build_chatgpt_send_script(
     let stop_button_selector_json = chatgpt_web::stop_button_selector_json();
     let send_click_function_json =
         serde_json::to_string(&chatgpt_web::build_send_button_click_function()).unwrap();
+    let open_attachment_ui_function_json =
+        serde_json::to_string(&chatgpt_web::build_open_attachment_ui_function()).unwrap();
+    let upload_menu_item_click_function_json =
+        serde_json::to_string(&chatgpt_web::build_upload_menu_item_click_function()).unwrap();
+    let scope_file_input_function_json =
+        serde_json::to_string(&chatgpt_web::build_scope_composer_file_input_function()).unwrap();
+    let composer_file_input_marker_json =
+        serde_json::to_string(chatgpt_web::COMPOSER_FILE_INPUT_MARKER).unwrap();
     let attachment_probe_function_json = bundle_file_name.map(|file_name| {
         serde_json::to_string(&chatgpt_web::build_attachment_probe_function(file_name).unwrap())
             .unwrap()
@@ -1059,7 +1108,8 @@ fn build_chatgpt_send_script(
     format!(
         r##"
 const PAGE_NAME = {page_name_json};
-const FILE_ON_CLIPBOARD = {file_on_clipboard_json};
+const FILE_UPLOAD_PATH = {file_upload_path_json};
+const UPLOAD_TIMEOUT_MS = {upload_timeout_ms};
 const DELIVERY_TEXT = {delivery_text_json};
 const PROMPT = {prompt_json};
 const DISABLE_EXTENDED = {disable_extended};
@@ -1068,18 +1118,55 @@ const COMPOSER_SELECTOR = {composer_selector_json};
 const SEND_BUTTON_SELECTOR = {send_button_selector_json};
 const STOP_BUTTON_SELECTOR = {stop_button_selector_json};
 const SEND_CLICK_FUNCTION_SOURCE = {send_click_function_json};
+const OPEN_ATTACHMENT_UI_FUNCTION_SOURCE = {open_attachment_ui_function_json};
+const UPLOAD_MENU_ITEM_CLICK_FUNCTION_SOURCE = {upload_menu_item_click_function_json};
+const SCOPE_FILE_INPUT_FUNCTION_SOURCE = {scope_file_input_function_json};
+const COMPOSER_FILE_INPUT_MARKER = {composer_file_input_marker_json};
 const ATTACHMENT_PROBE_FUNCTION_SOURCE = {attachment_probe_function_json};
+const CHATGPT_UPLOAD_STABLE_POLLS = {upload_stable_polls};
 const page = await browser.getPage(PAGE_NAME);
 let warning = null;
+const runPageFunction = async (functionSource) => await page.evaluate((source) => {{
+  const fn = eval("(" + source + ")");
+  return fn();
+}}, functionSource);
+const waitForScopedFileInput = async () => {{
+  const deadline = Date.now() + 15000;
+  let lastState = null;
+  while (Date.now() < deadline) {{
+    lastState = await runPageFunction(SCOPE_FILE_INPUT_FUNCTION_SOURCE);
+    if (lastState?.status === "marked") {{
+      return {{ ok: true, state: lastState }};
+    }}
+    await page.waitForTimeout(250);
+  }}
+  return {{ ok: false, state: lastState }};
+}};
+const markedFileInputSelector = () => `input[type='file'][title='${{COMPOSER_FILE_INPUT_MARKER}}']`;
+const trySetInputFiles = async () => {{
+  const attempts = [];
+  for (const selector of [markedFileInputSelector()]) {{
+    try {{
+      await page.setInputFiles(selector, FILE_UPLOAD_PATH);
+      return {{ ok: true, selector, attempts }};
+    }} catch (error) {{
+      attempts.push({{ selector, error: String(error?.message || error) }});
+    }}
+  }}
+  return {{ ok: false, attempts }};
+}};
 const waitForAttachmentReady = async () => {{
   if (!ATTACHMENT_PROBE_FUNCTION_SOURCE) return true;
-  const deadline = Date.now() + 30000;
+  const deadline = Date.now() + UPLOAD_TIMEOUT_MS;
   while (Date.now() < deadline) {{
     const state = await page.evaluate((functionSource) => {{
       const fn = eval("(" + functionSource + ")");
       return fn();
     }}, ATTACHMENT_PROBE_FUNCTION_SOURCE);
-    if (state?.status === "done") {{
+    if (state?.status === "failed") {{
+      throw new Error("file attachment upload failed: " + JSON.stringify(state));
+    }}
+    if (state?.status === "done" && Number(state?.stableReadyCount || 0) >= CHATGPT_UPLOAD_STABLE_POLLS) {{
       return true;
     }}
     await page.waitForTimeout(500);
@@ -1096,29 +1183,46 @@ if (DISABLE_EXTENDED) {{
   }}
 }}
 const composer = page.locator(COMPOSER_SELECTOR).first();
-if (FILE_ON_CLIPBOARD) {{
+if (FILE_UPLOAD_PATH !== null) {{
   await composer.waitFor({{ state: "visible", timeout: 15000 }});
-  await composer.click();
-  await page.keyboard.press("Meta+v");
+  let inputState = await waitForScopedFileInput();
+  if (!inputState.ok) {{
+    await runPageFunction(OPEN_ATTACHMENT_UI_FUNCTION_SOURCE);
+    await page.waitForTimeout(300);
+    inputState = await waitForScopedFileInput();
+  }}
+  if (!inputState.ok) {{
+    await runPageFunction(UPLOAD_MENU_ITEM_CLICK_FUNCTION_SOURCE);
+    await page.waitForTimeout(300);
+    inputState = await waitForScopedFileInput();
+  }}
+  let uploadResult = await trySetInputFiles();
+  if (!uploadResult.ok) {{
+    await runPageFunction(UPLOAD_MENU_ITEM_CLICK_FUNCTION_SOURCE);
+    await page.waitForTimeout(300);
+    inputState = await waitForScopedFileInput();
+    uploadResult = await trySetInputFiles();
+  }}
+  if (!uploadResult.ok) {{
+    throw new Error("could not set ChatGPT upload input files: " + JSON.stringify({{
+      scopeState: inputState.state || null,
+      attempts: uploadResult.attempts || [],
+    }}));
+  }}
   const attached = await waitForAttachmentReady();
   if (!attached) {{
-    throw new Error("file attachment did not finish uploading after clipboard paste");
+    throw new Error("file attachment did not finish uploading after setInputFiles");
   }}
 }}
 await composer.waitFor({{ state: "visible", timeout: 15000 }});
 await composer.click();
 await composer.pressSequentially(DELIVERY_TEXT, {{ delay: 15 }});
-const sendBtn = page.locator(SEND_BUTTON_SELECTOR).first();
 const readSendState = async () => await page.evaluate((composerSelector, sendSelector, bundleFileName) => {{
-  const send = Array.from(document.querySelectorAll(sendSelector)).find((button) => {{
-    const rect = button.getBoundingClientRect();
-    const style = window.getComputedStyle(button);
-    return rect.width > 0 &&
-      rect.height > 0 &&
-      style.visibility !== "hidden" &&
-      style.display !== "none";
-  }}) || null;
-  const composerEl = document.querySelector(composerSelector);
+  const COMPOSER_SELECTOR = composerSelector;
+{visibility_helpers}
+{composer_scope_helpers}
+  const {{ composerEl, roots }} = getComposerScope();
+  const send = roots.flatMap((root) => Array.from(root.querySelectorAll(sendSelector))).find((button) => isVisible(button)) || null;
   return {{
     sendButtonPresent: !!send,
     sendDisabled: send ? !!send.disabled : false,
@@ -1129,11 +1233,11 @@ const readSendState = async () => await page.evaluate((composerSelector, sendSel
 const enableDeadline = Date.now() + 10000;
 let sendState = await readSendState();
 while (Date.now() < enableDeadline) {{
-  if (await sendBtn.count() > 0 && await sendBtn.isEnabled()) break;
+  if (sendState.sendButtonPresent && !sendState.sendDisabled) break;
   await page.waitForTimeout(500);
   sendState = await readSendState();
 }}
-if (await sendBtn.count() === 0 || !(await sendBtn.isEnabled())) {{
+if (!sendState.sendButtonPresent || sendState.sendDisabled) {{
   console.log(JSON.stringify({{
     status: "error",
     error: "ChatGPT send button never became enabled after typing; this usually means dev-browser is still on the broken Playwright live-attach path. If you upgraded yoetz, run `yoetz browser reset` once so the dev-browser daemon restarts with the Chrome 147 compatibility flag. " + JSON.stringify(sendState),
@@ -1157,17 +1261,17 @@ const transitionDeadline = Date.now() + 10000;
 let transitionState = null;
 while (Date.now() < transitionDeadline) {{
   transitionState = await page.evaluate((baselineCount, composerSelector, sendSelector, stopSelector, bundleFileName) => {{
-    const send = Array.from(document.querySelectorAll(sendSelector)).find((button) => {{
-      const rect = button.getBoundingClientRect();
-      const style = window.getComputedStyle(button);
-      return rect.width > 0 &&
-        rect.height > 0 &&
-        style.visibility !== "hidden" &&
-        style.display !== "none";
-    }}) || null;
-    const stopButton = document.querySelector(stopSelector);
+    const COMPOSER_SELECTOR = composerSelector;
+{visibility_helpers}
+{composer_scope_helpers}
+{turn_root_helpers}
+    const {{ composerEl, roots }} = getComposerScope();
+    const send = roots.flatMap((root) => Array.from(root.querySelectorAll(sendSelector))).find((button) => isVisible(button)) || null;
     const assistantCount = document.querySelectorAll("[data-message-author-role='assistant']").length;
-    const composerEl = document.querySelector(composerSelector);
+    const lastAssistant = Array.from(document.querySelectorAll("[data-message-author-role='assistant']")).at(-1) || null;
+    const turnRoot = latestAssistantTurn(lastAssistant);
+    const stopButton = (turnRoot ? findVisible(turnRoot, stopSelector) : null) ||
+      (!turnRoot && findVisible(document, stopSelector));
     const composerText = (composerEl?.innerText || composerEl?.textContent || "").trim();
     return {{
       sendButtonPresent: !!send,
@@ -1205,7 +1309,8 @@ console.log(JSON.stringify({{
 }}));
 "##,
         page_name_json = page_name_json,
-        file_on_clipboard_json = file_on_clipboard_json,
+        file_upload_path_json = file_upload_path_json,
+        upload_timeout_ms = upload_timeout_ms,
         delivery_text_json = delivery_text_json,
         prompt_json = prompt_json,
         bundle_file_name_json = bundle_file_name_json,
@@ -1213,57 +1318,18 @@ console.log(JSON.stringify({{
         send_button_selector_json = send_button_selector_json,
         stop_button_selector_json = stop_button_selector_json,
         send_click_function_json = send_click_function_json,
+        open_attachment_ui_function_json = open_attachment_ui_function_json,
+        upload_menu_item_click_function_json = upload_menu_item_click_function_json,
+        scope_file_input_function_json = scope_file_input_function_json,
+        composer_file_input_marker_json = composer_file_input_marker_json,
         attachment_probe_function_json =
             attachment_probe_function_json.unwrap_or_else(|| "null".to_string()),
         disable_extended = disable_extended,
+        upload_stable_polls = chatgpt_web::CHATGPT_UPLOAD_STABLE_POLLS,
+        visibility_helpers = chatgpt_web::JS_VISIBILITY_HELPERS,
+        composer_scope_helpers = chatgpt_web::JS_COMPOSER_SCOPE_HELPERS,
+        turn_root_helpers = chatgpt_web::JS_TURN_ROOT_HELPERS,
     )
-}
-
-fn set_file_on_clipboard(path: &Path) -> Result<()> {
-    let canonical_path = path
-        .canonicalize()
-        .with_context(|| format!("resolve bundle path: {}", path.display()))?;
-
-    #[cfg(target_os = "macos")]
-    {
-        let output = Command::new("osascript")
-            .args([
-                "-e",
-                "on run argv",
-                "-e",
-                "set the clipboard to (POSIX file (item 1 of argv))",
-                "-e",
-                "end run",
-            ])
-            .arg(&canonical_path)
-            .output()
-            .context("failed to run osascript for ChatGPT file upload")?;
-        if output.status.success() {
-            return Ok(());
-        }
-
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        let detail = if !stderr.is_empty() {
-            stderr
-        } else if !stdout.is_empty() {
-            stdout
-        } else {
-            format!("exit code {:?}", output.status.code())
-        };
-        Err(anyhow!(
-            "failed to set macOS clipboard to bundle file `{}`: {detail}",
-            canonical_path.display()
-        ))
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    {
-        let _ = canonical_path;
-        Err(anyhow!(
-            "dev-browser file upload via clipboard currently requires macOS"
-        ))
-    }
 }
 
 fn build_chatgpt_poll_script(
@@ -1290,41 +1356,54 @@ let stableSince = null;
 let stableKey = null;
 while (Date.now() - start < POLL_TIMEOUT_MS) {{
   const state = await page.evaluate((baselineCount, baselineLastLen) => {{
-    const errorEl = document.querySelector("[role='alert'], [data-testid*='error']");
-    const hasThinkingIndicator = !!document.querySelector(".result-thinking, [data-testid*='thinking']");
+{visibility_helpers}
+{turn_root_helpers}
+      const errorEl = document.querySelector("[role='alert'], [data-testid*='error']");
     const allAssistantMessages = Array.from(document.querySelectorAll("[data-message-author-role='assistant']"));
     const assistantMessages = allAssistantMessages.slice(baselineCount);
     const lastAssistantMessage = allAssistantMessages.length > 0 ? allAssistantMessages[allAssistantMessages.length - 1] : null;
+    const turnRoot = latestAssistantTurn(lastAssistantMessage);
+    const stopButton = (turnRoot ? findVisible(turnRoot, "[data-testid='stop-button']") : null) ||
+      (!turnRoot ? findVisible(document, "[data-testid='stop-button']") : null);
+    const thinkingSelector = ".result-thinking, [data-testid*='thinking']";
+    const hasThinkingIndicator = !!((turnRoot ? findVisible(turnRoot, thinkingSelector) : null) ||
+      (!turnRoot ? findVisible(document, thinkingSelector) : null));
     const lastAssistantLen = (lastAssistantMessage?.innerText || "").length;
     const newAssistantCount = assistantMessages.length;
     const newMessage = allAssistantMessages.length > baselineCount;
     const sameMessageGrew = allAssistantMessages.length === baselineCount && lastAssistantLen > baselineLastLen;
-    const response = (newMessage
-      ? assistantMessages.map((message) => message.innerText).join("\n---\n")
-      : (sameMessageGrew ? (lastAssistantMessage?.innerText || "") : "")
-    ).trim();
-    return {{
+      const response = (newMessage
+        ? assistantMessages.map((message) => message.innerText).join("\n---\n")
+        : (sameMessageGrew ? (lastAssistantMessage?.innerText || "") : "")
+      ).trim();
+      const responseReady =
+        !stopButton &&
+        !hasThinkingIndicator &&
+        ((newMessage && (ALLOW_EMPTY_RESPONSE || response.length > 0)) || sameMessageGrew);
+      return {{
       error: errorEl ? errorEl.innerText.slice(0, 200).trim() : null,
       hasThinkingIndicator,
-      hasStopButton: !!document.querySelector("[data-testid='stop-button']"),
+      hasStopButton: !!stopButton,
       newAssistantCount,
       assistantCount: allAssistantMessages.length,
       lastAssistantLen,
       newMessage,
       sameMessageGrew,
-      response,
-    }};
+        responseLength: response.length,
+        responseTail: response.slice(-256),
+        response: responseReady ? response : "",
+      }};
   }}, BASELINE_COUNT, BASELINE_LAST_LEN);
   if (state.error) {{
     console.log(JSON.stringify({{ status: "error", error: state.error }}));
     return;
   }}
   const completionCandidate =
-    !state.hasStopButton &&
-    !state.hasThinkingIndicator &&
-    ((state.newMessage && (ALLOW_EMPTY_RESPONSE || state.response.length > 0)) || state.sameMessageGrew);
-  if (completionCandidate) {{
-    const responseKey = `${{state.assistantCount}}:${{state.lastAssistantLen}}:${{state.response.length}}`;
+      !state.hasStopButton &&
+      !state.hasThinkingIndicator &&
+      ((state.newMessage && (ALLOW_EMPTY_RESPONSE || state.responseLength > 0)) || state.sameMessageGrew);
+    if (completionCandidate) {{
+      const responseKey = `${{state.assistantCount}}:${{state.lastAssistantLen}}:${{state.responseLength}}:${{state.responseTail}}`;
     if (stableKey === responseKey) {{
       if (stableSince !== null && (Date.now() - stableSince) >= STABLE_IDLE_THRESHOLD_MS) {{
         console.log(JSON.stringify({{
@@ -1357,6 +1436,8 @@ console.log(JSON.stringify({{
         poll_interval_ms = poll_settings.interval_ms,
         stable_idle_threshold_ms = stable_idle_threshold_ms,
         allow_empty_response = allow_empty_response,
+        visibility_helpers = chatgpt_web::JS_VISIBILITY_HELPERS,
+        turn_root_helpers = chatgpt_web::JS_TURN_ROOT_HELPERS,
     )
 }
 
@@ -1444,19 +1525,36 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<ChatgptRecipe
         )
     };
 
-    let result = (|| -> Result<(String, Vec<String>, Option<String>)> {
+    let result = (|| -> Result<(
+        String,
+        Vec<String>,
+        Option<String>,
+        chatgpt_recipe::ChatgptModelSelectionStatus,
+    )> {
         let mut warnings = Vec::new();
-        let file_on_clipboard = if ctx.paste_mode {
-            false
+        let file_upload_path = if ctx.paste_mode {
+            None
         } else if let Some(bundle_path) = &ctx.bundle_path {
-            set_file_on_clipboard(bundle_path)?;
-            true
+            let canonical_path = bundle_path
+                .canonicalize()
+                .with_context(|| format!("resolve bundle path: {}", bundle_path.display()))?;
+            Some(
+                canonical_path
+                    .to_str()
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "bundle path is not valid UTF-8: {}",
+                            canonical_path.display()
+                        )
+                    })?
+                    .to_string(),
+            )
         } else if ctx.bundle_text.is_some() {
             return Err(anyhow!(
                 "dev-browser file upload requires a bundle path on disk; use `--var paste=true` for text-only delivery"
             ));
         } else {
-            false
+            None
         };
         let delivery_text = if ctx.paste_mode {
             format!(
@@ -1485,10 +1583,22 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<ChatgptRecipe
         };
         let prepare: ChatgptPrepareResult =
             parse_script_json("parse chatgpt prepare result", &prepare_stdout)?;
+        let model_selection = prepare
+            .model_selection
+            .clone()
+            .unwrap_or_else(|| serde_json::json!({"status": "unknown"}));
         let model_used = prepare
             .model_used
             .as_deref()
-            .and_then(chatgpt_web::canonical_chatgpt_model_slug);
+            .and_then(chatgpt_web::canonical_chatgpt_model_slug)
+            .or_else(|| {
+                prepare
+                    .model_selection
+                    .as_ref()
+                    .and_then(|selection| chatgpt_web::select_reported_chatgpt_model(selection, &ctx.model))
+            });
+        let model_selection_status =
+            chatgpt_web::chatgpt_model_selection_status(&model_selection, &ctx.model);
         let classified_issue =
             classify_dev_browser_page_issue(&prepare.url, &prepare.title, &prepare.body_text);
         match prepare.status.as_str() {
@@ -1523,14 +1633,20 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<ChatgptRecipe
             &page_name,
             &ctx.prompt,
             &delivery_text,
-            file_on_clipboard,
+            file_upload_path.as_deref(),
+            ctx.upload_timeout_ms,
             ctx.disable_extended,
-            ctx.bundle_path
+            file_upload_path
                 .as_deref()
+                .map(Path::new)
                 .and_then(|path| path.file_name())
                 .and_then(|value| value.to_str()),
         );
-        let send_stdout = run_script(&send_script, Some(90))?;
+        let send_stdout = run_script(
+            &send_script,
+            Some(chatgpt_script_timeout_secs(ctx.upload_timeout_ms)),
+        )
+        .with_chatgpt_phase(chatgpt_recipe::ChatgptTransportPhase::Upload)?;
         let send: ChatgptSendResult = parse_script_json("parse chatgpt send result", &send_stdout)?;
         match send.status.as_str() {
             "sent" => {}
@@ -1538,10 +1654,13 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<ChatgptRecipe
                 let detail = send
                     .error
                     .unwrap_or_else(|| "ChatGPT send phase failed".to_string());
-                return Err(anyhow!("{detail}"));
+                let phase = chatgpt_recipe::classify_terminal_fallback_phase_message(&detail)
+                    .unwrap_or(chatgpt_recipe::ChatgptTransportPhase::Send);
+                return Err(anyhow!("{detail}")).with_chatgpt_phase(phase);
             }
             other => {
-                return Err(anyhow!("unexpected ChatGPT send status `{other}`"));
+                return Err(anyhow!("unexpected ChatGPT send status `{other}`"))
+                    .with_chatgpt_phase(chatgpt_recipe::ChatgptTransportPhase::Send);
             }
         }
         if let Some(warning) = send.warning {
@@ -1562,24 +1681,27 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<ChatgptRecipe
             Some(chatgpt_script_timeout_secs(ctx.poll_settings.timeout_ms)),
         );
         heartbeat.stop();
-        let poll_stdout = poll_result?;
+        let poll_stdout =
+            poll_result.with_chatgpt_phase(chatgpt_recipe::ChatgptTransportPhase::WaitResponse)?;
         let (response, mut poll_warnings) =
-            parse_chatgpt_recipe_result(&poll_stdout, ctx.poll_settings.timeout_ms)?;
+            parse_chatgpt_recipe_result(&poll_stdout, ctx.poll_settings.timeout_ms)
+                .with_chatgpt_phase(chatgpt_recipe::ChatgptTransportPhase::WaitResponse)?;
         eprintln!(
             "info: ChatGPT response completed after {}",
             format_chatgpt_wait_duration(wait_started_at.elapsed())
         );
         warnings.append(&mut poll_warnings);
-        Ok((response, warnings, model_used))
+        Ok((response, warnings, model_used, model_selection_status))
     })();
 
-    let (response, warnings, model_used) = result?;
+    let (response, warnings, model_used, model_selection_status) = result?;
     for warning in &warnings {
         eprintln!("warn: {warning}");
     }
     Ok(ChatgptRecipeRunResult {
         response,
         model_used,
+        model_selection_status,
         warnings,
     })
 }
@@ -1645,6 +1767,35 @@ mod tests {
         let vars = BTreeMap::from([("wait_interval_ms".to_string(), "0".to_string())]);
         let err = resolve_chatgpt_poll_settings(&vars).unwrap_err();
         assert!(err.to_string().contains("wait_interval_ms"));
+    }
+
+    #[test]
+    fn resolve_chatgpt_upload_timeout_ms_accepts_recipe_var() {
+        let vars = BTreeMap::from([("upload_timeout_ms".to_string(), "180000".to_string())]);
+
+        assert_eq!(
+            resolve_chatgpt_upload_timeout_ms(&vars, None).unwrap(),
+            180_000
+        );
+        assert_eq!(
+            resolve_chatgpt_upload_timeout_ms(&BTreeMap::new(), None).unwrap(),
+            CHATGPT_UPLOAD_TIMEOUT_MS_DEFAULT
+        );
+    }
+
+    #[test]
+    fn resolve_chatgpt_upload_timeout_ms_scales_with_bundle_size() {
+        let dir =
+            env::temp_dir().join(format!("yoetz-upload-timeout-scale-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let bundle_path = dir.join("large-bundle.md");
+        fs::write(&bundle_path, vec![b'x'; 3 * 1024 * 1024 + 1]).unwrap();
+
+        let timeout =
+            resolve_chatgpt_upload_timeout_ms(&BTreeMap::new(), Some(&bundle_path)).unwrap();
+
+        assert_eq!(timeout, CHATGPT_UPLOAD_TIMEOUT_MS_DEFAULT + 20_000);
+        let _ = fs::remove_dir_all(dir);
     }
 
     #[test]
@@ -1844,7 +1995,7 @@ mod tests {
         assert!(script.contains("const PAGE_NAME = \"yoetz-chatgpt-test\";"));
         assert!(script.contains("const MODEL = \"gpt-5-4-pro\";"));
         assert!(script.contains(
-            "const AUTO_MODEL = !String(MODEL || \"\").trim() || String(MODEL || \"\").trim().toLowerCase() === \"auto\";"
+            "const KEEP_CURRENT_MODEL = !MODEL_TRIMMED || MODEL_LOWER === \"current\" || MODEL_LOWER === \"keep-current\";"
         ));
         assert!(script.contains("const MARKED_URL = \"https://chatgpt.com/?_yoetz=run-123\";"));
         assert!(script.contains("const WINDOW_NAME = \"yoetz:run-123\";"));
@@ -1867,12 +2018,17 @@ mod tests {
             "requested model '\" + (selection?.requested || MODEL || \"\") + \"' was not selected"
         ));
         assert!(script.contains("let selectedModel = null;"));
+        assert!(script.contains("let modelSelection = null;"));
         assert!(script.contains(
-            "const keepCurrentModel = AUTO_MODEL && [\"missing-selector\", \"not-found\"].includes(selectionStatus);"
+            "const keepCurrentModel = KEEP_CURRENT_MODEL && [\"missing-selector\", \"not-found\"].includes(selectionStatus);"
         ));
+        assert!(script.contains("modelSelection = selection || null;"));
+        assert!(!script.contains("modelSelectionStatus ="));
+        assert!(!script.contains("? (KEEP_CURRENT_MODEL ? \"kept_current\" : \"selected\")"));
         assert!(script.contains("selectedModel ="));
         assert!(script.contains("selection?.currentLabel ||"));
         assert!(script.contains("modelUsed: selectedModel,"));
+        assert!(script.contains("modelSelection,"));
         assert!(script.contains("bodyText"));
         assert!(script.contains(
             "status: !loggedIn ? \"login_required\" : composerReady ? \"ready\" : \"not_ready\""
@@ -1915,33 +2071,44 @@ mod tests {
     }
 
     #[test]
-    fn build_chatgpt_send_script_uses_clipboard_upload_and_press_sequentially() {
+    fn build_chatgpt_send_script_uses_file_input_upload_and_press_sequentially() {
         let script = build_chatgpt_send_script(
             "yoetz-chatgpt-test",
             "Review this file.",
             "Review this file.",
-            true,
+            Some("/tmp/bundle.txt"),
+            180_000,
             true,
             Some("bundle.txt"),
         );
 
         assert!(script.contains("const PAGE_NAME = \"yoetz-chatgpt-test\";"));
-        assert!(script.contains("const FILE_ON_CLIPBOARD = true;"));
+        assert!(script.contains("const FILE_UPLOAD_PATH = \"/tmp/bundle.txt\";"));
+        assert!(script.contains("if (FILE_UPLOAD_PATH !== null)"));
+        assert!(script.contains("const UPLOAD_TIMEOUT_MS = 180000;"));
         assert!(script.contains("await composer.waitFor({ state: \"visible\", timeout: 15000 });"));
-        assert!(script.contains("await page.keyboard.press(\"Meta+v\");"));
-        assert!(script.contains("file attachment did not finish uploading after clipboard paste"));
+        assert!(script.contains("const COMPOSER_FILE_INPUT_MARKER = \"yoetz-upload-target\";"));
+        assert!(script.contains("for (const selector of [markedFileInputSelector()])"));
+        assert!(!script.contains("#upload-files"));
+        assert!(script.contains("await page.setInputFiles(selector, FILE_UPLOAD_PATH);"));
+        assert!(script.contains("could not set ChatGPT upload input files"));
+        assert!(script.contains("file attachment did not finish uploading after setInputFiles"));
+        assert!(script.contains("const OPEN_ATTACHMENT_UI_FUNCTION_SOURCE ="));
+        assert!(script.contains("const UPLOAD_MENU_ITEM_CLICK_FUNCTION_SOURCE ="));
+        assert!(script.contains("const SCOPE_FILE_INPUT_FUNCTION_SOURCE ="));
         assert!(script.contains("const ATTACHMENT_PROBE_FUNCTION_SOURCE ="));
         assert!(script.contains("const SEND_CLICK_FUNCTION_SOURCE ="));
         assert!(script.contains("assistantLastLenBeforeSend"));
         assert!(script.contains("pressSequentially(DELIVERY_TEXT, { delay: 15 })"));
         assert!(script.contains("status: \"sent\""));
+        assert!(!script.contains("Meta+v"));
     }
 
     #[test]
     fn parse_script_json_reads_prepare_result() {
         let result: ChatgptPrepareResult = parse_script_json(
             "prepare",
-            r#"{"status":"ready","loggedIn":true,"composerReady":true,"modelUsed":"model-switcher-gpt-5-4-pro","url":"https://chatgpt.com/","title":"ChatGPT","bodyText":"Send a message"}"#,
+            r#"{"status":"ready","loggedIn":true,"composerReady":true,"modelUsed":"model-switcher-gpt-5-4-pro","modelSelection":{"status":"selected"},"url":"https://chatgpt.com/","title":"ChatGPT","bodyText":"Send a message"}"#,
         )
         .unwrap();
 
@@ -1951,6 +2118,14 @@ mod tests {
         assert_eq!(
             result.model_used.as_deref(),
             Some("model-switcher-gpt-5-4-pro")
+        );
+        assert_eq!(
+            result
+                .model_selection
+                .as_ref()
+                .and_then(|selection| selection.get("status"))
+                .and_then(Value::as_str),
+            Some("selected")
         );
         assert_eq!(result.title, "ChatGPT");
     }

--- a/crates/yoetz-cli/src/live_attach.rs
+++ b/crates/yoetz-cli/src/live_attach.rs
@@ -23,6 +23,8 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{futures::OwnedNotified, Mutex as AsyncMutex, Notify};
 
 use crate::browser::ResolvedCdpTarget;
+#[cfg(test)]
+use crate::chatgpt_recipe;
 use crate::chatgpt_web;
 use crate::chrome_devtools_mcp::{
     self,
@@ -786,6 +788,7 @@ impl TestSessionClient {
             TestRecipeBehavior::Succeed => Ok(ChatgptRunResult {
                 response: "ok".to_string(),
                 model_used: None,
+                model_selection_status: chatgpt_recipe::ChatgptModelSelectionStatus::Unavailable,
             }),
             TestRecipeBehavior::Error(message) => Err(anyhow!(message)),
             TestRecipeBehavior::CdpTargetCreateDeniedClosed => {
@@ -807,6 +810,7 @@ impl TestSessionClient {
                 Ok(ChatgptRunResult {
                     response: "ok".to_string(),
                     model_used: None,
+                    model_selection_status: chatgpt_recipe::ChatgptModelSelectionStatus::Unavailable,
                 })
             }
         }

--- a/crates/yoetz-cli/src/live_cdp_daemon.rs
+++ b/crates/yoetz-cli/src/live_cdp_daemon.rs
@@ -5,28 +5,43 @@ use serde_json::{json, Value};
 use std::env;
 use std::fs;
 use std::fs::File;
-use std::io::{self, BufRead, BufReader, Write};
+use std::io::{self, BufRead, BufReader, Read, Write};
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use yoetz_core::paths::home_dir;
 
 const EMBEDDED_DAEMON: &str = include_str!("../assets/live-cdp-daemon.mjs");
+const DAEMON_TOKEN_PATH_ANCHOR: &str =
+    r#"var PID_PATH = path.join(BASE_DIR, "live-cdp-daemon.pid");"#;
+const DAEMON_VERSION_ANCHOR: &str = "var YOETZ_DAEMON_VERSION = await computeDaemonVersion();";
+const DAEMON_COMPUTE_VERSION_ANCHOR: &str = r#"async function computeDaemonVersion() {
+  const source = await readFile(fileURLToPath(import.meta.url));
+  return createHash("sha256").update(source).digest("hex");
+}"#;
+const DAEMON_REQUEST_GUARD_ANCHOR: &str = "  if (shuttingDown && request.type !== \"stop\") {";
 const DAEMON_FILENAME: &str = "live-cdp-daemon.mjs";
 const DAEMON_SOCKET_FILENAME: &str = "live-cdp-daemon.sock";
 const DAEMON_PID_FILENAME: &str = "live-cdp-daemon.pid";
 const DAEMON_LOCK_FILENAME: &str = "live-cdp-daemon.lock";
 const DAEMON_LOG_FILENAME: &str = "live-cdp-daemon.log";
+const DAEMON_TOKEN_FILENAME: &str = "live-cdp-daemon.token";
 const DAEMON_START_TIMEOUT: Duration = Duration::from_secs(5);
 const DAEMON_START_POLL_MS: u64 = 100;
 // The child daemon enforces the script timeout exactly; the Rust parent keeps a
 // short grace window so queued stdout/stderr and the final complete/error frame
 // can still be read after script cancellation.
 const RESPONSE_READ_TIMEOUT_GRACE_SECS: u64 = 20;
+const DAEMON_OUTPUT_BUFFER_LIMIT_BYTES: usize = 1024 * 1024;
 pub(crate) const YOETZ_LIVE_CDP_DAEMON_ENV: &str = "YOETZ_LIVE_CDP_DAEMON";
+static HARDENED_DAEMON_SOURCE: OnceLock<String> = OnceLock::new();
+static DAEMON_TOKEN_CACHE: OnceLock<Mutex<Option<CachedDaemonToken>>> = OnceLock::new();
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum LiveCdpDaemonMode {
@@ -42,12 +57,40 @@ struct DaemonPaths {
     pid_path: PathBuf,
     lock_path: PathBuf,
     log_path: PathBuf,
+    token_path: PathBuf,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 struct DaemonStatus {
     version: Option<String>,
     pid: Option<u64>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct DaemonTokenCacheKey {
+    token_path: PathBuf,
+    modified: Option<SystemTime>,
+    len: u64,
+    #[cfg(unix)]
+    uid: u32,
+    #[cfg(unix)]
+    mode: u32,
+}
+
+#[derive(Clone, Eq, PartialEq)]
+struct CachedDaemonToken {
+    key: DaemonTokenCacheKey,
+    token: String,
+}
+
+impl std::fmt::Debug for CachedDaemonToken {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("CachedDaemonToken")
+            .field("key", &self.key)
+            .field("token", &"<redacted>")
+            .finish()
+    }
 }
 
 #[derive(Debug)]
@@ -60,6 +103,17 @@ impl std::fmt::Display for DaemonConnectError {
 }
 
 impl std::error::Error for DaemonConnectError {}
+
+#[derive(Debug)]
+struct DaemonAuthError(String);
+
+impl std::fmt::Display for DaemonAuthError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}", self.0)
+    }
+}
+
+impl std::error::Error for DaemonAuthError {}
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type")]
@@ -101,6 +155,7 @@ pub(crate) fn run_script_connect(
 
 pub(crate) fn stop_live_cdp_daemon() -> Result<bool> {
     let paths = daemon_paths()?;
+    ensure_private_runtime_dir(&paths)?;
     let Ok(mut stream) = connect_to_daemon(&paths) else {
         let terminated = terminate_daemon_from_pid(&paths)?;
         if !terminated || wait_until_daemon_down(&paths, Duration::from_secs(5)) {
@@ -108,11 +163,27 @@ pub(crate) fn stop_live_cdp_daemon() -> Result<bool> {
         }
         return Ok(terminated);
     };
+    let token = match read_daemon_token_for_request(&paths) {
+        Ok(token) => token,
+        Err(error) => {
+            let terminated = terminate_daemon_from_pid(&paths)?;
+            if terminated {
+                let _ = wait_until_daemon_down(&paths, Duration::from_secs(5));
+                cleanup_stale_files(&paths);
+                return Ok(true);
+            }
+            return Err(error.context(format!(
+                "read yoetz live-CDP daemon capability token from {}",
+                paths.token_path.display()
+            )));
+        }
+    };
 
     let request = json!({
         "id": request_id("stop"),
         "type": "stop",
         "version": daemon_version(),
+        "capabilityToken": token,
     });
     write_request(&mut stream, &request).context("send yoetz live-CDP daemon stop request")?;
     let mut reader = BufReader::new(stream);
@@ -131,8 +202,7 @@ pub(crate) fn stop_live_cdp_daemon() -> Result<bool> {
 
 fn ensure_daemon() -> Result<()> {
     let paths = daemon_paths()?;
-    fs::create_dir_all(&paths.base_dir)
-        .with_context(|| format!("create {}", paths.base_dir.display()))?;
+    ensure_private_runtime_dir(&paths)?;
 
     let _lock = acquire_spawn_lock(&paths)?;
     if daemon_is_current(&paths)? {
@@ -143,6 +213,7 @@ fn ensure_daemon() -> Result<()> {
     let _ = terminate_daemon_from_pid(&paths);
     let _ = wait_until_daemon_down(&paths, Duration::from_secs(5));
     cleanup_stale_files(&paths);
+    let _ = create_new_daemon_token(&paths)?;
 
     ensure_daemon_asset(&paths)?;
     spawn_daemon(&paths)?;
@@ -168,15 +239,23 @@ fn send_execute_request(
     cdp_endpoint: Option<&str>,
 ) -> Result<String> {
     let paths = daemon_paths()?;
+    ensure_private_runtime_dir(&paths)?;
+    let token = read_daemon_token_for_request(&paths)?;
     let mut stream = connect_to_daemon(&paths).context("connect to yoetz live-CDP daemon")?;
     let timeout =
         Duration::from_secs(timeout_secs.saturating_add(RESPONSE_READ_TIMEOUT_GRACE_SECS));
     set_stream_timeouts(&stream, timeout)?;
 
-    let request = build_execute_request(script, timeout_secs, browser_name, cdp_endpoint);
+    let request = build_execute_request(script, timeout_secs, browser_name, cdp_endpoint, &token);
     write_request(&mut stream, &request).context("send yoetz live-CDP daemon execute request")?;
     let mut reader = BufReader::new(stream);
-    read_until_complete(&mut reader, timeout)
+    match read_until_complete(&mut reader, timeout) {
+        Err(error) if is_daemon_auth_error(&error) => {
+            clear_daemon_token_cache();
+            Err(error)
+        }
+        result => result,
+    }
 }
 
 fn acquire_spawn_lock(paths: &DaemonPaths) -> Result<File> {
@@ -196,11 +275,19 @@ fn daemon_is_current(paths: &DaemonPaths) -> Result<bool> {
     match request_daemon_status(paths) {
         Ok(status) => Ok(status.version.as_deref() == Some(daemon_version().as_str())),
         Err(error) if is_daemon_connect_error(&error) => Ok(false),
+        Err(error) if is_daemon_auth_error(&error) => {
+            clear_daemon_token_cache();
+            Ok(false)
+        }
         Err(first_error) => {
             thread::sleep(Duration::from_millis(DAEMON_START_POLL_MS));
             match request_daemon_status(paths) {
                 Ok(status) => Ok(status.version.as_deref() == Some(daemon_version().as_str())),
                 Err(error) if is_daemon_connect_error(&error) => Ok(false),
+                Err(error) if is_daemon_auth_error(&error) => {
+                    clear_daemon_token_cache();
+                    Ok(false)
+                }
                 Err(error) => Err(error.context(format!(
                     "yoetz live-CDP daemon status failed after retry; first error: {first_error:#}"
                 ))),
@@ -210,6 +297,7 @@ fn daemon_is_current(paths: &DaemonPaths) -> Result<bool> {
 }
 
 fn request_daemon_status(paths: &DaemonPaths) -> Result<DaemonStatus> {
+    let token = read_daemon_token_for_request(paths)?;
     let mut stream = connect_to_daemon(paths)
         .map_err(DaemonConnectError)
         .context("connect to yoetz live-CDP daemon")?;
@@ -218,6 +306,7 @@ fn request_daemon_status(paths: &DaemonPaths) -> Result<DaemonStatus> {
         "id": request_id("status"),
         "type": "status",
         "version": daemon_version(),
+        "capabilityToken": token,
     });
     write_request(&mut stream, &request).context("send yoetz live-CDP daemon status request")?;
     let mut reader = BufReader::new(stream);
@@ -230,13 +319,21 @@ fn is_daemon_connect_error(error: &anyhow::Error) -> bool {
         .any(|cause| cause.downcast_ref::<DaemonConnectError>().is_some())
 }
 
+fn is_daemon_auth_error(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .any(|cause| cause.downcast_ref::<DaemonAuthError>().is_some())
+}
+
 fn request_daemon_stop(paths: &DaemonPaths) -> Result<()> {
+    let token = read_daemon_token_for_request(paths)?;
     let mut stream = connect_to_daemon(paths).context("connect to yoetz live-CDP daemon")?;
     set_stream_timeouts(&stream, Duration::from_secs(5))?;
     let request = json!({
         "id": request_id("stop"),
         "type": "stop",
         "version": daemon_version(),
+        "capabilityToken": token,
     });
     write_request(&mut stream, &request).context("send yoetz live-CDP daemon stop request")?;
     let mut reader = BufReader::new(stream);
@@ -282,6 +379,9 @@ fn read_status_until_complete<R: BufRead>(
                 return Err(anyhow!("yoetz live-CDP daemon status failed"));
             }
             DaemonResponse::Error { message } => {
+                if is_daemon_unauthorized_message(&message) {
+                    return Err(DaemonAuthError(message).into());
+                }
                 return Err(anyhow!("yoetz live-CDP daemon status failed: {message}"));
             }
             DaemonResponse::Stdout { .. } | DaemonResponse::Stderr { .. } => {}
@@ -313,15 +413,15 @@ fn read_until_complete<R: BufRead>(reader: &mut R, timeout: Duration) -> Result<
         let response: DaemonResponse = serde_json::from_str(line.trim_end())
             .with_context(|| format!("parse yoetz live-CDP daemon response: {line}"))?;
         match response {
-            DaemonResponse::Stdout { data } => stdout.push_str(&data),
+            DaemonResponse::Stdout { data } => append_bounded_output(&mut stdout, &data),
             DaemonResponse::Stderr { data } => {
                 eprint!("{data}");
-                stderr.push_str(&data);
+                append_bounded_output(&mut stderr, &data);
             }
             DaemonResponse::Result { data } => {
                 if !data.is_null() {
-                    stdout.push_str(&data.to_string());
-                    stdout.push('\n');
+                    append_bounded_output(&mut stdout, &data.to_string());
+                    append_bounded_output(&mut stdout, "\n");
                 }
             }
             DaemonResponse::Complete { success } => {
@@ -333,6 +433,9 @@ fn read_until_complete<R: BufRead>(reader: &mut R, timeout: Duration) -> Result<
                 ));
             }
             DaemonResponse::Error { message } => {
+                if is_daemon_unauthorized_message(&message) {
+                    return Err(DaemonAuthError(message).into());
+                }
                 if stderr.trim().is_empty() {
                     return Err(anyhow!("yoetz live-CDP script failed: {message}"));
                 }
@@ -344,16 +447,42 @@ fn read_until_complete<R: BufRead>(reader: &mut R, timeout: Duration) -> Result<
     }
 }
 
+/// Append daemon output while keeping only the last 1 MiB plus a truncation marker.
+fn append_bounded_output(buffer: &mut String, data: &str) {
+    buffer.push_str(data);
+    if buffer.len() <= DAEMON_OUTPUT_BUFFER_LIMIT_BYTES {
+        return;
+    }
+
+    let marker = format!(
+        "[truncated {} bytes]\n",
+        buffer
+            .len()
+            .saturating_sub(DAEMON_OUTPUT_BUFFER_LIMIT_BYTES)
+    );
+    let keep_limit = DAEMON_OUTPUT_BUFFER_LIMIT_BYTES.saturating_sub(marker.len());
+    let target_drop = buffer.len().saturating_sub(keep_limit);
+    let drop_at = buffer
+        .char_indices()
+        .map(|(index, _)| index)
+        .find(|index| *index >= target_drop)
+        .unwrap_or(target_drop);
+    buffer.drain(..drop_at);
+    buffer.insert_str(0, &marker);
+}
+
 fn build_execute_request(
     script: &str,
     timeout_secs: u64,
     browser_name: Option<&str>,
     cdp_endpoint: Option<&str>,
+    capability_token: &str,
 ) -> Value {
     let request = json!({
         "id": request_id("execute"),
         "type": "execute",
         "version": daemon_version(),
+        "capabilityToken": capability_token,
         "browser": browser_name.unwrap_or("default"),
         "script": script,
         "connect": cdp_endpoint.unwrap_or("auto"),
@@ -366,8 +495,63 @@ fn daemon_version() -> String {
     use sha2::{Digest, Sha256};
 
     let mut hasher = Sha256::new();
-    hasher.update(EMBEDDED_DAEMON.as_bytes());
+    hasher.update(daemon_source().as_bytes());
     hex::encode(hasher.finalize())
+}
+
+fn daemon_source() -> &'static str {
+    HARDENED_DAEMON_SOURCE
+        .get_or_init(build_hardened_daemon_source)
+        .as_str()
+}
+
+fn build_hardened_daemon_source() -> String {
+    let source = replace_once(
+        EMBEDDED_DAEMON,
+        DAEMON_TOKEN_PATH_ANCHOR,
+        r#"var PID_PATH = path.join(BASE_DIR, "live-cdp-daemon.pid");
+  var TOKEN_PATH = path.join(BASE_DIR, "live-cdp-daemon.token");"#,
+    );
+    let source = replace_once(
+        &source,
+        DAEMON_VERSION_ANCHOR,
+        "var YOETZ_DAEMON_VERSION = await computeDaemonVersion();\nvar YOETZ_DAEMON_CAPABILITY_TOKEN = await readDaemonCapabilityToken();",
+    );
+    let source = replace_once(
+        &source,
+        DAEMON_COMPUTE_VERSION_ANCHOR,
+        r#"async function computeDaemonVersion() {
+  const source = await readFile(fileURLToPath(import.meta.url));
+  return createHash("sha256").update(source).digest("hex");
+}
+async function readDaemonCapabilityToken() {
+  const token = (await readFile(TOKEN_PATH, "utf8")).trim();
+  if (!token) {
+    throw new Error(`yoetz live-cdp daemon capability token is empty: ${TOKEN_PATH}`);
+  }
+  return token;
+}
+function requestHasValidCapabilityToken(line) {
+  try {
+    const value = JSON.parse(line);
+    return typeof value.capabilityToken === "string" && value.capabilityToken === YOETZ_DAEMON_CAPABILITY_TOKEN;
+  } catch {
+    return false;
+  }
+}"#,
+    );
+    replace_once(
+        &source,
+        DAEMON_REQUEST_GUARD_ANCHOR,
+        "  if (!requestHasValidCapabilityToken(line)) {\n    await writeMessage(socket, { id: request.id, type: \"error\", message: \"Unauthorized yoetz live-CDP daemon request: missing or invalid capability token\" });\n    return;\n  }\n  if (shuttingDown && request.type !== \"stop\") {",
+    )
+}
+
+fn replace_once(source: &str, needle: &str, replacement: &str) -> String {
+    if !source.contains(needle) {
+        panic!("embedded live-CDP daemon hardening anchor was not found: {needle}");
+    }
+    source.replacen(needle, replacement, 1)
 }
 
 fn request_id(prefix: &str) -> String {
@@ -387,9 +571,8 @@ fn write_request<W: Write>(writer: &mut W, request: &Value) -> io::Result<()> {
 }
 
 fn ensure_daemon_asset(paths: &DaemonPaths) -> Result<()> {
-    fs::create_dir_all(&paths.base_dir)
-        .with_context(|| format!("create {}", paths.base_dir.display()))?;
-    sync_text_file(&paths.daemon_path, EMBEDDED_DAEMON)
+    ensure_private_runtime_dir(paths)?;
+    sync_text_file(&paths.daemon_path, daemon_source())
         .with_context(|| format!("write {}", paths.daemon_path.display()))?;
     Ok(())
 }
@@ -427,27 +610,367 @@ fn sync_text_file(path: &Path, contents: &str) -> Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+fn ensure_private_runtime_dir(paths: &DaemonPaths) -> Result<()> {
+    use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
+
+    match fs::symlink_metadata(&paths.base_dir) {
+        Ok(metadata) => validate_private_runtime_dir_metadata(paths, &metadata),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            let mut builder = fs::DirBuilder::new();
+            builder.mode(0o700);
+            match builder.create(&paths.base_dir) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(error) => {
+                    return Err(error)
+                        .with_context(|| format!("create {}", paths.base_dir.display()));
+                }
+            }
+            fs::set_permissions(&paths.base_dir, fs::Permissions::from_mode(0o700))
+                .with_context(|| format!("chmod 700 {}", paths.base_dir.display()))?;
+            let metadata = fs::symlink_metadata(&paths.base_dir)
+                .with_context(|| format!("inspect {}", paths.base_dir.display()))?;
+            validate_private_runtime_dir_metadata(paths, &metadata)
+        }
+        Err(error) => Err(error).with_context(|| format!("inspect {}", paths.base_dir.display())),
+    }
+}
+
+#[cfg(unix)]
+fn validate_private_runtime_dir_metadata(
+    paths: &DaemonPaths,
+    metadata: &fs::Metadata,
+) -> Result<()> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    if metadata.file_type().is_symlink() {
+        return Err(anyhow!(
+            "refusing to use yoetz live-CDP daemon directory {}: path is a symlink; remove it and create a private directory with `mkdir -m 700 {}`",
+            paths.base_dir.display(),
+            paths.base_dir.display()
+        ));
+    }
+    if !metadata.is_dir() {
+        return Err(anyhow!(
+            "refusing to use yoetz live-CDP daemon directory {}: path is not a directory; remove it and create a private directory with `mkdir -m 700 {}`",
+            paths.base_dir.display(),
+            paths.base_dir.display()
+        ));
+    }
+
+    let owner_uid = metadata.uid();
+    let current_uid = current_uid();
+    if owner_uid != current_uid {
+        return Err(anyhow!(
+            "refusing to use yoetz live-CDP daemon directory {}: owned by uid {}, current uid is {}; fix ownership with `chown $(id -un) {}` and `chmod 700 {}`",
+            paths.base_dir.display(),
+            owner_uid,
+            current_uid,
+            paths.base_dir.display(),
+            paths.base_dir.display()
+        ));
+    }
+
+    let mode = metadata.permissions().mode() & 0o777;
+    if mode & 0o077 != 0 {
+        fs::set_permissions(&paths.base_dir, fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("chmod 700 {}", paths.base_dir.display()))?;
+        let metadata = fs::symlink_metadata(&paths.base_dir)
+            .with_context(|| format!("inspect {}", paths.base_dir.display()))?;
+        let tightened_mode = metadata.permissions().mode() & 0o777;
+        if tightened_mode & 0o077 != 0 {
+            return Err(anyhow!(
+                "refusing to use yoetz live-CDP daemon directory {}: permissions are {:03o}; run `chmod 700 {}` so group and world cannot access the daemon socket",
+                paths.base_dir.display(),
+                tightened_mode,
+                paths.base_dir.display()
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn ensure_private_runtime_dir(paths: &DaemonPaths) -> Result<()> {
+    fs::create_dir_all(&paths.base_dir)
+        .with_context(|| format!("create {}", paths.base_dir.display()))?;
+    Ok(())
+}
+
+fn create_new_daemon_token(paths: &DaemonPaths) -> Result<String> {
+    clear_daemon_token_cache();
+    let token = random_daemon_token();
+    match fs::symlink_metadata(&paths.token_path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() {
+                return Err(anyhow!(
+                    "refusing to replace yoetz live-CDP daemon token {}: path is a symlink",
+                    paths.token_path.display()
+                ));
+            }
+            if !metadata.is_file() {
+                return Err(anyhow!(
+                    "refusing to replace yoetz live-CDP daemon token {}: path is not a regular file",
+                    paths.token_path.display()
+                ));
+            }
+            fs::remove_file(&paths.token_path)
+                .with_context(|| format!("remove {}", paths.token_path.display()))?;
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error).with_context(|| format!("inspect {}", paths.token_path.display()));
+        }
+    }
+
+    write_new_daemon_token_file(&paths.token_path, &token)?;
+    Ok(token)
+}
+
+fn clear_daemon_token_cache() {
+    if let Some(cache) = DAEMON_TOKEN_CACHE.get() {
+        *cache.lock().expect("daemon token cache mutex poisoned") = None;
+    }
+}
+
+#[cfg(unix)]
+fn write_new_daemon_token_file(path: &Path, token: &str) -> Result<()> {
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+    let mut file = fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .mode(0o600)
+        .open(path)
+        .with_context(|| format!("create {}", path.display()))?;
+    file.write_all(token.as_bytes())
+        .with_context(|| format!("write {}", path.display()))?;
+    file.write_all(b"\n")
+        .with_context(|| format!("write {}", path.display()))?;
+    file.flush()
+        .with_context(|| format!("flush {}", path.display()))?;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("chmod 600 {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn write_new_daemon_token_file(path: &Path, token: &str) -> Result<()> {
+    let mut file = fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(path)
+        .with_context(|| format!("create {}", path.display()))?;
+    file.write_all(token.as_bytes())
+        .with_context(|| format!("write {}", path.display()))?;
+    file.write_all(b"\n")
+        .with_context(|| format!("write {}", path.display()))?;
+    file.flush()
+        .with_context(|| format!("flush {}", path.display()))?;
+    Ok(())
+}
+
+fn read_daemon_token_for_request(paths: &DaemonPaths) -> Result<String> {
+    read_daemon_token_for_request_cached(paths)
+        .map_err(|error| DaemonAuthError(format!("{error:#}")).into())
+}
+
+fn read_daemon_token_for_request_cached(paths: &DaemonPaths) -> Result<String> {
+    let key = daemon_token_cache_key(paths)?;
+    let cache = DAEMON_TOKEN_CACHE.get_or_init(|| Mutex::new(None));
+    if let Some(cached) = cache
+        .lock()
+        .expect("daemon token cache mutex poisoned")
+        .as_ref()
+        .filter(|cached| cached.key == key)
+        .cloned()
+    {
+        return Ok(cached.token);
+    }
+
+    let token = read_daemon_token(paths)?;
+    *cache.lock().expect("daemon token cache mutex poisoned") = Some(CachedDaemonToken {
+        key,
+        token: token.clone(),
+    });
+    Ok(token)
+}
+
+fn daemon_token_cache_key(paths: &DaemonPaths) -> Result<DaemonTokenCacheKey> {
+    let metadata = fs::symlink_metadata(&paths.token_path)
+        .with_context(|| format!("inspect {}", paths.token_path.display()))?;
+    if metadata.file_type().is_symlink() {
+        return Err(anyhow!(
+            "refusing to use yoetz live-CDP daemon capability token {}: path is a symlink",
+            paths.token_path.display()
+        ));
+    }
+    if !metadata.is_file() {
+        return Err(anyhow!(
+            "refusing to use yoetz live-CDP daemon capability token {}: path is not a regular file",
+            paths.token_path.display()
+        ));
+    }
+    Ok(DaemonTokenCacheKey {
+        token_path: paths.token_path.clone(),
+        modified: metadata.modified().ok(),
+        len: metadata.len(),
+        #[cfg(unix)]
+        uid: {
+            use std::os::unix::fs::MetadataExt;
+            metadata.uid()
+        },
+        #[cfg(unix)]
+        mode: {
+            use std::os::unix::fs::PermissionsExt;
+            metadata.permissions().mode() & 0o777
+        },
+    })
+}
+
+fn read_daemon_token(paths: &DaemonPaths) -> Result<String> {
+    let token = read_validated_daemon_token_file(paths)?.trim().to_owned();
+    if token.is_empty() {
+        return Err(anyhow!(
+            "yoetz live-CDP daemon capability token is empty: {}",
+            paths.token_path.display()
+        ));
+    }
+    Ok(token)
+}
+
+#[cfg(unix)]
+fn read_validated_daemon_token_file(paths: &DaemonPaths) -> Result<String> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut file = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(&paths.token_path)
+        .with_context(|| format!("open {}", paths.token_path.display()))?;
+    validate_open_daemon_token_file(paths, &file)?;
+    let mut token = String::new();
+    file.read_to_string(&mut token)
+        .with_context(|| format!("read {}", paths.token_path.display()))?;
+    Ok(token)
+}
+
+#[cfg(unix)]
+fn validate_open_daemon_token_file(paths: &DaemonPaths, file: &File) -> Result<()> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("inspect {}", paths.token_path.display()))?;
+    if !metadata.is_file() {
+        return Err(anyhow!(
+            "refusing to use yoetz live-CDP daemon capability token {}: path is not a regular file",
+            paths.token_path.display()
+        ));
+    }
+    let owner_uid = metadata.uid();
+    let current_uid = current_uid();
+    if owner_uid != current_uid {
+        return Err(anyhow!(
+            "refusing to use yoetz live-CDP daemon capability token {}: owned by uid {}, current uid is {}",
+            paths.token_path.display(),
+            owner_uid,
+            current_uid
+        ));
+    }
+    let mode = metadata.permissions().mode() & 0o777;
+    if mode != 0o600 {
+        return Err(anyhow!(
+            "refusing to use yoetz live-CDP daemon capability token {}: permissions are {:03o}; run `chmod 600 {}`",
+            paths.token_path.display(),
+            mode,
+            paths.token_path.display()
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn read_validated_daemon_token_file(paths: &DaemonPaths) -> Result<String> {
+    let metadata = fs::metadata(&paths.token_path)
+        .with_context(|| format!("inspect {}", paths.token_path.display()))?;
+    if !metadata.is_file() {
+        return Err(anyhow!(
+            "refusing to use yoetz live-CDP daemon capability token {}: path is not a regular file",
+            paths.token_path.display()
+        ));
+    }
+    fs::read_to_string(&paths.token_path)
+        .with_context(|| format!("read {}", paths.token_path.display()))
+}
+
+fn random_daemon_token() -> String {
+    let token: [u8; 32] = rand::random();
+    hex::encode(token)
+}
+
+fn is_daemon_unauthorized_message(message: &str) -> bool {
+    message.contains("Unauthorized yoetz live-CDP daemon request")
+}
+
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn current_uid() -> u32 {
+    unsafe extern "C" {
+        fn getuid() -> std::os::raw::c_uint;
+    }
+    unsafe { getuid() as u32 }
+}
+
 fn daemon_paths() -> Result<DaemonPaths> {
     let home = home_dir()
         .ok_or_else(|| anyhow!("could not determine home directory for yoetz live-CDP daemon"))?;
-    Ok(daemon_paths_for_home(&home))
+    Ok(daemon_paths_for_base_dir(&live_cdp_runtime_base_dir(
+        &home,
+    )?))
 }
 
+#[cfg(test)]
 fn daemon_paths_for_home(home: &Path) -> DaemonPaths {
-    let base_dir = home.join(".yoetz");
+    daemon_paths_for_base_dir(&home.join(".yoetz"))
+}
+
+#[cfg(unix)]
+fn daemon_paths_for_runtime_dir(runtime_dir: &Path) -> DaemonPaths {
+    daemon_paths_for_base_dir(&runtime_dir.join("yoetz"))
+}
+
+fn daemon_paths_for_base_dir(base_dir: &Path) -> DaemonPaths {
     DaemonPaths {
         daemon_path: base_dir.join(DAEMON_FILENAME),
         socket_path: base_dir.join(DAEMON_SOCKET_FILENAME),
         pid_path: base_dir.join(DAEMON_PID_FILENAME),
         lock_path: base_dir.join(DAEMON_LOCK_FILENAME),
         log_path: base_dir.join(DAEMON_LOG_FILENAME),
-        base_dir,
+        token_path: base_dir.join(DAEMON_TOKEN_FILENAME),
+        base_dir: base_dir.to_path_buf(),
     }
+}
+
+fn live_cdp_runtime_base_dir(home: &Path) -> Result<PathBuf> {
+    #[cfg(unix)]
+    if let Some(runtime_dir) = env::var_os("XDG_RUNTIME_DIR")
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+    {
+        return Ok(daemon_paths_for_runtime_dir(&runtime_dir).base_dir);
+    }
+
+    Ok(home.join(".yoetz"))
 }
 
 fn cleanup_stale_files(paths: &DaemonPaths) {
     let _ = fs::remove_file(&paths.pid_path);
     let _ = fs::remove_file(&paths.socket_path);
+    let _ = fs::remove_file(&paths.token_path);
+    clear_daemon_token_cache();
 }
 
 fn wait_until_daemon_down(paths: &DaemonPaths, timeout: Duration) -> bool {
@@ -552,8 +1075,101 @@ fn wait_for_child_success(child: &mut Child, timeout: Duration) -> bool {
 #[cfg(unix)]
 fn connect_to_daemon(paths: &DaemonPaths) -> io::Result<UnixStream> {
     let stream = UnixStream::connect(&paths.socket_path)?;
+    verify_daemon_peer(&stream)?;
     stream.set_write_timeout(Some(Duration::from_secs(5)))?;
     Ok(stream)
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[allow(unsafe_code)]
+fn verify_daemon_peer(stream: &UnixStream) -> io::Result<()> {
+    let mut creds = libc::ucred {
+        pid: 0,
+        uid: 0,
+        gid: 0,
+    };
+    let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+    let result = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            std::ptr::addr_of_mut!(creds).cast(),
+            std::ptr::addr_of_mut!(len),
+        )
+    };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if creds.uid != current_uid() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "refusing yoetz live-CDP daemon connection from uid {}; current uid is {}",
+                creds.uid,
+                current_uid()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "freebsd",
+    target_os = "dragonfly",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
+#[allow(unsafe_code)]
+fn verify_daemon_peer(stream: &UnixStream) -> io::Result<()> {
+    let mut uid = 0u32;
+    let mut gid = 0u32;
+    unsafe extern "C" {
+        fn getpeereid(
+            socket: std::os::raw::c_int,
+            euid: *mut std::os::raw::c_uint,
+            egid: *mut std::os::raw::c_uint,
+        ) -> std::os::raw::c_int;
+    }
+    let result = unsafe {
+        getpeereid(
+            stream.as_raw_fd(),
+            std::ptr::addr_of_mut!(uid),
+            std::ptr::addr_of_mut!(gid),
+        )
+    };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if uid != current_uid() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "refusing yoetz live-CDP daemon connection from uid {uid}; current uid is {}",
+                current_uid()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))
+))]
+fn verify_daemon_peer(_stream: &UnixStream) -> io::Result<()> {
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -601,6 +1217,21 @@ mod tests {
             paths.socket_path,
             PathBuf::from("/tmp/example-home/.yoetz/live-cdp-daemon.sock")
         );
+        assert_eq!(
+            paths.token_path,
+            PathBuf::from("/tmp/example-home/.yoetz/live-cdp-daemon.token")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn daemon_paths_can_use_xdg_runtime_dir() {
+        let paths = daemon_paths_for_runtime_dir(Path::new("/tmp/example-runtime"));
+        assert_eq!(paths.base_dir, PathBuf::from("/tmp/example-runtime/yoetz"));
+        assert_eq!(
+            paths.socket_path,
+            PathBuf::from("/tmp/example-runtime/yoetz/live-cdp-daemon.sock")
+        );
     }
 
     #[test]
@@ -610,9 +1241,11 @@ mod tests {
             45,
             Some("yoetz-chatgpt"),
             Some("ws://127.0.0.1:9222/devtools/browser/test"),
+            "test-token",
         );
         assert_eq!(request["type"], "execute");
         assert_eq!(request["version"], daemon_version());
+        assert_eq!(request["capabilityToken"], "test-token");
         assert_eq!(request["browser"], "yoetz-chatgpt");
         assert_eq!(request["script"], "console.log('ok')");
         assert_eq!(request["timeoutMs"], 45_000);
@@ -624,10 +1257,11 @@ mod tests {
 
     #[test]
     fn execute_request_uses_auto_connect_without_endpoint() {
-        let request = build_execute_request("await browser.listPages()", 10, None, None);
+        let request = build_execute_request("await browser.listPages()", 10, None, None, "token");
         assert_eq!(request["browser"], "default");
         assert_eq!(request["connect"], "auto");
         assert_eq!(request["timeoutMs"], 10_000);
+        assert_eq!(request["capabilityToken"], "token");
     }
 
     #[test]
@@ -645,6 +1279,42 @@ mod tests {
     }
 
     #[test]
+    fn hardened_daemon_source_requires_capability_token() {
+        let source = daemon_source();
+        assert!(source.contains("live-cdp-daemon.token"));
+        assert!(source.contains("YOETZ_DAEMON_CAPABILITY_TOKEN"));
+        assert!(source.contains("requestHasValidCapabilityToken"));
+        assert!(source.contains("Unauthorized yoetz live-CDP daemon request"));
+    }
+
+    #[test]
+    fn embedded_daemon_contains_hardening_patch_anchors() {
+        for anchor in [
+            DAEMON_TOKEN_PATH_ANCHOR,
+            DAEMON_VERSION_ANCHOR,
+            DAEMON_COMPUTE_VERSION_ANCHOR,
+            DAEMON_REQUEST_GUARD_ANCHOR,
+        ] {
+            assert!(
+                EMBEDDED_DAEMON.contains(anchor),
+                "embedded daemon hardening anchor should still exist: {anchor}"
+            );
+        }
+    }
+
+    #[test]
+    fn append_bounded_output_marks_truncation() {
+        let mut buffer = "prefix".to_string();
+        append_bounded_output(
+            &mut buffer,
+            &"x".repeat(DAEMON_OUTPUT_BUFFER_LIMIT_BYTES + 32),
+        );
+        assert!(buffer.starts_with("[truncated "));
+        assert!(buffer.contains(" bytes]\n"));
+        assert!(buffer.len() <= DAEMON_OUTPUT_BUFFER_LIMIT_BYTES);
+    }
+
+    #[test]
     fn daemon_asset_sync_writes_and_skips_unchanged_content() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("daemon.mjs");
@@ -657,15 +1327,98 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn private_runtime_dir_tightens_world_accessible_existing_dir() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let paths = daemon_paths_for_home(dir.path());
+        fs::create_dir_all(&paths.base_dir).unwrap();
+        fs::set_permissions(&paths.base_dir, fs::Permissions::from_mode(0o755)).unwrap();
+
+        ensure_private_runtime_dir(&paths).unwrap();
+        let metadata = fs::symlink_metadata(&paths.base_dir).unwrap();
+        assert_eq!(metadata.permissions().mode() & 0o777, 0o700);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_runtime_dir_rejects_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = daemon_paths_for_home(dir.path());
+        let target = dir.path().join("target");
+        fs::create_dir(&target).unwrap();
+        std::os::unix::fs::symlink(&target, &paths.base_dir).unwrap();
+
+        let error = ensure_private_runtime_dir(&paths).unwrap_err();
+        let message = format!("{error:#}");
+        assert!(message.contains("path is a symlink"));
+        assert!(message.contains("mkdir -m 700"));
+    }
+
+    #[test]
+    fn daemon_token_file_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths = daemon_paths_for_home(dir.path());
+        ensure_private_runtime_dir(&paths).unwrap();
+
+        let token = create_new_daemon_token(&paths).unwrap();
+        assert_eq!(token.len(), 64);
+        assert_eq!(read_daemon_token(&paths).unwrap(), token);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+            let metadata = fs::symlink_metadata(&paths.token_path).unwrap();
+            assert_eq!(metadata.permissions().mode() & 0o777, 0o600);
+            assert_eq!(metadata.uid(), current_uid());
+        }
+    }
+
+    #[test]
+    fn cached_daemon_token_debug_redacts_secret() {
+        let fake_secret = "redaction-test-secret-value";
+        let cached = CachedDaemonToken {
+            key: DaemonTokenCacheKey {
+                token_path: PathBuf::from("/tmp/live-cdp-daemon.token"),
+                modified: None,
+                len: 64,
+                #[cfg(unix)]
+                uid: current_uid(),
+                #[cfg(unix)]
+                mode: 0o600,
+            },
+            token: fake_secret.to_string(),
+        };
+        let debug = format!("{cached:?}");
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains(fake_secret));
+    }
+
+    #[cfg(unix)]
+    #[test]
     #[serial_test::serial]
     fn bundled_daemon_status_round_trips_under_isolated_home() {
         let dir = tempfile::tempdir().unwrap();
         let _home = EnvVarGuard::set("HOME", dir.path().as_os_str());
+        let _runtime = EnvVarGuard::remove("XDG_RUNTIME_DIR");
         let _enabled = EnvVarGuard::remove(YOETZ_LIVE_CDP_DAEMON_ENV);
 
         let paths = daemon_paths_for_home(dir.path());
         let result = (|| -> Result<()> {
             ensure_daemon()?;
+            let token_metadata = fs::symlink_metadata(&paths.token_path)
+                .with_context(|| format!("inspect {}", paths.token_path.display()))?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                if token_metadata.permissions().mode() & 0o777 != 0o600 {
+                    return Err(anyhow!(
+                        "unexpected daemon token permissions: {:03o}",
+                        token_metadata.permissions().mode() & 0o777
+                    ));
+                }
+            }
             let status = request_daemon_status(&paths)?;
             if status.version.as_deref() != Some(daemon_version().as_str()) {
                 return Err(anyhow!("unexpected daemon status version: {status:?}"));
@@ -684,12 +1437,59 @@ mod tests {
     #[cfg(unix)]
     #[test]
     #[serial_test::serial]
+    fn bundled_daemon_rejects_status_without_capability_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let _home = EnvVarGuard::set("HOME", dir.path().as_os_str());
+        let _runtime = EnvVarGuard::remove("XDG_RUNTIME_DIR");
+        let _enabled = EnvVarGuard::remove(YOETZ_LIVE_CDP_DAEMON_ENV);
+
+        let paths = daemon_paths_for_home(dir.path());
+        let result = (|| -> Result<()> {
+            ensure_daemon()?;
+            let mut stream = connect_to_daemon(&paths)?;
+            set_stream_timeouts(&stream, Duration::from_secs(5))?;
+            let request = json!({
+                "id": request_id("status"),
+                "type": "status",
+                "version": daemon_version(),
+            });
+            write_request(&mut stream, &request)?;
+
+            let mut reader = BufReader::new(stream);
+            let mut line = String::new();
+            reader.read_line(&mut line)?;
+            let response: DaemonResponse = serde_json::from_str(line.trim_end())?;
+            match response {
+                DaemonResponse::Error { message } => {
+                    if !is_daemon_unauthorized_message(&message) {
+                        return Err(anyhow!("unexpected daemon error: {message}"));
+                    }
+                }
+                other => return Err(anyhow!("unexpected daemon response: {other:?}")),
+            }
+            Ok(())
+        })();
+        let stopped = stop_live_cdp_daemon();
+
+        result.unwrap();
+        stopped.unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial_test::serial]
     fn stale_socket_file_is_cleaned_and_recovered() {
         let dir = tempfile::tempdir().unwrap();
         let _home = EnvVarGuard::set("HOME", dir.path().as_os_str());
+        let _runtime = EnvVarGuard::remove("XDG_RUNTIME_DIR");
         let _enabled = EnvVarGuard::remove(YOETZ_LIVE_CDP_DAEMON_ENV);
         let paths = daemon_paths_for_home(dir.path());
         fs::create_dir_all(&paths.base_dir).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&paths.base_dir, fs::Permissions::from_mode(0o700)).unwrap();
+        }
         fs::write(&paths.socket_path, "not a socket").unwrap();
 
         let result = (|| -> Result<()> {

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -980,6 +980,27 @@ fn recipe_transport_error_detail(err: &anyhow::Error) -> String {
     format!("{err:#}")
 }
 
+fn recipe_transport_error_detail_for_recipe(
+    err: &anyhow::Error,
+    recipe_vars: &BTreeMap<String, String>,
+) -> String {
+    let mut detail = recipe_transport_error_detail(err);
+    if chatgpt_recipe::terminal_fallback_phase(err).is_some() {
+        if let Some(run_id) = recipe_vars
+            .get("run_id")
+            .map(String::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            let marked_url = chatgpt_web::mark_chatgpt_url(run_id);
+            detail.push_str(&format!(
+                "\nManual recovery: continue in the yoetz-owned ChatGPT tab for run `{run_id}` ({marked_url}, window.name `yoetz:{run_id}`). The request may already be uploaded or sent; do not rerun automatically unless you intend a duplicate submission."
+            ));
+        }
+    }
+    detail
+}
+
 fn recipe_has_remaining_manual_fallback(
     transports: &[browser::RecipeTransport],
     current_index: usize,
@@ -1000,6 +1021,9 @@ fn recipe_should_stop_live_transport_fallback(
         return true;
     }
     if browser::is_chrome_approval_wait_error(err) {
+        return true;
+    }
+    if chatgpt_recipe::terminal_fallback_phase(err).is_some() {
         return true;
     }
     if browser::is_chatgpt_auth_issue_error(err) {
@@ -1472,6 +1496,7 @@ async fn run_recipe_via_chrome_devtools_mcp(
     selected_cdp_target: Option<&browser::ResolvedCdpTarget>,
     format: OutputFormat,
     is_chatgpt: bool,
+    fallback_used: bool,
 ) -> Result<Value> {
     if !is_chatgpt {
         return Err(anyhow!(
@@ -1511,6 +1536,7 @@ async fn run_recipe_via_chrome_devtools_mcp(
         run_id: recipe_spec.run_id.clone(),
         response_timeout_ms: recipe_spec.wait_timeout_ms,
         response_poll_interval_ms: recipe_spec.wait_interval_ms,
+        upload_timeout_ms: recipe_spec.upload_timeout_ms,
         disable_extended: recipe_spec.disable_extended,
         show_approval_guidance: matches!(format, OutputFormat::Text | OutputFormat::Markdown),
     };
@@ -1521,13 +1547,15 @@ async fn run_recipe_via_chrome_devtools_mcp(
         matches!(format, OutputFormat::Text | OutputFormat::Markdown),
     )
     .await?;
+    let model_selection_status = response.model_selection_status;
     let payload = chatgpt_recipe::ChatgptRecipeOutput {
         transport: "chrome-devtools-mcp".to_string(),
         backend: "chrome-devtools-mcp".to_string(),
         response: response.response,
         model_used: response.model_used,
+        model_selection_status,
         warnings: Vec::new(),
-        fallback_used: false,
+        fallback_used,
         delivery_mode: chatgpt_recipe::ChatgptDeliveryMode::FileUpload,
         auto_paste_fallback: false,
     }
@@ -1544,6 +1572,7 @@ async fn run_recipe_via_chrome_devtools_mcp(
                 backend: "chrome-devtools-mcp".to_string(),
                 response: payload["response"].as_str().unwrap_or_default().to_string(),
                 model_used: payload["model_used"].as_str().map(str::to_owned),
+                model_selection_status,
                 warnings: payload["warnings"]
                     .as_array()
                     .map(|items| {
@@ -1554,7 +1583,7 @@ async fn run_recipe_via_chrome_devtools_mcp(
                             .collect::<Vec<_>>()
                     })
                     .unwrap_or_default(),
-                fallback_used: false,
+                fallback_used,
                 delivery_mode: chatgpt_recipe::ChatgptDeliveryMode::FileUpload,
                 auto_paste_fallback: false,
             }
@@ -1574,6 +1603,8 @@ fn build_chatgpt_recipe_spec(
     recipe_vars: &BTreeMap<String, String>,
 ) -> Result<chatgpt_recipe::ChatgptRecipeSpec> {
     let poll_settings = dev_browser::resolve_chatgpt_poll_settings(recipe_vars)?;
+    let upload_timeout_ms =
+        dev_browser::resolve_chatgpt_upload_timeout_ms(recipe_vars, recipe_args.bundle.as_deref())?;
     chrome_devtools_mcp::RecipeThreadMode::parse(recipe_vars.get("thread").map(String::as_str))?;
     Ok(chatgpt_recipe::ChatgptRecipeSpec {
         bundle_path: recipe_args.bundle.clone(),
@@ -1597,6 +1628,7 @@ fn build_chatgpt_recipe_spec(
             .unwrap_or_else(chatgpt_web::generate_run_id),
         wait_timeout_ms: poll_settings.timeout_ms,
         wait_interval_ms: poll_settings.interval_ms,
+        upload_timeout_ms,
         disable_extended: recipe_vars
             .get("extended")
             .is_some_and(|value| value == "false"),
@@ -1607,25 +1639,17 @@ fn resolve_dev_browser_delivery_mode(
     recipe_args: &BrowserRecipeArgs,
     recipe_vars: &BTreeMap<String, String>,
 ) -> Result<(bool, Option<String>, bool)> {
-    resolve_dev_browser_delivery_mode_for_platform(
-        cfg!(target_os = "macos"),
-        recipe_args,
-        recipe_vars,
-    )
+    resolve_dev_browser_delivery_mode_for_platform(recipe_args, recipe_vars)
 }
 
 fn resolve_dev_browser_delivery_mode_for_platform(
-    supports_clipboard_file_upload: bool,
     recipe_args: &BrowserRecipeArgs,
     recipe_vars: &BTreeMap<String, String>,
 ) -> Result<(bool, Option<String>, bool)> {
     let requested_paste_mode = recipe_vars
         .get("paste")
         .is_some_and(|value| value == "true");
-    let auto_paste_fallback =
-        !requested_paste_mode && recipe_args.bundle.is_some() && !supports_clipboard_file_upload;
-    let effective_paste_mode = requested_paste_mode || auto_paste_fallback;
-    let bundle_text = if effective_paste_mode {
+    let bundle_text = if requested_paste_mode {
         recipe_args
             .bundle
             .as_ref()
@@ -1634,7 +1658,7 @@ fn resolve_dev_browser_delivery_mode_for_platform(
     } else {
         None
     };
-    Ok((effective_paste_mode, bundle_text, auto_paste_fallback))
+    Ok((requested_paste_mode, bundle_text, false))
 }
 
 fn run_recipe_via_dev_browser(
@@ -1644,6 +1668,7 @@ fn run_recipe_via_dev_browser(
     cdp_endpoint: Option<&str>,
     format: OutputFormat,
     is_chatgpt: bool,
+    fallback_used: bool,
 ) -> Result<Value> {
     if !is_chatgpt {
         return Err(anyhow!(
@@ -1665,11 +1690,6 @@ fn run_recipe_via_dev_browser(
 
     let (paste_mode, bundle_text, auto_paste_fallback) =
         resolve_dev_browser_delivery_mode(recipe_args, recipe_vars)?;
-    if auto_paste_fallback {
-        eprintln!(
-            "info: dev-browser clipboard file upload requires macOS; falling back to paste mode for this run"
-        );
-    }
     let recipe_spec = build_chatgpt_recipe_spec(recipe_args, recipe_vars)?;
     let recipe_ctx = dev_browser::DevBrowserRecipeContext {
         bundle_path: recipe_spec.bundle_path.clone(),
@@ -1688,6 +1708,7 @@ fn run_recipe_via_dev_browser(
             .is_some_and(|value| value == "true"),
         cdp_endpoint: cdp_endpoint.map(str::to_owned),
         show_approval_guidance: matches!(format, OutputFormat::Text | OutputFormat::Markdown),
+        upload_timeout_ms: recipe_spec.upload_timeout_ms,
     };
 
     let response = dev_browser::run_chatgpt_recipe(&recipe_ctx)?;
@@ -1696,8 +1717,9 @@ fn run_recipe_via_dev_browser(
         backend: "dev-browser".to_string(),
         response: response.response,
         model_used: response.model_used,
+        model_selection_status: response.model_selection_status,
         warnings: response.warnings,
-        fallback_used: true,
+        fallback_used,
         delivery_mode: if paste_mode {
             chatgpt_recipe::ChatgptDeliveryMode::Paste
         } else {
@@ -1731,6 +1753,7 @@ fn run_recipe_via_agent_browser(
     profile_dir: PathBuf,
     format: OutputFormat,
     is_chatgpt: bool,
+    fallback_used: bool,
     prefer_auto_connect: bool,
     selected_cdp_target: &mut Option<browser::ResolvedCdpTarget>,
 ) -> Result<Value> {
@@ -1745,6 +1768,7 @@ fn run_recipe_via_agent_browser(
         } else if let Some(target) = selected_cdp_target.as_ref().cloned() {
             Some(browser::BrowserConnection::Cdp {
                 endpoint: target.endpoint,
+                run_id: recipe_vars.get("run_id").cloned(),
             })
         } else if prefer_auto_connect {
             // Avoid a separate auto-connect probe here. The recipe run should
@@ -1787,6 +1811,7 @@ fn run_recipe_via_agent_browser(
         bundle_text,
         profile_dir: Some(profile_dir),
         profile_mode,
+        fallback_used,
         use_stealth: needs_auth,
         headed: needs_auth,
         target_url: browser::CHATGPT_URL.to_string(),
@@ -2195,7 +2220,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                             })?
                         };
                         let method = match &connection {
-                            browser::BrowserConnection::Cdp { endpoint } => {
+                            browser::BrowserConnection::Cdp { endpoint, .. } => {
                                 format!("cdp: {endpoint}")
                             }
                             browser::BrowserConnection::AutoConnect => "auto_connect".to_string(),
@@ -2330,9 +2355,10 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             );
             if is_chatgpt {
                 chatgpt_web::validate_thread_mode(recipe_vars.get("thread").map(String::as_str))?;
-                recipe_vars
+                let run_id = recipe_vars
                     .entry("run_id".to_string())
                     .or_insert_with(chatgpt_web::generate_run_id);
+                chatgpt_web::validate_run_id(run_id)?;
             }
             let mut resolved_cdp_target = browser::resolve_cdp_target_with_selector(
                 recipe_args.cdp.as_deref(),
@@ -2366,6 +2392,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
 
             let mut skip_remaining_live_cdp = false;
             for (index, transport) in transports.iter().copied().enumerate() {
+                let fallback_used = index > 0;
                 let cdp_endpoint = resolved_cdp_target
                     .as_ref()
                     .map(|target| target.endpoint.clone());
@@ -2391,6 +2418,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         cdp_endpoint.as_deref(),
                         format,
                         is_chatgpt,
+                        fallback_used,
                     ),
                     browser::RecipeTransport::AgentBrowser => run_recipe_via_agent_browser(
                         ctx,
@@ -2400,6 +2428,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         profile_dir.clone(),
                         format,
                         is_chatgpt,
+                        fallback_used,
                         prefer_auto_connect,
                         &mut resolved_cdp_target,
                     ),
@@ -2411,6 +2440,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                             resolved_cdp_target.as_ref(),
                             format,
                             is_chatgpt,
+                            fallback_used,
                         )
                         .await
                     }
@@ -2446,7 +2476,10 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                             transport,
                             &recipe_vars,
                         ) {
-                            transport_errors.push((transport, recipe_transport_error_detail(&err)));
+                            transport_errors.push((
+                                transport,
+                                recipe_transport_error_detail_for_recipe(&err, &recipe_vars),
+                            ));
                             if recipe_has_remaining_manual_fallback(&transports, index) {
                                 transport_errors.push((
                                     browser::RecipeTransport::Manual,
@@ -2464,7 +2497,10 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                                 recipe_transport_name(transport)
                             );
                         }
-                        transport_errors.push((transport, recipe_transport_error_detail(&err)));
+                        transport_errors.push((
+                            transport,
+                            recipe_transport_error_detail_for_recipe(&err, &recipe_vars),
+                        ));
                     }
                 }
             }
@@ -3285,6 +3321,28 @@ mod tests {
     }
 
     #[test]
+    fn recipe_should_stop_live_transport_fallback_on_terminal_chatgpt_phases() {
+        let vars = std::collections::BTreeMap::new();
+        let typed_send = chatgpt_recipe::mark_terminal_fallback_phase(
+            anyhow!("send click returned a transport error"),
+            chatgpt_recipe::ChatgptTransportPhase::Send,
+        );
+        let upload = anyhow!("recipe step 7 (upload) failed: agent-browser failed");
+        let wait = anyhow!(
+            "recipe step 10 (chatgpt_wait_response) failed: timed out waiting for ChatGPT response"
+        );
+
+        for err in [&typed_send, &upload, &wait] {
+            assert!(recipe_should_stop_live_transport_fallback(
+                err,
+                None,
+                browser::RecipeTransport::ChromeDevtoolsMcp,
+                &vars,
+            ));
+        }
+    }
+
+    #[test]
     fn recipe_should_stop_live_transport_fallback_on_live_attach_daemon_timeout() {
         let err = anyhow!(
             "yoetz live-attach daemon at 127.0.0.1:45555 timed out after 75000ms waiting for a response"
@@ -3300,7 +3358,7 @@ mod tests {
 
     #[test]
     fn recipe_should_not_stop_live_transport_fallback_on_non_approval_error() {
-        let err = anyhow!("chatgpt send button not found");
+        let err = anyhow!("browser executable was not found before the recipe opened ChatGPT");
         let vars = std::collections::BTreeMap::new();
         assert!(!recipe_should_stop_live_transport_fallback(
             &err,
@@ -3378,13 +3436,13 @@ mod tests {
     }
 
     #[test]
-    fn recipe_should_not_stop_dev_browser_page_errors_before_agent_browser() {
+    fn recipe_should_stop_dev_browser_send_errors_before_agent_browser() {
         let err = anyhow!(
             "{}",
             r#"ChatGPT send button never became enabled after typing. {"send":"missing"}"#
         );
         let vars = std::collections::BTreeMap::new();
-        assert!(!recipe_should_stop_live_transport_fallback(
+        assert!(recipe_should_stop_live_transport_fallback(
             &err,
             None,
             browser::RecipeTransport::DevBrowser,
@@ -3911,6 +3969,7 @@ mod tests {
             None,
             OutputFormat::Text,
             /* is_chatgpt */ false,
+            /* fallback_used */ false,
         )
         .await
         .unwrap_err();
@@ -3940,6 +3999,7 @@ mod tests {
             None,
             OutputFormat::Text,
             /* is_chatgpt */ true,
+            /* fallback_used */ false,
         )
         .await
         .unwrap_err();
@@ -3965,6 +4025,7 @@ mod tests {
             None,
             OutputFormat::Text,
             /* is_chatgpt */ true,
+            /* fallback_used */ false,
         )
         .await
         .unwrap_err();
@@ -3991,6 +4052,7 @@ mod tests {
             None,
             OutputFormat::Text,
             /* is_chatgpt */ true,
+            /* fallback_used */ false,
         )
         .await
         .unwrap_err();
@@ -4017,6 +4079,7 @@ mod tests {
             None,
             OutputFormat::Text,
             /* is_chatgpt */ true,
+            /* fallback_used */ false,
         )
         .await
         .unwrap_err();
@@ -4043,6 +4106,7 @@ mod tests {
             None,
             OutputFormat::Text,
             /* is_chatgpt */ true,
+            /* fallback_used */ false,
         )
         .await
         .unwrap_err();
@@ -4052,8 +4116,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_dev_browser_delivery_mode_falls_back_to_paste_when_clipboard_upload_is_unavailable()
-    {
+    fn resolve_dev_browser_delivery_mode_uses_file_upload_by_default() {
         let bundle_path = temp_output_path("yoetz_bundle_text");
         fs::write(&bundle_path, "bundle body").unwrap();
         let recipe_args = BrowserRecipeArgs {
@@ -4067,11 +4130,33 @@ mod tests {
         let recipe_vars = BTreeMap::new();
 
         let (paste_mode, bundle_text, auto_fallback) =
-            resolve_dev_browser_delivery_mode_for_platform(false, &recipe_args, &recipe_vars)
-                .unwrap();
+            resolve_dev_browser_delivery_mode_for_platform(&recipe_args, &recipe_vars).unwrap();
+
+        assert!(!paste_mode);
+        assert!(!auto_fallback);
+        assert_eq!(bundle_text.as_deref(), None);
+        let _ = fs::remove_file(bundle_path);
+    }
+
+    #[test]
+    fn resolve_dev_browser_delivery_mode_honors_explicit_paste() {
+        let bundle_path = temp_output_path("yoetz_bundle_text_paste");
+        fs::write(&bundle_path, "bundle body").unwrap();
+        let recipe_args = BrowserRecipeArgs {
+            recipe: PathBuf::from("recipes/chatgpt.yaml"),
+            bundle: Some(bundle_path.clone()),
+            profile: None,
+            cdp: None,
+            browser_id: None,
+            vars: vec![],
+        };
+        let recipe_vars = BTreeMap::from([("paste".to_string(), "true".to_string())]);
+
+        let (paste_mode, bundle_text, auto_fallback) =
+            resolve_dev_browser_delivery_mode_for_platform(&recipe_args, &recipe_vars).unwrap();
 
         assert!(paste_mode);
-        assert!(auto_fallback);
+        assert!(!auto_fallback);
         assert_eq!(bundle_text.as_deref(), Some("bundle body"));
         let _ = fs::remove_file(bundle_path);
     }
@@ -4094,6 +4179,7 @@ mod tests {
             ("run_id".to_string(), "run-123".to_string()),
             ("wait_timeout_ms".to_string(), "2400000".to_string()),
             ("wait_interval_ms".to_string(), "45000".to_string()),
+            ("upload_timeout_ms".to_string(), "180000".to_string()),
             ("extended".to_string(), "false".to_string()),
         ]);
 
@@ -4106,6 +4192,7 @@ mod tests {
         assert_eq!(spec.run_id, "run-123");
         assert_eq!(spec.wait_timeout_ms, 2_400_000);
         assert_eq!(spec.wait_interval_ms, 45_000);
+        assert_eq!(spec.upload_timeout_ms, 180_000);
         assert!(spec.disable_extended);
     }
 
@@ -4116,6 +4203,7 @@ mod tests {
             backend: "dev-browser".to_string(),
             response: "ok".to_string(),
             model_used: Some("gpt-5-4-pro".to_string()),
+            model_selection_status: crate::chatgpt_recipe::ChatgptModelSelectionStatus::Selected,
             warnings: vec!["clipboard fallback".to_string()],
             fallback_used: true,
             delivery_mode: crate::chatgpt_recipe::ChatgptDeliveryMode::Paste,
@@ -4125,6 +4213,7 @@ mod tests {
         let event = output.to_recipe_complete_event();
         assert_eq!(event["type"], "recipe_complete");
         assert_eq!(event["transport"], "dev-browser");
+        assert_eq!(event["model_selection_status"], "selected");
         assert_eq!(event["delivery_mode"], "paste");
         assert_eq!(event["auto_paste_fallback"], true);
         assert_eq!(event["warnings"], json!(["clipboard fallback"]));
@@ -4148,6 +4237,7 @@ mod tests {
             None,
             OutputFormat::Text,
             /* is_chatgpt */ true,
+            /* fallback_used */ false,
         )
         .unwrap_err();
         let msg = err.to_string();
@@ -4173,6 +4263,7 @@ mod tests {
             None,
             OutputFormat::Text,
             /* is_chatgpt */ true,
+            /* fallback_used */ false,
         )
         .unwrap_err();
         let msg = err.to_string();
@@ -4187,6 +4278,23 @@ mod tests {
         let detail = recipe_transport_error_detail(&err);
         assert!(detail.contains("dev-browser could not connect to Chrome"));
         assert!(detail.contains("browserType.connectOverCDP: Timeout 30000ms exceeded"));
+    }
+
+    #[test]
+    fn recipe_transport_error_detail_for_terminal_phase_includes_manual_recovery_run_id() {
+        let err = chatgpt_recipe::mark_terminal_fallback_phase(
+            anyhow::anyhow!("send click did not trigger a UI transition"),
+            chatgpt_recipe::ChatgptTransportPhase::Send,
+        );
+        let vars = BTreeMap::from([("run_id".to_string(), "run-123".to_string())]);
+
+        let detail = recipe_transport_error_detail_for_recipe(&err, &vars);
+
+        assert!(detail.contains("Manual recovery"));
+        assert!(detail.contains("run `run-123`"));
+        assert!(detail.contains("https://chatgpt.com/?_yoetz=run-123"));
+        assert!(detail.contains("window.name `yoetz:run-123`"));
+        assert!(detail.contains("duplicate submission"));
     }
 
     #[test]

--- a/crates/yoetz-cli/tests/daemon_policy.rs
+++ b/crates/yoetz-cli/tests/daemon_policy.rs
@@ -60,7 +60,7 @@ fn browser_keeps_destructive_helpers_in_whitelisted_locations() {
     );
     assert!(
         browser_rs.contains(
-            "pub fn close_browser_for_connection(connection: &BrowserConnection) -> Result<()> {\n    if connection.is_live_attach() {\n        return close_live_attach_session();\n    }\n    close_browser_daemon()\n}"
+            "pub fn close_browser_for_connection(connection: &BrowserConnection) -> Result<()> {\n    match connection {\n        BrowserConnection::AutoConnect => return close_live_attach_session(),\n        BrowserConnection::Cdp { run_id, .. } => {\n            let session_name = run_id\n                .as_deref()\n                .map(live_cdp_session_name_for_run)\n                .unwrap_or_else(|| CDP_SESSION_NAME.to_string());\n            return close_live_attach_session_name(&session_name);\n        }\n        BrowserConnection::CookieState { .. } | BrowserConnection::Profile { .. } => {}\n    }\n    close_browser_daemon()\n}"
         ),
         "live-attach close path must stay non-destructive"
     );

--- a/crates/yoetz-core/src/session.rs
+++ b/crates/yoetz-core/src/session.rs
@@ -12,14 +12,13 @@ static TS_FORMAT: &[FormatItem<'static>] =
 
 /// Create a new timestamped session directory under `~/.yoetz/sessions/`.
 pub fn create_session_dir() -> Result<SessionInfo> {
-    let base = session_base_dir();
+    let root = yoetz_root_dir();
+    fs::create_dir_all(&root).with_context(|| format!("create yoetz dir {}", root.display()))?;
+    chmod_owner_only_dir(&root)?;
+
+    let base = root.join("sessions");
     fs::create_dir_all(&base).with_context(|| format!("create sessions dir {}", base.display()))?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&base, fs::Permissions::from_mode(0o700))
-            .with_context(|| format!("chmod 700 {}", base.display()))?;
-    }
+    chmod_owner_only_dir(&base)?;
 
     let ts = OffsetDateTime::now_utc()
         .format(TS_FORMAT)
@@ -32,24 +31,36 @@ pub fn create_session_dir() -> Result<SessionInfo> {
     let id = format!("{ts}_{rand}");
     let path = base.join(&id);
     fs::create_dir_all(&path).with_context(|| format!("create session {}", path.display()))?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&path, fs::Permissions::from_mode(0o700))
-            .with_context(|| format!("chmod 700 {}", path.display()))?;
-    }
+    chmod_owner_only_dir(&path)?;
 
     Ok(SessionInfo { id, path })
 }
 
 pub fn session_base_dir() -> PathBuf {
+    yoetz_root_dir().join("sessions")
+}
+
+fn yoetz_root_dir() -> PathBuf {
     if let Ok(dir) = env::var("YOETZ_DIR") {
-        return PathBuf::from(dir).join("sessions");
+        return PathBuf::from(dir);
     }
     if let Some(home) = home_dir() {
-        return home.join(".yoetz/sessions");
+        return home.join(".yoetz");
     }
-    PathBuf::from(".yoetz/sessions")
+    PathBuf::from(".yoetz")
+}
+
+#[cfg(unix)]
+fn chmod_owner_only_dir(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+        .with_context(|| format!("chmod 700 {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn chmod_owner_only_dir(_path: &Path) -> Result<()> {
+    Ok(())
 }
 
 pub fn write_json<T: serde::Serialize>(path: &Path, value: &T) -> Result<()> {

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -20,6 +20,7 @@ name: chatgpt
 # Variables:
 #   model    — model slug (e.g., "gpt-5-4-pro"). Default: "auto" selects the
 #              best available model, preferring GPT-5/Pro when the account has it.
+#              Set to "" or "current" to keep the current ChatGPT selector state.
 #   extended — set to "false" to disable Extended Pro. Default: leave as-is.
 #   prompt   — prompt text to send with the attachment.
 #   browser_context_id — exact Chrome `browserContextId` to target when multiple
@@ -33,6 +34,8 @@ name: chatgpt
 #              yoetz runs work automatically because each run owns its own tab.
 #   wait_timeout_ms  — overall response wait deadline in ms (default: 1800000 = 30min).
 #   wait_interval_ms — poll interval in ms (default: 30000 = 30s).
+#   upload_timeout_ms  — attachment upload deadline in ms (default: 120000 = 2min).
+#   upload_interval_ms — attachment upload poll interval in ms (default: 2000 = 2s).
 
 transports:
   - chrome-devtools-mcp
@@ -45,6 +48,8 @@ defaults:
   model: "auto"
   extended: ""
   thread: "fresh"
+  upload_timeout_ms: "120000"
+  upload_interval_ms: "2000"
   wait_timeout_ms: "1800000"
   wait_interval_ms: "30000"
 
@@ -103,14 +108,13 @@ steps:
   - action: chatgpt_open_attachment_ui
   - sleep_ms: 500
 
-  # Upload the bundle file.
-  - action: upload
-    args: ["#upload-files", "{{bundle_path}}"]
+  # Upload the bundle file through the composer-scoped file input.
+  - action: chatgpt_upload_bundle
 
   # Poll until the upload spinner disappears. Short-burst Rust-side polling
   # keeps each eval under the agent-browser IPC ceiling (25s).
   - action: chatgpt_wait_upload
-    args: ["--attempts", "30", "--interval-ms", "1000"]
+    args: ["--interval-ms", "{{upload_interval_ms}}", "--timeout-ms", "{{upload_timeout_ms}}"]
 
   # Click back into the composer so the next step uses real keyboard input
   # against ProseMirror after the attachment flow completes.


### PR DESCRIPTION
## Summary

This ships the ChatGPT Pro hardening pass after three review cycles covering the original ChatGPT Pro findings, simplify follow-ups, and five-axis QA review.

- Harden the live-CDP daemon against same-machine arbitrary JS execution with private runtime dirs, same-user peer credential checks, capability-token RPCs, redacted token debug output, validated token reads, and bounded output truncation markers.
- Replace the macOS clipboard attachment path with composer-scoped file-input upload and stable attachment readiness checks across `chrome-devtools-mcp`, `dev-browser`, and generic browser recipe paths.
- Add run-scoped ChatGPT tabs, terminal phase markers for upload/send/wait side effects, run-id validation/URL encoding, model-selection status reporting, and manual recovery context.
- Fix the five-axis priority regressions: filename words like `failed` no longer trip attachment failure detection, and MCP eager upload no longer uploads then verifies with a 0ms deadline.

## Review Coverage

Resolved across the review stack:

- F1 daemon socket hardening and F2-F12 ChatGPT Pro findings.
- 22 simplify follow-up items.
- 18 five-axis findings.

Regression coverage includes:

- Attachment failure matching ignores failure words inside the expected filename.
- Eager file-input upload uses 0ms input discovery but keeps post-upload verify slack.
- Existing owner-matched live-CDP runtime dirs auto-tighten from `0755` to `0700`.
- Daemon hardening patch anchors are asserted against the embedded daemon bundle.
- Daemon token debug output is redacted.
- Upload poll arg errors are labeled as `chatgpt_wait_upload`.

## Verification

Local gates passed:

- `./scripts/build-live-cdp-daemon.sh --check`
- `cargo fmt --check`
- `cargo clippy -p yoetz --all-targets`
- `cargo test -p yoetz`

Test deltas: unit suite is now 444 passed / 2 ignored, plus 29 CLI tests and 3 daemon policy tests passing.

## Notes

Live smoke is still gated on the Chrome 147 remote-debugging consent click. That is an environment gate, not an outstanding code finding.

`CHANGELOG.md` stays under `[Unreleased]`.
