### PR TITLE
fix(deps): adapt to litellm-rust v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Changed
+
+- Bump `litellm-rust` from v0.1.2 to v0.2.0 and adapt to its breaking API
+  changes (new required `extra_body` field on `ImageRequest`; `LiteLLMError`
+  `Refusal`/`Truncated` are now struct variants). Image generation now passes
+  `extra_body: None`. Note the v0.2.0 runtime behavior change for Anthropic:
+  structured-output requests for unsupported models are rejected instead of
+  falling back to legacy tool-call workarounds, and Anthropic
+  `stop_reason=refusal`/`max_tokens` now surface as structured errors.
 
 ## [0.5.15] - 2026-05-28
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1275,8 +1275,8 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litellm-rust"
-version = "0.1.2"
-source = "git+https://github.com/avivsinai/litellm-rust?tag=v0.1.2#acf0514edf6b0fe1905970356091b8f63c3f40a9"
+version = "0.2.0"
+source = "git+https://github.com/avivsinai/litellm-rust?tag=v0.2.0#ef1906329119c615b4b5cb7f339a64076aea4c07"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1640,7 +1640,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1897,7 +1897,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1955,7 +1955,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2268,7 +2268,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2869,7 +2869,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2913,15 +2913,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -2953,28 +2944,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2990,12 +2964,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3006,12 +2974,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3026,22 +2988,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3056,12 +3006,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3072,12 +3016,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3092,12 +3030,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3108,12 +3040,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/crates/yoetz-cli/Cargo.toml
+++ b/crates/yoetz-cli/Cargo.toml
@@ -21,7 +21,7 @@ workspace = true
 
 [dependencies]
 yoetz-core = { path = "../yoetz-core" }
-litellm-rust = { git = "https://github.com/avivsinai/litellm-rust", tag = "v0.1.2" }
+litellm-rust = { git = "https://github.com/avivsinai/litellm-rust", tag = "v0.2.0" }
 
 anyhow.workspace = true
 dotenvy.workspace = true

--- a/crates/yoetz-cli/src/commands/generate.rs
+++ b/crates/yoetz-cli/src/commands/generate.rs
@@ -141,6 +141,7 @@ async fn handle_generate_image(
                 size: args.size.clone(),
                 quality: args.quality.clone(),
                 background: args.background.clone(),
+                extra_body: None,
             })
             .await?;
         let outputs =


### PR DESCRIPTION
## Summary

Supersedes Dependabot #217. That PR only bumped `litellm-rust` v0.1.2 → v0.2.0 in `Cargo.toml`/`Cargo.lock`, but CI was red because the yoetz source doesn't match v0.2.0's API. This branch is based on the Dependabot branch (so it **carries the same v0.2.0 bump**) and adds the source adaptation to make the workspace compile and pass CI.

## litellm-rust v0.2.0 breaking changes (read from the pinned rev `ef1906329119c615b4b5cb7f339a64076aea4c07`)

1. **New required field `extra_body`** on `ChatRequest`, `EmbeddingRequest`, `ImageRequest` — type `Option<serde_json::Map<String, serde_json::Value>>`. None of these structs derive `Default`; the idiomatic default is `None` (or the `::new()`/`.extra_body()` builders).
2. **`LiteLLMError::Refusal`/`Truncated` changed from tuple → struct variants** carrying `{ text: String, usage: Usage }`.

## Impact on yoetz / changes

- `crates/yoetz-cli/src/commands/generate.rs` — the `ImageRequest { .. }` struct literal was the **only** compile breakage (`E0063: missing field extra_body`). Added `extra_body: None`.
- `ChatRequest` is built via `ChatRequest::new(..)` (`crates/yoetz-cli/src/main.rs`), which already defaults `extra_body: None` — no change needed.
- `ImageEditRequest` / `VideoRequest` did **not** gain `extra_body` in v0.2.0 — no change needed.
- yoetz has **no** references to `LiteLLMError` in Rust, so the `Refusal`/`Truncated` variant reshape has zero source impact (the only `Truncated` hits in the repo are unrelated JS `diagnosticsTruncated` symbols).
- `CHANGELOG.md` — Unreleased entry documenting the bump + behavior note.

## Runtime behavior change to be aware of (from v0.2.0 changelog, not a yoetz bug)

For **Anthropic**: structured-output (`response_format`) requests for unsupported models are now **rejected** instead of falling back to legacy tool-call workarounds, and `stop_reason=refusal`/`max_tokens` now surface as structured `Refusal`/`Truncated` errors. Since yoetz passes `response_format` through and propagates litellm errors via `?` into `anyhow`, these conditions now surface as error messages rather than silent fallback.

## Local verification (all green)

- `cargo build --workspace` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ (0 warnings)
- `cargo test --workspace` ✅ (569 passed, 0 failed, 2 ignored)
- `cargo fmt --all -- --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)