### PR TITLE
fix(extension): resume pre-upload jobs after worker restart

### DIFF
--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -2157,6 +2157,9 @@ mod native_host_unix {
             let mut clients = clients.lock().unwrap();
             if let Some(client) = clients.get_mut(&job_id) {
                 update_client_effect_state(client, &envelope);
+                if should_replay_upload_from_start(&envelope) {
+                    client.next_chunk = 0;
+                }
                 let stream = match client.stream.try_clone() {
                     Ok(stream) => stream,
                     Err(err) => {
@@ -2333,6 +2336,20 @@ mod native_host_unix {
             return Ok(true);
         }
         Ok(false)
+    }
+
+    pub(super) fn should_replay_upload_from_start(envelope: &ProtocolEnvelope) -> bool {
+        envelope.kind == "job_progress"
+            && envelope
+                .payload
+                .get("phase")
+                .and_then(Value::as_str)
+                .is_some_and(|phase| phase == "ready_for_file")
+            && envelope
+                .payload
+                .get("restored")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
     }
 
     fn local_client_disconnected_cancel(client: &ClientJob) -> ProtocolEnvelope {
@@ -3210,6 +3227,31 @@ mod tests {
         assert_eq!(chunks[0]["total_bytes"], 3);
         assert_eq!(chunks[0]["filename"], "bundle.md");
         assert_eq!(chunks[0]["bytes_base64"], "YWJj");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn restored_ready_for_file_replays_upload_from_start() {
+        let restored = ProtocolEnvelope::new(
+            "job_progress",
+            Some("job_restore".to_string()),
+            Some("run_restore".to_string()),
+            json!({
+                "phase": "ready_for_file",
+                "restored": true,
+            }),
+        );
+        let fresh = ProtocolEnvelope::new(
+            "job_progress",
+            Some("job_fresh".to_string()),
+            Some("run_fresh".to_string()),
+            json!({
+                "phase": "ready_for_file",
+            }),
+        );
+
+        assert!(native_host_unix::should_replay_upload_from_start(&restored));
+        assert!(!native_host_unix::should_replay_upload_from_start(&fresh));
     }
 
     #[test]

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -676,6 +676,18 @@ async function restoreJobsFromStorage({ emitLostState = false } = {}) {
     if (TERMINAL_STATUSES.has(job.status)) {
       continue;
     }
+    if (canResumeJobAfterWorkerRestart(job)) {
+      job.connection_generation = connectionGeneration;
+      job.updated_at = Date.now();
+      jobs.set(job.job_id, job);
+      await persistJob(job);
+      postNative(progress(job, "ready_for_file", {
+        tab_id: job.tab_id,
+        restored: true,
+        message: "ChatGPT tab is ready for bundle upload"
+      }));
+      continue;
+    }
     if (emitLostState) {
       const lostStatus = job.status;
       await failJob(job, "state_lost", `job ${job.job_id} lost in-memory extension state after service-worker restart`, {
@@ -687,6 +699,13 @@ async function restoreJobsFromStorage({ emitLostState = false } = {}) {
       jobs.set(job.job_id, job);
     }
   }
+}
+
+function canResumeJobAfterWorkerRestart(job) {
+  // The tab is prepared and no file chunks have been accepted yet. There is no
+  // in-memory ChunkAssembler state to reconstruct, so the native process can
+  // continue by sending the first chunk after reconnect.
+  return job.status === "waiting_for_file" && Boolean(job.tab_id);
 }
 
 function normalizeJob(message) {

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -2709,6 +2709,129 @@ test("service worker cancelJob still removes the tab when the content script is 
   }
 });
 
+test("service worker resumes waiting_for_file jobs after service-worker restart", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const storage = makeStorage();
+  const now = Date.now();
+  const sentToTabs = [];
+  let sent = false;
+  await storage.set({
+    "jobs.job_restore_waiting": {
+      job_id: "job_restore_waiting",
+      run_id: "run_job_restore_waiting",
+      workspace_id: "workspace_test",
+      status: "waiting_for_file",
+      prompt: "prompt",
+      model: "current",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 1500,
+      tab_id: 42,
+      started_at: now,
+      updated_at: now
+    }
+  });
+
+  globalThis.chrome = chromeStub({
+    port,
+    storage,
+    tabs: {
+      create: async () => {
+        throw new Error("restore must reuse the prepared tab");
+      },
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (id, message) => {
+        sentToTabs.push({ id, message });
+        switch (message.type) {
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_extract_response":
+            return {
+              ok: true,
+              payload: sent
+                ? { method: "assistant_dom_fallback", text: "restored answer", is_generating: false, assistant_count: 1, copy_button_count: 1, has_copy_button: true, turn_index: 0 }
+                : { method: "none", text: "", is_generating: false, assistant_count: 0, turn_index: -1 }
+            };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true } };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?restore_waiting_for_file=${Date.now()}`);
+    await eventually(() => port.messages.some((message) => message.type === "hello"));
+    await eventually(async () => {
+      const restored = (await storage.get("jobs.job_restore_waiting"))["jobs.job_restore_waiting"];
+      return restored?.status === "waiting_for_file" && Number.isFinite(restored.connection_generation);
+    });
+    assert.equal(port.messages.some((message) => message.type === "job_error" && message.job_id === "job_restore_waiting"), false);
+    const restoredReady = port.messages.find((message) => message.type === "job_progress" && message.job_id === "job_restore_waiting" && message.payload?.phase === "ready_for_file");
+    assert.equal(restoredReady?.payload.restored, true);
+    assert.equal(restoredReady?.payload.tab_id, 42);
+
+    port.emit(envelope("job_file_chunk", "job_restore_waiting", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_restore_waiting.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_complete" && message.job_id === "job_restore_waiting"));
+    const complete = port.messages.find((message) => message.type === "job_complete" && message.job_id === "job_restore_waiting");
+    assert.equal(complete.payload.response, "restored answer");
+    assert.equal(sentToTabs.find((item) => item.message.type === "yoetz_upload_file")?.id, 42);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker still fails receiving_file jobs after service-worker restart", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const storage = makeStorage();
+  const now = Date.now();
+  await storage.set({
+    "jobs.job_restore_receiving": {
+      job_id: "job_restore_receiving",
+      run_id: "run_job_restore_receiving",
+      workspace_id: "workspace_test",
+      status: "receiving_file",
+      prompt: "prompt",
+      model: "current",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 1500,
+      tab_id: 43,
+      started_at: now,
+      updated_at: now
+    }
+  });
+
+  globalThis.chrome = chromeStub({
+    port,
+    storage,
+    tabs: {}
+  });
+
+  try {
+    await import(`../src/service-worker.js?restore_receiving_file=${Date.now()}`);
+    await eventually(() => port.messages.some((message) => message.type === "job_error" && message.job_id === "job_restore_receiving"));
+    const error = port.messages.find((message) => message.type === "job_error" && message.job_id === "job_restore_receiving");
+    assert.equal(error.payload.code, "state_lost");
+    assert.equal(error.payload.phase, "upload");
+    assert.equal(error.payload.side_effect_started, true);
+    assert.equal((await storage.get("jobs.job_restore_receiving"))["jobs.job_restore_receiving"].status, "state_lost");
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 function envelope(type, jobId, payload = {}, fields = {}) {
   return {
     protocol_version: 1,


### PR DESCRIPTION
## Summary
- Resume persisted ChatGPT extension jobs that reached `waiting_for_file` before a service-worker restart.
- Re-emit restored `ready_for_file` so the native host can continue upload.
- Reset the native chunk pointer on restored ready-for-file progress so upload replays from chunk 0 instead of hanging or skipping.
- Keep `receiving_file` and later non-terminal states fail-closed as `state_lost`.

## Evidence
Dogfood run against v0.5.9 failed during upload with:

> job lost in-memory extension state after service-worker restart

`inspect` showed the Yoetz-owned ChatGPT tab existed, Extended Pro was visible, no user turn was submitted, and the job was still at the pre-upload boundary.

## Validation
- `node --test extensions/chatgpt-native/tests/service-worker.test.js` => 45 pass
- `node --test extensions/chatgpt-native/tests/*.test.js` => 143 pass
- `./scripts/build-chatgpt-native-extension.sh --check` => pass
- `cargo fmt --all -- --check` => pass
- `cargo test -p yoetz --bin yoetz restored_ready_for_file_replays_upload_from_start` => pass
- `cargo test -p yoetz --bin yoetz browser_extension_native::tests` => 25 pass
- `git diff --check` => pass

Claude reviewed via AMQ and approved the state boundary/native replay contract.
