### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-07
 ### Changed
 
 - Hardened the ChatGPT Pro browser recipe across live transports: each run now
@@ -38,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Prefer `XDG_RUNTIME_DIR` for the live-CDP daemon on Unix and automatically
   tighten existing owner-matched `~/.yoetz` directories to `0700` during
   upgrade so the hardened socket and token checks do not reject normal users.
+
 
 ## [0.3.0] - 2026-05-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3190,7 +3190,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoetz"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3222,7 +3222,7 @@ dependencies = [
 
 [[package]]
 name = "yoetz-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/yoetz-core", "crates/yoetz-cli"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yoetz
-version: 0.3.0
+version: 0.4.0
 description: >
   Fast CLI-first LLM council, bundler, and multimodal gateway. Use ONLY when user
   explicitly mentions "yoetz", "yoetz ask", "yoetz council", "yoetz review",


### PR DESCRIPTION
## Release

- updates `CHANGELOG.md` for `v0.4.0`
- bumps workspace version to `0.4.0`
- aligns skill/plugin metadata to `0.4.0`
- merge triggers .github/workflows/release.yml, which creates the tag and
  publishes the release
- GitHub release notes come from the committed `CHANGELOG.md` entry