### PR TITLE
fix(deps): adapt to litellm-rust v0.2.0 + 0.5.16 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Added
+
+- `yoetz browser extension update --chatgpt`: re-sync the managed ChatGPT
+  extension copy, reload the loaded extension, and verify the running version.
+  `setup --chatgpt` now materializes the packaged extension into the stable
+  `$YOETZ_DIR/chatgpt-native-extension` directory (load that unpacked dir once;
+  future upgrades are handled by `update`). The extension is now shipped with
+  the Homebrew formula, and recipe runs auto-heal a version-skewed extension
+  before dispatch instead of failing with a cryptic ChatGPT error.
+- `yoetz ask --allow-uncosted`: opt in to running image/video requests when
+  `--max-cost-usd`/`--daily-budget-usd` are set. Pre-call budget enforcement is
+  skipped for the media request (multimodal input cost cannot be estimated
+  beforehand); only the provider-reported cost, when available, is recorded
+  post-call. The default stays fail-closed.
+
+### Changed
+
+- Bump `litellm-rust` from v0.1.2 to v0.2.0 and adapt to its breaking API
+  changes (new required `extra_body` field on image requests; `LiteLLMError`
+  `Refusal`/`Truncated` are now struct variants). Note the v0.2.0 runtime
+  behavior change for Anthropic: structured-output requests for unsupported
+  models are now rejected instead of falling back to legacy tool-call
+  workarounds, and `stop_reason=refusal`/`max_tokens` surface as structured
+  errors.
+- `yoetz models sync` now treats the live OpenRouter catalog as authoritative:
+  OpenRouter-sourced entries are reconciled into the natural `provider/model`
+  namespace and dead slugs no longer served by OpenRouter are pruned (only when
+  a non-empty live catalog was fetched), so the registry stops keeping models
+  that 404 and stops missing newly served ones.
+
+### Fixed
+
+- `yoetz models frontier` no longer returns non-chat models (image generation,
+  video, audio, embeddings, …) as a family flagship; it now classifies model
+  kind from litellm `mode` and OpenRouter output modalities and considers only
+  chat/multimodal models, while keeping vision (image-input) chat models.
+- Model resolution now infers the provider from a full nested id, so
+  `--model openrouter/google/<model>` resolves without requiring `--provider`,
+  consistent with the `--provider openrouter --model google/<model>` form.
 
 ## [0.5.15] - 2026-05-28
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,8 +1275,8 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litellm-rust"
-version = "0.1.2"
-source = "git+https://github.com/avivsinai/litellm-rust?tag=v0.1.2#acf0514edf6b0fe1905970356091b8f63c3f40a9"
+version = "0.2.0"
+source = "git+https://github.com/avivsinai/litellm-rust?tag=v0.2.0#ef1906329119c615b4b5cb7f339a64076aea4c07"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/crates/yoetz-cli/Cargo.toml
+++ b/crates/yoetz-cli/Cargo.toml
@@ -21,7 +21,7 @@ workspace = true
 
 [dependencies]
 yoetz-core = { path = "../yoetz-core" }
-litellm-rust = { git = "https://github.com/avivsinai/litellm-rust", tag = "v0.1.2" }
+litellm-rust = { git = "https://github.com/avivsinai/litellm-rust", tag = "v0.2.0" }
 
 anyhow.workspace = true
 dotenvy.workspace = true

--- a/crates/yoetz-cli/src/commands/generate.rs
+++ b/crates/yoetz-cli/src/commands/generate.rs
@@ -141,6 +141,7 @@ async fn handle_generate_image(
                 size: args.size.clone(),
                 quality: args.quality.clone(),
                 background: args.background.clone(),
+                extra_body: None,
             })
             .await?;
         let outputs =


### PR DESCRIPTION
## Summary
Release-prep for **0.5.16**. Supersedes #240 (re-done on current main so the `Cargo.lock` delta is **only** the litellm-rust tag — #240's stale dependabot base would have downgraded `windows-sys` 0.61.2→0.59.0).

- Bump `litellm-rust` v0.1.2 → **v0.2.0**; pass `extra_body: None` on the `ImageRequest` literal (the only v0.2.0 compile breakage — `ChatRequest::new()` defaults it, and yoetz has no `LiteLLMError` refs so the `Refusal`/`Truncated` struct-variant reshape has no source impact).
- Populate CHANGELOG `[Unreleased]` for 0.5.16: extension managed-update, frontier non-chat filter, OpenRouter sync reconcile, provider inference, `--allow-uncosted`, and the v0.2.0 bump + its Anthropic runtime behavior change.

Diagnosis credit: the fix-217 background agent (#240).

## Verification (on current main, with all registry changes)
- `cargo build`/`clippy -D warnings`/`fmt --check` clean; **509+37+3+40 tests** pass.
- `Cargo.lock` delta is litellm-only (no transitive regressions).

## v0.2.0 behavior change to note
Anthropic structured-output (`response_format`) on unsupported models is now rejected instead of silent legacy-tool-call fallback; `stop_reason=refusal`/`max_tokens` surface as structured errors. yoetz propagates these as error messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)