### PR TITLE
test(browser): guard cross-version ChatGPT Pro selection

### DIFF
--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -1446,6 +1446,49 @@ test("fake ChatGPT explicit GPT-5.4 Pro leaves Extended enabled by default", asy
   assert.equal(result.warning, null);
 });
 
+test("fake ChatGPT resolves a pinned gpt-5-4-pro request onto the live gpt-5-5 Pro option", async () => {
+  // ChatGPT silently bumps the Pro version (5.2 -> 5.4 -> 5.5 ...), so the picker
+  // no longer exposes the gpt-5-4-pro the recipe pins. Selection must fall back
+  // to the Pro tier by label and pick the live Pro option instead of failing
+  // "model unavailable". Guards cross-version drift: a naive exact-slug matcher
+  // would not find any of these options for "gpt-5-4-pro".
+  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+  const modelButton = new FakeElement("button", {
+    "aria-haspopup": "menu",
+    onClick: () => delete modelButton.attrs["aria-checked"]
+  }, "Instant");
+  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
+  const instantOption = new FakeElement("div", {
+    role: "menuitemradio",
+    "data-testid": "model-switcher-gpt-5-5"
+  }, "Instant");
+  const thinkingOption = new FakeElement("div", {
+    role: "menuitemradio",
+    "data-testid": "model-switcher-gpt-5-5-thinking"
+  }, "Thinking");
+  const proOption = new FakeElement("div", {
+    role: "menuitemradio",
+    "data-testid": "model-switcher-gpt-5-5-pro"
+  }, "Pro • Extended");
+  const body = new FakeElement("body", {}, "Ask anything Instant Thinking Pro Extended")
+    .append(form, instantOption, thinkingOption, proOption);
+  const doc = new FakeDocument(body);
+
+  const result = await configureModelState(doc, {
+    model: "gpt-5-4-pro",
+    disable_extended: false
+  });
+
+  assert.equal(modelButton.clicked, true);
+  assert.equal(proOption.clicked, true);
+  assert.equal(instantOption.clicked, false);
+  assert.equal(thinkingOption.clicked, false);
+  assert.equal(result.status, "selected");
+  assert.match(result.model_used, /pro/i);
+  assert.equal(result.extended_status, "not_requested");
+  assert.equal(result.warning, null);
+});
+
 test("fake ChatGPT personal composer model control accepts current Extended Pro for auto", async () => {
   const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
   const modelButton = new FakeElement("button", { "aria-haspopup": "menu" }, "Extended Pro");


### PR DESCRIPTION
## Summary
- ChatGPT silently bumped the Pro model version (5.2 → 5.4 → **5.5**). The live picker now exposes only `model-switcher-gpt-5-5` / `-thinking` / `-pro` ("Pro • Extended") — there is no `gpt-5-4-pro`, which the `chatgpt` recipe still pins as its default.
- The native-extension matcher already absorbs this: a pinned `gpt-5-4-pro` can't exact-match any `gpt-5-5` slug, so selection falls through to Pro-tier **label** matching and clicks the live Pro option. Verified end-to-end on a live ChatGPT Pro account (forced to Instant → requested `gpt-5-4-pro` → selected `gpt-5-5-pro`).
- Nothing locked that cross-version contract against the real gpt-5-5 DOM shape (the existing "explicit GPT-5.4 Pro" test uses an option text that no longer exists). This PR adds a fixture test that guards it.

## What this is NOT
- No selector code change. Research showed the current matcher already handles the drift; changing it would be churn on working, subtle code.
- The `chatgpt` recipe default stays `gpt-5-4-pro` (unchanged).

## Context
The original "stale user-local recipe shadows shipped recipe → model unavailable" report was wrong about root cause: `find_data_file` never reads `~/.yoetz/recipes/` (verified at the `v0.5.14` tag). The actual incident was a **stale manually-loaded extension** (binary 0.5.14, older loaded extension with a weaker matcher). Binary/extension version-skew detection is handled separately (codex, `browser_extension_native.rs`).

## Test plan
- [x] `node --test` in `extensions/chatgpt-native` → 154/154 passing
- [x] New test fails **red** when the label-fallback loop in `findModelOption` is removed (proves it guards real version-drift tolerance, not current behavior)
- [x] `./scripts/build-chatgpt-native-extension.sh --check` passes
- [x] Peer-reviewed (codex): approved, no blockers

🤖 Generated with [Claude Code](https://claude.com/claude-code)