### PR TITLE
feat(browser): auto-promote chrome-extension-native for chatgpt when connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Changed
+
+- The `chatgpt` browser recipe now auto-promotes the `chrome-extension-native`
+  transport when the Yoetz Chrome extension is installed and reports
+  `connected`. Pass `--transport <other>` or pin `transports:` in the recipe
+  to opt out; non-ChatGPT recipes and unhealthy extensions stay
+  extension-free.
 
 ## [0.5.8] - 2026-05-15
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,16 +98,23 @@ recipe flows, treat `dev-browser` as a QuickJS/WASM runner, not Node.js:
 
 ## Browser Architecture
 
-Yoetz browser integrations are extension-free by default.
+Yoetz browser integrations are extension-free by default unless the Yoetz
+Chrome extension is installed and connected, in which case the `chatgpt`
+recipe auto-promotes it.
 
 - Treat yoetz as a thin wrapper over the underlying browser transport unless
   yoetz must own behavior for correctness or UX.
 - Preferred transport order for live Chrome work is `chrome-devtools-mcp`
-  first, `dev-browser` second, `agent-browser` third. Keep the stack
-  extension-free.
-- The experimental `chrome-extension-native` path is the explicit exception for
-  ChatGPT Pro recipe robustness. It is opt-in only via
-  `yoetz browser recipe --recipe chatgpt --transport chrome-extension-native`
+  first, `dev-browser` second, `agent-browser` third. Keep the non-extension
+  stack extension-free.
+- For the `chatgpt` recipe specifically, when `yoetz browser extension
+  status --chatgpt` reports `connected`, `chrome-extension-native` is
+  auto-promoted to the front of the default transport funnel; pass
+  `--transport <other>` or pin `transports:` in the recipe yaml to opt out.
+  Non-ChatGPT recipes and unhealthy/missing extensions are not affected.
+- The `chrome-extension-native` path stays the explicit choice when callers
+  want it regardless of detection, via
+  `yoetz browser recipe --recipe chatgpt --transport chrome-extension-native`,
   and is managed with `yoetz browser extension install-host --chatgpt`,
   `setup --chatgpt --open-chrome`, `doctor --chatgpt`, `status --chatgpt`, `reconnect --chatgpt`,
   `canary --chatgpt`, `inspect --chatgpt --run-id <id>`, and

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -245,6 +245,29 @@ pub fn recipe_transports(recipe: &Recipe, is_chatgpt: bool) -> Vec<RecipeTranspo
     })
 }
 
+/// Prepend `chrome-extension-native` to the ChatGPT recipe transport list when
+/// the Yoetz Chrome extension is installed and connected and the recipe author
+/// did not pin their own transport order. The list is returned unchanged for
+/// any other recipe, when the recipe pinned `transports:`, when the extension
+/// is unhealthy, or when the list already contains `chrome-extension-native`.
+pub fn maybe_prefer_extension_native_for_chatgpt(
+    transports: Vec<RecipeTransport>,
+    is_chatgpt: bool,
+    recipe_transports_pinned: bool,
+    extension_connected: bool,
+) -> Vec<RecipeTransport> {
+    if !is_chatgpt || recipe_transports_pinned || !extension_connected {
+        return transports;
+    }
+    if transports.contains(&RecipeTransport::ChromeExtensionNative) {
+        return transports;
+    }
+    let mut promoted = Vec::with_capacity(transports.len() + 1);
+    promoted.push(RecipeTransport::ChromeExtensionNative);
+    promoted.extend(transports);
+    promoted
+}
+
 /// Returns (program, extra_prefix_args) for launching agent-browser.
 /// Checks YOETZ_AGENT_BROWSER_BIN on every call, then falls back to a cached
 /// PATH probe for the lifetime of the process.
@@ -7330,6 +7353,62 @@ steps:
             recipe_transports(&recipe, false),
             vec![RecipeTransport::AgentBrowser]
         );
+    }
+
+    #[test]
+    fn maybe_prefer_extension_native_prepends_for_chatgpt_when_connected() {
+        let base = vec![
+            RecipeTransport::ChromeDevtoolsMcp,
+            RecipeTransport::DevBrowser,
+            RecipeTransport::AgentBrowser,
+            RecipeTransport::Manual,
+        ];
+        let promoted = maybe_prefer_extension_native_for_chatgpt(base, true, false, true);
+        assert_eq!(
+            promoted,
+            vec![
+                RecipeTransport::ChromeExtensionNative,
+                RecipeTransport::ChromeDevtoolsMcp,
+                RecipeTransport::DevBrowser,
+                RecipeTransport::AgentBrowser,
+                RecipeTransport::Manual,
+            ]
+        );
+    }
+
+    #[test]
+    fn maybe_prefer_extension_native_noop_when_extension_disconnected() {
+        let base = vec![
+            RecipeTransport::ChromeDevtoolsMcp,
+            RecipeTransport::DevBrowser,
+        ];
+        let result = maybe_prefer_extension_native_for_chatgpt(base.clone(), true, false, false);
+        assert_eq!(result, base);
+    }
+
+    #[test]
+    fn maybe_prefer_extension_native_noop_when_recipe_pinned_transports() {
+        let base = vec![RecipeTransport::ChromeDevtoolsMcp, RecipeTransport::Manual];
+        let result = maybe_prefer_extension_native_for_chatgpt(base.clone(), true, true, true);
+        assert_eq!(result, base);
+    }
+
+    #[test]
+    fn maybe_prefer_extension_native_noop_for_non_chatgpt() {
+        let base = vec![RecipeTransport::AgentBrowser];
+        let result = maybe_prefer_extension_native_for_chatgpt(base.clone(), false, false, true);
+        assert_eq!(result, base);
+    }
+
+    #[test]
+    fn maybe_prefer_extension_native_noop_when_already_present() {
+        let base = vec![
+            RecipeTransport::ChromeDevtoolsMcp,
+            RecipeTransport::ChromeExtensionNative,
+            RecipeTransport::Manual,
+        ];
+        let result = maybe_prefer_extension_native_for_chatgpt(base.clone(), true, false, true);
+        assert_eq!(result, base);
     }
 
     #[test]

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -7472,6 +7472,43 @@ steps:
     }
 
     #[test]
+    fn builtin_chatgpt_recipe_does_not_pin_transports_so_auto_promotion_can_fire() {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../recipes/chatgpt.yaml");
+        let content = fs::read_to_string(&path).expect("read recipes/chatgpt.yaml");
+        let recipe: Recipe = serde_yaml_ng::from_str(&content).expect("parse chatgpt.yaml");
+
+        assert!(
+            recipe.transports.is_none(),
+            "built-in chatgpt.yaml must not pin `transports:` so that \
+             chrome-extension-native auto-promotion gates correctly"
+        );
+
+        let base = recipe_transports(&recipe, true);
+        let promoted = maybe_prefer_extension_native_for_chatgpt(
+            base,
+            true,
+            recipe.transports.is_some(),
+            true,
+        );
+        assert_eq!(
+            promoted.first(),
+            Some(&RecipeTransport::ChromeExtensionNative),
+            "with extension connected, the built-in chatgpt recipe must \
+             auto-promote chrome-extension-native to the front of the funnel"
+        );
+        assert_eq!(
+            &promoted[1..],
+            &[
+                RecipeTransport::ChromeDevtoolsMcp,
+                RecipeTransport::DevBrowser,
+                RecipeTransport::AgentBrowser,
+                RecipeTransport::Manual,
+            ],
+            "auto-promotion must preserve the existing extension-free funnel order behind it"
+        );
+    }
+
+    #[test]
     fn resolve_recipe_ignores_same_name_cwd_directory_for_bare_builtin_name() {
         let _guard = lock_env();
         let cwd = unique_test_dir("recipe_shadow_cwd");

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -3217,10 +3217,17 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 recipe_args.transport,
                 Some(browser::RecipeTransport::ChromeExtensionNative)
             );
-            if recipe_uses_extension_instance_selector(&recipe_vars) && !requested_extension_native
+            let recipe_transports_pinned = recipe.transports.is_some();
+            let extension_auto_promotion_eligible = recipe_args.transport.is_none()
+                && is_chatgpt
+                && !recipe_transports_pinned
+                && extension_status_connected_for_auto_promotion();
+            let extension_native_will_route =
+                requested_extension_native || extension_auto_promotion_eligible;
+            if recipe_uses_extension_instance_selector(&recipe_vars) && !extension_native_will_route
             {
                 bail!(
-                    "extension_instance_id and extension_profile_id selectors require --transport chrome-extension-native"
+                    "extension_instance_id and extension_profile_id selectors require chrome-extension-native; install the Yoetz Chrome extension (`yoetz browser extension setup --chatgpt`) or pass --transport chrome-extension-native"
                 );
             }
             if is_chatgpt {
@@ -3238,18 +3245,13 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                     && (!requested_extension_native || recipe_args.allow_cdp_fallback),
             )?;
             maybe_print_auto_selected_cdp_target(resolved_cdp_target.as_ref(), format);
-            let recipe_transports_pinned = recipe.transports.is_some();
-            let extension_connected = recipe_args.transport.is_none()
-                && is_chatgpt
-                && !recipe_transports_pinned
-                && extension_status_connected_for_auto_promotion();
             let base_transports = browser::maybe_prefer_extension_native_for_chatgpt(
                 browser::recipe_transports(&recipe, is_chatgpt),
                 is_chatgpt,
                 recipe_transports_pinned,
-                extension_connected,
+                extension_auto_promotion_eligible,
             );
-            let extension_native_auto_promoted = extension_connected
+            let extension_native_auto_promoted = extension_auto_promotion_eligible
                 && base_transports.first()
                     == Some(&browser::RecipeTransport::ChromeExtensionNative);
             let transports = constrain_chatgpt_transports_for_browser_context_selector(

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -253,7 +253,10 @@ struct BrowserRecipeArgs {
     #[arg(long)]
     recipe: PathBuf,
 
-    /// Explicitly select one browser recipe transport. Defaults stay extension-free.
+    /// Explicitly select one browser recipe transport. When omitted, the
+    /// chatgpt recipe auto-promotes `chrome-extension-native` if the Yoetz
+    /// Chrome extension is installed and reports `connected`; otherwise the
+    /// default funnel stays extension-free.
     #[arg(long, value_parser = parse_recipe_transport_flag)]
     transport: Option<browser::RecipeTransport>,
 
@@ -1370,6 +1373,35 @@ fn maybe_print_running_profile_auto_connect_preference(
     }
 }
 
+/// Returns true when the locally installed Yoetz Chrome extension reports
+/// `connected`. Any other status (`disconnected`, `missing_extension`,
+/// `manual_handoff`, `version_mismatch`, `not_installed`) or I/O error is
+/// treated as not available for auto-promotion. The probe is filesystem-local
+/// (status file + Unix socket reachability) and is cheap enough to run on
+/// every `yoetz browser recipe` invocation.
+fn extension_status_connected_for_auto_promotion() -> bool {
+    browser_extension_native::status()
+        .map(|status| status.status == "connected")
+        .unwrap_or(false)
+}
+
+fn maybe_print_auto_promoted_extension_native_transport(
+    auto_promoted: bool,
+    transports: &[browser::RecipeTransport],
+    format: OutputFormat,
+) {
+    if !auto_promoted
+        || transports.first() != Some(&browser::RecipeTransport::ChromeExtensionNative)
+    {
+        return;
+    }
+    if matches!(format, OutputFormat::Text | OutputFormat::Markdown) {
+        eprintln!(
+            "info: auto-selected chrome-extension-native transport because the Yoetz Chrome extension is installed and connected (pass --transport <other> or pin `transports:` in the recipe to opt out)"
+        );
+    }
+}
+
 fn running_profile_recipe_transport_priority(transport: browser::RecipeTransport) -> u8 {
     match transport {
         browser::RecipeTransport::ChromeDevtoolsMcp => 0,
@@ -1390,8 +1422,23 @@ fn prioritize_chatgpt_transports_for_running_profile_auto_connect(
 
     let has_dev_browser = transports.contains(&browser::RecipeTransport::DevBrowser);
     let has_chrome_devtools_mcp = transports.contains(&browser::RecipeTransport::ChromeDevtoolsMcp);
+    let has_chrome_extension_native =
+        transports.contains(&browser::RecipeTransport::ChromeExtensionNative);
     let has_agent_browser = transports.contains(&browser::RecipeTransport::AgentBrowser);
     let has_manual = transports.contains(&browser::RecipeTransport::Manual);
+    if has_chrome_extension_native {
+        let mut constrained = vec![browser::RecipeTransport::ChromeExtensionNative];
+        if has_chrome_devtools_mcp {
+            constrained.push(browser::RecipeTransport::ChromeDevtoolsMcp);
+        }
+        if has_dev_browser {
+            constrained.push(browser::RecipeTransport::DevBrowser);
+        }
+        if has_manual {
+            constrained.push(browser::RecipeTransport::Manual);
+        }
+        return constrained;
+    }
     if has_chrome_devtools_mcp {
         let mut constrained = vec![browser::RecipeTransport::ChromeDevtoolsMcp];
         if has_dev_browser {
@@ -3191,8 +3238,22 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                     && (!requested_extension_native || recipe_args.allow_cdp_fallback),
             )?;
             maybe_print_auto_selected_cdp_target(resolved_cdp_target.as_ref(), format);
-            let transports = constrain_chatgpt_transports_for_browser_context_selector(
+            let recipe_transports_pinned = recipe.transports.is_some();
+            let extension_connected = recipe_args.transport.is_none()
+                && is_chatgpt
+                && !recipe_transports_pinned
+                && extension_status_connected_for_auto_promotion();
+            let base_transports = browser::maybe_prefer_extension_native_for_chatgpt(
                 browser::recipe_transports(&recipe, is_chatgpt),
+                is_chatgpt,
+                recipe_transports_pinned,
+                extension_connected,
+            );
+            let extension_native_auto_promoted = extension_connected
+                && base_transports.first()
+                    == Some(&browser::RecipeTransport::ChromeExtensionNative);
+            let transports = constrain_chatgpt_transports_for_browser_context_selector(
+                base_transports,
                 &recipe_vars,
                 is_chatgpt,
             );
@@ -3216,6 +3277,11 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 recipe_args.allow_cdp_fallback,
                 is_chatgpt,
             )?;
+            maybe_print_auto_promoted_extension_native_transport(
+                extension_native_auto_promoted,
+                &transports,
+                format,
+            );
             let manual_fallback =
                 manual_browser_recipe_fallback(&recipe_path, recipe_args.bundle.as_deref());
             let mut transport_errors = Vec::new();
@@ -4733,6 +4799,29 @@ mod tests {
             vec![
                 browser::RecipeTransport::ChromeDevtoolsMcp,
                 browser::RecipeTransport::Manual
+            ]
+        );
+    }
+
+    #[test]
+    fn prioritize_chatgpt_transports_for_running_profile_keeps_extension_native_in_front() {
+        let transports = prioritize_chatgpt_transports_for_running_profile_auto_connect(
+            vec![
+                browser::RecipeTransport::ChromeExtensionNative,
+                browser::RecipeTransport::ChromeDevtoolsMcp,
+                browser::RecipeTransport::DevBrowser,
+                browser::RecipeTransport::AgentBrowser,
+                browser::RecipeTransport::Manual,
+            ],
+            true,
+        );
+        assert_eq!(
+            transports,
+            vec![
+                browser::RecipeTransport::ChromeExtensionNative,
+                browser::RecipeTransport::ChromeDevtoolsMcp,
+                browser::RecipeTransport::DevBrowser,
+                browser::RecipeTransport::Manual,
             ]
         );
     }

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -49,12 +49,6 @@ name: chatgpt
 #   send_timeout_ms — extension-native send-button enable deadline in ms
 #              (default: 120000 = 2min).
 
-transports:
-  - chrome-devtools-mcp
-  - dev-browser
-  - agent-browser
-  - manual
-
 defaults:
   prompt: Review the attached file and provide your analysis.
   model: "auto"


### PR DESCRIPTION
## Summary

- chatgpt recipe now prepends `chrome-extension-native` to the default transport funnel when `yoetz browser extension status` reports `connected`, the recipe yaml did not pin its own `transports:` order, and the caller did not pass `--transport`. Other recipes and any unhealthy extension status fall back to the existing extension-free waterfall.
- Added `browser::maybe_prefer_extension_native_for_chatgpt` (pure function with 5 unit tests) and threaded an `extension_connected` probe into the recipe pipeline in `main.rs`.
- Updated `prioritize_chatgpt_transports_for_running_profile_auto_connect` to keep `chrome-extension-native` at the head of the list during the prefer-auto-connect path instead of dropping it. New test guards the order.
- Emits an `info:` stderr note (text/markdown formats only) when promotion lands at index 0 so callers can see the auto-selection and how to opt out (`--transport <other>` or pin `transports:` in the recipe yaml).
- Updated `BrowserRecipeArgs.transport` doc, `CLAUDE.md` Browser Architecture section, and `CHANGELOG.md [Unreleased]`.

## Test plan

- [x] `cargo test -p yoetz --bin yoetz maybe_prefer_extension_native` — 5 pass
- [x] `cargo test -p yoetz --bin yoetz prioritize_chatgpt_transports` — 5 pass (including new keeps-extension-native-in-front)
- [x] `cargo test --workspace` — 564 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI green (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)