### PR TITLE
[codex] Pin ChatGPT recipe to Pro Extended

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,17 +319,10 @@ extension marker prefix) so an agent can decide whether to reuse the tab or
 abort. Pass `--allow-cdp-fallback` only if you understand that explicitly
 permits a second submission via CDP.
 
-The built-in ChatGPT recipe defaults to `model=gpt-5-4-pro` with Extended left
-enabled. This is a deliberate Pro-first default for review jobs where a silent
-tier downgrade is worse than a clear "model unavailable" error. `model=auto`
-still prefers the Pro/Extended personal UI control when it exists, and remains
-available as an explicit override for accounts or workflows that want graceful
-fallback. The enterprise model switcher remains supported. The
-`--var extended=false` toggle is best-effort and only runs when explicitly
-requested. Yoetz scopes the chip match to the ChatGPT composer with
-negative-control guards, but ChatGPT re-skins the Extended thinking control
-occasionally; on a miss the run continues with whatever Extended state the tab
-was in and emits a warning.
+The built-in ChatGPT recipe supports exactly one target: ChatGPT Pro with
+Extended enabled. `model` and `extended` recipe overrides are rejected. This is
+deliberate for review jobs where a silent tier downgrade is worse than a clear
+"Pro Extended unavailable" error.
 
 If the next ChatGPT run after an unexplained failure should inspect the
 Yoetz-owned tab without resubmitting, use

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -1585,17 +1585,12 @@ fn parse_upload_poll_options(args: Option<&[String]>) -> Result<ChatgptPollOptio
 }
 
 fn run_chatgpt_select_model(
-    ctx: &RecipeContext,
+    _ctx: &RecipeContext,
     connection: Option<&BrowserConnection>,
     use_stealth: bool,
     headed: bool,
 ) -> Result<String> {
-    let requested_model = ctx
-        .vars
-        .get("model")
-        .map(String::as_str)
-        .unwrap_or_default();
-    let keep_current_model = chatgpt_web::should_keep_current_chatgpt_model(requested_model);
+    let requested_model = crate::chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL;
     let function = chatgpt_web::build_model_selection_function(requested_model);
     let expression = chatgpt_web::wrap_function_source_for_json_eval(&function)?;
     let stdout = run_agent_browser_with_connection_timeout(
@@ -1617,14 +1612,6 @@ fn run_chatgpt_select_model(
         chatgpt_web::chatgpt_model_selection_status(&selection, requested_model);
     match status {
         "selected" | "already-selected" => {
-            Ok(json!({
-                "status": "ok",
-                "model_used": model_used,
-                "model_selection_status": model_selection_status,
-            })
-            .to_string())
-        }
-        "missing-selector" | "not-found" if keep_current_model => {
             Ok(json!({
                 "status": "ok",
                 "model_used": model_used,
@@ -5131,7 +5118,7 @@ case "$*" in
     count=$((count + 1))
     printf '%s' "$count" > "$EVAL_COUNT_PATH"
     if [ "$count" = "1" ]; then
-      printf '{"status":"already-selected","currentLabel":"GPT-5 Pro"}'
+      printf '{"status":"already-selected","currentLabel":"Pro Extended"}'
     elif [ "$count" = "2" ]; then
       printf '{"status":"marked"}'
     else
@@ -5162,7 +5149,7 @@ if %errorlevel%==0 (
   set /a count=count+1
   > "%EVAL_COUNT_PATH%" echo !count!
   if "!count!"=="1" (
-    echo {"status":"already-selected","currentLabel":"GPT-5 Pro"}
+    echo {"status":"already-selected","currentLabel":"Pro Extended"}
   ) else if "!count!"=="2" (
     echo {"status":"marked"}
   ) else (
@@ -6956,7 +6943,7 @@ steps:
                 "action": CHATGPT_SELECT_MODEL_ACTION,
                 "stdout": {
                     "status": "ok",
-                    "model_used": "gpt-5-4-pro",
+                    "model_used": crate::chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL,
                     "model_selection_status": "selected"
                 }
             }),
@@ -6975,7 +6962,10 @@ steps:
         assert_eq!(payload["transport"], "agent-browser");
         assert_eq!(payload["backend"], "agent-browser");
         assert_eq!(payload["response"], "final answer");
-        assert_eq!(payload["model_used"], "gpt-5-4-pro");
+        assert_eq!(
+            payload["model_used"],
+            crate::chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL
+        );
         assert_eq!(payload["model_selection_status"], "selected");
         assert_eq!(payload["fallback_used"], true);
         assert_eq!(payload["warnings"], json!(["used paste fallback"]));

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -874,7 +874,7 @@ pub fn canary(live: bool, selector: ExtensionInstanceSelector<'_>) -> Result<Val
     fs::write(&bundle_path, "Reply with exactly OK.\n")?;
     let spec = ChatgptRecipeSpec {
         bundle_path: Some(bundle_path),
-        model: "current".to_string(),
+        model: crate::chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL.to_string(),
         prompt: "Reply with exactly OK.".to_string(),
         browser_context_id: None,
         profile_email: selector.profile_email.map(str::to_string),
@@ -885,7 +885,6 @@ pub fn canary(live: bool, selector: ExtensionInstanceSelector<'_>) -> Result<Val
         wait_interval_ms: 1_000,
         upload_timeout_ms: 30_000,
         send_timeout_ms: 120_000,
-        disable_extended: false,
     };
     let response = run_chatgpt_recipe(&spec, OutputFormat::Json)?;
     validate_canary_response(&response.response)?;
@@ -987,7 +986,6 @@ pub fn run_chatgpt_recipe(
             "profile_email": spec.profile_email,
             "extension_instance_id": spec.extension_instance_id,
             "extension_profile_id": spec.extension_profile_id,
-            "disable_extended": spec.disable_extended,
             "wait_timeout_ms": spec.wait_timeout_ms,
             "wait_interval_ms": spec.wait_interval_ms,
             "upload_timeout_ms": spec.upload_timeout_ms,

--- a/crates/yoetz-cli/src/chatgpt_recipe.rs
+++ b/crates/yoetz-cli/src/chatgpt_recipe.rs
@@ -6,6 +6,8 @@ use serde_json::{json, Value};
 use std::fmt;
 use std::path::PathBuf;
 
+pub const CHATGPT_PRO_EXTENDED_MODEL: &str = "extended-pro";
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ChatgptTransportPhase {
     Upload,
@@ -162,7 +164,6 @@ pub struct ChatgptRecipeSpec {
     pub wait_interval_ms: u64,
     pub upload_timeout_ms: u64,
     pub send_timeout_ms: u64,
-    pub disable_extended: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -221,7 +222,7 @@ mod tests {
             transport: "dev-browser".to_string(),
             backend: "dev-browser".to_string(),
             response: "ok".to_string(),
-            model_used: Some("gpt-5-4-pro".to_string()),
+            model_used: Some(CHATGPT_PRO_EXTENDED_MODEL.to_string()),
             model_selection_status: ChatgptModelSelectionStatus::Selected,
             warnings: vec!["fallback".to_string()],
             fallback_used: true,
@@ -234,7 +235,7 @@ mod tests {
         assert_eq!(payload["transport"], "dev-browser");
         assert_eq!(payload["backend"], "dev-browser");
         assert_eq!(payload["response"], "ok");
-        assert_eq!(payload["model_used"], "gpt-5-4-pro");
+        assert_eq!(payload["model_used"], CHATGPT_PRO_EXTENDED_MODEL);
         assert_eq!(payload["model_selection_status"], "selected");
         assert_eq!(payload["warnings"], json!(["fallback"]));
         assert_eq!(payload["fallback_used"], true);

--- a/crates/yoetz-cli/src/chatgpt_web.rs
+++ b/crates/yoetz-cli/src/chatgpt_web.rs
@@ -486,10 +486,12 @@ async () => {{
     ) || null;
   const hasExactTierLabel = (item, slug) => {{
     const text = normalize(item?.text || "").toLowerCase();
+    if (slug === "extended-pro") return /\bextended\b/.test(text) && /\bpro\b/.test(text);
     return text === slug || text.startsWith(`${{slug}} `);
   }};
   const deriveRequestedTier = (value) => {{
     if (!value) return null;
+    if (/\bextended\b/.test(value) && /\bpro\b/.test(value)) return "extended-pro";
     if (/\bthinking\b/.test(value)) return "thinking";
     if (/\binstant\b/.test(value)) return "instant";
     if (/\bpro\b/.test(value) && !/\b5[- .]?3\b/.test(value)) return "pro";
@@ -497,6 +499,7 @@ async () => {{
   }};
   const hasTrustedUserFacingTierLabel = (item, slug) => {{
     const haystack = item?.haystack || "";
+    if (slug === "extended-pro") return /\bextended\b/.test(haystack) && /\bpro\b/.test(haystack);
     if (slug === "pro") return /research-grade intelligence/.test(haystack);
     if (slug === "thinking") return /for complex questions/.test(haystack);
     if (slug === "instant") return /for everyday chats/.test(haystack);
@@ -504,6 +507,7 @@ async () => {{
   }};
   const classifyTier = (item) => {{
     const haystack = item?.haystack || "";
+    if (hasTrustedUserFacingTierLabel(item, "extended-pro") || hasExactTierLabel(item, "extended-pro")) return "extended-pro";
     if (hasTrustedUserFacingTierLabel(item, "pro") || /\bpro\b/.test(haystack)) return "pro";
     if (hasTrustedUserFacingTierLabel(item, "thinking") || /thinking/.test(haystack)) return "thinking";
     if (hasTrustedUserFacingTierLabel(item, "instant") || /instant/.test(haystack)) return "instant";
@@ -531,6 +535,9 @@ async () => {{
   const hasConflictingTierHint = (item, slug) => {{
     const haystack = item?.haystack || "";
     if (hasTrustedUserFacingTierLabel(item, slug) || hasExactTierLabel(item, slug)) return false;
+    if (slug === "extended-pro") {{
+      return !(/\bextended\b/.test(haystack) && /\bpro\b/.test(haystack));
+    }}
     if (slug === "pro") {{
       return /\b5[- .]?3\b|gpt-5[- .]?3-pro/.test(haystack);
     }}
@@ -543,14 +550,14 @@ async () => {{
     return false;
   }};
   const findSingleGenericTierItem = (entries, slug) => {{
-    if (!(slug === "pro" || slug === "thinking" || slug === "instant")) return null;
+    if (!(slug === "extended-pro" || slug === "pro" || slug === "thinking" || slug === "instant")) return null;
     const matches = entries.filter((item) =>
       item.haystack.includes(slug) && !hasConflictingTierHint(item, slug)
     );
     return matches.length === 1 ? matches[0] : null;
   }};
   const findExactTierLabelItem = (entries, slug) => {{
-    if (!(slug === "pro" || slug === "thinking" || slug === "instant")) return null;
+    if (!(slug === "extended-pro" || slug === "pro" || slug === "thinking" || slug === "instant")) return null;
     return entries.find((item) => hasExactTierLabel(item, slug) && !hasConflictingTierHint(item, slug)) || null;
   }};
   const modelSlug = (value) => {{
@@ -568,6 +575,7 @@ async () => {{
       /\bgpt[\s.-]*\d+(?:[\s.-]*\d+)*[\s.-]*pro\b/.test(labelText) ||
       /\bpro\b/.test(labelText);
     if (autoMode) return isProLabel;
+    if (requestedGenericTier === "extended-pro") return /\bextended\b/.test(labelText) && /\bpro\b/.test(labelText);
     if (requestedGenericTier === "pro") return isProLabel;
     if (requestedGenericTier === "thinking") return /\bthinking\b/.test(labelText);
     if (requestedGenericTier === "instant") return /\binstant\b/.test(labelText);
@@ -584,11 +592,12 @@ async () => {{
   }};
   const buildTierRankings = (entries) => {{
     const tierMaxVersions = {{
+      "extended-pro": maxVersionPartsForTier(entries, "extended-pro"),
       pro: maxVersionPartsForTier(entries, "pro"),
       thinking: maxVersionPartsForTier(entries, "thinking"),
       instant: maxVersionPartsForTier(entries, "instant"),
     }};
-    const tierScore = (tier) => tier === "pro" ? 300 : tier === "thinking" ? 200 : tier === "instant" ? 100 : 0;
+    const tierScore = (tier) => tier === "extended-pro" ? 400 : tier === "pro" ? 300 : tier === "thinking" ? 200 : tier === "instant" ? 100 : 0;
     const candidateScore = (item) => {{
       const tier = classifyTier(item);
       const version = effectiveVersionParts(item, tier, tierMaxVersions);
@@ -652,7 +661,7 @@ async () => {{
     }};
   }}
 
-  if (currentLabelSatisfiesRequest(currentLabel)) {{
+  if (currentLabelSatisfiesRequest(currentLabel) && requestedGenericTier !== "extended-pro" && !autoMode) {{
     return {{
       ...responseBase,
       status: "already-selected",
@@ -754,6 +763,54 @@ async () => {{
       ""
     ).toLowerCase();
   }};
+  const targetCandidateForTier = (entries, slug) => {{
+    const rankings = buildTierRankings(entries);
+    return findExactTierLabelItem(entries, slug) ||
+      selectBestTierItem(entries, slug, rankings) ||
+      findSingleGenericTierItem(entries, slug) ||
+      null;
+  }};
+  const autoPreferredTargetCandidate = (entries) =>
+    targetCandidateForTier(entries, "extended-pro") ||
+    targetCandidateForTier(entries, "pro") ||
+    null;
+  const autoTargetCandidate = (entries) =>
+    autoPreferredTargetCandidate(entries) ||
+    targetCandidateForTier(entries, "thinking") ||
+    targetCandidateForTier(entries, "instant") ||
+    null;
+  const itemSetSignature = (entries) => entries
+    .map((item) => `${{item.testId}}|${{item.text}}|${{item.ariaChecked}}|${{item.dataState}}`)
+    .join("\n");
+  const waitForTargetOrStableItems = async (initialItems) => {{
+    let currentItems = initialItems;
+    let signature = itemSetSignature(currentItems);
+    let stableSince = signature ? Date.now() : null;
+    const deadline = Date.now() + 7000;
+    while (Date.now() < deadline) {{
+      if (requestedGenericTier && targetCandidateForTier(currentItems, requestedGenericTier)) {{
+        return currentItems;
+      }}
+      if (autoMode && autoPreferredTargetCandidate(currentItems)) {{
+        return currentItems;
+      }}
+      const nextSignature = itemSetSignature(currentItems);
+      if (nextSignature && nextSignature === signature) {{
+        if (stableSince !== null && Date.now() - stableSince >= 600) {{
+          return currentItems;
+        }}
+      }} else {{
+        signature = nextSignature;
+        stableSince = nextSignature ? Date.now() : null;
+      }}
+      await wait(100);
+      currentItems = readItems();
+      if (currentItems.length === 0) {{
+        currentItems = await openSelectorMenu();
+      }}
+    }}
+    return currentItems;
+  }};
 
   let items = readItems();
   if (items.length === 0) {{
@@ -763,6 +820,7 @@ async () => {{
       items = readItems();
     }}
   }}
+  items = await waitForTargetOrStableItems(items);
 
   if (items.length === 0) {{
     return {{
@@ -782,6 +840,9 @@ async () => {{
   let requestedTestIds = [];
   if (autoMode) {{
     target =
+      findExactTierLabelItem(items, "extended-pro") ||
+      selectBestTierItem(items, "extended-pro", rankings) ||
+      findSingleGenericTierItem(items, "extended-pro") ||
       findExactTierLabelItem(items, "pro") ||
       selectBestTierItem(items, "pro", rankings) ||
       findSingleGenericTierItem(items, "pro") ||
@@ -843,7 +904,7 @@ async () => {{
   }}
 
   const targetTestId = target.testId || null;
-  if (itemIsSelected(target)) {{
+  if (itemIsSelected(target) && classifyTier(target) !== "extended-pro") {{
     return {{
       ...responseBase,
       status: "already-selected",
@@ -1777,9 +1838,12 @@ mod tests {
         assert!(auto_script.contains("const deriveRequestedTier = (value) =>"));
         assert!(auto_script.contains("const classifyTier = (item) =>"));
         assert!(auto_script.contains("const buildTierRankings = (entries) =>"));
+        assert!(auto_script.contains("const waitForTargetOrStableItems = async (initialItems) =>"));
+        assert!(auto_script.contains("targetCandidateForTier(entries, \"extended-pro\")"));
 
-        let explicit_script = build_model_selection_function("gpt-5-4-pro");
-        assert!(explicit_script.contains(r#"const requested = "gpt-5-4-pro";"#));
+        let explicit_script =
+            build_model_selection_function(crate::chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL);
+        assert!(explicit_script.contains(r#"const requested = "extended-pro";"#));
         assert!(explicit_script.contains("\"extended-pro\":\"extended-pro\""));
         assert!(explicit_script.contains("\"gpt-5-pro\":\"gpt-5-4-pro\""));
         assert!(!explicit_script.contains("\"gpt-5-3-pro\""));

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
@@ -334,15 +334,10 @@ async fn run_attached_recipe_inner(
         .await
         .context("mark yoetz-owned ChatGPT tab with window.name")?;
 
-    // Step 2: wait for the composer to mount, then select the best model the
-    // user can actually access. `model=auto` actively selects the strongest
-    // visible Pro/GPT-5 option; an empty/current model keeps the current UI
-    // selection.
+    // Step 2: wait for the composer to mount, then select ChatGPT Pro Extended
+    // before any upload/send side effects.
     wait_for_composer_ready(client, /* focus_composer */ true).await?;
     let model_selection = maybe_select_model(client, &ctx.model).await?;
-    if ctx.disable_extended {
-        maybe_disable_extended(client).await?;
-    }
 
     // Step 3: upload the bundle if we have a path.
     //
@@ -866,22 +861,6 @@ fn format_model_selection_diagnostics(selection: &serde_json::Value) -> String {
         item_count,
         available_items
     )
-}
-
-async fn maybe_disable_extended(client: &ChromeCdpClient) -> Result<()> {
-    let script = r##"
-() => {
-  const button = document.querySelector("button[aria-label*='click to remove'][aria-label*='Extended'], button[aria-label*='remove'][aria-label*='Extended']");
-  if (!button) return "already-off";
-  button.click();
-  return "disabled";
-}
-"##;
-    let _ = client
-        .evaluate_script(script, vec![])
-        .await
-        .context("evaluate_script disable Extended Pro")?;
-    Ok(())
 }
 
 fn parse_response_baseline(state: &serde_json::Value) -> Result<ResponseBaseline> {
@@ -2190,8 +2169,10 @@ mod tests {
         assert!(auto_script.contains("const classifyTier = (item) =>"));
         assert!(auto_script.contains("const buildTierRankings = (entries) =>"));
 
-        let explicit_script = build_model_selection_script("gpt-5-4-pro");
-        assert!(explicit_script.contains(r#"const requested = "gpt-5-4-pro";"#));
+        let explicit_script =
+            build_model_selection_script(crate::chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL);
+        assert!(explicit_script.contains(r#"const requested = "extended-pro";"#));
+        assert!(explicit_script.contains("targetCandidateForTier(entries, \"extended-pro\")"));
         assert!(explicit_script.contains("\"gpt-5-pro\":\"gpt-5-4-pro\""));
         assert!(!explicit_script.contains("\"gpt-5-3-pro\""));
         assert!(explicit_script.contains("const selectBestTierItem = (entries, slug, rankings) =>"));

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/mod.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/mod.rs
@@ -80,8 +80,7 @@ pub struct DevtoolsMcpRecipeContext {
     /// live-attach Chrome transport does not use inline bundle text.
     pub bundle_text: Option<String>,
 
-    /// Model slug to select in the LLM provider's UI (e.g. `gpt-5-4-pro`,
-    /// `claude-sonnet-4-6`, `gemini-3-1-pro`). Empty string = keep current.
+    /// ChatGPT model slug to select.
     pub model: String,
 
     /// User prompt to send alongside the bundle.
@@ -108,9 +107,6 @@ pub struct DevtoolsMcpRecipeContext {
     /// Maximum time to wait for file input discovery and attachment readiness.
     pub upload_timeout_ms: u64,
 
-    /// Whether to disable Extended Pro before sending.
-    pub disable_extended: bool,
-
     /// Whether to surface approval-dialog guidance to stderr in text mode.
     pub show_approval_guidance: bool,
 }
@@ -129,7 +125,6 @@ impl Default for DevtoolsMcpRecipeContext {
             response_timeout_ms: 5_400_000, // 90 min default for ChatGPT Pro Extended
             response_poll_interval_ms: 30_000,
             upload_timeout_ms: 120_000,
-            disable_extended: false,
             show_approval_guidance: true,
         }
     }

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -679,10 +679,8 @@ pub struct DevBrowserRecipeContext {
     pub bundle_path: Option<PathBuf>,
     /// Bundle text content (for paste mode).
     pub bundle_text: Option<String>,
-    /// Model slug (e.g., "gpt-5-4-pro"). Empty string = keep current.
+    /// ChatGPT model slug to select.
     pub model: String,
-    /// Whether to disable Extended Pro.
-    pub disable_extended: bool,
     /// Whether to paste text instead of uploading as file.
     pub paste_mode: bool,
     /// Custom prompt text.
@@ -709,7 +707,6 @@ impl Default for DevBrowserRecipeContext {
             model: String::new(),
             prompt: "Review the attached file and provide your analysis.".to_string(),
             run_id: String::new(),
-            disable_extended: false,
             paste_mode: false,
             poll_settings: ChatgptPollSettings::default(),
             upload_timeout_ms: CHATGPT_UPLOAD_TIMEOUT_MS_DEFAULT,
@@ -1086,7 +1083,6 @@ fn build_chatgpt_send_script(
     delivery_text: &str,
     file_upload_path: Option<&str>,
     upload_timeout_ms: u64,
-    disable_extended: bool,
     bundle_file_name: Option<&str>,
 ) -> String {
     let page_name_json = serde_json::to_string(page_name).unwrap();
@@ -1118,7 +1114,6 @@ const FILE_UPLOAD_PATH = {file_upload_path_json};
 const UPLOAD_TIMEOUT_MS = {upload_timeout_ms};
 const DELIVERY_TEXT = {delivery_text_json};
 const PROMPT = {prompt_json};
-const DISABLE_EXTENDED = {disable_extended};
 const BUNDLE_FILE_NAME = {bundle_file_name_json};
 const COMPOSER_SELECTOR = {composer_selector_json};
 const SEND_BUTTON_SELECTOR = {send_button_selector_json};
@@ -1179,15 +1174,6 @@ const waitForAttachmentReady = async () => {{
   }}
   return false;
 }};
-if (DISABLE_EXTENDED) {{
-  const extButton = page.locator("button[aria-label*='click to remove'][aria-label*='Extended'], button[aria-label*='remove'][aria-label*='Extended']").first();
-  if (await extButton.count() > 0) {{
-    await extButton.click();
-    await page.waitForTimeout(500);
-  }} else {{
-    warning = "extended disable requested but toggle not found";
-  }}
-}}
 const composer = page.locator(COMPOSER_SELECTOR).first();
 if (FILE_UPLOAD_PATH !== null) {{
   await composer.waitFor({{ state: "visible", timeout: 15000 }});
@@ -1330,7 +1316,6 @@ console.log(JSON.stringify({{
         composer_file_input_marker_json = composer_file_input_marker_json,
         attachment_probe_function_json =
             attachment_probe_function_json.unwrap_or_else(|| "null".to_string()),
-        disable_extended = disable_extended,
         upload_stable_polls = chatgpt_web::CHATGPT_UPLOAD_STABLE_POLLS,
         visibility_helpers = chatgpt_web::JS_VISIBILITY_HELPERS,
         composer_scope_helpers = chatgpt_web::JS_COMPOSER_SCOPE_HELPERS,
@@ -1641,7 +1626,6 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<ChatgptRecipe
             &delivery_text,
             file_upload_path.as_deref(),
             ctx.upload_timeout_ms,
-            ctx.disable_extended,
             file_upload_path
                 .as_deref()
                 .map(Path::new)
@@ -1996,10 +1980,14 @@ mod tests {
 
     #[test]
     fn build_chatgpt_prepare_script_uses_named_page_and_login_check() {
-        let script = build_chatgpt_prepare_script("yoetz-chatgpt-test", "gpt-5-4-pro", "run-123");
+        let script = build_chatgpt_prepare_script(
+            "yoetz-chatgpt-test",
+            crate::chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL,
+            "run-123",
+        );
 
         assert!(script.contains("const PAGE_NAME = \"yoetz-chatgpt-test\";"));
-        assert!(script.contains("const MODEL = \"gpt-5-4-pro\";"));
+        assert!(script.contains("const MODEL = \"extended-pro\";"));
         assert!(script.contains(
             "const KEEP_CURRENT_MODEL = !MODEL_TRIMMED || MODEL_LOWER === \"current\" || MODEL_LOWER === \"keep-current\";"
         ));
@@ -2018,6 +2006,7 @@ mod tests {
         assert!(script.contains("state.assistantCount === 0"));
         assert!(script.contains("pathname.startsWith(\"/c/\")"));
         assert!(script.contains("const selection = await page.evaluate((functionSource) => {"));
+        assert!(script.contains("targetCandidateForTier(entries, \\\"extended-pro\\\")"));
         assert!(script.contains("\\\"gpt-5-pro\\\":\\\"gpt-5-4-pro\\\""));
         assert!(!script.contains("\\\"gpt-5-3-pro\\\""));
         assert!(script.contains(
@@ -2084,7 +2073,6 @@ mod tests {
             "Review this file.",
             Some("/tmp/bundle.txt"),
             180_000,
-            true,
             Some("bundle.txt"),
         );
 
@@ -2092,6 +2080,7 @@ mod tests {
         assert!(script.contains("const FILE_UPLOAD_PATH = \"/tmp/bundle.txt\";"));
         assert!(script.contains("if (FILE_UPLOAD_PATH !== null)"));
         assert!(script.contains("const UPLOAD_TIMEOUT_MS = 180000;"));
+        assert!(!script.contains("DISABLE_EXTENDED"));
         assert!(script.contains("await composer.waitFor({ state: \"visible\", timeout: 15000 });"));
         assert!(script.contains("const COMPOSER_FILE_INPUT_MARKER = \"yoetz-upload-target\";"));
         assert!(script.contains("for (const selector of [markedFileInputSelector()])"));

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -1877,7 +1877,6 @@ async fn run_recipe_via_chrome_devtools_mcp(
         response_timeout_ms: recipe_spec.wait_timeout_ms,
         response_poll_interval_ms: recipe_spec.wait_interval_ms,
         upload_timeout_ms: recipe_spec.upload_timeout_ms,
-        disable_extended: recipe_spec.disable_extended,
         show_approval_guidance: matches!(format, OutputFormat::Text | OutputFormat::Markdown),
     };
 
@@ -1942,6 +1941,7 @@ fn build_chatgpt_recipe_spec(
     recipe_args: &BrowserRecipeArgs,
     recipe_vars: &BTreeMap<String, String>,
 ) -> Result<chatgpt_recipe::ChatgptRecipeSpec> {
+    ensure_chatgpt_pro_extended_only_vars(recipe_vars)?;
     let poll_settings = dev_browser::resolve_chatgpt_poll_settings(recipe_vars)?;
     let upload_timeout_ms =
         dev_browser::resolve_chatgpt_upload_timeout_ms(recipe_vars, recipe_args.bundle.as_deref())?;
@@ -1949,7 +1949,7 @@ fn build_chatgpt_recipe_spec(
     chrome_devtools_mcp::RecipeThreadMode::parse(recipe_vars.get("thread").map(String::as_str))?;
     Ok(chatgpt_recipe::ChatgptRecipeSpec {
         bundle_path: recipe_args.bundle.clone(),
-        model: recipe_vars.get("model").cloned().unwrap_or_default(),
+        model: chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL.to_string(),
         prompt: recipe_vars
             .get("prompt")
             .cloned()
@@ -1979,10 +1979,21 @@ fn build_chatgpt_recipe_spec(
         wait_interval_ms: poll_settings.interval_ms,
         upload_timeout_ms,
         send_timeout_ms,
-        disable_extended: recipe_vars
-            .get("extended")
-            .is_some_and(|value| value == "false"),
     })
+}
+
+fn ensure_chatgpt_pro_extended_only_vars(recipe_vars: &BTreeMap<String, String>) -> Result<()> {
+    let unsupported = ["model", "extended"]
+        .into_iter()
+        .filter(|key| recipe_vars.contains_key(*key))
+        .collect::<Vec<_>>();
+    if unsupported.is_empty() {
+        return Ok(());
+    }
+    bail!(
+        "ChatGPT recipe supports only ChatGPT Pro Extended; remove unsupported var(s): {}",
+        unsupported.join(", ")
+    )
 }
 
 fn apply_chatgpt_prompt_default(
@@ -2211,7 +2222,6 @@ fn run_recipe_via_dev_browser(
         bundle_path: recipe_spec.bundle_path.clone(),
         bundle_text,
         model: recipe_spec.model.clone(),
-        disable_extended: recipe_spec.disable_extended,
         paste_mode,
         prompt: recipe_spec.prompt.clone(),
         run_id: recipe_spec.run_id.clone(),
@@ -5375,7 +5385,6 @@ mod tests {
             vars: vec![],
         };
         let recipe_vars = BTreeMap::from([
-            ("model".to_string(), "pro".to_string()),
             ("prompt".to_string(), "Review this repo".to_string()),
             ("browser_context_id".to_string(), "ctx-123".to_string()),
             ("profile_email".to_string(), "user@example.com".to_string()),
@@ -5386,12 +5395,11 @@ mod tests {
             ("wait_interval_ms".to_string(), "45000".to_string()),
             ("upload_timeout_ms".to_string(), "180000".to_string()),
             ("send_timeout_ms".to_string(), "150000".to_string()),
-            ("extended".to_string(), "false".to_string()),
         ]);
 
         let spec = build_chatgpt_recipe_spec(&recipe_args, &recipe_vars).unwrap();
         assert_eq!(spec.bundle_path, Some(PathBuf::from("/tmp/bundle.md")));
-        assert_eq!(spec.model, "pro");
+        assert_eq!(spec.model, chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL);
         assert_eq!(spec.prompt, "Review this repo");
         assert_eq!(spec.browser_context_id.as_deref(), Some("ctx-123"));
         assert_eq!(spec.profile_email.as_deref(), Some("user@example.com"));
@@ -5402,7 +5410,30 @@ mod tests {
         assert_eq!(spec.wait_interval_ms, 45_000);
         assert_eq!(spec.upload_timeout_ms, 180_000);
         assert_eq!(spec.send_timeout_ms, 150_000);
-        assert!(spec.disable_extended);
+    }
+
+    #[test]
+    fn build_chatgpt_recipe_spec_rejects_model_and_extended_overrides() {
+        let recipe_args = BrowserRecipeArgs {
+            recipe: PathBuf::from("recipes/chatgpt.yaml"),
+            transport: None,
+            allow_cdp_fallback: false,
+            bundle: Some(PathBuf::from("/tmp/bundle.md")),
+            profile: None,
+            cdp: None,
+            browser_id: None,
+            vars: vec![],
+        };
+        let recipe_vars = BTreeMap::from([
+            ("model".to_string(), "auto".to_string()),
+            ("extended".to_string(), "false".to_string()),
+        ]);
+
+        let err = build_chatgpt_recipe_spec(&recipe_args, &recipe_vars).unwrap_err();
+        let message = format!("{err:#}");
+        assert!(message.contains("only ChatGPT Pro Extended"));
+        assert!(message.contains("model"));
+        assert!(message.contains("extended"));
     }
 
     #[test]
@@ -5426,15 +5457,9 @@ mod tests {
             .expect("build recipe vars");
         let spec = build_chatgpt_recipe_spec(&recipe_args, &recipe_vars).unwrap();
 
-        assert_eq!(spec.model, "gpt-5-4-pro");
-        assert!(!spec.disable_extended);
-
-        let auto_vars =
-            browser::build_recipe_vars(recipe.defaults.as_ref(), &["model=auto".to_string()])
-                .expect("build recipe vars with auto override");
-        let auto_spec = build_chatgpt_recipe_spec(&recipe_args, &auto_vars).unwrap();
-        assert_eq!(auto_spec.model, "auto");
-        assert!(!auto_spec.disable_extended);
+        assert_eq!(spec.model, chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL);
+        assert!(!recipe_vars.contains_key("model"));
+        assert!(!recipe_vars.contains_key("extended"));
     }
 
     #[test]
@@ -5612,7 +5637,7 @@ mod tests {
             transport: "dev-browser".to_string(),
             backend: "dev-browser".to_string(),
             response: "ok".to_string(),
-            model_used: Some("gpt-5-4-pro".to_string()),
+            model_used: Some(chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL.to_string()),
             model_selection_status: crate::chatgpt_recipe::ChatgptModelSelectionStatus::Selected,
             warnings: vec!["clipboard fallback".to_string()],
             fallback_used: true,

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -201,126 +201,19 @@ export async function ensureFreshChat(root = document, job = {}, options = {}) {
   };
 }
 
-export async function configureModelState(root, job) {
-  const warnings = [];
-  const extended = configureExtendedState(root, Boolean(job.disable_extended));
-  if (extended.warning) {
-    warnings.push(extended.warning);
-  }
-
-  const requested = normalizeRequestedModel(job.model);
-  if (requested.keepCurrent) {
-    return {
-      status: "kept_current",
-      model_used: currentModelLabel(root),
-      extended_status: extended.status,
-      warning: warnings[0] ?? null
-    };
-  }
-
+export async function configureModelState(root) {
+  const requested = proExtendedModelRequest();
   const selection = await selectRequestedModel(root, requested);
-  if (selection.warning) {
-    warnings.push(selection.warning);
-  }
+  const warnings = selection.warning ? [selection.warning] : [];
   return {
     status: selection.status,
     model_used: selection.model_used,
-    requested_model: job.model,
+    requested_model: requested.raw,
     available_options: selection.available_options ?? [],
-    extended_status: extended.status,
+    extended_status: "required",
     warning: warnings[0] ?? null,
     warnings
   };
-}
-
-export function configureExtendedState(root, disableExtended) {
-  if (!disableExtended) {
-    return { status: "not_requested" };
-  }
-  const button = findExtendedControl(root);
-  if (!button) {
-    return {
-      status: "unavailable",
-      warning: "extended disable requested but Extended toggle was not found"
-    };
-  }
-  button.click();
-  return { status: "disabled" };
-}
-
-function findExtendedControl(root) {
-  const direct = firstVisible(root, [
-    'button[aria-label*="click to remove"][aria-label*="Extended" i]',
-    'button[aria-label*="remove"][aria-label*="Extended" i]',
-    '[data-testid*="extended" i][role="button"]',
-    '[data-testid*="extended" i][role="switch"]'
-  ]);
-  if (direct) {
-    return direct;
-  }
-
-  for (const scope of composerScopes(root, { includeRoot: false })) {
-    const candidates = uniqueElements(Array.from(scope.querySelectorAll([
-      "button",
-      '[role="button"]',
-      '[role="switch"]',
-      '[role="checkbox"]',
-      "[tabindex]",
-      "[aria-label]",
-      "[title]",
-      "[data-testid]",
-      "span",
-      "div"
-    ].join(","))));
-    for (const node of candidates) {
-      const target = extendedClickTarget(node, scope);
-      if (!target || !isVisible(target, { allowDisabled: true })) {
-        continue;
-      }
-      const haystack = extendedCandidateText(node, target);
-      if (!/\bextended\b/.test(haystack)) {
-        continue;
-      }
-      if (/\b(send|stop|copy|share|new chat|attach|upload|search|history)\b/.test(haystack)) {
-        continue;
-      }
-      if (isActionableElement(target) || isExtendedChipLike(target)) {
-        return target;
-      }
-    }
-  }
-  return null;
-}
-
-function extendedCandidateText(node, target = node) {
-  return normalizeText([
-    node?.getAttribute?.("aria-label"),
-    node?.getAttribute?.("title"),
-    node?.getAttribute?.("data-testid"),
-    node?.getAttribute?.("class"),
-    node?.innerText,
-    node?.textContent,
-    target?.getAttribute?.("aria-label"),
-    target?.getAttribute?.("title"),
-    target?.getAttribute?.("data-testid"),
-    target?.getAttribute?.("class"),
-    target?.innerText,
-    target?.textContent
-  ].filter(Boolean).join(" ")).toLowerCase();
-}
-
-function extendedClickTarget(node, stopAt) {
-  let current = node;
-  while (current) {
-    if (isActionableElement(current) || isExtendedChipLike(current)) {
-      return current;
-    }
-    if (current === stopAt) {
-      return null;
-    }
-    current = current.parentElement;
-  }
-  return null;
 }
 
 function isActionableElement(node) {
@@ -329,14 +222,6 @@ function isActionableElement(node) {
   return tag === "button"
     || ["button", "switch", "checkbox"].includes(role)
     || node?.getAttribute?.("tabindex") !== null;
-}
-
-function isExtendedChipLike(node) {
-  const marker = normalizeText([
-    node?.getAttribute?.("data-testid"),
-    node?.getAttribute?.("class")
-  ].filter(Boolean).join(" ")).toLowerCase();
-  return /\bextended\b/.test(marker) && /\b(chip|pill|token|toggle|badge|model)\b/.test(marker);
 }
 
 function findComposerModelControl(root) {
@@ -435,16 +320,6 @@ function isModelChipLike(node) {
 }
 
 export async function selectRequestedModel(root, requested) {
-  const currentBefore = currentModelLabel(root);
-  if (modelTextMatchesRequest(currentBefore, requested)) {
-    return {
-      status: "selected",
-      model_used: currentBefore,
-      available_options: [],
-      already_selected: true
-    };
-  }
-
   let modelButton = null;
   try {
     modelButton = await waitForElement(root, findModelButton, "ChatGPT model selector", {
@@ -459,48 +334,31 @@ export async function selectRequestedModel(root, requested) {
     };
   }
   modelButton.click();
-  try {
-    await waitForCondition(() => visibleModelOptionLabels(root).length > 0, "ChatGPT model options did not appear", {
-      timeoutMs: 5000,
-      intervalMs: 100
-    });
-  } catch {
-    // Keep the fixed delay as a compatibility backstop for menu implementations
-    // that do not expose ARIA option roles.
-    await sleep(250);
-  }
 
-  const option = findModelOption(root, requested);
-  const availableOptions = visibleModelOptionLabels(root);
+  const { option, availableOptions } = await waitForRequestedModelOption(root, requested);
   if (!option) {
-    const currentAfterOpen = currentModelLabel(root);
-    if (modelTextMatchesRequest(currentAfterOpen, requested)) {
-      return {
-        status: "selected",
-        model_used: currentAfterOpen,
-        available_options: availableOptions,
-        already_selected: true
-      };
-    }
     return {
       status: "unavailable",
-      model_used: currentAfterOpen,
+      model_used: currentModelLabel(root),
       available_options: availableOptions,
-      warning: `requested ChatGPT model ${requested.raw} was not visible`
+      warning: "ChatGPT Pro Extended was not visible in the model picker"
     };
   }
   option.click();
-  await sleep(500);
 
-  const selected = currentModelLabel(root);
-  if (modelTextMatchesRequest(selected, requested)) {
-    return { status: "selected", model_used: selected || textOf(option), available_options: availableOptions };
+  const verification = await waitForRequestedModelSelected(root, requested, option);
+  if (verification.selected) {
+    return {
+      status: "selected",
+      model_used: verification.model_used || textOf(option),
+      available_options: availableOptions
+    };
   }
   return {
     status: "mismatch",
-    model_used: selected || textOf(option),
+    model_used: verification.model_used || textOf(option),
     available_options: availableOptions,
-    warning: `requested ChatGPT model ${requested.raw} was clicked but selected label is ${selected || "unknown"}`
+    warning: `ChatGPT Pro Extended was clicked but selected label is ${verification.model_used || "unknown"}`
   };
 }
 
@@ -1125,6 +983,72 @@ function visibleModelOptionLabels(root) {
     .filter(Boolean);
 }
 
+async function waitForRequestedModelOption(root, requested, options = {}) {
+  const timeoutMs = Number(options.timeoutMs ?? 7000);
+  const intervalMs = Number(options.intervalMs ?? 100);
+  const stableForMs = Number(options.stableForMs ?? 600);
+  const startedAt = Date.now();
+  let lastSignature = "";
+  let stableSince = 0;
+  let availableOptions = [];
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const option = findModelOption(root, requested);
+    availableOptions = visibleModelOptionLabels(root);
+    if (option) {
+      return { option, availableOptions };
+    }
+
+    const signature = availableOptions.join("\n");
+    const now = Date.now();
+    if (signature !== lastSignature) {
+      lastSignature = signature;
+      stableSince = signature ? now : 0;
+    }
+
+    if (signature && stableSince > 0 && now - stableSince >= stableForMs) {
+      return { option: null, availableOptions };
+    }
+    await sleep(intervalMs);
+  }
+
+  return { option: null, availableOptions };
+}
+
+async function waitForRequestedModelSelected(root, requested, option, options = {}) {
+  const timeoutMs = Number(options.timeoutMs ?? 4000);
+  const intervalMs = Number(options.intervalMs ?? 100);
+  const startedAt = Date.now();
+  let modelUsed = currentModelLabel(root);
+
+  while (Date.now() - startedAt < timeoutMs) {
+    modelUsed = currentModelLabel(root);
+    if (modelTextMatchesRequest(modelUsed, requested)) {
+      return { selected: true, model_used: modelUsed };
+    }
+    if (modelOptionIsSelected(option)) {
+      return { selected: true, model_used: textOf(option) };
+    }
+    await sleep(intervalMs);
+  }
+
+  return { selected: false, model_used: modelUsed };
+}
+
+function modelOptionIsSelected(node) {
+  const truthy = ["true", "checked", "selected", "active"];
+  return [
+    node?.getAttribute?.("aria-checked"),
+    node?.getAttribute?.("aria-selected"),
+    node?.getAttribute?.("aria-current"),
+    node?.getAttribute?.("data-state"),
+    node?.getAttribute?.("data-selected"),
+    node?.getAttribute?.("data-current")
+  ]
+    .map((value) => String(value ?? "").trim().toLowerCase())
+    .some((value) => truthy.includes(value));
+}
+
 function optionSlugs(node) {
   return [
     node.getAttribute?.("data-testid")?.replace(/^model-switcher-/, ""),
@@ -1641,41 +1565,16 @@ function currentModelLabel(root) {
   return modelControlLabel(findModelButton(root));
 }
 
-function normalizeRequestedModel(model) {
-  const raw = String(model ?? "").trim();
-  const slug = canonicalModelSlug(raw);
-  if (!raw || slug === "current") {
-    return { raw, keepCurrent: true, labels: [], slugs: [] };
-  }
-  if (slug === "auto") {
-    return {
-      raw,
-      keepCurrent: false,
-      labels: ["Extended Pro", "GPT-5.4 Pro", "GPT-5 Pro", "Pro", "GPT-5.4 Thinking", "Thinking", "GPT-5.4", "GPT-5"],
-      slugs: ["extended-pro", "gpt-5-4-pro", "gpt-5-pro", "pro", "thinking", "gpt-5-4", "gpt-5"]
-    };
-  }
-  const labelsBySlug = {
-    "extended-pro": ["Extended Pro"],
-    "pro": ["Extended Pro", "GPT-5.4 Pro", "GPT-5 Pro", "Pro"],
-    "gpt-5-pro": ["Extended Pro", "GPT-5 Pro", "Pro"],
-    "gpt-5-4-pro": ["Extended Pro", "GPT-5.4 Pro", "GPT-5 Pro", "Pro"],
-    "thinking": ["GPT-5.4 Thinking", "Thinking"],
-    "gpt-5": ["GPT-5"],
-    "gpt-5-4": ["GPT-5.4", "GPT-5"]
-  };
+function proExtendedModelRequest() {
   return {
-    raw,
-    keepCurrent: false,
-    labels: labelsBySlug[slug] ?? [raw.replace(/-/g, " ")],
-    slugs: [slug]
+    raw: "extended-pro",
+    labels: ["Extended Pro"],
+    slugs: ["extended-pro"]
   };
 }
 
 function canonicalModelSlug(value) {
   const folded = normalizeText(value).toLowerCase();
-  if (!folded || folded === "current" || folded === "keep current") return "current";
-  if (folded === "auto") return "auto";
   if (folded === "pro") return "pro";
   if (/\bextended\b/.test(folded) && /\bpro\b/.test(folded)) return "extended-pro";
   if (folded.includes("thinking")) return "thinking";

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -241,7 +241,7 @@ async function startJob(message) {
     await recordTerminalDeliveryLost(job, "model_selection");
     return;
   }
-  if (requiresExplicitModel(job.model) && !isAcceptableModelSelection(modelSelection)) {
+  if (!isAcceptableModelSelection(modelSelection)) {
     await failJob(job, "model_selection_failed", `Requested ChatGPT model was not selected: ${modelSelection.status ?? "unknown"}`, {
       phase: "model_selection",
       side_effect_started: false,
@@ -823,12 +823,11 @@ function normalizeJob(message) {
     capability_token: message.capability_token,
     request_id: message.request_id,
     prompt: payload.prompt ?? "",
-    model: payload.model ?? "",
+    model: "extended-pro",
     wait_timeout_ms: payload.wait_timeout_ms ?? DEFAULT_WAIT_TIMEOUT_MS,
     wait_interval_ms: payload.wait_interval_ms ?? 30000,
     upload_timeout_ms: payload.upload_timeout_ms ?? 120000,
     send_timeout_ms: payload.send_timeout_ms ?? 120000,
-    disable_extended: Boolean(payload.disable_extended),
     browser_context_id: payload.browser_context_id ?? null,
     profile_email: payload.profile_email ?? null,
     extension_instance_id: payload.extension_instance_id ?? null,
@@ -1420,11 +1419,6 @@ function isPostSendAssistantActivity(job, extraction, allowUnknownTurnIndex = fa
 function nonNegativeFiniteNumber(value) {
   const number = Number(value);
   return Number.isFinite(number) && number >= 0 ? number : null;
-}
-
-function requiresExplicitModel(model) {
-  const value = String(model ?? "").trim().toLowerCase();
-  return Boolean(value) && value !== "auto" && value !== "current" && value !== "keep-current" && value !== "keep current";
 }
 
 function isAcceptableModelSelection(selection) {

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -1388,76 +1388,46 @@ test("clickSend reports disabled send controls distinctly from missing controls"
   assert.equal(send.clicked, false);
 });
 
-test("fake ChatGPT model controls select model and disable Extended", async () => {
-  const extended = new FakeElement("button", { "aria-label": "click to remove Extended" }, "Extended");
-  const modelButton = new FakeElement("button", {
-    "data-testid": "model-switcher-dropdown-button",
-    "aria-haspopup": "menu"
-  }, "ChatGPT");
-  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Default");
-  const proOption = new FakeElement("div", {
-    role: "menuitemradio",
-    onClick: () => {
-      selected.innerText = "GPT-5.4 Pro";
-      selected.textContent = "GPT-5.4 Pro";
-    }
-  }, "GPT-5.4 Pro");
-  const body = new FakeElement("body", {}, "ChatGPT GPT-5.4 Pro").append(extended, modelButton, proOption, selected);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {
-    model: "pro",
-    disable_extended: true
-  });
-  assert.equal(extended.clicked, true);
-  assert.equal(modelButton.clicked, true);
-  assert.equal(proOption.clicked, true);
-  assert.equal(result.status, "selected");
-  assert.equal(result.extended_status, "disabled");
-});
-
-test("fake ChatGPT explicit GPT-5.4 Pro leaves Extended enabled by default", async () => {
-  const extended = new FakeElement("button", { "aria-label": "click to remove Extended" }, "Extended");
-  const modelButton = new FakeElement("button", {
-    "data-testid": "model-switcher-dropdown-button",
-    "aria-haspopup": "menu"
-  }, "ChatGPT");
-  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Default");
-  const proOption = new FakeElement("div", {
-    role: "menuitemradio",
-    onClick: () => {
-      selected.innerText = "GPT-5.4 Pro";
-      selected.textContent = "GPT-5.4 Pro";
-    }
-  }, "GPT-5.4 Pro");
-  const body = new FakeElement("body", {}, "ChatGPT GPT-5.4 Pro").append(extended, modelButton, proOption, selected);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {
-    model: "gpt-5-4-pro",
-    disable_extended: false
-  });
-
-  assert.equal(extended.clicked, false);
-  assert.equal(modelButton.clicked, true);
-  assert.equal(proOption.clicked, true);
-  assert.equal(result.status, "selected");
-  assert.equal(result.extended_status, "not_requested");
-  assert.equal(result.warning, null);
-});
-
-test("fake ChatGPT resolves a pinned gpt-5-4-pro request onto the live gpt-5-5 Pro option", async () => {
-  // ChatGPT silently bumps the Pro version (5.2 -> 5.4 -> 5.5 ...), so the picker
-  // no longer exposes the gpt-5-4-pro the recipe pins. Selection must fall back
-  // to the Pro tier by label and pick the live Pro option instead of failing
-  // "model unavailable". Guards cross-version drift: a naive exact-slug matcher
-  // would not find any of these options for "gpt-5-4-pro".
+test("fake ChatGPT model controls always select Pro Extended", async () => {
   const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
   const modelButton = new FakeElement("button", {
+    "data-testid": "model-switcher-dropdown-button",
     "aria-haspopup": "menu",
     onClick: () => delete modelButton.attrs["aria-checked"]
   }, "Instant");
+  const extended = new FakeElement("button", { "aria-label": "click to remove Extended" }, "Extended");
+  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Instant");
+  const instantOption = new FakeElement("div", { role: "menuitemradio" }, "Instant");
+  const thinkingOption = new FakeElement("div", { role: "menuitemradio" }, "Thinking");
+  const extendedProOption = new FakeElement("div", {
+    role: "menuitemradio",
+    "data-testid": "model-switcher-gpt-5-5-pro",
+    onClick: () => {
+      selected.innerText = "Pro • Extended";
+      selected.textContent = "Pro • Extended";
+    }
+  }, "Pro • Extended");
   const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
+  const body = new FakeElement("body", {}, "Ask anything Instant Thinking Pro Extended")
+    .append(extended, form, selected, instantOption, thinkingOption, extendedProOption);
+  const doc = new FakeDocument(body);
+
+  const result = await configureModelState(doc, {});
+
+  assert.equal(extended.clicked, false);
+  assert.equal(modelButton.clicked, true);
+  assert.equal(instantOption.clicked, false);
+  assert.equal(thinkingOption.clicked, false);
+  assert.equal(extendedProOption.clicked, true);
+  assert.equal(result.status, "selected");
+  assert.equal(result.model_used, "Pro • Extended");
+  assert.equal(result.extended_status, "required");
+  assert.equal(result.warning, null);
+});
+
+test("fake ChatGPT waits for late Pro Extended option before selecting", async () => {
+  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Instant");
   const instantOption = new FakeElement("div", {
     role: "menuitemradio",
     "data-testid": "model-switcher-gpt-5-5"
@@ -1468,230 +1438,54 @@ test("fake ChatGPT resolves a pinned gpt-5-4-pro request onto the live gpt-5-5 P
   }, "Thinking");
   const proOption = new FakeElement("div", {
     role: "menuitemradio",
-    "data-testid": "model-switcher-gpt-5-5-pro"
+    "data-testid": "model-switcher-gpt-5-5-pro",
+    onClick: () => {
+      selected.innerText = "Pro • Extended";
+      selected.textContent = "Pro • Extended";
+    }
   }, "Pro • Extended");
-  const body = new FakeElement("body", {}, "Ask anything Instant Thinking Pro Extended")
-    .append(form, instantOption, thinkingOption, proOption);
+  const modelButton = new FakeElement("button", {
+    "data-testid": "model-switcher-dropdown-button",
+    "aria-haspopup": "menu",
+    onClick: () => {
+      body.append(instantOption, thinkingOption);
+      setTimeout(() => body.append(proOption), 250);
+    }
+  }, "Instant");
+  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
+  const body = new FakeElement("body", {}, "Ask anything Instant Thinking").append(form, selected);
   const doc = new FakeDocument(body);
 
-  const result = await configureModelState(doc, {
-    model: "gpt-5-4-pro",
-    disable_extended: false
-  });
+  const result = await configureModelState(doc, {});
 
   assert.equal(modelButton.clicked, true);
-  assert.equal(proOption.clicked, true);
   assert.equal(instantOption.clicked, false);
   assert.equal(thinkingOption.clicked, false);
+  assert.equal(proOption.clicked, true);
   assert.equal(result.status, "selected");
-  assert.match(result.model_used, /pro/i);
-  assert.equal(result.extended_status, "not_requested");
-  assert.equal(result.warning, null);
+  assert.equal(result.model_used, "Pro • Extended");
 });
 
-test("fake ChatGPT personal composer model control accepts current Extended Pro for auto", async () => {
-  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
-  const modelButton = new FakeElement("button", { "aria-haspopup": "menu" }, "Extended Pro");
-  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
-  const body = new FakeElement("body", {}, "Ask anything Extended Pro").append(form);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {
-    model: "auto",
-    disable_extended: false
-  });
-
-  assert.equal(modelButton.clicked, false);
-  assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "Extended Pro");
-  assert.deepEqual(result.available_options, []);
-});
-
-test("fake ChatGPT personal composer model control can switch from Instant to Extended Pro", async () => {
-  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+test("fake ChatGPT fails when Pro Extended is absent", async () => {
   const modelButton = new FakeElement("button", {
-    "aria-haspopup": "menu",
-    onClick: () => delete modelButton.attrs["aria-checked"]
-  }, "Instant");
-  const extendedProOption = new FakeElement("div", { role: "menuitemradio" }, "Extended Pro");
+    "data-testid": "model-switcher-dropdown-button",
+    "aria-haspopup": "menu"
+  }, "ChatGPT");
+  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Instant");
   const instantOption = new FakeElement("div", { role: "menuitemradio" }, "Instant");
-  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
-  const body = new FakeElement("body", {}, "Ask anything Instant Extended Pro").append(form, instantOption, extendedProOption);
+  const thinkingOption = new FakeElement("div", { role: "menuitemradio" }, "Thinking");
+  const body = new FakeElement("body", {}, "ChatGPT Instant Thinking")
+    .append(modelButton, selected, instantOption, thinkingOption);
   const doc = new FakeDocument(body);
 
-  const result = await configureModelState(doc, {
-    model: "auto",
-    disable_extended: false
-  });
+  const result = await configureModelState(doc, {});
 
   assert.equal(modelButton.clicked, true);
   assert.equal(instantOption.clicked, false);
-  assert.equal(extendedProOption.clicked, true);
-  assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "Extended Pro");
-});
-
-test("fake ChatGPT auto accepts selected Pro label that appears only after menu opens", async () => {
-  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
-  let selected = null;
-  const modelButton = new FakeElement("button", {
-    "aria-haspopup": "menu",
-    onClick: () => {
-      selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Extended Pro");
-      body.append(new FakeElement("div", { role: "menuitemradio" }, "Instant"), selected);
-    }
-  }, "Model");
-  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
-  const body = new FakeElement("body", {}, "Ask anything Model").append(form);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {
-    model: "auto",
-    disable_extended: false
-  });
-
-  assert.equal(modelButton.clicked, true);
-  assert.ok(selected, "menu open should expose the selected model label");
-  assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "Extended Pro");
-  assert.deepEqual(result.available_options, ["Instant"]);
-  assert.equal(result.warning, null);
-});
-
-test("fake ChatGPT Extended disable falls back to visible chip text", async () => {
-  const composer = new FakeElement("form", { "data-testid": "composer" }, "");
-  const extended = new FakeElement("button", {}, "Extended Pro");
-  composer.append(extended);
-  const body = new FakeElement("body", {}, "ChatGPT Extended Pro").append(composer);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {
-    model: "current",
-    disable_extended: true
-  });
-
-  assert.equal(extended.clicked, true);
-  assert.equal(result.status, "kept_current");
-  assert.equal(result.extended_status, "disabled");
-});
-
-test("fake ChatGPT Extended disable clicks a nested composer chip", async () => {
-  const composer = new FakeElement("form", { "data-testid": "composer" }, "");
-  const extended = new FakeElement("div", { "data-testid": "extended-thinking-chip", class: "composer-chip" }, "Extended Pro");
-  composer.append(extended);
-  const body = new FakeElement("body", {}, "ChatGPT Extended Pro").append(composer);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {
-    model: "current",
-    disable_extended: true
-  });
-
-  assert.equal(extended.clicked, true);
-  assert.equal(result.status, "kept_current");
-  assert.equal(result.extended_status, "disabled");
-});
-
-test("fake ChatGPT Extended disable ignores unrelated controls with extended text", async () => {
-  const send = new FakeElement("button", { "aria-label": "Send extended prompt" }, "Send");
-  const body = new FakeElement("body", {}, "ChatGPT").append(send);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {
-    model: "current",
-    disable_extended: true
-  });
-
-  assert.equal(send.clicked, false);
-  assert.equal(result.status, "kept_current");
-  assert.equal(result.extended_status, "unavailable");
-  assert.match(result.warning, /Extended toggle was not found/);
-});
-
-test("fake ChatGPT model controls can select data-testid only model items", async () => {
-  const modelButton = new FakeElement("button", {
-    "data-testid": "model-switcher-dropdown-button",
-    "aria-haspopup": "menu"
-  }, "ChatGPT");
-  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Default");
-  const proOption = new FakeElement("div", {
-    "data-testid": "model-switcher-gpt-5-4-pro",
-    onClick: () => {
-      selected.innerText = "GPT-5.4 Pro";
-      selected.textContent = "GPT-5.4 Pro";
-    }
-  }, "");
-  const body = new FakeElement("body", {}, "ChatGPT").append(modelButton, proOption, selected);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {
-    model: "auto",
-    disable_extended: false
-  });
-
-  assert.equal(modelButton.clicked, true);
-  assert.equal(proOption.clicked, true);
-  assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "GPT-5.4 Pro");
-  assert.deepEqual(result.available_options, ["model-switcher-gpt-5-4-pro"]);
-});
-
-test("fake ChatGPT model controls do not match gpt-5 by gpt-5.4 substring", async () => {
-  const modelButton = new FakeElement("button", {
-    "data-testid": "model-switcher-dropdown-button",
-    "aria-haspopup": "menu"
-  }, "ChatGPT");
-  const proOption = new FakeElement("div", { role: "menuitemradio" }, "GPT-5.4 Pro");
-  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Default");
-  const gpt5Option = new FakeElement("div", {
-    role: "menuitemradio",
-    onClick: () => {
-      selected.innerText = "GPT-5";
-      selected.textContent = "GPT-5";
-    }
-  }, "GPT-5");
-  const body = new FakeElement("body", {}, "ChatGPT GPT-5.4 Pro GPT-5").append(modelButton, proOption, gpt5Option, selected);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {
-    model: "gpt-5",
-    disable_extended: false
-  });
-
-  assert.equal(modelButton.clicked, true);
-  assert.equal(proOption.clicked, false);
-  assert.equal(gpt5Option.clicked, true);
-  assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "GPT-5");
-});
-
-test("fake ChatGPT model controls keep hyphenated Pro slugs as Pro", async () => {
-  const modelButton = new FakeElement("button", {
-    "data-testid": "model-switcher-dropdown-button",
-    "aria-haspopup": "menu"
-  }, "ChatGPT");
-  const baseOption = new FakeElement("div", { role: "menuitemradio" }, "GPT-5.4");
-  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Default");
-  const proOption = new FakeElement("div", {
-    role: "menuitemradio",
-    onClick: () => {
-      selected.innerText = "GPT-5.4 Pro";
-      selected.textContent = "GPT-5.4 Pro";
-    }
-  }, "GPT-5.4 Pro");
-  const body = new FakeElement("body", {}, "ChatGPT GPT-5.4 GPT-5.4 Pro").append(modelButton, baseOption, proOption, selected);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {
-    model: "gpt-5.4-pro",
-    disable_extended: false
-  });
-
-  assert.equal(modelButton.clicked, true);
-  assert.equal(baseOption.clicked, false);
-  assert.equal(proOption.clicked, true);
-  assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "GPT-5.4 Pro");
+  assert.equal(thinkingOption.clicked, false);
+  assert.equal(result.status, "unavailable");
+  assert.equal(result.extended_status, "required");
+  assert.match(result.warning, /Pro Extended was not visible/);
 });
 
 function flatten(root) {

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -51,7 +51,7 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro • Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -90,8 +90,6 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
     for (const jobId of jobs) {
       port.emit(envelope("job_start", jobId, {
         prompt: `prompt ${jobId}`,
-        model: "current",
-        disable_extended: jobId === "job_b",
         wait_interval_ms: 500,
         wait_timeout_ms: 2500
       }));
@@ -123,8 +121,8 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
     );
     assert.equal(sentToTabs.filter((item) => item.message.type === "yoetz_upload_file").length, 2);
     assert.equal(
-      sentToTabs.find((item) => item.message.type === "yoetz_configure_model" && item.message.job.job_id === "job_b")?.message.job.disable_extended,
-      true
+      sentToTabs.find((item) => item.message.type === "yoetz_configure_model" && item.message.job.job_id === "job_b")?.message.job.model,
+      "extended-pro"
     );
   } finally {
     globalThis.chrome = originalChrome;
@@ -185,7 +183,7 @@ test("service worker fails fast on metadata manual handoff detected while waitin
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -246,7 +244,7 @@ test("service worker fails fast on metadata manual handoff detected while waitin
   }
 });
 
-test("service worker fails closed when an explicit model is unavailable", async () => {
+test("service worker fails closed when Pro Extended is unavailable", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
   const sentToTabs = [];
@@ -269,9 +267,9 @@ test("service worker fails closed when an explicit model is unavailable", async 
               payload: {
                 status: "unavailable",
                 model_used: "Default",
-                requested_model: "pro",
+                requested_model: "extended-pro",
                 available_options: ["Default"],
-                warning: "requested ChatGPT model pro was not visible"
+                warning: "ChatGPT Pro Extended was not visible in the model picker"
               }
             };
           default:
@@ -285,7 +283,6 @@ test("service worker fails closed when an explicit model is unavailable", async 
     await import(`../src/service-worker.js?model_unavailable=${Date.now()}`);
     port.emit(envelope("job_start", "job_model_fail", {
       prompt: "prompt",
-      model: "pro"
     }));
     await eventually(() => port.messages.some((message) => message.type === "job_error"));
     const error = port.messages.find((message) => message.type === "job_error");
@@ -300,7 +297,7 @@ test("service worker fails closed when an explicit model is unavailable", async 
   }
 });
 
-test("service worker fails closed when explicit model selection is only kept_current", async () => {
+test("service worker fails closed when Pro Extended selection is only kept_current", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
   const sentToTabs = [];
@@ -330,7 +327,6 @@ test("service worker fails closed when explicit model selection is only kept_cur
     await import(`../src/service-worker.js?model_kept_current=${Date.now()}`);
     port.emit(envelope("job_start", "job_model_kept_current", {
       prompt: "prompt",
-      model: "pro"
     }));
     await eventually(() => port.messages.some((message) => message.type === "job_error"));
     const error = port.messages.find((message) => message.type === "job_error");
@@ -343,7 +339,7 @@ test("service worker fails closed when explicit model selection is only kept_cur
   }
 });
 
-test("service worker treats auto model selection as best-effort", async () => {
+test("service worker fails closed when Pro Extended selection fails", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
   let tabId = 0;
@@ -375,13 +371,15 @@ test("service worker treats auto model selection as best-effort", async () => {
   });
 
   try {
-    await import(`../src/service-worker.js?model_auto_best_effort=${Date.now()}`);
-    port.emit(envelope("job_start", "job_auto_best_effort", {
+    await import(`../src/service-worker.js?model_selection_failed=${Date.now()}`);
+    port.emit(envelope("job_start", "job_selection_failed", {
       prompt: "prompt",
-      model: "auto"
     }));
-    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
-    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
+    await eventually(() => port.messages.some((message) => message.type === "job_error"));
+    const error = port.messages.find((message) => message.type === "job_error");
+    assert.equal(error.payload.code, "model_selection_failed");
+    assert.equal(error.payload.requested_model, "extended-pro");
+    assert.equal(port.messages.some((message) => message.payload?.phase === "ready_for_file"), false);
   } finally {
     globalThis.chrome = originalChrome;
   }
@@ -403,7 +401,7 @@ test("service worker rejects duplicate active job starts before opening another 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           default:
             throw new Error(`unexpected tab message ${message.type}`);
         }
@@ -413,9 +411,9 @@ test("service worker rejects duplicate active job starts before opening another 
 
   try {
     await import(`../src/service-worker.js?duplicate_job=${Date.now()}`);
-    port.emit(envelope("job_start", "job_duplicate", { prompt: "prompt", model: "current" }));
+    port.emit(envelope("job_start", "job_duplicate", { prompt: "prompt" }));
     await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
-    port.emit(envelope("job_start", "job_duplicate", { prompt: "prompt", model: "current" }));
+    port.emit(envelope("job_start", "job_duplicate", { prompt: "prompt" }));
     await eventually(() => port.messages.some((message) => message.type === "job_error" && message.payload.code === "duplicate_job"));
     assert.equal(createdTabs, 1);
   } finally {
@@ -441,7 +439,7 @@ test("service worker rejects follow-on messages with the wrong capability token"
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           default:
             throw new Error(`unexpected tab message ${message.type}`);
         }
@@ -451,7 +449,7 @@ test("service worker rejects follow-on messages with the wrong capability token"
 
   try {
     await import(`../src/service-worker.js?capability_mismatch=${Date.now()}`);
-    port.emit(envelope("job_start", "job_capability", { prompt: "prompt", model: "current" }, { capability_token: "secret" }));
+    port.emit(envelope("job_start", "job_capability", { prompt: "prompt" }, { capability_token: "secret" }));
     await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
     port.emit(envelope("job_file_chunk", "job_capability", {
       sequence: 0,
@@ -608,7 +606,7 @@ test("service worker allows matching extension instance id when profile identity
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           default:
             throw new Error(`unexpected tab message ${message.type}`);
         }
@@ -684,7 +682,7 @@ test("service worker allows matching profile email before opening a tab", async 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           default:
             throw new Error(`unexpected tab message ${message.type}`);
         }
@@ -896,7 +894,7 @@ test("service worker times out stale pre-send assistant text as job_error", asyn
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -955,7 +953,7 @@ test("service worker classifies final affordance without scoped assistant text",
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1039,7 +1037,7 @@ test("service worker fails extraction when final affordance page text alternates
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1124,7 +1122,7 @@ test("service worker completes post-send response when preceding user count is u
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1196,7 +1194,7 @@ test("service worker does not complete on brief stable assistant text without a 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1269,7 +1267,7 @@ test("service worker emits low-noise waiting progress while ChatGPT is quiet", a
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1353,7 +1351,7 @@ test("service worker completion is structural and does not classify response tex
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1423,7 +1421,7 @@ test("service worker accepts a scoped single-letter assistant markdown response"
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1499,7 +1497,7 @@ test("service worker reports oversized completed responses before native deliver
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1584,7 +1582,7 @@ test("service worker latches a completed scoped response when later ChatGPT DOM 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1664,7 +1662,7 @@ test("service worker preserves the best final response across a transient genera
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1775,7 +1773,7 @@ test("service worker settles same-length post-final text churn instead of timing
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1853,7 +1851,7 @@ test("service worker waits for scoped response text bytes to stabilize after fin
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1938,7 +1936,7 @@ test("service worker waits for streaming one-letter prefix to reach final assist
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2029,7 +2027,7 @@ test("service worker does not complete when ChatGPT idles before final assistant
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2117,7 +2115,7 @@ test("service worker rejects stale copy-button extraction from a pre-send assist
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2193,7 +2191,7 @@ test("service worker does not complete on copy button while response is still ge
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2262,7 +2260,7 @@ test("service worker completes when a generating response becomes idle without t
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2335,7 +2333,7 @@ test("service worker does not complete only because post-send copy controls incr
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2367,7 +2365,6 @@ test("service worker does not complete only because post-send copy controls incr
     await import(`../src/service-worker.js?copy_count_not_final=${Date.now()}`);
     port.emit(envelope("job_start", "job_copy_count_final", {
       prompt: "prompt",
-      model: "current",
       wait_interval_ms: 50,
       wait_timeout_ms: 1200
     }));
@@ -2409,7 +2406,7 @@ test("service worker rebinds owned tab after content script reload during respon
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2440,7 +2437,6 @@ test("service worker rebinds owned tab after content script reload during respon
     await import(`../src/service-worker.js?rebind_wait=${Date.now()}`);
     port.emit(envelope("job_start", "job_rebind_wait", {
       prompt: "prompt",
-      model: "current",
       wait_interval_ms: 50,
       wait_timeout_ms: 1200
     }));
@@ -2480,7 +2476,7 @@ test("service worker preserves content-script committed-send error metadata", as
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_extract_response":
@@ -2504,7 +2500,6 @@ test("service worker preserves content-script committed-send error metadata", as
     await import(`../src/service-worker.js?send_unknown=${Date.now()}`);
     port.emit(envelope("job_start", "job_send_unknown", {
       prompt: "prompt",
-      model: "current"
     }));
     await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
     port.emit(envelope("job_file_chunk", "job_send_unknown", {
@@ -2640,7 +2635,7 @@ test("service worker stops before upload when final chunk ack cannot reach nativ
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           default:
             throw new Error(`unexpected tab message ${message.type}`);
         }
@@ -2652,7 +2647,6 @@ test("service worker stops before upload when final chunk ack cannot reach nativ
     await import(`../src/service-worker.js?ack_throw=${Date.now()}`);
     port.emit(envelope("job_start", "job_ack_throw", {
       prompt: "prompt",
-      model: "current"
     }));
     await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
     port.emit(envelope("job_file_chunk", "job_ack_throw", {
@@ -2692,7 +2686,7 @@ test("service worker shards storage by job id so concurrent jobs do not clobber 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2720,7 +2714,6 @@ test("service worker shards storage by job id so concurrent jobs do not clobber 
     for (const jobId of ids) {
       port.emit(envelope("job_start", jobId, {
         prompt: `prompt ${jobId}`,
-        model: "current",
         wait_interval_ms: 50,
         wait_timeout_ms: 1500
       }));
@@ -2777,7 +2770,7 @@ test("service worker caps last_response_progress_text on disk while keeping the 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2828,7 +2821,6 @@ test("service worker caps last_response_progress_text on disk while keeping the 
     await eventually(() => port.messages.some((message) => message.type === "hello"));
     port.emit(envelope("job_start", "job_long_response", {
       prompt: "prompt",
-      model: "current",
       wait_interval_ms: 50,
       wait_timeout_ms: 5000
     }));
@@ -2900,7 +2892,7 @@ test("service worker does not persist on every in-flight chunk", async () => {
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 16 } };
           case "yoetz_send_prompt":
@@ -2925,7 +2917,6 @@ test("service worker does not persist on every in-flight chunk", async () => {
     await eventually(() => port.messages.some((message) => message.type === "hello"));
     port.emit(envelope("job_start", "job_chunk_persist", {
       prompt: "prompt",
-      model: "current",
       wait_interval_ms: 50,
       wait_timeout_ms: 1500
     }));
@@ -3082,7 +3073,7 @@ test("service worker cancelJob clicks stop, removes tab, and evicts the in-memor
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -3112,7 +3103,6 @@ test("service worker cancelJob clicks stop, removes tab, and evicts the in-memor
 
     port.emit(envelope("job_start", "job_cancel_a", {
       prompt: "prompt",
-      model: "current",
       wait_interval_ms: 50,
       wait_timeout_ms: 60000
     }));
@@ -3187,7 +3177,7 @@ test("service worker cancelJob still removes the tab when the content script is 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "kept_current", model_used: "ChatGPT" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -3216,7 +3206,6 @@ test("service worker cancelJob still removes the tab when the content script is 
 
     port.emit(envelope("job_start", "job_cancel_b", {
       prompt: "prompt",
-      model: "current",
       wait_interval_ms: 50,
       wait_timeout_ms: 60000
     }));
@@ -3258,7 +3247,6 @@ test("service worker resumes waiting_for_file jobs after service-worker restart"
       workspace_id: "workspace_test",
       status: "waiting_for_file",
       prompt: "prompt",
-      model: "current",
       wait_interval_ms: 50,
       wait_timeout_ms: 1500,
       tab_id: 42,
@@ -3341,7 +3329,6 @@ test("service worker resumes waiting_response jobs after service-worker restart"
       workspace_id: "workspace_test",
       status: "waiting_response",
       prompt: "prompt",
-      model: "current",
       wait_interval_ms: 50,
       wait_timeout_ms: 2500,
       tab_id: 44,
@@ -3453,7 +3440,6 @@ test("service worker still fails receiving_file jobs after service-worker restar
       workspace_id: "workspace_test",
       status: "receiving_file",
       prompt: "prompt",
-      model: "current",
       wait_interval_ms: 50,
       wait_timeout_ms: 1500,
       tab_id: 43,

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -18,12 +18,8 @@ name: chatgpt
 # transports connect directly to Chrome via CDP.
 #
 # Variables:
-#   model    — model slug (e.g., "gpt-5-4-pro"). Default: "gpt-5-4-pro" with
-#              Extended enabled when the account exposes it.
-#              Set to "auto" to select the best available model, preferring
-#              Pro with Extended enabled when the account has it.
-#              Set to "" or "current" to keep the current ChatGPT selector state.
-#   extended — set to "false" to disable Extended Pro. Default: keep Extended on.
+#   This recipe supports exactly one ChatGPT target: Pro with Extended enabled.
+#   `model` and `extended` overrides are intentionally unsupported.
 #   prompt   — prompt text to send with the attachment. For Yoetz bundle
 #              sessions, typed ChatGPT transports default this to bundle.json's
 #              stored user prompt unless --var prompt=... explicitly overrides.
@@ -52,8 +48,6 @@ name: chatgpt
 
 defaults:
   prompt: Review the attached file and provide your analysis.
-  model: "gpt-5-4-pro"
-  extended: ""
   thread: "fresh"
   upload_timeout_ms: "120000"
   upload_interval_ms: "2000"
@@ -96,19 +90,6 @@ steps:
   # Model selection is handled by the built-in Rust action so MCP,
   # dev-browser, and the generic browser transport share one selector.
   - action: chatgpt_select_model
-  - sleep_ms: 500
-
-  # Disable Extended Pro only when explicitly requested (--var extended=false).
-  - action: eval
-    args:
-      - |
-        (() => {
-          const extended = "{{extended}}";
-          if (extended !== "false") return "skipped: extended not disabled";
-          const btn = document.querySelector('button[aria-label*="click to remove"][aria-label*="Extended"]');
-          if (btn) { btn.click(); return "disabled Extended Pro"; }
-          return "Extended Pro already off";
-        })()
   - sleep_ms: 500
 
   # File attachment is the only delivery path.

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -357,16 +357,15 @@ Requires Node >= 24.4. If macOS shows a Keychain prompt for `Chrome Safe Storage
 
 ### Use ChatGPT Pro via recipe
 
+The built-in ChatGPT recipe always targets Pro with Extended enabled. Do not pass
+`model` or `extended` overrides; the CLI rejects them.
+
 ```bash
 # Create bundle and get bundle.md path
 BUNDLE=$(yoetz bundle -p "Review this code" -f src/*.rs --format json | jq -r .artifacts.bundle_md)
 
 # Send to ChatGPT
 yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE"
-
-# By default yoetz selects GPT-5.4 Pro with Extended enabled, preferring a clear
-# unavailable-model error over silent tier fallback. Override it only if needed.
-yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE" --var model=gpt-5-4-pro
 
 # Every request opens a fresh, yoetz-owned ChatGPT tab marked with ?_yoetz=<run-id>
 # so your own ChatGPT conversations are never touched. `--var thread=reuse` is


### PR DESCRIPTION
## Summary
- Simplify the built-in ChatGPT recipe to support only ChatGPT Pro Extended.
- Reject `model` and `extended` recipe vars instead of preserving auto/current/disable paths.
- Pin extension-native, CDP/dev-browser, and generic agent-browser model selection to `extended-pro`.
- Make native picker selection wait for Pro Extended or a stable bounded option set, click Pro Extended explicitly, and fail before upload/send if selection is not proven.
- Update docs, recipe YAML, skill docs, and regression tests.

## Validation
- `npm test` in `extensions/chatgpt-native` (145 passed)
- `cargo test -p yoetz` (510 passed, 2 ignored; CLI 37 passed; daemon policy 3 passed)
- `cargo test -p yoetz chatgpt_recipe_payload_extracts_response_model_and_warnings`
- `git diff --check`

## Review
Claude approved the six-point robustness bar across extension-native, CDP/dev-browser, agent-browser, and contract/docs. Aviv explicitly approved the Pro Extended-only contract change before publication.