### PR TITLE
ci: skip redundant heavy jobs on release/* PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,13 @@ jobs:
               base="$PR_BASE_SHA"
               head="$PR_HEAD_SHA"
               if [[ "${PR_HEAD_REF:-}" == release/* ]]; then
-                build_os_matrix="$full_build_matrix"
+                # Release PRs only bump version metadata (CHANGELOG, Cargo.*,
+                # plugin/skill/extension manifests). release.yml is the real
+                # cross-platform build+publish gate and release.sh already ran
+                # local gates, so the heavy PR build/test/browser jobs here are
+                # pure redundancy. Treat the PR as light to skip them.
+                emit_outputs true false "$linux_build_matrix" false
+                exit 0
               fi
               ;;
             push)
@@ -130,8 +136,9 @@ jobs:
           # whole PR under a minute. See clippy / test jobs below.
           #
           # Ordinary PRs and main pushes intentionally use the Ubuntu build
-          # only. Cross-platform release builds remain covered before release
-          # by release/* PRs, and on demand by workflow_dispatch.
+          # only. Cross-platform release builds run in release.yml at tag time
+          # (and on demand via workflow_dispatch); release/* PRs are treated as
+          # light here because they only bump version metadata.
           # Bash case-pattern `*` matches any characters including `/`, so
           # `docs/*` covers any depth under `docs/`.
           light_only=true
@@ -373,7 +380,7 @@ jobs:
   browser-integration:
     name: Real-Browser Smoke (Chrome for Testing)
     needs: changes
-    if: needs.changes.outputs.release_push != 'true' && needs.changes.outputs.light_only != 'true' && (github.event_name != 'pull_request' || needs.changes.outputs.browser_changed == 'true' || startsWith(github.head_ref, 'release/'))
+    if: needs.changes.outputs.release_push != 'true' && needs.changes.outputs.light_only != 'true' && (github.event_name != 'pull_request' || needs.changes.outputs.browser_changed == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
## Summary
Part 1 of the release-speed work (with codex; codex owns part 2 — trimming the `Verify Release Commit` serial gate in `release.yml`).

A `release/*` PR only bumps version metadata (CHANGELOG, Cargo.*, plugin/skill/extension manifests) — by construction it contains **no source change**. Yet the v0.5.15 release PR ran the full **~7-min** CI: Build×3 (windows 7m9s), Test (6m6s), Real-Browser Smoke (6m23s). Two causes:
1. The bumped `extensions/chatgpt-native/manifest.json` is **not** in the light-only allowlist and **is** in `browser_changed` → `light_only=false`, browser smoke forced.
2. `release/*` PRs were pinned to the full 3-OS build matrix and force-run through browser smoke (ci.yml:376).

This treats `release/*` PRs as light: required checks (Format, Clippy, Test) still run **short-circuited** (so the required-status list stays satisfied), while Build/Test/Real-Browser Smoke skip.

**Cuts release-PR CI from ~7 min to ~1 min.**

## Trade-off (deliberate, agreed with codex)
Ordinary feature PRs build ubuntu-only, so the `release/*` PR was the last place macOS/Windows compiled before the tag. With this change the first cross-platform build moves to `release.yml` post-merge — a macOS/Windows-only break would fail the release run instead of the PR. Still covered by: `release.sh` local gates before the PR, and `release.yml` at tag time.

## Test plan
- [x] YAML parses
- [ ] This PR's own CI is light (it's a `.github/*`-only change) — Build/Smoke skip, Format/Clippy/Test short-circuit
- [ ] Validate on the next real release PR that Build×3/Test/Smoke skip and required checks stay green

🤖 Generated with [Claude Code](https://claude.com/claude-code)