### PR TITLE
fix(extension): resume response waits after worker restart

### DIFF
--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -369,11 +369,16 @@ async function runJobWithFile(job, file) {
   }
 
   job.status = "waiting_response";
+  job.response_wait_started_at = Date.now();
   job.updated_at = Date.now();
   await persistJob(job);
   const extraction = await waitForResponse(job);
   assertJobConnectionCurrent(job);
   if (job.cancelled || !extraction) return;
+  await completeJobWithExtraction(job, extraction);
+}
+
+async function completeJobWithExtraction(job, extraction) {
   job.status = "complete";
   job.updated_at = Date.now();
   await persistJob(job);
@@ -406,6 +411,33 @@ async function runJobWithFile(job, file) {
   rememberTerminalJob(job.job_id);
   jobs.delete(job.job_id);
   chunks.discard(job.job_id);
+}
+
+async function resumeWaitingResponseJob(job) {
+  try {
+    await waitForChatgptTab(job.tab_id);
+    await waitForContentScript(job.tab_id);
+    const rebound = await sendToTab(job.tab_id, { type: "yoetz_bind_job", job });
+    postNative(progress(job, "content_script_recovered", {
+      restored: true,
+      url: rebound?.url ?? null,
+      title: rebound?.title ?? null
+    }));
+    const extraction = await waitForResponse(job);
+    assertJobConnectionCurrent(job);
+    if (job.cancelled || !extraction) return;
+    await completeJobWithExtraction(job, extraction);
+  } catch (error) {
+    if (!jobs.has(job.job_id) || TERMINAL_STATUSES.has(job.status)) {
+      return;
+    }
+    await failJob(
+      job,
+      error?.code ?? "extension_error",
+      String(error?.message ?? error),
+      errorContextForJob(job, error)
+    );
+  }
 }
 
 async function cancelJob(message) {
@@ -676,6 +708,9 @@ async function restoreJobsFromStorage({ emitLostState = false } = {}) {
     if (TERMINAL_STATUSES.has(job.status)) {
       continue;
     }
+    if (jobs.has(job.job_id)) {
+      continue;
+    }
     if (canResumeJobAfterWorkerRestart(job)) {
       job.connection_generation = connectionGeneration;
       job.updated_at = Date.now();
@@ -686,6 +721,30 @@ async function restoreJobsFromStorage({ emitLostState = false } = {}) {
         restored: true,
         message: "ChatGPT tab is ready for bundle upload"
       }));
+      continue;
+    }
+    if (canResumeWaitingResponseAfterWorkerRestart(job)) {
+      job.connection_generation = connectionGeneration;
+      job.response_wait_started_at = job.response_wait_started_at ?? Date.now();
+      if (
+        !job.last_response_progress_text
+        && job.last_response_progress_length === job.last_response_progress_tail?.length
+      ) {
+        job.last_response_progress_text = job.last_response_progress_tail;
+      }
+      job.updated_at = Date.now();
+      jobs.set(job.job_id, job);
+      await persistJob(job);
+      if (!postNative(progress(job, "waiting_response", {
+        tab_id: job.tab_id,
+        restored: true,
+        inspect_command: inspectCommandForJob(job),
+        message: "restored ChatGPT response wait after service-worker restart"
+      }))) {
+        await recordTerminalDeliveryLost(job, "wait_response");
+        continue;
+      }
+      void resumeWaitingResponseJob(job);
       continue;
     }
     if (emitLostState) {
@@ -706,6 +765,13 @@ function canResumeJobAfterWorkerRestart(job) {
   // in-memory ChunkAssembler state to reconstruct, so the native process can
   // continue by sending the first chunk after reconnect.
   return job.status === "waiting_for_file" && Boolean(job.tab_id);
+}
+
+function canResumeWaitingResponseAfterWorkerRestart(job) {
+  // The prompt has already been accepted by ChatGPT and the only remaining
+  // mutable state is the DOM polling loop. Rebind the content script to the
+  // persisted owned tab and continue structural-finality polling.
+  return job.status === "waiting_response" && Boolean(job.tab_id);
 }
 
 function normalizeJob(message) {
@@ -1004,7 +1070,8 @@ async function maybeGroupTab(tabId, job) {
 }
 
 async function waitForResponse(job) {
-  const startedAt = Date.now();
+  const startedAt = Number(job.response_wait_started_at) || Date.now();
+  job.response_wait_started_at = startedAt;
   const interval = Math.max(500, Math.min(Number(job.wait_interval_ms) || 30000, 30000));
   const finalAffordanceIdleMs = Math.min(MIN_STABLE_IDLE_MS, Math.max(FINAL_AFFORDANCE_STABLE_IDLE_MS, 0));
   let best = { method: "none", text: "", is_generating: true };

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -2792,6 +2792,120 @@ test("service worker resumes waiting_for_file jobs after service-worker restart"
   }
 });
 
+test("service worker resumes waiting_response jobs after service-worker restart", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const storage = makeStorage();
+  const now = Date.now();
+  const sentToTabs = [];
+  let extractCount = 0;
+  await storage.set({
+    "jobs.job_restore_waiting_response": {
+      job_id: "job_restore_waiting_response",
+      run_id: "run_job_restore_waiting_response",
+      workspace_id: "workspace_test",
+      status: "waiting_response",
+      prompt: "prompt",
+      model: "current",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 2500,
+      tab_id: 44,
+      response_baseline: {
+        method: "none",
+        text: "",
+        is_generating: false,
+        assistant_count: 0,
+        turn_index: -1
+      },
+      submitted_user_count: 1,
+      submitted_assistant_count: 0,
+      started_at: now,
+      response_wait_started_at: now,
+      updated_at: now
+    }
+  });
+
+  globalThis.chrome = chromeStub({
+    port,
+    storage,
+    tabs: {
+      create: async () => {
+        throw new Error("restore must reuse the submitted tab");
+      },
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/?_yoetz=run_job_restore_waiting_response" }),
+      sendMessage: async (id, message) => {
+        sentToTabs.push({ id, message });
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: { url: "https://chatgpt.com/", title: "ChatGPT" } };
+          case "yoetz_bind_job":
+            return { ok: true, payload: { url: "https://chatgpt.com/", title: "ChatGPT" } };
+          case "yoetz_extract_response": {
+            extractCount += 1;
+            const streaming = {
+              method: "assistant_dom_fallback",
+              text: "I",
+              is_generating: true,
+              assistant_count: 1,
+              copy_button_count: 0,
+              has_copy_button: false,
+              turn_index: 0,
+              preceding_user_count: 1
+            };
+            const complete = {
+              method: "assistant_dom_fallback",
+              text: "restored final answer",
+              is_generating: false,
+              assistant_count: 1,
+              copy_button_count: 1,
+              has_copy_button: true,
+              turn_index: 0,
+              preceding_user_count: 1
+            };
+            return { ok: true, payload: extractCount < 3 ? streaming : complete };
+          }
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?restore_waiting_response=${Date.now()}`);
+    await eventually(() => port.messages.some((message) => message.type === "hello"));
+    await eventually(() => port.messages.some((message) =>
+      message.type === "job_progress"
+      && message.job_id === "job_restore_waiting_response"
+      && message.payload?.phase === "waiting_response"
+      && message.payload.restored === true
+    ));
+    port.emit(envelope("reconnect", "job_restore_waiting_response_control"));
+    await eventually(() => port.messages.some((message) =>
+      message.type === "job_complete" && message.job_id === "job_restore_waiting_response"
+    ));
+    assert.equal(port.messages.some((message) => message.type === "job_error" && message.job_id === "job_restore_waiting_response"), false);
+    const waiting = port.messages.find((message) =>
+      message.type === "job_progress"
+      && message.job_id === "job_restore_waiting_response"
+      && message.payload?.phase === "waiting_response"
+    );
+    assert.equal(waiting?.payload.restored, true);
+    assert.equal(waiting?.payload.tab_id, 44);
+    const complete = port.messages.find((message) => message.type === "job_complete" && message.job_id === "job_restore_waiting_response");
+    assert.equal(complete.payload.response, "restored final answer");
+    assert.equal(sentToTabs.some((item) => item.message.type === "yoetz_upload_file"), false);
+    assert.equal(sentToTabs.some((item) => item.message.type === "yoetz_send_prompt"), false);
+    assert.equal(sentToTabs.find((item) => item.message.type === "yoetz_extract_response")?.id, 44);
+    assert.equal(sentToTabs.filter((item) => item.message.type === "yoetz_bind_job").length, 1);
+    assert.equal(port.messages.filter((message) =>
+      message.type === "job_complete" && message.job_id === "job_restore_waiting_response"
+    ).length, 1);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker still fails receiving_file jobs after service-worker restart", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();


### PR DESCRIPTION
## Summary
- Resume persisted `waiting_response` jobs after MV3 service-worker restart by rebinding the owned ChatGPT tab and reusing the existing structural response wait loop.
- Keep pre-upload resume behavior intact and continue failing `receiving_file` jobs closed as `state_lost`.
- Guard reconnect-triggered restore from starting duplicate pollers for an already-restored job.

## Verification
- `node --test --test-name-pattern "resumes waiting_response" extensions/chatgpt-native/tests/service-worker.test.js`
- `node --test extensions/chatgpt-native/tests/*.test.js`
- `./scripts/build-chatgpt-native-extension.sh --check`
- `git diff --check`

Claude reviewed via AMQ and approved before commit/push.