### PR TITLE
Fix ChatGPT extension final response detection

### DIFF
--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -986,7 +986,6 @@ async function maybeGroupTab(tabId, job) {
 async function waitForResponse(job) {
   const startedAt = Date.now();
   const interval = Math.max(500, Math.min(Number(job.wait_interval_ms) || 30000, 30000));
-  const stableIdleMs = Math.max(MIN_STABLE_IDLE_MS, interval * 3);
   const finalAffordanceIdleMs = Math.min(MIN_STABLE_IDLE_MS, Math.max(FINAL_AFFORDANCE_STABLE_IDLE_MS, 0));
   const stablePolls = 2;
   let best = { method: "none", text: "", is_generating: true };
@@ -1032,6 +1031,8 @@ async function waitForResponse(job) {
     const scopedFinalAffordance = Boolean(postSend && hasFinalAssistantAffordance(job, extraction));
     const text = meaningfulResponseText(rawText) ? rawText : "";
     const finalAffordance = Boolean(scopedFinalAffordance && text);
+    // Broad page text is diagnostic only; final controls without scoped text
+    // means extraction failed, not that page chrome is safe to return.
     const finalAffordanceWithoutScopedText = Boolean(
       postSendAssistantActivity
       && extraction?.method === "page_text_fallback"
@@ -1049,12 +1050,16 @@ async function waitForResponse(job) {
       stableSinceMs = stableCount > 0 ? Date.now() : 0;
     }
     const stableForMs = stableSinceMs ? Date.now() - stableSinceMs : 0;
+    const awaitingFinalAffordance = Boolean(
+      postSend
+      && extractionIdle
+      && text
+      && extraction?.method !== "page_text_fallback"
+      && !finalAffordance
+    );
     if (postSend && extractionIdle && text && stableCount >= stablePolls && extraction?.method !== "page_text_fallback") {
       if (finalAffordance && stableForMs >= finalAffordanceIdleMs) {
         return completedExtraction(extraction, "copy_button", stableForMs);
-      }
-      if (stableForMs >= stableIdleMs) {
-        return completedExtraction(extraction, "stable_idle", stableForMs);
       }
     }
     if (finalAffordanceWithoutScopedText) {
@@ -1087,14 +1092,19 @@ async function waitForResponse(job) {
     const nowMs = Date.now();
     const elapsedMs = nowMs - startedAt;
     if (nowMs - lastWaitingProgressAt >= WAITING_RESPONSE_PROGRESS_INTERVAL_MS) {
-      postWaitingResponseProgress(job, extraction, {
+      const waitingDetail = {
         elapsed_ms: elapsedMs,
         timeout_ms: timeoutMs,
         next_poll_ms: nextDelay,
         stable_for_ms: stableForMs,
         final_affordance: finalAffordance,
         extraction_failure_candidate: finalAffordanceWithoutScopedText
-      });
+      };
+      if (awaitingFinalAffordance) {
+        waitingDetail.awaiting_final_affordance = true;
+        waitingDetail.inspect_command = inspectCommandForJob(job);
+      }
+      postWaitingResponseProgress(job, extraction, waitingDetail);
       lastWaitingProgressAt = nowMs;
     }
     await sleep(nextDelay);
@@ -1153,9 +1163,10 @@ function postResponseProgress(job, extraction) {
 function postWaitingResponseProgress(job, extraction, detail = {}) {
   const elapsedMs = Number(detail.elapsed_ms ?? 0);
   const timeoutMs = Number(detail.timeout_ms ?? job.wait_timeout_ms ?? 1800000);
+  const finalityStatus = detail.awaiting_final_affordance ? ", waiting for final assistant controls" : "";
   postNative(progress(job, "waiting_response", {
     ...detail,
-    message: `waiting for ChatGPT response (${formatDurationForMessage(elapsedMs)} elapsed of ${formatDurationForMessage(timeoutMs)} timeout; method=${extraction?.method ?? "none"}, assistant_count=${extraction?.assistant_count ?? 0}, copy_buttons=${extraction?.copy_button_count ?? 0}${extraction?.is_generating ? ", generating" : ""})`,
+    message: `waiting for ChatGPT response (${formatDurationForMessage(elapsedMs)} elapsed of ${formatDurationForMessage(timeoutMs)} timeout; method=${extraction?.method ?? "none"}, assistant_count=${extraction?.assistant_count ?? 0}, copy_buttons=${extraction?.copy_button_count ?? 0}${extraction?.is_generating ? ", generating" : ""}${finalityStatus})`,
     extraction_method: extraction?.method ?? "none",
     is_generating: Boolean(extraction?.is_generating),
     assistant_count: extraction?.assistant_count ?? 0,
@@ -1164,6 +1175,11 @@ function postWaitingResponseProgress(job, extraction, detail = {}) {
     has_copy_button: Boolean(extraction?.has_copy_button),
     response_length: extraction?.text?.length ?? 0
   }));
+}
+
+function inspectCommandForJob(job) {
+  const selector = job.extension_instance_id ? ` --extension-instance-id ${job.extension_instance_id}` : "";
+  return `yoetz browser extension inspect --chatgpt --run-id ${job.run_id}${selector}`;
 }
 
 function formatDurationForMessage(ms) {

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -1381,7 +1381,7 @@ test("service worker accepts a scoped single-letter assistant markdown response"
   }
 });
 
-test("service worker waits for streaming one-letter prefix to become stable idle text", async () => {
+test("service worker waits for streaming one-letter prefix to reach final assistant affordance", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
   let tabId = 0;
@@ -1422,7 +1422,7 @@ test("service worker waits for streaming one-letter prefix to become stable idle
                 user_count: 1,
                 preceding_user_count: 1,
                 copy_button_count: 1,
-                has_copy_button: streaming,
+                has_copy_button: !streaming,
                 turn_index: 0
               }
             };
@@ -1457,17 +1457,107 @@ test("service worker waits for streaming one-letter prefix to become stable idle
         message.type === "job_progress" &&
         message.payload.phase === "response_observed" &&
         message.payload.response_length === 1 &&
-        message.payload.is_generating === true &&
-        message.payload.has_copy_button === true
+        message.payload.is_generating === true
     );
     const complete = port.messages.find((message) => message.type === "job_complete");
     assert.ok(observedPrefix, "streaming one-letter prefix should be observed before completion");
-    assert.ok(extractCount >= 5, "completion should wait for idle stable polls after streaming stops");
+    assert.ok(extractCount >= 4, "completion should wait for final affordance after streaming stops");
     assert.equal(complete.payload.response, "I reviewed the bundle.");
-    assert.equal(complete.payload.completion_reason, "stable_idle");
+    assert.equal(complete.payload.completion_reason, "copy_button");
     assert.equal(port.messages.some((message) => message.type === "job_error"), false);
   } finally {
     globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker does not complete when ChatGPT idles before final assistant affordance", async () => {
+  const originalChrome = globalThis.chrome;
+  const previousWaitingProgressInterval = globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS;
+  globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS = 100;
+  const port = makePort();
+  let tabId = 0;
+  let sent = false;
+  let extractCount = 0;
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true } };
+          case "yoetz_extract_response": {
+            if (!sent) {
+              return { ok: true, payload: { method: "none", text: "", is_generating: false, assistant_count: 0, copy_button_count: 0, has_copy_button: false, turn_index: -1 } };
+            }
+            extractCount += 1;
+            const final = extractCount >= 6;
+            return {
+              ok: true,
+              payload: {
+                method: final ? "copy_scope_dom_fallback" : "assistant_dom_fallback",
+                text: final ? "I reviewed the bundle." : "I",
+                is_generating: extractCount === 1,
+                assistant_count: 1,
+                user_count: 1,
+                preceding_user_count: 1,
+                copy_button_count: 1,
+                has_copy_button: final,
+                turn_index: 0
+              }
+            };
+          }
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?idle_before_final_affordance=${Date.now()}`);
+    port.emit(envelope("job_start", "job_idle_before_final_affordance", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 5000
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_idle_before_final_affordance", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_idle_before_final_affordance.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) => message.payload?.awaiting_final_affordance), 7000);
+    await eventually(() => port.messages.some((message) => message.type === "job_complete"), 7000);
+    const waiting = port.messages.find((message) => message.payload?.awaiting_final_affordance);
+    const complete = port.messages.find((message) => message.type === "job_complete");
+    assert.match(waiting.payload.message, /waiting for final assistant controls/);
+    assert.equal(waiting.payload.inspect_command, "yoetz browser extension inspect --chatgpt --run-id run_job_idle_before_final_affordance");
+    assert.ok(extractCount >= 6, "completion should not happen during the idle one-letter prefix");
+    assert.equal(complete.payload.response, "I reviewed the bundle.");
+    assert.equal(complete.payload.completion_reason, "copy_button");
+    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+    if (previousWaitingProgressInterval === undefined) {
+      delete globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS;
+    } else {
+      globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS = previousWaitingProgressInterval;
+    }
   }
 });
 

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -197,6 +197,11 @@ to exceed that. If the extension returns a terminal upload/send/wait error, use
 `yoetz browser extension inspect --chatgpt --run-id <run-id>` before deciding
 whether an intentional rerun is safe.
 
+If progress says `waiting for final assistant controls`, ChatGPT has exposed
+post-send assistant text but not a final scoped action affordance yet. Do not
+treat the visible text as complete and do not start a duplicate run; use the
+reported inspect command to check the preserved tab if you need live state.
+
 ### Prerequisites
 
 ```bash


### PR DESCRIPTION
## Summary
- remove the stable-idle response completion fallback from the ChatGPT native extension
- require scoped post-send assistant text plus ChatGPT final assistant controls before returning `status=ok`
- add agent-facing waiting progress with an inspect command while waiting for final controls
- document the new recovery state in the Yoetz skill

## Root cause / repro
Live v0.5.5 extension repro with `run_id=codex-self-review-20260515T100546Z` returned `status=ok` and `response="I"` using `transport=chrome-extension-native`, `model_used=Extended Pro`. The tab inspection still showed `assistant_dom_fallback`, `text_chars=1`, `is_generating=false`, `has_copy_button=false`, `copy_button_count=1`, `stop_count=0`. The bad branch was treating stable idle DOM text as final.

## Tests
- `node --test extensions/chatgpt-native/tests/service-worker.test.js`
- `node --test extensions/chatgpt-native/tests/*.test.js`
- `./scripts/build-chatgpt-native-extension.sh --check`
- `git diff --check`

Peer review: rentseek session1 Claude approved via AMQ.
