### PR TITLE
docs(changelog): record extension version-skew fix under Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- The ChatGPT native-extension transport now detects when the loaded Chrome
+  extension version does not match the yoetz CLI: `browser extension status`
+  reports `version_mismatch`, `browser extension doctor` fails the
+  `version_compatible` check, and recipe runs print a reload/reconnect warning
+  before dispatch. A stale, manually-loaded extension no longer surfaces only as
+  a cryptic ChatGPT "model unavailable" error.
 
 ## [0.5.14] - 2026-05-23
 ### Fixed


### PR DESCRIPTION
## Summary
Adds the `[Unreleased]` changelog entry for the ChatGPT native-extension version-skew detection (#231), so the upcoming `0.5.15` release ships meaningful GitHub release notes (release.yml sources notes from the committed CHANGELOG section).

Internal-only changes (#227 CI speedup, #229 guard test, #230 Dependabot pin) are intentionally omitted as non-user-facing.

## Test plan
- [x] Docs-only change; CHANGELOG renders