### PR TITLE
fix(browser): make ChatGPT finality structural

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - ChatGPT native-extension wait progress now distinguishes total page copy
   buttons from the scoped final assistant copy button required for completion.
+- ChatGPT native-extension response completion is now driven only by scoped
+  assistant DOM structure and final controls, not response-content heuristics.
 - ChatGPT browser recipes now default to a 90-minute response wait for
   Pro/Extended Pro runs and include the owned-tab inspect command on timeout.
 

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -686,7 +686,7 @@ function standaloneAssistantSegment(root, conversation, ordered, marker, latestU
         && !isNonConversationChrome(node);
     });
   const textEntries = markdownNodes
-    .map((node) => ({ node, text: cleanAssistantText(node, { allowSingleLetter: true }) }))
+    .map((node) => ({ node, text: cleanAssistantText(node) }))
     .filter((entry) => entry.text);
   if (textEntries.length === 0) {
     return null;
@@ -758,7 +758,7 @@ function hasResponseBoundaryBetween(ordered, startIndex, endIndex) {
     if (role === "user" || role === "assistant") {
       return true;
     }
-    if (isMarkdownNode(node) && cleanAssistantText(node, { allowSingleLetter: true })) {
+    if (isMarkdownNode(node) && cleanAssistantText(node)) {
       return true;
     }
   }
@@ -859,7 +859,7 @@ function assistantMessageTextEntry(turn) {
   const leafContentNodes = leafNodes(contentNodes);
   const textEntries = [];
   for (const node of leafContentNodes) {
-    const text = cleanAssistantText(node, { allowSingleLetter: isMarkdownNode(node) });
+    const text = cleanAssistantText(node);
     if (text) {
       textEntries.push({ node, text });
     }
@@ -889,11 +889,11 @@ function leafNodes(nodes) {
   return nodes.filter((node) => !nodes.some((other) => other !== node && containsNode(node, other)));
 }
 
-function cleanAssistantText(node, options = {}) {
+function cleanAssistantText(node) {
   const lines = textOf(node)
     .split(/\n+/)
     .map((line) => normalizeText(line))
-    .filter((line) => line && !isAssistantControlLine(line) && !isAssistantNoiseLine(line, options));
+    .filter((line) => line && !isAssistantControlLine(line));
   return normalizeText(lines.join("\n"));
 }
 
@@ -907,10 +907,6 @@ function isModelStatusText(text) {
   const value = normalizeText(text);
   return /^(pro thinking|extended thinking|thinking|pro|extended pro)$/i.test(value)
     || /^gpt[\s.-]*\d+(?:[\s.-]*\d+)*(?:\s+(?:pro|thinking))?$/i.test(value);
-}
-
-function isAssistantNoiseLine(line, options = {}) {
-  return !options.allowSingleLetter && /^[A-Z]$/.test(line);
 }
 
 function isMarkdownNode(node) {

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -988,12 +988,10 @@ async function waitForResponse(job) {
   const startedAt = Date.now();
   const interval = Math.max(500, Math.min(Number(job.wait_interval_ms) || 30000, 30000));
   const finalAffordanceIdleMs = Math.min(MIN_STABLE_IDLE_MS, Math.max(FINAL_AFFORDANCE_STABLE_IDLE_MS, 0));
-  const stablePolls = 2;
   let best = { method: "none", text: "", is_generating: true };
   let last = { method: "none", text: "", is_generating: true };
-  let lastStableText = "";
-  let stableCount = 0;
-  let stableSinceMs = 0;
+  let finalAffordanceAnchor = "";
+  let finalAffordanceSinceMs = 0;
   let extractionFailureAnchor = "";
   let extractionFailureSinceMs = 0;
   let lastWaitingProgressAt = startedAt;
@@ -1027,15 +1025,13 @@ async function waitForResponse(job) {
       postResponseProgress(job, extraction);
       assertJobConnectionCurrent(job);
     }
-    const rawText = extraction?.text ?? "";
     const extractionIdle = !extraction?.is_generating;
-    const text = meaningfulResponseText(rawText) ? rawText : "";
-    const stableTextCandidate = Boolean(postSend && extractionIdle && text);
-    const scopedStableTextCandidate = Boolean(
-      stableTextCandidate
+    const scopedExtractionCandidate = Boolean(
+      postSend
+      && extractionIdle
       && extraction?.method !== "page_text_fallback"
     );
-    const finalAffordance = Boolean(scopedStableTextCandidate && hasFinalAssistantAffordance(extraction));
+    const finalAffordance = Boolean(scopedExtractionCandidate && hasFinalAssistantAffordance(extraction));
     // Broad page text is diagnostic only; final controls without scoped text
     // means extraction failed, not that page chrome is safe to return.
     const finalAffordanceWithoutScopedText = Boolean(
@@ -1044,23 +1040,22 @@ async function waitForResponse(job) {
       && !extraction?.is_generating
       && hasFinalAssistantAffordance(extraction)
     );
-    if (stableTextCandidate && text === lastStableText) {
-      stableCount += 1;
-      if (!stableSinceMs) {
-        stableSinceMs = Date.now();
+    let stableForMs = 0;
+    if (finalAffordance) {
+      const anchor = responseFinalityAnchor(extraction);
+      if (anchor !== finalAffordanceAnchor) {
+        finalAffordanceAnchor = anchor;
+        finalAffordanceSinceMs = Date.now();
       }
-    } else {
-      lastStableText = text;
-      stableCount = stableTextCandidate ? 1 : 0;
-      stableSinceMs = stableCount > 0 ? Date.now() : 0;
-    }
-    const stableForMs = stableSinceMs ? Date.now() - stableSinceMs : 0;
-    const awaitingFinalAffordance = Boolean(scopedStableTextCandidate && !finalAffordance);
-    if (scopedStableTextCandidate && stableCount >= stablePolls) {
-      if (finalAffordance && stableForMs >= finalAffordanceIdleMs) {
+      stableForMs = Date.now() - finalAffordanceSinceMs;
+      if (stableForMs >= finalAffordanceIdleMs) {
         return completedExtraction(extraction, "copy_button", stableForMs);
       }
+    } else {
+      finalAffordanceAnchor = "";
+      finalAffordanceSinceMs = 0;
     }
+    const awaitingFinalAffordance = Boolean(scopedExtractionCandidate && !finalAffordance);
     if (finalAffordanceWithoutScopedText) {
       const anchor = finalAffordanceExtractionFailureAnchor(extraction);
       if (anchor !== extractionFailureAnchor) {
@@ -1299,38 +1294,22 @@ function hasFinalAssistantAffordance(extraction) {
   return Boolean(!extraction?.is_generating && extraction?.has_copy_button);
 }
 
-function finalAffordanceExtractionFailureAnchor(extraction) {
+function responseFinalityAnchor(extraction) {
   return [
     extraction?.method ?? "none",
     extraction?.assistant_count ?? 0,
     extraction?.turn_index ?? -1,
     extraction?.copy_button_count ?? 0,
-    extraction?.text?.length ?? 0
+    extraction?.has_copy_button ? 1 : 0
   ].join(":");
+}
+
+function finalAffordanceExtractionFailureAnchor(extraction) {
+  return responseFinalityAnchor(extraction);
 }
 
 function finalAffordanceExtractionFailureMessage(job, extraction, stableForMs) {
   return `ChatGPT rendered a final assistant affordance but Yoetz could not extract scoped assistant text (method=${extraction?.method ?? "none"}, assistant_count=${extraction?.assistant_count ?? 0}, turn_index=${extraction?.turn_index ?? -1}, copy_button_count=${extraction?.copy_button_count ?? 0}, stable_for_ms=${stableForMs}). Inspect the owned tab with \`yoetz browser extension inspect --chatgpt --run-id ${job.run_id}\` before rerunning.`;
-}
-
-function meaningfulResponseText(text) {
-  const lines = String(text ?? "")
-    .split(/\n+/)
-    .map((line) => line.replace(/\s+/g, " ").trim())
-    .filter(Boolean);
-  if (lines.length === 0) {
-    return false;
-  }
-  return lines.some((line) => !isResponseChromeLine(line));
-}
-
-function isResponseChromeLine(line) {
-  return /^(copy|copied|read aloud|share|regenerate|retry|edit|like|dislike)$/i.test(line)
-    || /^(thought|reasoned)\s+for\s+\S.*$/i.test(line)
-    || /^(analyzing|thinking|working|searching)[.…]*$/i.test(line)
-    || /^show\s+(more|reasoning)$/i.test(line)
-    || /^(pro thinking|extended thinking|thinking|pro|extended pro)$/i.test(line)
-    || /^gpt[\s.-]*\d+(?:[\s.-]*\d+)*(?:\s+(?:pro|thinking))?$/i.test(line);
 }
 
 function completedExtraction(extraction, completionReason, stableForMs) {

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -387,7 +387,7 @@ test("extractResponse prefers assistant markdown over wrapper model status text"
   assert.equal(extraction.has_copy_button, true);
 });
 
-test("extractResponse ignores single-letter assistant fragments", () => {
+test("extractResponse returns single-letter assistant text with a copy affordance", () => {
   const copy = new FakeElement("button", { "aria-label": "Copy" }, "Copy");
   const assistant = new FakeElement("article", { "data-message-author-role": "assistant" }, "I")
     .append(copy);
@@ -396,7 +396,9 @@ test("extractResponse ignores single-letter assistant fragments", () => {
 
   const extraction = extractResponse(doc);
 
-  assert.equal(extraction.method, "page_text_fallback");
+  assert.equal(extraction.method, "copy_scope_dom_fallback");
+  assert.equal(extraction.text, "I");
+  assert.equal(extraction.has_copy_button, true);
   assert.equal(extraction.assistant_count, 1);
 });
 

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -1241,7 +1241,7 @@ test("service worker emits low-noise waiting progress while ChatGPT is quiet", a
   }
 });
 
-test("service worker does not complete on thought/status-only assistant text", async () => {
+test("service worker completion is structural and does not classify response text", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
   let tabId = 0;
@@ -1287,7 +1287,7 @@ test("service worker does not complete on thought/status-only assistant text", a
   });
 
   try {
-    await import(`../src/service-worker.js?thought_only=${Date.now()}`);
+    await import(`../src/service-worker.js?structural_finality=${Date.now()}`);
     port.emit(envelope("job_start", "job_thought_only", {
       prompt: "prompt",
       wait_interval_ms: 50,
@@ -1302,8 +1302,10 @@ test("service worker does not complete on thought/status-only assistant text", a
       mime_type: "text/markdown",
       bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
     }));
-    await eventually(() => port.messages.some((message) => message.type === "job_error" && message.payload.code === "response_timeout"));
-    assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
+    await eventually(() => port.messages.some((message) => message.type === "job_complete"));
+    const complete = port.messages.find((message) => message.type === "job_complete");
+    assert.equal(complete.payload.response, "Thought for 9m 55s\nThought for 9m 55s");
+    assert.equal(complete.payload.completion_reason, "copy_button");
   } finally {
     globalThis.chrome = originalChrome;
   }


### PR DESCRIPTION
## Summary
- remove service-worker response-content heuristics from ChatGPT native-extension completion
- complete only on post-send scoped assistant extraction plus stable final assistant copy affordance
- allow single-letter assistant responses through the DOM scraper instead of suppressing them

## Verification
- node --test extensions/chatgpt-native/tests/service-worker.test.js
- node --test extensions/chatgpt-native/tests/fake-chatgpt.test.js
- node --test extensions/chatgpt-native/tests/*.test.js
- ./scripts/build-chatgpt-native-extension.sh --check
- git diff --check

Peer review: Claude approved via AMQ before commit/push.