### PR TITLE
ci: pin taiki-e/install-action to a release tag for Dependabot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,7 +236,9 @@ jobs:
 
       - name: Install cross
         if: matrix.cross
-        uses: taiki-e/install-action@9c28cc1e9a88ba271487a912a46f2ef66471dbc6 # cross
+        uses: taiki-e/install-action@6ed6112eb9893c58dd600eebccdf6e77ab7bfa9c # v2.79.12
+        with:
+          tool: cross
 
       - name: Build (native)
         if: "!matrix.cross"


### PR DESCRIPTION
## Summary
- The weekly **Dependabot Updates** run has failed on `main` since 2026-05-23: the github-actions group update errors with `taiki-e/install-action … unknown_error / null`, failing the whole group (cargo-deny + setup-chrome bumps get rolled back with it).
- Root cause: `release.yml` pinned `taiki-e/install-action@<sha> # cross`. The `# cross` comment is a **rolling tool-tag**, not a semver, so Dependabot's github-actions updater can't resolve an update path and throws.
- Fix: pin to the `v2.79.12` release SHA (verified live: `6ed6112…`) and install cross via `with: tool: cross` — the canonical equivalent of the `@cross` shortcut. Dependabot can now track and bump it like any other action.

## Risk / validation
- Functionally identical: `@cross` is just `@v2 + tool: cross`. SHA-pinned (no security regression).
- The cross install step only runs during a **release** (cross-compiled targets), so it can't be exercised by PR CI here. Low risk — this is the documented canonical usage.

## Test plan
- [x] YAML parses
- [ ] PR CI green
- [ ] Confirm next weekly Dependabot Updates run is green (or re-trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)