### PR TITLE
ci: speed up browser smoke binary build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,9 +409,10 @@ jobs:
         env:
           YOETZ_CHROME_BIN: ${{ steps.install-chrome.outputs.chrome-path }}
         run: cargo test -p yoetz fake_chatgpt_fixture_ -- --ignored
-      - name: Build yoetz
-        run: cargo build --release --bin yoetz
+      - name: Build yoetz smoke binary
+        run: cargo build --bin yoetz
       - name: Real-browser smoke
         env:
           YOETZ_CHROME_BIN: ${{ steps.install-chrome.outputs.chrome-path }}
+          YOETZ_BIN: target/debug/yoetz
         run: ./scripts/ci-real-browser-smoke.sh

--- a/scripts/ci-real-browser-smoke.sh
+++ b/scripts/ci-real-browser-smoke.sh
@@ -8,8 +8,8 @@
 #
 # Requires:
 #   - YOETZ_CHROME_BIN pointing at a Chrome (or Chrome for Testing) binary
-#   - `yoetz` binary built in release mode at the expected target path
-#     (override with YOETZ_BIN=...)
+#   - `yoetz` binary built at the expected target path (override with
+#     YOETZ_BIN=...)
 #   - curl, jq
 #
 # The fixture is a throwaway user-data-dir under $TMPDIR so we never touch the
@@ -33,10 +33,10 @@ fi
 yoetz_bin="${YOETZ_BIN:-}"
 if [[ -z "${yoetz_bin}" ]]; then
   repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-  yoetz_bin="${repo_root}/target/release/yoetz"
+  yoetz_bin="${repo_root}/target/debug/yoetz"
 fi
 if [[ ! -x "${yoetz_bin}" ]]; then
-  die "yoetz binary not found or not executable: ${yoetz_bin} (build with \`cargo build --release --bin yoetz\` or set YOETZ_BIN)"
+  die "yoetz binary not found or not executable: ${yoetz_bin} (build with \`cargo build --bin yoetz\` or set YOETZ_BIN)"
 fi
 
 for cmd in curl jq; do


### PR DESCRIPTION
## Summary

- build the browser-smoke CLI in debug mode instead of release mode
- pass `YOETZ_BIN=target/debug/yoetz` to the real-browser smoke script
- make the smoke script's fallback/default docs match the debug binary path

## Why

The CI browser-smoke job already runs after the separate Build job, which keeps `cargo build --release --workspace` coverage. The smoke probe only needs a runnable `yoetz` binary, so avoiding the duplicate release optimizer pass should shorten browser-affecting CI runs while preserving release-build coverage.

## Verification

- `git diff --check HEAD~1..HEAD`
- `bash -n scripts/ci-real-browser-smoke.sh`
- `cargo build --bin yoetz`
- Claude AMQ review: APPROVE; applied the requested fallback-path consistency fix