### PR TITLE
change(browser): default ChatGPT recipe to Pro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Changed
+
+- The built-in ChatGPT browser recipe now defaults to `model=gpt-5-4-pro`
+  with Extended left enabled; `model=auto` remains available as an explicit
+  override.
 
 ## [0.5.12] - 2026-05-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - The built-in ChatGPT browser recipe now defaults to `model=gpt-5-4-pro`
   with Extended left enabled; `model=auto` remains available as an explicit
-  override.
+  override for callers that prefer graceful tier fallback.
 
 ## [0.5.12] - 2026-05-17
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -318,13 +318,14 @@ extension marker prefix) so an agent can decide whether to reuse the tab or
 abort. Pass `--allow-cdp-fallback` only if you understand that explicitly
 permits a second submission via CDP.
 
-The default ChatGPT target is Pro with Extended enabled. `model=auto` prefers
-the Pro/Extended personal UI control when it exists, and the enterprise model
-switcher remains supported. The `--var extended=false` toggle is best-effort
-and only runs when explicitly requested. Yoetz scopes the chip match to the
-ChatGPT composer with negative-control guards, but ChatGPT re-skins the
-Extended thinking control occasionally; on a miss the run continues with
-whatever Extended state the tab was in and emits a warning.
+The built-in ChatGPT recipe defaults to `model=gpt-5-4-pro` with Extended left
+enabled. `model=auto` still prefers the Pro/Extended personal UI control when
+it exists, and the enterprise model switcher remains supported. The
+`--var extended=false` toggle is best-effort and only runs when explicitly
+requested. Yoetz scopes the chip match to the ChatGPT composer with
+negative-control guards, but ChatGPT re-skins the Extended thinking control
+occasionally; on a miss the run continues with whatever Extended state the tab
+was in and emits a warning.
 
 If the next ChatGPT run after an unexplained failure should inspect the
 Yoetz-owned tab without resubmitting, use

--- a/README.md
+++ b/README.md
@@ -319,8 +319,11 @@ abort. Pass `--allow-cdp-fallback` only if you understand that explicitly
 permits a second submission via CDP.
 
 The built-in ChatGPT recipe defaults to `model=gpt-5-4-pro` with Extended left
-enabled. `model=auto` still prefers the Pro/Extended personal UI control when
-it exists, and the enterprise model switcher remains supported. The
+enabled. This is a deliberate Pro-first default for review jobs where a silent
+tier downgrade is worse than a clear "model unavailable" error. `model=auto`
+still prefers the Pro/Extended personal UI control when it exists, and remains
+available as an explicit override for accounts or workflows that want graceful
+fallback. The enterprise model switcher remains supported. The
 `--var extended=false` toggle is best-effort and only runs when explicitly
 requested. Yoetz scopes the chip match to the ChatGPT composer with
 negative-control guards, but ChatGPT re-skins the Extended thinking control

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -7472,20 +7472,6 @@ steps:
     }
 
     #[test]
-    fn builtin_chatgpt_recipe_defaults_to_explicit_pro_with_extended_enabled() {
-        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../recipes/chatgpt.yaml");
-        let content = fs::read_to_string(&path).expect("read recipes/chatgpt.yaml");
-        let recipe: Recipe = serde_yaml_ng::from_str(&content).expect("parse chatgpt.yaml");
-        let defaults = recipe.defaults.expect("chatgpt recipe defaults");
-
-        assert_eq!(
-            defaults.get("model").map(String::as_str),
-            Some("gpt-5-4-pro")
-        );
-        assert_eq!(defaults.get("extended").map(String::as_str), Some(""));
-    }
-
-    #[test]
     fn builtin_chatgpt_recipe_does_not_pin_transports_so_auto_promotion_can_fire() {
         let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../recipes/chatgpt.yaml");
         let content = fs::read_to_string(&path).expect("read recipes/chatgpt.yaml");

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -7472,6 +7472,20 @@ steps:
     }
 
     #[test]
+    fn builtin_chatgpt_recipe_defaults_to_explicit_pro_with_extended_enabled() {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../recipes/chatgpt.yaml");
+        let content = fs::read_to_string(&path).expect("read recipes/chatgpt.yaml");
+        let recipe: Recipe = serde_yaml_ng::from_str(&content).expect("parse chatgpt.yaml");
+        let defaults = recipe.defaults.expect("chatgpt recipe defaults");
+
+        assert_eq!(
+            defaults.get("model").map(String::as_str),
+            Some("gpt-5-4-pro")
+        );
+        assert_eq!(defaults.get("extended").map(String::as_str), Some(""));
+    }
+
+    #[test]
     fn builtin_chatgpt_recipe_does_not_pin_transports_so_auto_promotion_can_fire() {
         let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../recipes/chatgpt.yaml");
         let content = fs::read_to_string(&path).expect("read recipes/chatgpt.yaml");

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -5370,6 +5370,38 @@ mod tests {
     }
 
     #[test]
+    fn builtin_chatgpt_recipe_defaults_flow_into_shared_spec_with_extended_enabled() {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../recipes/chatgpt.yaml");
+        let content = fs::read_to_string(&path).expect("read recipes/chatgpt.yaml");
+        let recipe: browser::Recipe =
+            serde_yaml_ng::from_str(&content).expect("parse chatgpt.yaml");
+        let recipe_args = BrowserRecipeArgs {
+            recipe: PathBuf::from("recipes/chatgpt.yaml"),
+            transport: None,
+            allow_cdp_fallback: false,
+            bundle: Some(PathBuf::from("/tmp/bundle.md")),
+            profile: None,
+            cdp: None,
+            browser_id: None,
+            vars: vec![],
+        };
+
+        let recipe_vars = browser::build_recipe_vars(recipe.defaults.as_ref(), &recipe_args.vars)
+            .expect("build recipe vars");
+        let spec = build_chatgpt_recipe_spec(&recipe_args, &recipe_vars).unwrap();
+
+        assert_eq!(spec.model, "gpt-5-4-pro");
+        assert!(!spec.disable_extended);
+
+        let auto_vars =
+            browser::build_recipe_vars(recipe.defaults.as_ref(), &["model=auto".to_string()])
+                .expect("build recipe vars with auto override");
+        let auto_spec = build_chatgpt_recipe_spec(&recipe_args, &auto_vars).unwrap();
+        assert_eq!(auto_spec.model, "auto");
+        assert!(!auto_spec.disable_extended);
+    }
+
+    #[test]
     fn build_chatgpt_recipe_spec_uses_bundle_prompt_when_prompt_var_absent() {
         let dir = TempDir::new().unwrap();
         let bundle_md = dir.path().join("bundle.md");

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -1416,6 +1416,36 @@ test("fake ChatGPT model controls select model and disable Extended", async () =
   assert.equal(result.extended_status, "disabled");
 });
 
+test("fake ChatGPT explicit GPT-5.4 Pro leaves Extended enabled by default", async () => {
+  const extended = new FakeElement("button", { "aria-label": "click to remove Extended" }, "Extended");
+  const modelButton = new FakeElement("button", {
+    "data-testid": "model-switcher-dropdown-button",
+    "aria-haspopup": "menu"
+  }, "ChatGPT");
+  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Default");
+  const proOption = new FakeElement("div", {
+    role: "menuitemradio",
+    onClick: () => {
+      selected.innerText = "GPT-5.4 Pro";
+      selected.textContent = "GPT-5.4 Pro";
+    }
+  }, "GPT-5.4 Pro");
+  const body = new FakeElement("body", {}, "ChatGPT GPT-5.4 Pro").append(extended, modelButton, proOption, selected);
+  const doc = new FakeDocument(body);
+
+  const result = await configureModelState(doc, {
+    model: "gpt-5-4-pro",
+    disable_extended: false
+  });
+
+  assert.equal(extended.clicked, false);
+  assert.equal(modelButton.clicked, true);
+  assert.equal(proOption.clicked, true);
+  assert.equal(result.status, "selected");
+  assert.equal(result.extended_status, "not_requested");
+  assert.equal(result.warning, null);
+});
+
 test("fake ChatGPT personal composer model control accepts current Extended Pro for auto", async () => {
   const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
   const modelButton = new FakeElement("button", { "aria-haspopup": "menu" }, "Extended Pro");

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -18,9 +18,10 @@ name: chatgpt
 # transports connect directly to Chrome via CDP.
 #
 # Variables:
-#   model    — model slug (e.g., "gpt-5-4-pro"). Default: "auto" selects the
-#              best available model, preferring Pro with Extended enabled when
-#              the account has it.
+#   model    — model slug (e.g., "gpt-5-4-pro"). Default: "gpt-5-4-pro" with
+#              Extended enabled when the account exposes it.
+#              Set to "auto" to select the best available model, preferring
+#              Pro with Extended enabled when the account has it.
 #              Set to "" or "current" to keep the current ChatGPT selector state.
 #   extended — set to "false" to disable Extended Pro. Default: keep Extended on.
 #   prompt   — prompt text to send with the attachment. For Yoetz bundle
@@ -51,7 +52,7 @@ name: chatgpt
 
 defaults:
   prompt: Review the attached file and provide your analysis.
-  model: "auto"
+  model: "gpt-5-4-pro"
   extended: ""
   thread: "fresh"
   upload_timeout_ms: "120000"

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -363,8 +363,8 @@ BUNDLE=$(yoetz bundle -p "Review this code" -f src/*.rs --format json | jq -r .a
 # Send to ChatGPT
 yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE"
 
-# By default yoetz selects GPT-5.4 Pro with Extended enabled when the logged-in
-# account exposes it. Override it only if needed.
+# By default yoetz selects GPT-5.4 Pro with Extended enabled, preferring a clear
+# unavailable-model error over silent tier fallback. Override it only if needed.
 yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE" --var model=gpt-5-4-pro
 
 # Every request opens a fresh, yoetz-owned ChatGPT tab marked with ?_yoetz=<run-id>

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -363,7 +363,7 @@ BUNDLE=$(yoetz bundle -p "Review this code" -f src/*.rs --format json | jq -r .a
 # Send to ChatGPT
 yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE"
 
-# By default yoetz auto-selects Pro with Extended enabled when the logged-in
+# By default yoetz selects GPT-5.4 Pro with Extended enabled when the logged-in
 # account exposes it. Override it only if needed.
 yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE" --var model=gpt-5-4-pro
 


### PR DESCRIPTION
## Summary
- change the built-in ChatGPT recipe default from `model=auto` to `model=gpt-5-4-pro`
- keep Extended enabled by default by leaving `extended` unset unless callers pass `--var extended=false`
- document that this is a deliberate Pro-first review default: a clear unavailable-model error is preferable to silent lower-tier fallback for review jobs
- keep `model=auto` available as an explicit override for callers that prefer graceful tier fallback
- add runtime-path and fake-DOM coverage for the default model and Extended behavior

## Verification
- red regression test confirmed old default flowed as `Some("auto")` instead of `Some("gpt-5-4-pro")`
- `cargo fmt --check`
- `cargo test -p yoetz builtin_chatgpt_recipe`
- `node --test extensions/chatgpt-native/tests/fake-chatgpt.test.js`
- `git diff --check`
- prior full local gates before review-fix commit: `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `node --test extensions/chatgpt-native/tests/*.test.js`, `./scripts/build-chatgpt-native-extension.sh --check`

Claude AMQ review requested rationale/test tightening; follow-up commit adds both.