### PR TITLE
ci(release): ship ChatGPT extension via Homebrew formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -522,6 +522,7 @@ jobs:
           SHA_ARM_MAC=$(sha256sum artifacts/yoetz-aarch64-apple-darwin.tar.gz | awk '{print $1}')
           SHA_X86_LINUX=$(sha256sum artifacts/yoetz-x86_64-unknown-linux-gnu.tar.gz | awk '{print $1}')
           SHA_ARM_LINUX=$(sha256sum artifacts/yoetz-aarch64-unknown-linux-gnu.tar.gz | awk '{print $1}')
+          SHA_EXT=$(sha256sum artifacts/yoetz-chatgpt-native-extension-${VERSION}.zip | awk '{print $1}')
 
           git clone "https://x-access-token:${HOMEBREW_TAP_GITHUB_TOKEN}@github.com/avivsinai/homebrew-tap.git" tap
 
@@ -558,9 +559,17 @@ jobs:
               end
             end
 
+            resource "chatgpt_native_extension" do
+              url "https://github.com/avivsinai/yoetz/releases/download/${TAG}/yoetz-chatgpt-native-extension-${VERSION}.zip"
+              sha256 "${SHA_EXT}"
+            end
+
             def install
               bin.install "yoetz"
               (share/"yoetz").install "scripts", "recipes"
+              resource("chatgpt_native_extension").stage do
+                (share/"yoetz/extensions/chatgpt-native").install Dir["*"]
+              end
             end
 
             test do


### PR DESCRIPTION
## Summary
Brew-side half of the managed-unpacked extension update process (co-designed with codex; codex owns the CLI sync+reload+auto-heal lifecycle in `browser_extension_native.rs`).

Today brew installs only `scripts`+`recipes`; the ChatGPT native extension is a GitHub-release zip the user downloads and loads by hand, **fully decoupled from `brew upgrade`** — the root cause of the loaded-extension-vs-CLI version skew that #231 only *detects*.

This adds a Homebrew `resource` to the generated formula pointing at the existing `yoetz-chatgpt-native-extension-<ver>.zip` release asset (the homebrew job already downloads it via `merge-multiple`), sha256-pinned, staged into **`share/yoetz/extensions/chatgpt-native`** — the first candidate path `chatgpt_extension_source_dir()` already probes. No change to the platform build matrix; the canonical 13-file zip stays the single source of truth.

## Interface contract (with codex's half)
- This PR guarantees `share/yoetz/extensions/chatgpt-native` exists on brew installs.
- codex's lifecycle (`yoetz browser extension update`, auto-heal on skew) syncs from that path into a stable yoetz-owned dir + fires `chrome.runtime.reload()`.

## Verification (real, not just lint)
- `brew style` clean (only the pre-existing Sorbet/Documentation offenses the released tap formula already has; the `ComponentsOrder` finding was fixed by placing `resource` after the `on_*` blocks).
- **End-to-end against the live v0.5.15 release**: rendered the formula with the real release SHAs, swapped it into the tap, `brew reinstall`ed → confirmed all 13 files land at `share/yoetz/extensions/chatgpt-native` (manifest 0.5.15, `key` present for stable ID, satisfies `is_chatgpt_extension_source_dir`), then restored the clean formula (146 files, dir gone).
- Only the in-CI artifact path is exercise-at-next-release (same property as #230); the `artifacts/yoetz-chatgpt-native-extension-<ver>.zip` it reads is the same artifact the `release` job already consumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)