### PR TITLE
fix(registry): exclude non-chat models from frontier picks

### DIFF
--- a/crates/yoetz-cli/src/registry.rs
+++ b/crates/yoetz-cli/src/registry.rs
@@ -12,7 +12,7 @@ use crate::http::send_json;
 use litellm_rust::registry::Registry as EmbeddedRegistry;
 use yoetz_core::config::Config;
 use yoetz_core::paths::home_dir;
-use yoetz_core::registry::{ModelCapability, ModelEntry, ModelPricing, ModelRegistry};
+use yoetz_core::registry::{ModelCapability, ModelEntry, ModelKind, ModelPricing, ModelRegistry};
 
 pub struct RegistryFetchResult {
     pub registry: ModelRegistry,
@@ -216,7 +216,14 @@ fn embedded_gemini_registry() -> Result<ModelRegistry> {
                 request: None,
             },
             provider: pricing.provider.clone(),
-            capability: None,
+            capability: pricing
+                .mode
+                .as_deref()
+                .and_then(ModelKind::from_litellm_mode)
+                .map(|kind| ModelCapability {
+                    kind: Some(kind),
+                    ..Default::default()
+                }),
             tier: None,
         });
     }
@@ -450,6 +457,19 @@ fn parse_openrouter_capability(item: &Value) -> Option<ModelCapability> {
         cap.vision = Some(has_image);
     }
 
+    if let Some(out) = item
+        .get("architecture")
+        .and_then(|v| v.get("output_modalities"))
+        .and_then(|v| v.as_array())
+    {
+        let mods: Vec<String> = out
+            .iter()
+            .filter_map(|m| m.as_str())
+            .map(|s| s.to_ascii_lowercase())
+            .collect();
+        cap.kind = classify_output_modalities(&mods);
+    }
+
     if let Some(params) = item.get("supported_parameters").and_then(|v| v.as_array()) {
         let has_reasoning = params.iter().any(|p| {
             p.as_str().is_some_and(|s| {
@@ -473,17 +493,74 @@ fn parse_openrouter_capability(item: &Value) -> Option<ModelCapability> {
         cap.web_search = Some(true);
     }
 
-    if cap.vision.is_none() && cap.reasoning.is_none() && cap.web_search.is_none() {
+    if cap.vision.is_none()
+        && cap.reasoning.is_none()
+        && cap.web_search.is_none()
+        && cap.kind.is_none()
+    {
         None
     } else {
         Some(cap)
     }
 }
 
+/// Classify a model's OpenRouter `architecture.output_modalities` into a kind.
+/// Chat is exactly `["text"]`; anything carrying a non-text output modality is a
+/// media/non-chat model. Returns `None` (fail-open, chat-eligible) when the list
+/// is empty or carries only unrecognized modalities.
+fn classify_output_modalities(mods: &[String]) -> Option<ModelKind> {
+    let has = |needle: &str| mods.iter().any(|m| m == needle);
+    if mods.is_empty() {
+        return None;
+    }
+    if mods.len() == 1 && has("text") {
+        return Some(ModelKind::Chat);
+    }
+    if has("image") {
+        return Some(ModelKind::ImageGeneration);
+    }
+    if has("video") {
+        return Some(ModelKind::VideoGeneration);
+    }
+    if has("audio") {
+        return Some(ModelKind::Audio);
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use yoetz_core::config::RegistryConfig;
+
+    fn mods(values: &[&str]) -> Vec<String> {
+        values.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn classify_output_modalities_matches_openrouter_catalog_shapes() {
+        // Verified live against OpenRouter /models (2026-05-29): output tokens
+        // are only text/image/audio, and every media model also carries "text"
+        // (so exactly ["text"] is the chat predicate).
+        assert_eq!(
+            classify_output_modalities(&mods(&["text"])),
+            Some(ModelKind::Chat)
+        );
+        assert_eq!(
+            classify_output_modalities(&mods(&["image", "text"])),
+            Some(ModelKind::ImageGeneration)
+        );
+        assert_eq!(
+            classify_output_modalities(&mods(&["audio", "text"])),
+            Some(ModelKind::Audio)
+        );
+        assert_eq!(
+            classify_output_modalities(&mods(&["text", "video"])),
+            Some(ModelKind::VideoGeneration)
+        );
+        // Empty / unrecognized -> fail-open (chat-eligible).
+        assert_eq!(classify_output_modalities(&[]), None);
+    }
 
     fn config_with_sync(secs: u64) -> Config {
         Config {

--- a/crates/yoetz-cli/src/registry.rs
+++ b/crates/yoetz-cli/src/registry.rs
@@ -505,9 +505,11 @@ fn parse_openrouter_capability(item: &Value) -> Option<ModelCapability> {
 }
 
 /// Classify a model's OpenRouter `architecture.output_modalities` into a kind.
-/// Chat is exactly `["text"]`; anything carrying a non-text output modality is a
-/// media/non-chat model. Returns `None` (fail-open, chat-eligible) when the list
-/// is empty or carries only unrecognized modalities.
+/// Chat is exactly `["text"]`. Any non-empty list that is not exactly `["text"]`
+/// carries a non-text output modality and is therefore non-chat — classified
+/// specifically when recognized (image/video/audio) and `Other` otherwise.
+/// Returns `None` (fail-open, chat-eligible) only when the list is empty, i.e.
+/// the catalog gave no output-modality signal at all.
 fn classify_output_modalities(mods: &[String]) -> Option<ModelKind> {
     let has = |needle: &str| mods.iter().any(|m| m == needle);
     if mods.is_empty() {
@@ -525,7 +527,9 @@ fn classify_output_modalities(mods: &[String]) -> Option<ModelKind> {
     if has("audio") {
         return Some(ModelKind::Audio);
     }
-    None
+    // Non-empty and not exactly ["text"], with no recognized media token: still a
+    // non-text output, so it is non-chat (excluded from frontier), not fail-open.
+    Some(ModelKind::Other)
 }
 
 #[cfg(test)]
@@ -558,7 +562,17 @@ mod tests {
             classify_output_modalities(&mods(&["text", "video"])),
             Some(ModelKind::VideoGeneration)
         );
-        // Empty / unrecognized -> fail-open (chat-eligible).
+        // Non-empty and not exactly ["text"], no recognized media token: still a
+        // non-text output -> non-chat (Other), NOT fail-open chat-eligible.
+        assert_eq!(
+            classify_output_modalities(&mods(&["text", "speech"])),
+            Some(ModelKind::Other)
+        );
+        assert_eq!(
+            classify_output_modalities(&mods(&["embeddings"])),
+            Some(ModelKind::Other)
+        );
+        // Only a truly empty list (no output-modality signal) is fail-open.
         assert_eq!(classify_output_modalities(&[]), None);
     }
 

--- a/crates/yoetz-core/src/registry.rs
+++ b/crates/yoetz-core/src/registry.rs
@@ -21,6 +21,56 @@ impl std::fmt::Display for ModelTier {
     }
 }
 
+/// Output modality / task kind of a model. Used to keep non-chat models
+/// (image generation, video, audio, embeddings, …) out of frontier chat picks.
+/// Fail-open: an unknown or unset kind is treated as chat-eligible so a new
+/// chat-like model is never silently dropped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelKind {
+    Chat,
+    ImageGeneration,
+    VideoGeneration,
+    Audio,
+    Embedding,
+    Moderation,
+    Rerank,
+    /// A recognized non-chat mode that does not fit the categories above
+    /// (litellm `search`, `ocr`, `vector_store`, …). Excluded from chat frontier.
+    Other,
+    /// Deserialize fallback for a serialized kind string this build does not
+    /// recognize. Treated as chat-eligible (fail-open) so a future kind is
+    /// never silently dropped from frontier.
+    #[serde(other)]
+    Unknown,
+}
+
+impl ModelKind {
+    /// Whether a model of this kind can serve chat/multimodal completions and is
+    /// therefore eligible to be a family frontier pick. Unknown kinds are
+    /// eligible (fail-open) so a new chat-like mode is never silently dropped.
+    pub fn is_chat_eligible(self) -> bool {
+        matches!(self, ModelKind::Chat | ModelKind::Unknown)
+    }
+
+    /// Map a litellm `mode` string to a kind, covering the full authoritative
+    /// litellm mode set. Returns `None` for unrecognized modes so ingest stays
+    /// fail-open (the model remains chat-eligible).
+    pub fn from_litellm_mode(mode: &str) -> Option<Self> {
+        match mode.trim().to_ascii_lowercase().as_str() {
+            "chat" | "completion" | "responses" => Some(ModelKind::Chat),
+            "image_generation" | "image_edit" => Some(ModelKind::ImageGeneration),
+            "video_generation" => Some(ModelKind::VideoGeneration),
+            "audio_speech" | "audio_transcription" => Some(ModelKind::Audio),
+            "embedding" => Some(ModelKind::Embedding),
+            "moderation" => Some(ModelKind::Moderation),
+            "rerank" => Some(ModelKind::Rerank),
+            "search" | "ocr" | "vector_store" => Some(ModelKind::Other),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FrontierEntry {
     pub family: String,
@@ -77,6 +127,8 @@ pub struct ModelCapability {
     pub vision: Option<bool>,
     pub reasoning: Option<bool>,
     pub web_search: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub kind: Option<ModelKind>,
 }
 
 impl ModelCapability {
@@ -89,6 +141,9 @@ impl ModelCapability {
         }
         if other.web_search.is_some() {
             self.web_search = other.web_search;
+        }
+        if other.kind.is_some() {
+            self.kind = other.kind;
         }
     }
 }
@@ -249,6 +304,18 @@ impl ModelRegistry {
             if tier == ModelTier::Mini {
                 continue;
             }
+            // Skip non-chat models (image generation, video, audio, embeddings, …):
+            // a family frontier query must return the chat/multimodal flagship,
+            // not a media generator. Fail-open — an unknown/unset kind stays
+            // eligible so a new chat-like model is never silently dropped.
+            let chat_eligible = model
+                .capability
+                .as_ref()
+                .and_then(|cap| cap.kind)
+                .is_none_or(ModelKind::is_chat_eligible);
+            if !chat_eligible {
+                continue;
+            }
             let family = model.family().to_string();
             let dominated = best.get(&family).is_some_and(|existing| {
                 let existing_ver = extract_version(&existing.model.id);
@@ -399,6 +466,7 @@ mod tests {
                     vision: Some(true),
                     reasoning: None,
                     web_search: Some(false),
+                    kind: None,
                 }),
                 tier: None,
             }],
@@ -421,6 +489,7 @@ mod tests {
                     vision: None,
                     reasoning: Some(true),
                     web_search: None,
+                    kind: None,
                 }),
                 tier: None,
             }],
@@ -627,6 +696,170 @@ mod tests {
         let google_frontier = frontier.iter().find(|e| e.family == "google").unwrap();
         assert_eq!(google_frontier.model.id, "google/gemini-3.1-pro-preview");
         assert_eq!(google_frontier.tier, ModelTier::Preview);
+    }
+
+    #[test]
+    fn frontier_excludes_image_generation_models() {
+        // Reproduces the reported bug: an image-generation model
+        // (imagen-4.0-ultra, version 4 beats gemini-3 on the primary version
+        // signal) must NOT be returned as the gemini family frontier.
+        let mut reg = ModelRegistry {
+            models: vec![
+                ModelEntry {
+                    id: "google/gemini-3-pro-preview".to_string(),
+                    pricing: ModelPricing {
+                        completion_per_1k: Some(0.01),
+                        ..Default::default()
+                    },
+                    capability: Some(ModelCapability {
+                        kind: Some(ModelKind::Chat),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                ModelEntry {
+                    id: "google/imagen-4.0-ultra-generate-001".to_string(),
+                    pricing: ModelPricing {
+                        completion_per_1k: Some(0.04),
+                        ..Default::default()
+                    },
+                    capability: Some(ModelCapability {
+                        kind: Some(ModelKind::ImageGeneration),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        reg.rebuild_index();
+
+        let frontier = reg.frontier();
+        let google = frontier
+            .iter()
+            .find(|e| e.family == "google")
+            .expect("google family has a chat frontier");
+        assert_eq!(google.model.id, "google/gemini-3-pro-preview");
+        assert!(
+            !frontier.iter().any(|e| e.model.id.contains("imagen")),
+            "image-generation model must never be a frontier pick"
+        );
+    }
+
+    #[test]
+    fn frontier_keeps_vision_chat_and_unknown_kind_models() {
+        // A vision (image-INPUT) chat model stays eligible, and a model with no
+        // kind at all is fail-open (still eligible).
+        let mut reg = ModelRegistry {
+            models: vec![
+                ModelEntry {
+                    id: "google/gemini-3.1-pro-preview".to_string(),
+                    pricing: ModelPricing {
+                        completion_per_1k: Some(0.02),
+                        ..Default::default()
+                    },
+                    capability: Some(ModelCapability {
+                        vision: Some(true),
+                        kind: Some(ModelKind::Chat),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                ModelEntry {
+                    id: "anthropic/claude-opus-4-6".to_string(),
+                    pricing: ModelPricing {
+                        completion_per_1k: Some(0.075),
+                        ..Default::default()
+                    },
+                    capability: None,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        reg.rebuild_index();
+
+        let frontier = reg.frontier();
+        assert_eq!(
+            frontier
+                .iter()
+                .find(|e| e.family == "google")
+                .unwrap()
+                .model
+                .id,
+            "google/gemini-3.1-pro-preview"
+        );
+        assert_eq!(
+            frontier
+                .iter()
+                .find(|e| e.family == "anthropic")
+                .unwrap()
+                .model
+                .id,
+            "anthropic/claude-opus-4-6"
+        );
+    }
+
+    #[test]
+    fn model_kind_from_litellm_mode_maps_known_and_unknown() {
+        // Chat-eligible modes.
+        for m in ["chat", "completion", "responses"] {
+            assert_eq!(
+                ModelKind::from_litellm_mode(m),
+                Some(ModelKind::Chat),
+                "{m}"
+            );
+        }
+        // Non-chat modes from the authoritative litellm set.
+        assert_eq!(
+            ModelKind::from_litellm_mode("image_generation"),
+            Some(ModelKind::ImageGeneration)
+        );
+        assert_eq!(
+            ModelKind::from_litellm_mode("image_edit"),
+            Some(ModelKind::ImageGeneration)
+        );
+        assert_eq!(
+            ModelKind::from_litellm_mode("video_generation"),
+            Some(ModelKind::VideoGeneration)
+        );
+        assert_eq!(
+            ModelKind::from_litellm_mode("audio_transcription"),
+            Some(ModelKind::Audio)
+        );
+        assert_eq!(
+            ModelKind::from_litellm_mode("embedding"),
+            Some(ModelKind::Embedding)
+        );
+        assert_eq!(
+            ModelKind::from_litellm_mode("rerank"),
+            Some(ModelKind::Rerank)
+        );
+        for m in ["search", "ocr", "vector_store"] {
+            assert_eq!(
+                ModelKind::from_litellm_mode(m),
+                Some(ModelKind::Other),
+                "{m}"
+            );
+        }
+        // Unknown / new modes stay fail-open (None -> chat-eligible).
+        assert_eq!(ModelKind::from_litellm_mode("brand_new_mode"), None);
+
+        // Eligibility: only Chat (and the Unknown deserialize fallback) is a
+        // valid frontier pick; every recognized non-chat kind is excluded.
+        assert!(ModelKind::Chat.is_chat_eligible());
+        assert!(ModelKind::Unknown.is_chat_eligible());
+        for k in [
+            ModelKind::ImageGeneration,
+            ModelKind::VideoGeneration,
+            ModelKind::Audio,
+            ModelKind::Embedding,
+            ModelKind::Moderation,
+            ModelKind::Rerank,
+            ModelKind::Other,
+        ] {
+            assert!(!k.is_chat_eligible(), "{k:?} must not be chat-eligible");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
SP1 of the models-registry fix (workflow-designed, split with codex who owns SP2 sync-reconcile).

`yoetz models frontier --family gemini` returned an **image-generation** model (`imagen-4.0-ultra`) as the flagship: frontier ranked every namespaced model by version/tier with no concept of model *kind*, so an image generator with a higher version number won. The signal existed but was dropped — the embedded litellm registry discarded `ModelPricing.mode`, and OpenRouter parsing read only `input_modalities`.

## Fix
- New `ModelKind` (core) covering the **full authoritative litellm `mode` set** (verified against the embedded snapshot: chat/completion/responses → Chat; image_generation/image_edit, video_generation, audio_*, embedding, moderation, rerank, search/ocr/vector_store → non-chat), plus a serde `other` `Unknown` fallback. **Fail-open**: an unset/unrecognized kind stays chat-eligible so a new chat-like mode is never silently dropped.
- Populate at ingest from litellm `mode` (embedded) and OpenRouter `architecture.output_modalities`. Chat predicate = `output_modalities == exactly ["text"]` — **verified live** against OpenRouter `/models` (2026-05-29, 357 models): output tokens are only text/image/audio and every media model also carries `"text"`, so the naive "(image) and not text" rule would be a no-op.
- `frontier()` skips known non-chat kinds; vision (image-INPUT) chat models stay eligible.

## Verification
- Live: full `models frontier` now returns **only chat models across all 9 major families, zero non-chat leaks**; `--family gemini` returns a chat model instead of imagen.
- Tests: 39 core + cli unit tests incl. the imagen-as-flagship reproduction (fails without the kind gate), fail-open, and the full mode-mapping set. `cargo fmt`/`clippy -D warnings` clean.

## Coordination note (codex)
Shared file `crates/yoetz-cli/src/registry.rs`: this PR edits `parse_openrouter_capability` (adds output_modalities→kind) and `embedded_gemini_registry` (capability from mode). SP2 edits `parse_openrouter_models`/`fetch_registry` and `embedded_gemini_registry` (strip `openrouter/` prefix). Overlap is in `embedded_gemini_registry` (different lines). Land SP2 first; I'll rebase this on it.

Follow-up (out of SP1 scope, overlaps SP2): `--family gemini`/`google` resolves to a *gemma* chat model rather than gemini-pro (preview tier loses to standard at same version; namespacing). Noted, not fixed here — the reported image-gen bug is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)