### PR TITLE
Add browser extension setup helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,14 @@ jobs:
     timeout-minutes: 5
     outputs:
       light_only: ${{ steps.detect.outputs.light_only }}
+      browser_changed: ${{ steps.detect.outputs.browser_changed }}
+      build_os_matrix: ${{ steps.detect.outputs.build_os_matrix }}
     env:
+      PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
       PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       PR_TITLE: ${{ github.event.pull_request.title }}
+      PUSH_BEFORE_SHA: ${{ github.event.before }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -56,25 +61,48 @@ jobs:
         run: |
           set -euo pipefail
 
+          full_build_matrix='["ubuntu-latest","macos-latest","windows-latest"]'
+          linux_build_matrix='["ubuntu-latest"]'
+          build_os_matrix="$linux_build_matrix"
+
+          emit_outputs() {
+            {
+              echo "light_only=$1"
+              echo "browser_changed=$2"
+              echo "build_os_matrix=$3"
+            } >> "$GITHUB_OUTPUT"
+          }
+
           case "${GITHUB_EVENT_NAME}" in
             pull_request)
-              base="${{ github.event.pull_request.base.sha }}"
-              head="${{ github.event.pull_request.head.sha }}"
+              base="$PR_BASE_SHA"
+              head="$PR_HEAD_SHA"
+              if [[ "${PR_HEAD_REF:-}" == release/* ]]; then
+                build_os_matrix="$full_build_matrix"
+              fi
               ;;
-            push|*)
-              echo "light_only=false" >> "$GITHUB_OUTPUT"
+            push)
+              base="$PUSH_BEFORE_SHA"
+              head="$GITHUB_SHA"
+              ;;
+            workflow_dispatch)
+              emit_outputs false true "$full_build_matrix"
+              exit 0
+              ;;
+            *)
+              emit_outputs false true "$linux_build_matrix"
               exit 0
               ;;
           esac
 
           if [[ -z "${base:-}" || "$base" == "0000000000000000000000000000000000000000" ]]; then
-            echo "light_only=false" >> "$GITHUB_OUTPUT"
+            emit_outputs false true "$build_os_matrix"
             exit 0
           fi
 
           mapfile -t files < <(git diff --name-only "$base" "$head")
           if ((${#files[@]} == 0)); then
-            echo "light_only=false" >> "$GITHUB_OUTPUT"
+            emit_outputs false true "$build_os_matrix"
             exit 0
           fi
 
@@ -91,9 +119,14 @@ jobs:
           # GitHub "required status checks" list satisfied without needing
           # admin-bypass, but they short-circuit after checkout to keep the
           # whole PR under a minute. See clippy / test jobs below.
+          #
+          # Ordinary PRs and main pushes intentionally use the Ubuntu build
+          # only. Cross-platform release builds remain covered before release
+          # by release/* PRs, and on demand by workflow_dispatch.
           # Bash case-pattern `*` matches any characters including `/`, so
           # `docs/*` covers any depth under `docs/`.
           light_only=true
+          browser_changed=false
           for file in "${files[@]}"; do
             matched=false
             case "$file" in
@@ -108,13 +141,27 @@ jobs:
               .gitignore|.gitleaks.toml) matched=true ;;
               LICENSE*) matched=true ;;
             esac
+
+            case "$file" in
+              extensions/*) browser_changed=true ;;
+              recipes/*) browser_changed=true ;;
+              scripts/build-chatgpt-native-extension.sh) browser_changed=true ;;
+              scripts/build-live-cdp-daemon.sh) browser_changed=true ;;
+              scripts/ci-real-browser-smoke.sh) browser_changed=true ;;
+              crates/yoetz-cli/src/*browser*) browser_changed=true ;;
+              crates/yoetz-cli/src/*chatgpt*) browser_changed=true ;;
+              crates/yoetz-cli/src/live_*) browser_changed=true ;;
+              crates/yoetz-cli/src/chrome_*) browser_changed=true ;;
+              crates/yoetz-cli/tests/*browser*) browser_changed=true ;;
+              crates/yoetz-cli/tests/*chatgpt*) browser_changed=true ;;
+            esac
+
             if [[ "$matched" != "true" ]]; then
               light_only=false
-              break
             fi
           done
 
-          echo "light_only=$light_only" >> "$GITHUB_OUTPUT"
+          emit_outputs "$light_only" "$browser_changed" "$build_os_matrix"
 
   browser-scripts:
     name: Browser Scripts
@@ -275,7 +322,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: ${{ fromJSON(needs.changes.outputs.build_os_matrix) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -300,7 +347,7 @@ jobs:
   browser-integration:
     name: Real-Browser Smoke (Chrome for Testing)
     needs: changes
-    if: needs.changes.outputs.light_only != 'true'
+    if: needs.changes.outputs.light_only != 'true' && (github.event_name != 'pull_request' || needs.changes.outputs.browser_changed == 'true' || startsWith(github.head_ref, 'release/'))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ Yoetz browser integrations are extension-free by default.
   ChatGPT Pro recipe robustness. It is opt-in only via
   `yoetz browser recipe --recipe chatgpt --transport chrome-extension-native`
   and is managed with `yoetz browser extension install-host --chatgpt`,
-  `doctor --chatgpt`, `status --chatgpt`, `reconnect --chatgpt`,
+  `setup --chatgpt --open-chrome`, `doctor --chatgpt`, `status --chatgpt`, `reconnect --chatgpt`,
   `canary --chatgpt`, `inspect --chatgpt --run-id <id>`, and
   `grant-identity --chatgpt`. Use
   `yoetz browser check --transport chrome-extension-native` for extension

--- a/README.md
+++ b/README.md
@@ -318,10 +318,13 @@ extension marker prefix) so an agent can decide whether to reuse the tab or
 abort. Pass `--allow-cdp-fallback` only if you understand that explicitly
 permits a second submission via CDP.
 
-The `--var extended=false` toggle is best-effort. Yoetz scopes the chip
-match to the ChatGPT composer with negative-control guards, but ChatGPT
-re-skins the Extended thinking control occasionally; on a miss the run
-continues with whatever Extended state the tab was in and emits a warning.
+The default ChatGPT target is Pro with Extended enabled. `model=auto` prefers
+the Pro/Extended personal UI control when it exists, and the enterprise model
+switcher remains supported. The `--var extended=false` toggle is best-effort
+and only runs when explicitly requested. Yoetz scopes the chip match to the
+ChatGPT composer with negative-control guards, but ChatGPT re-skins the
+Extended thinking control occasionally; on a miss the run continues with
+whatever Extended state the tab was in and emits a warning.
 
 If the next ChatGPT run after an unexplained failure should inspect the
 Yoetz-owned tab without resubmitting, use

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ macOS/Linux-only; Windows CLI artifacts still ship, but Windows native-host
 registration is not implemented yet.
 
 ```bash
+yoetz browser extension setup --chatgpt --open-chrome
 yoetz browser extension install-host --chatgpt
 yoetz browser extension doctor --chatgpt
 yoetz browser extension status --chatgpt
@@ -264,6 +265,15 @@ button, or run `yoetz browser extension reload --chatgpt` when the currently
 loaded extension already supports the reload command; then run
 `yoetz browser extension reconnect --chatgpt` and
 `yoetz browser extension doctor --chatgpt`.
+
+For agent-driven setup, `yoetz browser extension setup --chatgpt --open-chrome`
+does everything Chrome allows from the CLI: it installs or updates the native
+host, finds the unpacked extension directory when available, opens
+`chrome://extensions`, and prints the exact folder to select. Chrome still
+requires the explicit **Load unpacked** UI step for local unpacked extensions.
+If the extension directory is not discoverable from the current checkout or
+installation, set `YOETZ_CHATGPT_NATIVE_EXTENSION_DIR` to the extracted
+extension directory and rerun `setup`.
 
 For normal Google Chrome profiles, `install-host` writes the Native Messaging
 host manifest to Chrome's default user path. If Chrome is launched with a custom

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -30,6 +30,8 @@ pub const TOKEN_FILENAME: &str = "chatgpt-native.token";
 pub const STATUS_FILENAME: &str = "chatgpt-native-status.json";
 pub const WRAPPER_FILENAME: &str = "yoetz-chrome-native-host";
 pub const INSTANCES_DIRNAME: &str = "instances";
+pub const CHROME_EXTENSIONS_URL: &str = "chrome://extensions/";
+pub const CHATGPT_EXTENSION_DIR_ENV: &str = "YOETZ_CHATGPT_NATIVE_EXTENSION_DIR";
 pub const MAX_CHROME_NATIVE_EXTENSION_MESSAGE_BYTES: usize = 64 * 1024 * 1024;
 pub const MAX_CHROME_NATIVE_HOST_MESSAGE_BYTES: usize = 1024 * 1024;
 pub const MAX_FRAME_BYTES: usize = MAX_CHROME_NATIVE_EXTENSION_MESSAGE_BYTES;
@@ -211,6 +213,60 @@ pub fn install_host() -> Result<InstallHostResult> {
     {
         bail!("chrome-extension-native install-host is currently supported on macOS/Linux only")
     }
+}
+
+pub fn chatgpt_extension_source_dir() -> Option<PathBuf> {
+    chatgpt_extension_source_dir_candidates()
+        .into_iter()
+        .find_map(|candidate| {
+            if !is_chatgpt_extension_source_dir(&candidate) {
+                return None;
+            }
+            Some(candidate.canonicalize().unwrap_or(candidate))
+        })
+}
+
+pub fn chatgpt_extension_source_dir_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Ok(path) = env::var(CHATGPT_EXTENSION_DIR_ENV) {
+        let path = path.trim();
+        if !path.is_empty() {
+            candidates.push(PathBuf::from(path));
+        }
+    }
+    if let Ok(cwd) = env::current_dir() {
+        candidates.push(cwd.join("extensions").join("chatgpt-native"));
+    }
+
+    let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    candidates.push(
+        crate_dir
+            .join("..")
+            .join("..")
+            .join("extensions")
+            .join("chatgpt-native"),
+    );
+
+    if let Ok(exe) = env::current_exe() {
+        if let Some(prefix) = exe.parent().and_then(Path::parent) {
+            candidates.push(
+                prefix
+                    .join("share")
+                    .join("yoetz")
+                    .join("extensions")
+                    .join("chatgpt-native"),
+            );
+            candidates.push(prefix.join("share").join("yoetz").join("chatgpt-native"));
+        }
+    }
+
+    candidates
+}
+
+fn is_chatgpt_extension_source_dir(path: &Path) -> bool {
+    path.join("manifest.json").is_file()
+        && path.join("src").join("service-worker.js").is_file()
+        && path.join("src").join("content-script.js").is_file()
 }
 
 pub fn status() -> Result<ExtensionStatus> {

--- a/crates/yoetz-cli/src/chatgpt_web.rs
+++ b/crates/yoetz-cli/src/chatgpt_web.rs
@@ -170,6 +170,7 @@ pub fn build_set_window_name_js(run_id: &str) -> String {
 
 pub fn model_testid_alias_map() -> BTreeMap<&'static str, &'static str> {
     BTreeMap::from([
+        ("extended-pro", "extended-pro"),
         ("pro", "gpt-5-4-pro"),
         ("gpt-5-pro", "gpt-5-4-pro"),
         ("thinking", "gpt-5-4-thinking"),
@@ -180,6 +181,7 @@ pub fn model_testid_alias_map() -> BTreeMap<&'static str, &'static str> {
 
 pub fn model_testid_candidate_map() -> BTreeMap<&'static str, Vec<&'static str>> {
     BTreeMap::from([
+        ("extended-pro", vec!["extended-pro"]),
         ("pro", vec!["gpt-5-4-pro"]),
         ("gpt-5-pro", vec!["gpt-5-4-pro"]),
         ("gpt-5-4-pro", vec!["gpt-5-4-pro"]),
@@ -335,6 +337,7 @@ pub fn build_model_selection_function(requested_model: &str) -> String {
     let requested_model =
         serde_json::to_string(requested_model).expect("serialize requested model");
     let model_button_selector = model_selector_button_selector_json();
+    let composer_selector = composer_selector_json();
     let model_item_selector = model_item_selector_json();
     let model_testid_aliases = model_testid_aliases_json();
     let model_testid_candidates = model_testid_candidates_json();
@@ -343,6 +346,7 @@ pub fn build_model_selection_function(requested_model: &str) -> String {
 async () => {{
   const requested = {requested_model};
   const MODEL_BUTTON_SELECTOR = {model_button_selector};
+  const COMPOSER_SELECTOR = {composer_selector};
   const MODEL_ITEM_SELECTOR = {model_item_selector};
   const MODEL_TESTID_ALIASES = {model_testid_aliases};
   const MODEL_TESTID_CANDIDATES = {model_testid_candidates};
@@ -359,6 +363,73 @@ async () => {{
       hasSelectedCurrentMarker(item.ariaSelected || "", item.ariaCurrent || "", item.dataSelected || "", item.dataCurrent || "")
     );
 {visibility_helpers}
+  const composerScopes = () => {{
+    const composer = document.querySelector(COMPOSER_SELECTOR);
+    const scopes = [];
+    const add = (scope) => {{
+      if (scope && !scopes.includes(scope)) scopes.push(scope);
+    }};
+    add(composer?.closest("form"));
+    add(composer?.closest("[data-testid*='composer'], [class*='composer'], main, [role='main']"));
+    add(composer?.parentElement);
+    return scopes;
+  }};
+  const modelCandidateText = (node, target = node) => normalize([
+    node?.getAttribute?.("aria-label"),
+    node?.getAttribute?.("title"),
+    node?.getAttribute?.("data-testid"),
+    node?.getAttribute?.("class"),
+    node?.innerText,
+    node?.textContent,
+    target?.getAttribute?.("aria-label"),
+    target?.getAttribute?.("title"),
+    target?.getAttribute?.("data-testid"),
+    target?.getAttribute?.("class"),
+    target?.innerText,
+    target?.textContent,
+  ].filter(Boolean).join(" ")).toLowerCase();
+  const isModelActionableElement = (node) => {{
+    const tag = String(node?.tagName || "").toLowerCase();
+    const role = normalize(node?.getAttribute?.("role") || "").toLowerCase();
+    return tag === "button" ||
+      role === "button" ||
+      node?.getAttribute?.("aria-haspopup") !== null ||
+      node?.getAttribute?.("tabindex") !== null;
+  }};
+  const isModelChipLike = (node) => {{
+    const marker = normalize([
+      node?.getAttribute?.("data-testid"),
+      node?.getAttribute?.("class"),
+      node?.getAttribute?.("aria-label"),
+      node?.getAttribute?.("title"),
+    ].filter(Boolean).join(" ")).toLowerCase();
+    return /\b(model|model-switcher)\b/.test(marker) && /\b(chip|pill|token|button|menu|dropdown|switcher)\b/.test(marker);
+  }};
+  const modelClickTarget = (node, stopAt) => {{
+    for (let current = node; current; current = current.parentElement) {{
+      if (isModelActionableElement(current) || isModelChipLike(current)) return current;
+      if (current === stopAt) return null;
+    }}
+    return null;
+  }};
+  const looksLikeModelControl = (text) =>
+    /\bextended\s+pro\b/.test(text) ||
+    /\bgpt[\s.-]*\d/.test(text) ||
+    /\b(pro|instant|thinking|model)\b/.test(text);
+  const findComposerModelControl = () => {{
+    for (const scope of composerScopes()) {{
+      const candidates = Array.from(scope.querySelectorAll("button, [role='button'], [aria-haspopup], [tabindex], [aria-label], [title], [data-testid], span, div"));
+      for (const node of candidates) {{
+        const target = modelClickTarget(node, scope);
+        if (!target || !isVisible(target)) continue;
+        const haystack = modelCandidateText(node, target);
+        if (!looksLikeModelControl(haystack)) continue;
+        if (/\b(send|stop|copy|share|new chat|attach|upload|search|history|dictation|voice|microphone|account|profile|settings|upgrade)\b/.test(haystack)) continue;
+        return target;
+      }}
+    }}
+    return null;
+  }};
     const slugify = (value) => normalize(value).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
   const isLowSignalSelectorLabel = (value) => {{
     const key = slugify(value);
@@ -482,6 +553,35 @@ async () => {{
     if (!(slug === "pro" || slug === "thinking" || slug === "instant")) return null;
     return entries.find((item) => hasExactTierLabel(item, slug) && !hasConflictingTierHint(item, slug)) || null;
   }};
+  const modelSlug = (value) => {{
+    let key = slugify(value);
+    if (key.startsWith("model-switcher-")) key = key.slice("model-switcher-".length);
+    if (!key || isLowSignalSelectorLabel(key)) return "";
+    if (key === "extended-pro") return "extended-pro";
+    return (MODEL_TESTID_CANDIDATES[key] || [MODEL_TESTID_ALIASES[key] || key])[0] || "";
+  }};
+  const currentLabelSatisfiesRequest = (label) => {{
+    const labelText = normalize(label).toLowerCase();
+    const labelSlug = modelSlug(labelText);
+    if (!labelSlug) return false;
+    const isProLabel = /\bextended\s+pro\b/.test(labelText) ||
+      /\bgpt[\s.-]*\d+(?:[\s.-]*\d+)*[\s.-]*pro\b/.test(labelText) ||
+      /\bpro\b/.test(labelText);
+    if (autoMode) return isProLabel;
+    if (requestedGenericTier === "pro") return isProLabel;
+    if (requestedGenericTier === "thinking") return /\bthinking\b/.test(labelText);
+    if (requestedGenericTier === "instant") return /\binstant\b/.test(labelText);
+    const requestedKeys = Array.from(new Set(
+      (MODEL_TESTID_CANDIDATES[requestedLower] || [MODEL_TESTID_ALIASES[requestedLower] || requestedLower])
+        .map((value) => modelSlug(value))
+        .filter(Boolean)
+    ));
+    return requestedKeys.includes(labelSlug);
+  }};
+  const selectorLabelConfirmsTextTarget = (label, item, tierSlug, needles) => {{
+    if (!item || item.testId) return false;
+    return selectorLabelMatchesTarget(label, item, tierSlug, null, needles || []);
+  }};
   const buildTierRankings = (entries) => {{
     const tierMaxVersions = {{
       pro: maxVersionPartsForTier(entries, "pro"),
@@ -511,7 +611,7 @@ async () => {{
         right.item.text.length - left.item.text.length
       )
       .map(({{ item }}) => item)[0] || null;
-  const findSelectorButton = () => document.querySelector(MODEL_BUTTON_SELECTOR);
+  const findSelectorButton = () => document.querySelector(MODEL_BUTTON_SELECTOR) || findComposerModelControl();
   const requestedTrimmed = normalize(requested);
   const requestedLower = requestedTrimmed.toLowerCase();
   const keepCurrentMode = !requestedTrimmed || requestedLower === "current" || requestedLower === "keep-current";
@@ -532,6 +632,7 @@ async () => {{
     selectorButton?.innerText ||
     selectorButton?.textContent ||
     selectorButton?.getAttribute?.("aria-label") ||
+    selectorButton?.getAttribute?.("title") ||
     ""
   );
   const responseBase = {{
@@ -548,6 +649,14 @@ async () => {{
       status: "already-selected",
       modelUsed: currentLabel || null,
       keepCurrent: true,
+    }};
+  }}
+
+  if (currentLabelSatisfiesRequest(currentLabel)) {{
+    return {{
+      ...responseBase,
+      status: "already-selected",
+      modelUsed: currentLabel,
     }};
   }}
 
@@ -640,6 +749,8 @@ async () => {{
       liveSelectorButton?.querySelector?.("[data-testid='selected-model'], [data-testid='model-switcher-selected-model']")?.textContent ||
       liveSelectorButton?.innerText ||
       liveSelectorButton?.textContent ||
+      liveSelectorButton?.getAttribute?.("aria-label") ||
+      liveSelectorButton?.getAttribute?.("title") ||
       ""
     ).toLowerCase();
   }};
@@ -806,7 +917,15 @@ async () => {{
         ) ||
         itemIsSelected(updatedTarget);
       selectedLabel = readSelectorLabel();
+      const textTargetLabelConfirmed = selectorLabelConfirmsTextTarget(
+        selectedLabel,
+        updatedTarget || currentTarget || target,
+        targetTierSlug,
+        selectionNeedles
+      );
       if (targetChecked) {{
+        verifyConfirmed = true;
+      }} else if (textTargetLabelConfirmed) {{
         verifyConfirmed = true;
       }}
     }}
@@ -879,6 +998,7 @@ async () => {{
 }}
 "##,
         model_button_selector = model_button_selector,
+        composer_selector = composer_selector,
         model_item_selector = model_item_selector,
         model_testid_aliases = model_testid_aliases,
         model_testid_candidates = model_testid_candidates,
@@ -1374,10 +1494,12 @@ mod tests {
     #[test]
     fn model_aliases_cover_shortcuts() {
         let aliases = model_testid_alias_map();
+        assert_eq!(aliases.get("extended-pro"), Some(&"extended-pro"));
         assert_eq!(aliases.get("pro"), Some(&"gpt-5-4-pro"));
         assert_eq!(aliases.get("gpt-5-thinking"), Some(&"gpt-5-4-thinking"));
         assert_eq!(aliases.get("instant"), Some(&"gpt-5-3"));
         let candidates = model_testid_candidate_map();
+        assert_eq!(candidates.get("extended-pro"), Some(&vec!["extended-pro"]));
         assert_eq!(candidates.get("pro"), Some(&vec!["gpt-5-4-pro"]));
         assert_eq!(candidates.get("gpt-5-3-pro"), None);
     }
@@ -1389,6 +1511,10 @@ mod tests {
         assert_eq!(
             canonical_chatgpt_model_slug("Pro"),
             Some("gpt-5-4-pro".to_string())
+        );
+        assert_eq!(
+            canonical_chatgpt_model_slug("Extended Pro"),
+            Some("extended-pro".to_string())
         );
         assert_eq!(
             canonical_chatgpt_model_slug("model-switcher-gpt-5-4-thinking"),
@@ -1555,6 +1681,22 @@ mod tests {
     }
 
     #[test]
+    fn model_selection_function_supports_personal_composer_model_control() {
+        // Personal ChatGPT can expose the selected model as a composer pop-up
+        // labeled `Extended Pro` instead of the enterprise
+        // model-switcher-dropdown-button. The shared script must support that
+        // surface without removing the battle-tested enterprise selector.
+        let script = build_model_selection_function("auto");
+        assert!(script.contains("const findComposerModelControl = () =>"));
+        assert!(script.contains(
+            "document.querySelector(MODEL_BUTTON_SELECTOR) || findComposerModelControl()"
+        ));
+        assert!(script.contains("const currentLabelSatisfiesRequest = (label) =>"));
+        assert!(script.contains(r#"if (key === "extended-pro") return "extended-pro";"#));
+        assert!(script.contains("return isProLabel;"));
+    }
+
+    #[test]
     fn model_selection_function_prefers_exact_tier_labels_before_fuzzy_matching() {
         // Live ChatGPT currently exposes generic tier labels like
         // `Pro Research-grade intelligence` while the selector button itself
@@ -1638,6 +1780,7 @@ mod tests {
 
         let explicit_script = build_model_selection_function("gpt-5-4-pro");
         assert!(explicit_script.contains(r#"const requested = "gpt-5-4-pro";"#));
+        assert!(explicit_script.contains("\"extended-pro\":\"extended-pro\""));
         assert!(explicit_script.contains("\"gpt-5-pro\":\"gpt-5-4-pro\""));
         assert!(!explicit_script.contains("\"gpt-5-3-pro\""));
     }

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -348,6 +348,8 @@ struct BrowserExtensionArgs {
 
 #[derive(Subcommand)]
 enum BrowserExtensionCommand {
+    /// Prepare the native-extension install and open Chrome's extension page.
+    Setup(BrowserExtensionSetupArgs),
     /// Install the ChatGPT native messaging host. Currently macOS/Linux only.
     InstallHost(BrowserExtensionScopeArgs),
     Status(BrowserExtensionScopeArgs),
@@ -365,6 +367,16 @@ enum BrowserExtensionCommand {
 struct BrowserExtensionScopeArgs {
     #[arg(long)]
     chatgpt: bool,
+}
+
+#[derive(Args)]
+struct BrowserExtensionSetupArgs {
+    #[arg(long)]
+    chatgpt: bool,
+
+    /// Open chrome://extensions after preparing the native host.
+    #[arg(long)]
+    open_chrome: bool,
 }
 
 #[derive(Args)]
@@ -2274,6 +2286,37 @@ fn handle_browser_extension(
 ) -> Result<()> {
     let mut text_output = None;
     let (kind, payload) = match args.command {
+        BrowserExtensionCommand::Setup(args) => {
+            ensure_chatgpt_extension_scope(args.chatgpt)?;
+            let install = browser_extension_native::install_host()?;
+            let extension_dir = browser_extension_native::chatgpt_extension_source_dir();
+            let opened_chrome = if args.open_chrome {
+                open_chrome_extensions_page()?;
+                true
+            } else {
+                false
+            };
+            let status = browser_extension_native::status()?;
+            let payload = json!({
+                "status": "prepared",
+                "native_host": install,
+                "extension_id": browser_extension_native::EXTENSION_ID,
+                "extension_dir": extension_dir,
+                "extension_dir_env": browser_extension_native::CHATGPT_EXTENSION_DIR_ENV,
+                "chrome_extensions_url": browser_extension_native::CHROME_EXTENSIONS_URL,
+                "opened_chrome": opened_chrome,
+                "extension_status": status,
+                "next_steps": [
+                    "open chrome://extensions",
+                    "enable Developer mode",
+                    "click Load unpacked",
+                    "select extension_dir",
+                    "run yoetz browser extension doctor --chatgpt"
+                ],
+            });
+            text_output = Some(format_extension_setup(&payload));
+            ("browser.extension.setup", payload)
+        }
         BrowserExtensionCommand::InstallHost(args) => {
             ensure_chatgpt_extension_scope(args.chatgpt)?;
             (
@@ -2367,6 +2410,88 @@ fn handle_browser_extension(
             Ok(())
         }
     }
+}
+
+fn open_chrome_extensions_page() -> Result<()> {
+    let url = browser_extension_native::CHROME_EXTENSIONS_URL;
+    #[cfg(target_os = "macos")]
+    let mut cmd = {
+        let mut cmd = Command::new("open");
+        cmd.args(["-a", "Google Chrome", url]);
+        cmd
+    };
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let mut cmd = {
+        let mut cmd = Command::new("xdg-open");
+        cmd.arg(url);
+        cmd
+    };
+    #[cfg(windows)]
+    let mut cmd = {
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", "start", "", url]);
+        cmd
+    };
+    let output = cmd
+        .output()
+        .with_context(|| format!("open {}", browser_extension_native::CHROME_EXTENSIONS_URL))?;
+    if !output.status.success() {
+        bail!(
+            "failed to open {}: {}",
+            browser_extension_native::CHROME_EXTENSIONS_URL,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+fn format_extension_setup(payload: &Value) -> String {
+    let extension_dir = payload
+        .get("extension_dir")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            format!(
+                "<not found; set {} to the unpacked extension directory>",
+                browser_extension_native::CHATGPT_EXTENSION_DIR_ENV
+            )
+        });
+    let opened = payload
+        .get("opened_chrome")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let native_manifest = payload
+        .get("native_host")
+        .and_then(|value| value.get("manifest_path"))
+        .and_then(Value::as_str)
+        .unwrap_or("<unknown>");
+    let status = payload
+        .get("extension_status")
+        .and_then(|value| value.get("status"))
+        .and_then(Value::as_str)
+        .unwrap_or("<unknown>");
+
+    let mut lines = vec![
+        "Yoetz ChatGPT native extension setup prepared.".to_string(),
+        format!("native_host_manifest: {native_manifest}"),
+        format!("extension_id: {}", browser_extension_native::EXTENSION_ID),
+        format!("extension_dir: {extension_dir}"),
+        format!("chrome_extensions_url: {}", browser_extension_native::CHROME_EXTENSIONS_URL),
+        format!("opened_chrome: {opened}"),
+        format!("current_bridge_status: {status}"),
+        "next: in Chrome, enable Developer mode, click Load unpacked, select extension_dir, then run `yoetz browser extension doctor --chatgpt`.".to_string(),
+    ];
+    if payload
+        .get("extension_dir")
+        .and_then(Value::as_str)
+        .is_none()
+    {
+        lines.push(
+            "release installs may need the extension zip extracted first; pass the extracted path via YOETZ_CHATGPT_NATIVE_EXTENSION_DIR."
+                .to_string(),
+        );
+    }
+    lines.join("\n")
 }
 
 fn format_extension_status(status: &browser_extension_native::ExtensionStatus) -> String {

--- a/crates/yoetz-cli/tests/cli.rs
+++ b/crates/yoetz-cli/tests/cli.rs
@@ -302,11 +302,22 @@ fn browser_extension_help_shows_chatgpt_lifecycle() {
         .args(["browser", "extension", "--help"])
         .assert()
         .success()
+        .stdout(predicate::str::contains("setup"))
         .stdout(predicate::str::contains("install-host"))
         .stdout(predicate::str::contains("doctor"))
         .stdout(predicate::str::contains("status"))
         .stdout(predicate::str::contains("reconnect"))
         .stdout(predicate::str::contains("canary"));
+}
+
+#[test]
+fn browser_extension_setup_help_shows_open_chrome() {
+    yoetz()
+        .args(["browser", "extension", "setup", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--open-chrome"))
+        .stdout(predicate::str::contains("--chatgpt"));
 }
 
 #[test]

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -84,7 +84,7 @@ export function findSendButton(root = document) {
 }
 
 export function findModelButton(root = document) {
-  return firstVisible(root, [
+  const enterpriseButton = firstVisible(root, [
     'button[data-testid="model-switcher-dropdown-button"]',
     'button:has([data-testid="selected-model"])',
     'button:has([data-testid="model-switcher-selected-model"])',
@@ -92,6 +92,7 @@ export function findModelButton(root = document) {
     'button[aria-controls*="model" i]',
     'button[id*="model" i]'
   ]);
+  return enterpriseButton ?? findComposerModelControl(root);
 }
 
 export function getPageText(root = document) {
@@ -338,7 +339,112 @@ function isExtendedChipLike(node) {
   return /\bextended\b/.test(marker) && /\b(chip|pill|token|toggle|badge|model)\b/.test(marker);
 }
 
+function findComposerModelControl(root) {
+  for (const scope of composerScopes(root, { includeRoot: false })) {
+    const candidates = uniqueElements(Array.from(scope.querySelectorAll([
+      "button",
+      '[role="button"]',
+      "[aria-haspopup]",
+      "[tabindex]",
+      "[aria-label]",
+      "[title]",
+      "[data-testid]",
+      "span",
+      "div"
+    ].join(","))));
+    for (const node of candidates) {
+      const target = modelClickTarget(node, scope);
+      if (!target || !isVisible(target, { allowDisabled: true })) {
+        continue;
+      }
+      const haystack = modelCandidateText(node, target);
+      if (!looksLikeModelControl(haystack)) {
+        continue;
+      }
+      if (/\b(send|stop|copy|share|new chat|attach|upload|search|history|dictation|voice|microphone|account|profile|settings|upgrade)\b/.test(haystack)) {
+        continue;
+      }
+      return target;
+    }
+  }
+  return null;
+}
+
+function modelClickTarget(node, stopAt) {
+  let current = node;
+  while (current) {
+    if (isModelActionableElement(current) || isModelChipLike(current)) {
+      return current;
+    }
+    if (current === stopAt) {
+      return null;
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+
+function modelCandidateText(node, target = node) {
+  return normalizeText([
+    node?.getAttribute?.("aria-label"),
+    node?.getAttribute?.("title"),
+    node?.getAttribute?.("data-testid"),
+    node?.getAttribute?.("class"),
+    node?.innerText,
+    node?.textContent,
+    target?.getAttribute?.("aria-label"),
+    target?.getAttribute?.("title"),
+    target?.getAttribute?.("data-testid"),
+    target?.getAttribute?.("class"),
+    target?.innerText,
+    target?.textContent
+  ].filter(Boolean).join(" ")).toLowerCase();
+}
+
+function modelControlLabel(node) {
+  return normalizeText([
+    textOf(node),
+    node?.getAttribute?.("aria-label"),
+    node?.getAttribute?.("title")
+  ].filter(Boolean).join(" "));
+}
+
+function looksLikeModelControl(text) {
+  return /\bextended\s+pro\b/.test(text)
+    || /\bgpt[\s.-]*\d/.test(text)
+    || /\b(pro|instant|thinking|model)\b/.test(text);
+}
+
+function isModelActionableElement(node) {
+  const tag = String(node?.tagName ?? "").toLowerCase();
+  const role = String(node?.getAttribute?.("role") ?? "").toLowerCase();
+  return tag === "button"
+    || role === "button"
+    || node?.getAttribute?.("aria-haspopup") !== null
+    || node?.getAttribute?.("tabindex") !== null;
+}
+
+function isModelChipLike(node) {
+  const marker = normalizeText([
+    node?.getAttribute?.("data-testid"),
+    node?.getAttribute?.("class"),
+    node?.getAttribute?.("aria-label"),
+    node?.getAttribute?.("title")
+  ].filter(Boolean).join(" ")).toLowerCase();
+  return /\b(model|model-switcher)\b/.test(marker) && /\b(chip|pill|token|button|menu|dropdown|switcher)\b/.test(marker);
+}
+
 export async function selectRequestedModel(root, requested) {
+  const currentBefore = currentModelLabel(root);
+  if (modelTextMatchesRequest(currentBefore, requested)) {
+    return {
+      status: "selected",
+      model_used: currentBefore,
+      available_options: [],
+      already_selected: true
+    };
+  }
+
   let modelButton = null;
   try {
     modelButton = await waitForElement(root, findModelButton, "ChatGPT model selector", {
@@ -1489,7 +1595,11 @@ function currentModelLabel(root) {
     '[aria-checked="true"]',
     '[aria-selected="true"]'
   ]);
-  return normalizeText(selected?.innerText ?? selected?.textContent ?? findModelButton(root)?.innerText ?? "");
+  const selectedText = normalizeText(selected?.innerText ?? selected?.textContent ?? "");
+  if (selectedText) {
+    return selectedText;
+  }
+  return modelControlLabel(findModelButton(root));
 }
 
 function normalizeRequestedModel(model) {
@@ -1502,14 +1612,15 @@ function normalizeRequestedModel(model) {
     return {
       raw,
       keepCurrent: false,
-      labels: ["GPT-5.4 Pro", "GPT-5 Pro", "Pro", "GPT-5.4 Thinking", "Thinking", "GPT-5.4", "GPT-5"],
-      slugs: ["gpt-5-4-pro", "gpt-5-pro", "pro", "thinking", "gpt-5-4", "gpt-5"]
+      labels: ["Extended Pro", "GPT-5.4 Pro", "GPT-5 Pro", "Pro", "GPT-5.4 Thinking", "Thinking", "GPT-5.4", "GPT-5"],
+      slugs: ["extended-pro", "gpt-5-4-pro", "gpt-5-pro", "pro", "thinking", "gpt-5-4", "gpt-5"]
     };
   }
   const labelsBySlug = {
-    "pro": ["GPT-5.4 Pro", "GPT-5 Pro", "Pro"],
-    "gpt-5-pro": ["GPT-5 Pro", "Pro"],
-    "gpt-5-4-pro": ["GPT-5.4 Pro", "GPT-5 Pro", "Pro"],
+    "extended-pro": ["Extended Pro"],
+    "pro": ["Extended Pro", "GPT-5.4 Pro", "GPT-5 Pro", "Pro"],
+    "gpt-5-pro": ["Extended Pro", "GPT-5 Pro", "Pro"],
+    "gpt-5-4-pro": ["Extended Pro", "GPT-5.4 Pro", "GPT-5 Pro", "Pro"],
     "thinking": ["GPT-5.4 Thinking", "Thinking"],
     "gpt-5": ["GPT-5"],
     "gpt-5-4": ["GPT-5.4", "GPT-5"]
@@ -1527,6 +1638,7 @@ function canonicalModelSlug(value) {
   if (!folded || folded === "current" || folded === "keep current") return "current";
   if (folded === "auto") return "auto";
   if (folded === "pro") return "pro";
+  if (/\bextended\b/.test(folded) && /\bpro\b/.test(folded)) return "extended-pro";
   if (folded.includes("thinking")) return "thinking";
   const match = folded.match(/^gpt[\s-]*(\d+)(?:[.\s-]*(\d+))?(?:[.\s-]*(\d+))?(?:[\s.-]*(pro))?$/);
   if (!match) return folded.replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -1291,7 +1291,7 @@ function finalAffordanceExtractionFailureMessage(job, extraction, stableForMs) {
   return `ChatGPT rendered a final assistant affordance but Yoetz could not extract scoped assistant text (method=${extraction?.method ?? "none"}, assistant_count=${extraction?.assistant_count ?? 0}, turn_index=${extraction?.turn_index ?? -1}, copy_button_count=${extraction?.copy_button_count ?? 0}, stable_for_ms=${stableForMs}). Inspect the owned tab with \`yoetz browser extension inspect --chatgpt --run-id ${job.run_id}\` before rerunning.`;
 }
 
-function meaningfulResponseText(text, options = {}) {
+function meaningfulResponseText(text) {
   const lines = String(text ?? "")
     .split(/\n+/)
     .map((line) => line.replace(/\s+/g, " ").trim())
@@ -1299,17 +1299,16 @@ function meaningfulResponseText(text, options = {}) {
   if (lines.length === 0) {
     return false;
   }
-  return lines.some((line) => !isResponseChromeLine(line, options));
+  return lines.some((line) => !isResponseChromeLine(line));
 }
 
-function isResponseChromeLine(line, options = {}) {
+function isResponseChromeLine(line) {
   return /^(copy|copied|read aloud|share|regenerate|retry|edit|like|dislike)$/i.test(line)
     || /^(thought|reasoned)\s+for\s+\S.*$/i.test(line)
     || /^(analyzing|thinking|working|searching)[.…]*$/i.test(line)
     || /^show\s+(more|reasoning)$/i.test(line)
     || /^(pro thinking|extended thinking|thinking|pro|extended pro)$/i.test(line)
-    || /^gpt[\s.-]*\d+(?:[\s.-]*\d+)*(?:\s+(?:pro|thinking))?$/i.test(line)
-    || (!options.allowSingleLetter && /^[A-Z]$/.test(line));
+    || /^gpt[\s.-]*\d+(?:[\s.-]*\d+)*(?:\s+(?:pro|thinking))?$/i.test(line);
 }
 
 function completedExtraction(extraction, completionReason, stableForMs) {

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -1030,8 +1030,7 @@ async function waitForResponse(job) {
     const rawText = extraction?.text ?? "";
     const extractionIdle = !extraction?.is_generating;
     const scopedFinalAffordance = Boolean(postSend && hasFinalAssistantAffordance(job, extraction));
-    const allowStableSingleLetter = Boolean(postSend && extractionIdle);
-    const text = meaningfulResponseText(rawText, { allowSingleLetter: scopedFinalAffordance || allowStableSingleLetter }) ? rawText : "";
+    const text = meaningfulResponseText(rawText) ? rawText : "";
     const finalAffordance = Boolean(scopedFinalAffordance && text);
     const finalAffordanceWithoutScopedText = Boolean(
       postSendAssistantActivity

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -1356,8 +1356,14 @@ test("fake ChatGPT model controls select model and disable Extended", async () =
     "data-testid": "model-switcher-dropdown-button",
     "aria-haspopup": "menu"
   }, "ChatGPT");
-  const proOption = new FakeElement("div", { role: "menuitemradio" }, "GPT-5.4 Pro");
-  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "GPT-5.4 Pro");
+  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Default");
+  const proOption = new FakeElement("div", {
+    role: "menuitemradio",
+    onClick: () => {
+      selected.innerText = "GPT-5.4 Pro";
+      selected.textContent = "GPT-5.4 Pro";
+    }
+  }, "GPT-5.4 Pro");
   const body = new FakeElement("body", {}, "ChatGPT GPT-5.4 Pro").append(extended, modelButton, proOption, selected);
   const doc = new FakeDocument(body);
 
@@ -1370,6 +1376,48 @@ test("fake ChatGPT model controls select model and disable Extended", async () =
   assert.equal(proOption.clicked, true);
   assert.equal(result.status, "selected");
   assert.equal(result.extended_status, "disabled");
+});
+
+test("fake ChatGPT personal composer model control accepts current Extended Pro for auto", async () => {
+  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+  const modelButton = new FakeElement("button", { "aria-haspopup": "menu" }, "Extended Pro");
+  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
+  const body = new FakeElement("body", {}, "Ask anything Extended Pro").append(form);
+  const doc = new FakeDocument(body);
+
+  const result = await configureModelState(doc, {
+    model: "auto",
+    disable_extended: false
+  });
+
+  assert.equal(modelButton.clicked, false);
+  assert.equal(result.status, "selected");
+  assert.equal(result.model_used, "Extended Pro");
+  assert.deepEqual(result.available_options, []);
+});
+
+test("fake ChatGPT personal composer model control can switch from Instant to Extended Pro", async () => {
+  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+  const modelButton = new FakeElement("button", {
+    "aria-haspopup": "menu",
+    onClick: () => delete modelButton.attrs["aria-checked"]
+  }, "Instant");
+  const extendedProOption = new FakeElement("div", { role: "menuitemradio" }, "Extended Pro");
+  const instantOption = new FakeElement("div", { role: "menuitemradio" }, "Instant");
+  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
+  const body = new FakeElement("body", {}, "Ask anything Instant Extended Pro").append(form, instantOption, extendedProOption);
+  const doc = new FakeDocument(body);
+
+  const result = await configureModelState(doc, {
+    model: "auto",
+    disable_extended: false
+  });
+
+  assert.equal(modelButton.clicked, true);
+  assert.equal(instantOption.clicked, false);
+  assert.equal(extendedProOption.clicked, true);
+  assert.equal(result.status, "selected");
+  assert.equal(result.model_used, "Extended Pro");
 });
 
 test("fake ChatGPT Extended disable falls back to visible chip text", async () => {
@@ -1427,8 +1475,14 @@ test("fake ChatGPT model controls can select data-testid only model items", asyn
     "data-testid": "model-switcher-dropdown-button",
     "aria-haspopup": "menu"
   }, "ChatGPT");
-  const proOption = new FakeElement("div", { "data-testid": "model-switcher-gpt-5-4-pro" }, "");
-  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "GPT-5.4 Pro");
+  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Default");
+  const proOption = new FakeElement("div", {
+    "data-testid": "model-switcher-gpt-5-4-pro",
+    onClick: () => {
+      selected.innerText = "GPT-5.4 Pro";
+      selected.textContent = "GPT-5.4 Pro";
+    }
+  }, "");
   const body = new FakeElement("body", {}, "ChatGPT").append(modelButton, proOption, selected);
   const doc = new FakeDocument(body);
 
@@ -1450,8 +1504,14 @@ test("fake ChatGPT model controls do not match gpt-5 by gpt-5.4 substring", asyn
     "aria-haspopup": "menu"
   }, "ChatGPT");
   const proOption = new FakeElement("div", { role: "menuitemradio" }, "GPT-5.4 Pro");
-  const gpt5Option = new FakeElement("div", { role: "menuitemradio" }, "GPT-5");
-  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "GPT-5");
+  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Default");
+  const gpt5Option = new FakeElement("div", {
+    role: "menuitemradio",
+    onClick: () => {
+      selected.innerText = "GPT-5";
+      selected.textContent = "GPT-5";
+    }
+  }, "GPT-5");
   const body = new FakeElement("body", {}, "ChatGPT GPT-5.4 Pro GPT-5").append(modelButton, proOption, gpt5Option, selected);
   const doc = new FakeDocument(body);
 
@@ -1473,8 +1533,14 @@ test("fake ChatGPT model controls keep hyphenated Pro slugs as Pro", async () =>
     "aria-haspopup": "menu"
   }, "ChatGPT");
   const baseOption = new FakeElement("div", { role: "menuitemradio" }, "GPT-5.4");
-  const proOption = new FakeElement("div", { role: "menuitemradio" }, "GPT-5.4 Pro");
-  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "GPT-5.4 Pro");
+  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Default");
+  const proOption = new FakeElement("div", {
+    role: "menuitemradio",
+    onClick: () => {
+      selected.innerText = "GPT-5.4 Pro";
+      selected.textContent = "GPT-5.4 Pro";
+    }
+  }, "GPT-5.4 Pro");
   const body = new FakeElement("body", {}, "ChatGPT GPT-5.4 GPT-5.4 Pro").append(modelButton, baseOption, proOption, selected);
   const doc = new FakeDocument(body);
 

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -1307,7 +1307,7 @@ test("service worker does not complete on thought/status-only assistant text", a
   }
 });
 
-test("service worker completes a scoped single-letter assistant markdown response", async () => {
+test("service worker rejects a scoped single-letter assistant markdown response", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
   let tabId = 0;
@@ -1359,7 +1359,7 @@ test("service worker completes a scoped single-letter assistant markdown respons
     port.emit(envelope("job_start", "job_single_letter_scoped_response", {
       prompt: "prompt",
       wait_interval_ms: 50,
-      wait_timeout_ms: 2000
+      wait_timeout_ms: 1200
     }));
     await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
     port.emit(envelope("job_file_chunk", "job_single_letter_scoped_response", {
@@ -1371,12 +1371,8 @@ test("service worker completes a scoped single-letter assistant markdown respons
       bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
     }));
 
-    await eventually(() => port.messages.some((message) => message.type === "job_complete"));
-    const complete = port.messages.find((message) => message.type === "job_complete");
-    assert.equal(complete.payload.response, "I");
-    assert.equal(complete.payload.extraction_method, "copy_scope_dom_fallback");
-    assert.equal(complete.payload.completion_reason, "copy_button");
-    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
+    await eventually(() => port.messages.some((message) => message.type === "job_error" && message.payload.code === "response_timeout"));
+    assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
   } finally {
     globalThis.chrome = originalChrome;
   }
@@ -1453,7 +1449,7 @@ test("service worker does not fast-complete a single-letter response without a f
   }
 });
 
-test("service worker completes a stable idle single-letter response without a final affordance", async () => {
+test("service worker rejects a stable idle single-letter response without a final affordance", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
   let tabId = 0;
@@ -1517,12 +1513,8 @@ test("service worker completes a stable idle single-letter response without a fi
       bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
     }));
 
-    await eventually(() => port.messages.some((message) => message.type === "job_complete"));
-    const complete = port.messages.find((message) => message.type === "job_complete");
-    assert.equal(complete.payload.response, "I");
-    assert.equal(complete.payload.extraction_method, "assistant_dom_fallback");
-    assert.equal(complete.payload.completion_reason, "stable_idle");
-    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
+    await eventually(() => port.messages.some((message) => message.type === "job_error" && message.payload.code === "response_timeout"));
+    assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
   } finally {
     globalThis.chrome = originalChrome;
   }

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -1307,7 +1307,7 @@ test("service worker does not complete on thought/status-only assistant text", a
   }
 });
 
-test("service worker rejects a scoped single-letter assistant markdown response", async () => {
+test("service worker accepts a scoped single-letter assistant markdown response", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
   let tabId = 0;
@@ -1336,7 +1336,7 @@ test("service worker rejects a scoped single-letter assistant markdown response"
               payload: sent
                 ? {
                     method: "copy_scope_dom_fallback",
-                    text: "I",
+                    text: "A",
                     is_generating: false,
                     assistant_count: 1,
                     user_count: 1,
@@ -1355,34 +1355,38 @@ test("service worker rejects a scoped single-letter assistant markdown response"
   });
 
   try {
-    await import(`../src/service-worker.js?single_letter_scoped_response=${Date.now()}`);
-    port.emit(envelope("job_start", "job_single_letter_scoped_response", {
+    await import(`../src/service-worker.js?single_letter_scoped_valid=${Date.now()}`);
+    port.emit(envelope("job_start", "job_single_letter_scoped_valid", {
       prompt: "prompt",
       wait_interval_ms: 50,
       wait_timeout_ms: 1200
     }));
     await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
-    port.emit(envelope("job_file_chunk", "job_single_letter_scoped_response", {
+    port.emit(envelope("job_file_chunk", "job_single_letter_scoped_valid", {
       sequence: 0,
       total_chunks: 1,
       total_bytes: 4,
-      filename: "job_single_letter_scoped_response.md",
+      filename: "job_single_letter_scoped_valid.md",
       mime_type: "text/markdown",
       bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
     }));
 
-    await eventually(() => port.messages.some((message) => message.type === "job_error" && message.payload.code === "response_timeout"));
-    assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
+    await eventually(() => port.messages.some((message) => message.type === "job_complete"));
+    const complete = port.messages.find((message) => message.type === "job_complete");
+    assert.equal(complete.payload.response, "A");
+    assert.equal(complete.payload.completion_reason, "copy_button");
+    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
   } finally {
     globalThis.chrome = originalChrome;
   }
 });
 
-test("service worker does not fast-complete a single-letter response without a final affordance", async () => {
+test("service worker waits for streaming one-letter prefix to become stable idle text", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
   let tabId = 0;
   let sent = false;
+  let extractCount = 0;
   globalThis.chrome = chromeStub({
     port,
     tabs: {
@@ -1401,23 +1405,28 @@ test("service worker does not fast-complete a single-letter response without a f
           case "yoetz_send_prompt":
             sent = true;
             return { ok: true, payload: { sent: true } };
-          case "yoetz_extract_response":
+          case "yoetz_extract_response": {
+            if (!sent) {
+              return { ok: true, payload: { method: "none", text: "", is_generating: false, assistant_count: 0, copy_button_count: 0, has_copy_button: false, turn_index: -1 } };
+            }
+            extractCount += 1;
+            const streaming = extractCount <= 2;
+            const text = extractCount === 1 ? "I" : "I reviewed the bundle.";
             return {
               ok: true,
-              payload: sent
-                ? {
-                    method: "assistant_dom_fallback",
-                    text: "I",
-                    is_generating: false,
-                    assistant_count: 1,
-                    user_count: 1,
-                    preceding_user_count: 1,
-                    copy_button_count: 0,
-                    has_copy_button: false,
-                    turn_index: 0
-                  }
-                : { method: "none", text: "", is_generating: false, assistant_count: 0, copy_button_count: 0, has_copy_button: false, turn_index: -1 }
+              payload: {
+                method: "assistant_dom_fallback",
+                text,
+                is_generating: streaming,
+                assistant_count: 1,
+                user_count: 1,
+                preceding_user_count: 1,
+                copy_button_count: 1,
+                has_copy_button: streaming,
+                turn_index: 0
+              }
             };
+          }
           default:
             throw new Error(`unexpected tab message ${message.type}`);
         }
@@ -1426,166 +1435,37 @@ test("service worker does not fast-complete a single-letter response without a f
   });
 
   try {
-    await import(`../src/service-worker.js?single_letter_without_final_affordance_fast=${Date.now()}`);
-    port.emit(envelope("job_start", "job_single_letter_without_final_affordance", {
+    await import(`../src/service-worker.js?streaming_single_letter_prefix=${Date.now()}`);
+    port.emit(envelope("job_start", "job_streaming_single_letter_prefix", {
       prompt: "prompt",
       wait_interval_ms: 50,
-      wait_timeout_ms: 900
+      wait_timeout_ms: 5000
     }));
     await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
-    port.emit(envelope("job_file_chunk", "job_single_letter_without_final_affordance", {
+    port.emit(envelope("job_file_chunk", "job_streaming_single_letter_prefix", {
       sequence: 0,
       total_chunks: 1,
       total_bytes: 4,
-      filename: "job_single_letter_without_final_affordance.md",
+      filename: "job_streaming_single_letter_prefix.md",
       mime_type: "text/markdown",
       bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
     }));
 
-    await eventually(() => port.messages.some((message) => message.type === "job_error" && message.payload.code === "response_timeout"));
-    assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
-  } finally {
-    globalThis.chrome = originalChrome;
-  }
-});
-
-test("service worker rejects a stable idle single-letter response without a final affordance", async () => {
-  const originalChrome = globalThis.chrome;
-  const port = makePort();
-  let tabId = 0;
-  let sent = false;
-  globalThis.chrome = chromeStub({
-    port,
-    tabs: {
-      create: async (opts) => ({ id: ++tabId, ...opts }),
-      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
-      sendMessage: async (_id, message) => {
-        switch (message.type) {
-          case "yoetz_probe":
-            return { ok: true, payload: {} };
-          case "yoetz_prepare_job":
-            return { ok: true, payload: { manual_handoff: null } };
-          case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
-          case "yoetz_upload_file":
-            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
-          case "yoetz_send_prompt":
-            sent = true;
-            return { ok: true, payload: { sent: true } };
-          case "yoetz_extract_response":
-            return {
-              ok: true,
-              payload: sent
-                ? {
-                    method: "assistant_dom_fallback",
-                    text: "I",
-                    is_generating: false,
-                    assistant_count: 1,
-                    user_count: 1,
-                    preceding_user_count: 1,
-                    copy_button_count: 0,
-                    has_copy_button: false,
-                    turn_index: 0
-                  }
-                : { method: "none", text: "", is_generating: false, assistant_count: 0, copy_button_count: 0, has_copy_button: false, turn_index: -1 }
-            };
-          default:
-            throw new Error(`unexpected tab message ${message.type}`);
-        }
-      }
-    }
-  });
-
-  try {
-    await import(`../src/service-worker.js?single_letter_without_final_affordance_stable=${Date.now()}`);
-    port.emit(envelope("job_start", "job_single_letter_stable_idle", {
-      prompt: "prompt",
-      wait_interval_ms: 50,
-      wait_timeout_ms: 2600
-    }));
-    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
-    port.emit(envelope("job_file_chunk", "job_single_letter_stable_idle", {
-      sequence: 0,
-      total_chunks: 1,
-      total_bytes: 4,
-      filename: "job_single_letter_stable_idle.md",
-      mime_type: "text/markdown",
-      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
-    }));
-
-    await eventually(() => port.messages.some((message) => message.type === "job_error" && message.payload.code === "response_timeout"));
-    assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
-  } finally {
-    globalThis.chrome = originalChrome;
-  }
-});
-
-test("service worker does not complete a single-letter response from copy count alone", async () => {
-  const originalChrome = globalThis.chrome;
-  const port = makePort();
-  let tabId = 0;
-  let sent = false;
-  globalThis.chrome = chromeStub({
-    port,
-    tabs: {
-      create: async (opts) => ({ id: ++tabId, ...opts }),
-      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
-      sendMessage: async (_id, message) => {
-        switch (message.type) {
-          case "yoetz_probe":
-            return { ok: true, payload: {} };
-          case "yoetz_prepare_job":
-            return { ok: true, payload: { manual_handoff: null } };
-          case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
-          case "yoetz_upload_file":
-            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
-          case "yoetz_send_prompt":
-            sent = true;
-            return { ok: true, payload: { sent: true } };
-          case "yoetz_extract_response":
-            return {
-              ok: true,
-              payload: sent
-                ? {
-                    method: "assistant_dom_fallback",
-                    text: "I",
-                    is_generating: false,
-                    assistant_count: 1,
-                    user_count: 1,
-                    preceding_user_count: 1,
-                    copy_button_count: 1,
-                    has_copy_button: false,
-                    turn_index: 0
-                  }
-                : { method: "none", text: "", is_generating: false, assistant_count: 0, copy_button_count: 0, has_copy_button: false, turn_index: -1 }
-            };
-          default:
-            throw new Error(`unexpected tab message ${message.type}`);
-        }
-      }
-    }
-  });
-
-  try {
-    await import(`../src/service-worker.js?single_letter_copy_count_only=${Date.now()}`);
-    port.emit(envelope("job_start", "job_single_letter_copy_count_only", {
-      prompt: "prompt",
-      wait_interval_ms: 50,
-      wait_timeout_ms: 900
-    }));
-    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
-    port.emit(envelope("job_file_chunk", "job_single_letter_copy_count_only", {
-      sequence: 0,
-      total_chunks: 1,
-      total_bytes: 4,
-      filename: "job_single_letter_copy_count_only.md",
-      mime_type: "text/markdown",
-      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
-    }));
-
-    await eventually(() => port.messages.some((message) => message.type === "job_error" && message.payload.code === "response_timeout"));
-    assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
+    await eventually(() => port.messages.some((message) => message.type === "job_complete"), 7000);
+    const observedPrefix = port.messages.find(
+      (message) =>
+        message.type === "job_progress" &&
+        message.payload.phase === "response_observed" &&
+        message.payload.response_length === 1 &&
+        message.payload.is_generating === true &&
+        message.payload.has_copy_button === true
+    );
+    const complete = port.messages.find((message) => message.type === "job_complete");
+    assert.ok(observedPrefix, "streaming one-letter prefix should be observed before completion");
+    assert.ok(extractCount >= 5, "completion should wait for idle stable polls after streaming stops");
+    assert.equal(complete.payload.response, "I reviewed the bundle.");
+    assert.equal(complete.payload.completion_reason, "stable_idle");
+    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
   } finally {
     globalThis.chrome = originalChrome;
   }

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -19,9 +19,10 @@ name: chatgpt
 #
 # Variables:
 #   model    — model slug (e.g., "gpt-5-4-pro"). Default: "auto" selects the
-#              best available model, preferring GPT-5/Pro when the account has it.
+#              best available model, preferring Pro with Extended enabled when
+#              the account has it.
 #              Set to "" or "current" to keep the current ChatGPT selector state.
-#   extended — set to "false" to disable Extended Pro. Default: leave as-is.
+#   extended — set to "false" to disable Extended Pro. Default: keep Extended on.
 #   prompt   — prompt text to send with the attachment. For Yoetz bundle
 #              sessions, typed ChatGPT transports default this to bundle.json's
 #              stored user prompt unless --var prompt=... explicitly overrides.

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -267,6 +267,7 @@ Use this only when ChatGPT Pro recipe robustness needs install-once native
 messaging instead of CDP approval prompts:
 
 ```bash
+yoetz browser extension setup --chatgpt --open-chrome
 yoetz browser extension install-host --chatgpt
 yoetz browser extension doctor --chatgpt
 yoetz browser extension status --chatgpt
@@ -330,6 +331,10 @@ mode enabled, and click the extension reload button after replacing files. Then
 run `yoetz browser extension reconnect --chatgpt` and `doctor --chatgpt`.
 From a source checkout, load `extensions/chatgpt-native`; from a release zip,
 load the extracted zip directory itself.
+For agent-driven setup, prefer `yoetz browser extension setup --chatgpt
+--open-chrome`; it installs the host, opens Chrome's extension page, and prints
+the exact folder to select. Chrome still requires the **Load unpacked** UI
+confirmation for local extensions.
 When multiple Chrome profiles have the extension loaded, pass
 `--var profile_email=<email>` if Chrome exposes one, or the stable
 `--var extension_instance_id=<id>` shown by `status --chatgpt`.

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -358,8 +358,8 @@ BUNDLE=$(yoetz bundle -p "Review this code" -f src/*.rs --format json | jq -r .a
 # Send to ChatGPT
 yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE"
 
-# By default yoetz now auto-selects the strongest model the logged-in account
-# can access, preferring GPT-5/Pro when available. Override it only if needed.
+# By default yoetz auto-selects Pro with Extended enabled when the logged-in
+# account exposes it. Override it only if needed.
 yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE" --var model=gpt-5-4-pro
 
 # Every request opens a fresh, yoetz-owned ChatGPT tab marked with ?_yoetz=<run-id>


### PR DESCRIPTION
## Summary
- add `yoetz browser extension setup --chatgpt --open-chrome` to prepare native host setup and open Chrome extensions
- discover and report the unpacked ChatGPT native extension directory, with `YOETZ_CHATGPT_NATIVE_EXTENSION_DIR` override support
- document the agent-driven setup path in README, CLAUDE, and the Yoetz skill

## Validation
- `cargo fmt --check`
- `cargo test -p yoetz --test cli browser_extension`
- local Chrome extension install verified with `yoetz browser extension doctor --chatgpt` and `yoetz browser check --transport chrome-extension-native`

Peer review was requested via AMQ before publish; no drain within 30s, so proceeding under the approved release request.