### PR TITLE
Fix ChatGPT native Pro response finality

### DIFF
--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -1347,6 +1347,36 @@ fn constrain_chatgpt_transports_for_browser_context_selector(
     transports
 }
 
+fn ensure_chatgpt_transport_constraints_allow_any(
+    transports: &[browser::RecipeTransport],
+    requested: Option<browser::RecipeTransport>,
+    recipe_vars: &std::collections::BTreeMap<String, String>,
+    is_chatgpt: bool,
+) -> Result<()> {
+    if !transports.is_empty() || !is_chatgpt {
+        return Ok(());
+    }
+
+    let requested = requested
+        .map(recipe_transport_name)
+        .map(|name| format!("requested transport `{name}`"))
+        .unwrap_or_else(|| "configured transports".to_string());
+
+    if recipe_uses_exact_browser_context_selector(recipe_vars) {
+        bail!(
+            "browser_context_id requires chrome-devtools-mcp or manual; {requested} is not compatible"
+        );
+    }
+
+    if recipe_uses_profile_email_selector(recipe_vars) {
+        bail!(
+            "profile_email requires chrome-devtools-mcp, chrome-extension-native, agent-browser, or manual; {requested} is not compatible"
+        );
+    }
+
+    Ok(())
+}
+
 fn live_attach_owner_present(summary: &live_attach::DaemonSummary) -> bool {
     matches!(summary.health, live_attach::DaemonHealth::Busy)
         || matches!(summary.health, live_attach::DaemonHealth::Healthy) && summary.session_count > 0
@@ -3254,11 +3284,12 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             let extension_native_auto_promoted = extension_auto_promotion_eligible
                 && base_transports.first()
                     == Some(&browser::RecipeTransport::ChromeExtensionNative);
-            let transports = constrain_chatgpt_transports_for_browser_context_selector(
+            let transports = recipe_transports_with_explicit_override(
                 base_transports,
-                &recipe_vars,
+                recipe_args.transport,
+                recipe_args.allow_cdp_fallback,
                 is_chatgpt,
-            );
+            )?;
             let live_attach_owner_is_present =
                 live_attach_owner_present(&live_attach::inspect_daemon_sync());
             let prefer_auto_connect = is_chatgpt
@@ -3273,10 +3304,15 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 transports,
                 prefer_auto_connect,
             );
-            let transports = recipe_transports_with_explicit_override(
+            let transports = constrain_chatgpt_transports_for_browser_context_selector(
                 transports,
+                &recipe_vars,
+                is_chatgpt,
+            );
+            ensure_chatgpt_transport_constraints_allow_any(
+                &transports,
                 recipe_args.transport,
-                recipe_args.allow_cdp_fallback,
+                &recipe_vars,
                 is_chatgpt,
             )?;
             maybe_print_auto_promoted_extension_native_transport(
@@ -4659,6 +4695,39 @@ mod tests {
                 browser::RecipeTransport::Manual
             ]
         );
+    }
+
+    #[test]
+    fn exact_browser_context_selector_rejects_explicit_dev_browser_transport() {
+        let vars = std::collections::BTreeMap::from([(
+            "browser_context_id".to_string(),
+            "ctx-123".to_string(),
+        )]);
+        let transports = recipe_transports_with_explicit_override(
+            vec![
+                browser::RecipeTransport::ChromeDevtoolsMcp,
+                browser::RecipeTransport::DevBrowser,
+                browser::RecipeTransport::Manual,
+            ],
+            Some(browser::RecipeTransport::DevBrowser),
+            false,
+            true,
+        )
+        .unwrap();
+        let transports =
+            constrain_chatgpt_transports_for_browser_context_selector(transports, &vars, true);
+        let err = ensure_chatgpt_transport_constraints_allow_any(
+            &transports,
+            Some(browser::RecipeTransport::DevBrowser),
+            &vars,
+            true,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("browser_context_id requires"));
+        assert!(err
+            .to_string()
+            .contains("requested transport `dev-browser`"));
     }
 
     #[test]

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -686,7 +686,7 @@ function standaloneAssistantSegment(root, conversation, ordered, marker, latestU
         && !isNonConversationChrome(node);
     });
   const textEntries = markdownNodes
-    .map((node) => ({ node, text: cleanAssistantText(node) }))
+    .map((node) => ({ node, text: cleanAssistantText(node, { preserveContentStatusText: true }) }))
     .filter((entry) => entry.text);
   if (textEntries.length === 0) {
     return null;
@@ -758,7 +758,7 @@ function hasResponseBoundaryBetween(ordered, startIndex, endIndex) {
     if (role === "user" || role === "assistant") {
       return true;
     }
-    if (isMarkdownNode(node) && cleanAssistantText(node)) {
+    if (isMarkdownNode(node) && cleanAssistantText(node, { preserveContentStatusText: true })) {
       return true;
     }
   }
@@ -841,7 +841,7 @@ function assistantMessageTextEntry(turn) {
       contentNodes.push(node);
     }
   };
-  if (isAssistantContentNode(turn)) {
+  if (isAssistantContentNode(turn, turn)) {
     addContentNode(turn);
   }
   for (const selector of [
@@ -851,7 +851,7 @@ function assistantMessageTextEntry(turn) {
     '[class*="markdown"]'
   ]) {
     for (const node of Array.from(turn.querySelectorAll?.(selector) ?? [])) {
-      if (!looksLikeUserTurn(node)) {
+      if (!looksLikeUserTurn(node) && isAssistantContentNode(node, turn)) {
         addContentNode(node);
       }
     }
@@ -859,7 +859,7 @@ function assistantMessageTextEntry(turn) {
   const leafContentNodes = leafNodes(contentNodes);
   const textEntries = [];
   for (const node of leafContentNodes) {
-    const text = cleanAssistantText(node);
+    const text = cleanAssistantText(node, { preserveContentStatusText: node !== turn });
     if (text) {
       textEntries.push({ node, text });
     }
@@ -874,33 +874,45 @@ function assistantMessageTextEntry(turn) {
   return { node: turn, text: isModelStatusText(fallback) ? "" : fallback };
 }
 
-function isAssistantContentNode(node) {
-  const marker = [
-    node?.getAttribute?.("data-testid"),
-    node?.getAttribute?.("class"),
-    node?.getAttribute?.("data-message-author-role")
-  ].filter(Boolean).join(" ");
-  return /\bassistant-(message|response)\b/i.test(marker)
-    || /\bmarkdown\b/i.test(marker)
-    || /\bassistant\b/i.test(marker);
+function isAssistantContentNode(node, turn = null) {
+  if (!node || looksLikeUserTurn(node) || isInsideUserTurn(node) || isNonConversationChrome(node)) {
+    return false;
+  }
+  const role = node.getAttribute?.("data-message-author-role");
+  if (role === "assistant") {
+    return true;
+  }
+  if (role === "user") {
+    return false;
+  }
+  const testId = String(node.getAttribute?.("data-testid") ?? "");
+  if (/assistant-(message|response)/i.test(testId)) {
+    return true;
+  }
+  if (isMarkdownNode(node)) {
+    return isAssistantMarkdownInTurn(node, turn ?? assistantTurnForNode(node));
+  }
+  return false;
 }
 
 function leafNodes(nodes) {
   return nodes.filter((node) => !nodes.some((other) => other !== node && containsNode(node, other)));
 }
 
-function cleanAssistantText(node) {
+function cleanAssistantText(node, options = {}) {
   const lines = textOf(node)
     .split(/\n+/)
     .map((line) => normalizeText(line))
-    .filter((line) => line && !isAssistantControlLine(line));
+    .filter((line) => line && !isAssistantControlLine(line, options));
   return normalizeText(lines.join("\n"));
 }
 
-function isAssistantControlLine(line) {
-  return /^(copy|copied|read aloud|share|regenerate|retry|edit|like|dislike)$/i.test(line)
-    || isThoughtStatusLine(line)
-    || isModelStatusText(line);
+function isAssistantControlLine(line, options = {}) {
+  const value = normalizeText(line);
+  return /^(copy|copied|read aloud|share|regenerate|retry|edit|like|dislike)$/i.test(value)
+    || /^(thought|reasoned)\s+for\s+\S.*$/i.test(value)
+    || /^show\s+(more|reasoning)$/i.test(value)
+    || (!options.preserveContentStatusText && (isThoughtStatusLine(line) || isModelStatusText(line)));
 }
 
 function isModelStatusText(text) {
@@ -1445,6 +1457,22 @@ function hasUserRoleDescendant(node) {
   return false;
 }
 
+function hasAssistantRoleDescendant(node) {
+  if (!node) {
+    return false;
+  }
+  const queried = Array.from(node.querySelectorAll?.('[data-message-author-role="assistant"]') ?? []);
+  if (queried.length > 0) {
+    return true;
+  }
+  for (const child of Array.from(node.children ?? [])) {
+    if (child.getAttribute?.("data-message-author-role") === "assistant" || hasAssistantRoleDescendant(child)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function hasConversationResidue(root) {
   const residue = conversationResidue(root);
   return residue.user_count > 0 || residue.assistant_count > 0 || residue.copy_button_count > 0;
@@ -1528,12 +1556,12 @@ function isCodeCopyControl(node) {
 }
 
 function isAssistantMarkerNode(node) {
-  const marker = [
-    node?.getAttribute?.("data-testid"),
-    node?.getAttribute?.("class"),
-    node?.getAttribute?.("data-message-author-role")
-  ].filter(Boolean).join(" ");
-  return /\bassistant\b/i.test(marker);
+  const role = node?.getAttribute?.("data-message-author-role");
+  if (role === "assistant") {
+    return true;
+  }
+  const testId = String(node?.getAttribute?.("data-testid") ?? "");
+  return /assistant-(message|response)/i.test(testId);
 }
 
 function isAssistantMarkdownInTurn(node, turn) {
@@ -1543,7 +1571,13 @@ function isAssistantMarkdownInTurn(node, turn) {
     turn?.getAttribute?.("data-testid")
   ].filter(Boolean).join(" ");
   return /\bmarkdown\b/i.test(marker)
-    && (/\bagent-turn\b/i.test(marker) || /\bassistant\b/i.test(marker) || /\bconversation-turn\b/i.test(marker));
+    && (
+      /\bagent-turn\b/i.test(marker)
+      || /\bassistant\b/i.test(marker)
+      || /\bconversation-turn\b/i.test(marker)
+      || turn?.getAttribute?.("data-message-author-role") === "assistant"
+      || hasAssistantRoleDescendant(turn)
+    );
 }
 
 function looksLikeUserTurn(turn) {

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -18,7 +18,8 @@ const RECONNECT_ALARM = "yoetz-reconnect";
 const TERMINAL_STATUSES = new Set(["complete", "cancelled", "failed", "manual_handoff", "state_lost", "terminal_delivery_lost"]);
 const EXTENSION_ID_STORAGE_KEY = "yoetz_extension_instance_id";
 const MIN_STABLE_IDLE_MS = Number(globalThis.__YOETZ_MIN_STABLE_IDLE_MS ?? 90000);
-const FINAL_AFFORDANCE_STABLE_IDLE_MS = Number(globalThis.__YOETZ_FINAL_AFFORDANCE_STABLE_IDLE_MS ?? 5000);
+// Require multiple stable polls so final controls cannot win before late text hydration.
+const STABLE_IDLE_INTERVAL_MULTIPLIER = Number(globalThis.__YOETZ_STABLE_IDLE_INTERVAL_MULTIPLIER ?? 3);
 const WAITING_RESPONSE_PROGRESS_INTERVAL_MS = Math.max(50, Number(globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS ?? 60000) || 60000);
 const JOBS_KEY_PREFIX = "jobs.";
 const LEGACY_JOBS_KEY = "jobs";
@@ -1073,7 +1074,7 @@ async function waitForResponse(job) {
   const startedAt = Number(job.response_wait_started_at) || Date.now();
   job.response_wait_started_at = startedAt;
   const interval = Math.max(500, Math.min(Number(job.wait_interval_ms) || 30000, 30000));
-  const finalAffordanceIdleMs = Math.min(MIN_STABLE_IDLE_MS, Math.max(FINAL_AFFORDANCE_STABLE_IDLE_MS, 0));
+  const finalAffordanceIdleMs = responseStableIdleThresholdMs(interval);
   let best = { method: "none", text: "", is_generating: true };
   let last = { method: "none", text: "", is_generating: true };
   let finalAffordanceAnchor = "";
@@ -1380,18 +1381,46 @@ function hasFinalAssistantAffordance(extraction) {
   return Boolean(!extraction?.is_generating && extraction?.has_copy_button);
 }
 
+function responseStableIdleThresholdMs(intervalMs) {
+  const interval = Math.max(0, Number(intervalMs) || 0);
+  return Math.max(MIN_STABLE_IDLE_MS, interval * STABLE_IDLE_INTERVAL_MULTIPLIER);
+}
+
 function responseFinalityAnchor(extraction) {
+  const text = normalizedResponseText(extraction?.text);
+  // Tail hashing catches late citation/code-block changes without making logs huge.
+  const textTail = text.slice(-4096);
   return [
     extraction?.method ?? "none",
     extraction?.assistant_count ?? 0,
     extraction?.turn_index ?? -1,
     extraction?.copy_button_count ?? 0,
-    extraction?.has_copy_button ? 1 : 0
+    extraction?.has_copy_button ? 1 : 0,
+    text.length,
+    stableTextHash(text),
+    stableTextHash(textTail)
   ].join(":");
 }
 
 function finalAffordanceExtractionFailureAnchor(extraction) {
   return responseFinalityAnchor(extraction);
+}
+
+function normalizedResponseText(value) {
+  return String(value ?? "")
+    .replace(/\r\n/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function stableTextHash(value) {
+  let hash = 0x811c9dc5;
+  const text = String(value ?? "");
+  for (let index = 0; index < text.length; index += 1) {
+    hash = Math.imul(hash ^ text.charCodeAt(index), 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, "0");
 }
 
 function finalAffordanceExtractionFailureMessage(job, extraction, stableForMs) {

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -416,6 +416,42 @@ test("extractResponse returns single-letter assistant markdown with a copy affor
   assert.equal(extraction.has_copy_button, true);
 });
 
+test("extractResponse preserves one-word assistant markdown answers that look like model status labels", () => {
+  for (const answer of ["GPT-5", "Pro", "Thinking"]) {
+    const user = new FakeElement("article", { "data-message-author-role": "user", class: "user-turn" }, "One word");
+    const marker = new FakeElement("div", { "data-message-author-role": "assistant" }, "");
+    const markdown = new FakeElement("div", { class: "markdown prose" }, answer);
+    const copy = new FakeElement("button", { "aria-label": "Copy" }, "Copy");
+    const conversation = new FakeElement("main", { role: "main" }, `One word ${answer} Copy`)
+      .append(user, marker, markdown, copy);
+    const body = new FakeElement("body", {}, `One word ${answer} Copy`).append(conversation);
+    const doc = new FakeDocument(body);
+
+    const extraction = extractResponse(doc);
+
+    assert.equal(extraction.method, "copy_scope_dom_fallback");
+    assert.equal(extraction.text, answer);
+    assert.equal(extraction.has_copy_button, true);
+  }
+});
+
+test("extractResponse ignores assistant-like preview chrome without structural ownership", () => {
+  const user = new FakeElement("article", { "data-message-author-role": "user", class: "user-turn" }, "Review bundle");
+  const previewCopy = new FakeElement("button", { "aria-label": "Copy" }, "Copy");
+  const preview = new FakeElement("div", { class: "assistant-preview thinking-node" }, "I")
+    .append(previewCopy);
+  const conversation = new FakeElement("main", { role: "main" }, "Review bundle I Copy")
+    .append(user, preview);
+  const body = new FakeElement("body", {}, "Review bundle I Copy").append(conversation);
+  const doc = new FakeDocument(body);
+
+  const extraction = extractResponse(doc);
+
+  assert.equal(extraction.method, "page_text_fallback");
+  assert.equal(extraction.assistant_count, 0);
+  assert.equal(extraction.has_copy_button, false);
+});
+
 test("extractResponse does not reuse an earlier assistant copy button for a newer assistant text", () => {
   const user = new FakeElement("article", { "data-message-author-role": "user", class: "user-turn" }, "Review bundle");
   const oldMarker = new FakeElement("div", { "data-message-author-role": "assistant" }, "");

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -3,6 +3,7 @@ import test from "node:test";
 import { uint8ArrayToBase64 } from "../src/chunks.js";
 
 globalThis.__YOETZ_MIN_STABLE_IDLE_MS = 100;
+globalThis.__YOETZ_STABLE_IDLE_INTERVAL_MULTIPLIER = 0;
 
 test("service worker routes reconnect and multiplexes two native jobs", async () => {
   const originalChrome = globalThis.chrome;
@@ -1378,6 +1379,85 @@ test("service worker accepts a scoped single-letter assistant markdown response"
     await eventually(() => port.messages.some((message) => message.type === "job_complete"));
     const complete = port.messages.find((message) => message.type === "job_complete");
     assert.equal(complete.payload.response, "A");
+    assert.equal(complete.payload.completion_reason, "copy_button");
+    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker waits for scoped response text bytes to stabilize after final controls appear", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  let tabId = 0;
+  let sent = false;
+  let extractCount = 0;
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true } };
+          case "yoetz_extract_response": {
+            if (!sent) {
+              return { ok: true, payload: { method: "none", text: "", is_generating: false, assistant_count: 0, copy_button_count: 0, has_copy_button: false, turn_index: -1 } };
+            }
+            extractCount += 1;
+            return {
+              ok: true,
+              payload: {
+                method: "copy_scope_dom_fallback",
+                text: `final answer revision ${Math.min(extractCount, 4)}`,
+                is_generating: false,
+                assistant_count: 1,
+                user_count: 1,
+                preceding_user_count: 1,
+                copy_button_count: 1,
+                has_copy_button: true,
+                turn_index: 0
+              }
+            };
+          }
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?text_hash_stability=${Date.now()}`);
+    port.emit(envelope("job_start", "job_text_hash_stability", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 5000
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_text_hash_stability", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_text_hash_stability.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_complete"), 7000);
+    const complete = port.messages.find((message) => message.type === "job_complete");
+    assert.ok(extractCount >= 5, "completion should wait past repeated text mutations under the same structural anchor");
+    assert.equal(complete.payload.response, "final answer revision 4");
     assert.equal(complete.payload.completion_reason, "copy_button");
     assert.equal(port.messages.some((message) => message.type === "job_error"), false);
   } finally {


### PR DESCRIPTION
## Summary
- enforce ChatGPT recipe selector constraints after explicit transport overrides so `browser_context_id` cannot fall through to incompatible transports
- require scoped response text bytes to stabilize before extension-native treats final controls as complete
- tighten ChatGPT DOM response ownership so preview/thinking chrome fails closed while legitimate short assistant answers still return

## Review
- AMQ peer review: Claude approved the worktree before commit/push

## Validation
- `node --test extensions/chatgpt-native/tests/*.test.js`
- `./scripts/build-chatgpt-native-extension.sh --check`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p yoetz`
- `cargo clippy -p yoetz --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- targeted post-review comment check: `node --test --test-name-pattern 'text bytes|one-word|preview chrome' extensions/chatgpt-native/tests/service-worker.test.js extensions/chatgpt-native/tests/fake-chatgpt.test.js`
