### PR TITLE
fix(chatgpt): harden post-smoke follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   menu state instead of accepting selector-label text alone, scoped response
   polling indicators to the active assistant turn, and scales upload timeouts
   with bundle size for large attachments.
+- Fixed the live ChatGPT browser canary on macOS bash 3.2 and made explicit
+  ChatGPT model selection wait briefly for the selector button on fresh tabs.
 
 ### Security
 

--- a/crates/yoetz-cli/src/chatgpt_web.rs
+++ b/crates/yoetz-cli/src/chatgpt_web.rs
@@ -512,7 +512,21 @@ async () => {{
       )
       .map(({{ item }}) => item)[0] || null;
   const findSelectorButton = () => document.querySelector(MODEL_BUTTON_SELECTOR);
-  const selectorButton = findSelectorButton();
+  const requestedTrimmed = normalize(requested);
+  const requestedLower = requestedTrimmed.toLowerCase();
+  const keepCurrentMode = !requestedTrimmed || requestedLower === "current" || requestedLower === "keep-current";
+  const autoMode = requestedLower === "auto";
+  const requestedGenericTier = deriveRequestedTier(requestedLower);
+  const waitForSelectorButton = async () => {{
+    let button = findSelectorButton();
+    if (button || keepCurrentMode) return button;
+    for (let attempt = 0; attempt < 5 && !button; attempt += 1) {{
+      await wait(1000);
+      button = findSelectorButton();
+    }}
+    return button;
+  }};
+  const selectorButton = await waitForSelectorButton();
   const currentLabel = normalize(
     selectorButton?.querySelector?.("[data-testid='selected-model'], [data-testid='model-switcher-selected-model']")?.textContent ||
     selectorButton?.innerText ||
@@ -527,11 +541,6 @@ async () => {{
     title: document.title || "",
     bodyText: normalize(document.body?.innerText || "").slice(0, 240),
   }};
-  const requestedTrimmed = normalize(requested);
-  const requestedLower = requestedTrimmed.toLowerCase();
-  const keepCurrentMode = !requestedTrimmed || requestedLower === "current" || requestedLower === "keep-current";
-  const autoMode = requestedLower === "auto";
-  const requestedGenericTier = deriveRequestedTier(requestedLower);
 
   if (keepCurrentMode) {{
     return {{
@@ -1530,6 +1539,19 @@ mod tests {
             script.contains("let verifyConfirmed = false;"),
             "verify confirmation flag missing"
         );
+    }
+
+    #[test]
+    fn model_selection_function_waits_for_selector_button_before_failing() {
+        // Fresh ChatGPT tabs can render the shell before the model selector
+        // exists in the React tree. Explicit model selection should wait
+        // briefly for that button instead of failing on the first probe.
+        let script = build_model_selection_function("pro");
+        assert!(script.contains("const waitForSelectorButton = async () =>"));
+        assert!(script.contains("attempt < 5 && !button"));
+        assert!(script.contains("await wait(1000);"));
+        assert!(script.contains("if (button || keepCurrentMode) return button;"));
+        assert!(script.contains("const selectorButton = await waitForSelectorButton();"));
     }
 
     #[test]

--- a/scripts/chatgpt-browser-canary.sh
+++ b/scripts/chatgpt-browser-canary.sh
@@ -44,8 +44,8 @@ echo "==> running live ChatGPT browser canary via ${yoetz_bin}"
 result="$("${yoetz_bin}" browser recipe \
   --recipe chatgpt \
   --bundle "${bundle_path}" \
-  "${cdp_args[@]}" \
-  "${profile_args[@]}" \
+  ${cdp_args[@]+"${cdp_args[@]}"} \
+  ${profile_args[@]+"${profile_args[@]}"} \
   --var model=pro \
   --var wait_timeout_ms="${YOETZ_CHATGPT_WAIT_TIMEOUT_MS:-2400000}" \
   --format json)"


### PR DESCRIPTION
## Summary
- Fix `scripts/chatgpt-browser-canary.sh` optional args under macOS bash 3.2 with `set -u`
- Wait up to 5s for the ChatGPT model selector button before explicit model selection fails on fresh tabs
- Add a regression guard and changelog note

## Tests
- `/bin/bash -n scripts/chatgpt-browser-canary.sh`
- `/bin/bash -uc ...` empty/non-empty optional array expansion check
- `cargo test -p yoetz chatgpt_web::tests::model_selection_function_waits_for_selector_button_before_failing`
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p yoetz`
- `cargo clippy -p yoetz --all-targets`