### PR TITLE
Fix ChatGPT native Pro Extended selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,8 +264,9 @@ packaged source into the stable Yoetz-owned directory
 `~/.yoetz/chatgpt-native-extension`). Load that directory once from
 `chrome://extensions` with Developer mode enabled. Future updates use
 `yoetz browser extension update --chatgpt`: Yoetz refreshes the managed copy,
-asks the loaded extension to reload, and verifies that Chrome reports the
-current CLI version.
+also refreshes the legacy `$YOETZ_DIR/chrome-extension-native/unpacked` loaded
+directory when it exists, asks the loaded extension to reload, and verifies that
+Chrome reports the current CLI version.
 
 For agent-driven setup, `yoetz browser extension setup --chatgpt --open-chrome`
 does everything Chrome allows from the CLI: it installs or updates the native
@@ -322,7 +323,9 @@ permits a second submission via CDP.
 The built-in ChatGPT recipe supports exactly one target: ChatGPT Pro with
 Extended enabled. `model` and `extended` recipe overrides are rejected. This is
 deliberate for review jobs where a silent tier downgrade is worse than a clear
-"Pro Extended unavailable" error.
+"Pro Extended unavailable" error. The selector covers both ChatGPT Enterprise
+and personal ChatGPT picker layouts; it must prove Pro Extended is selected in
+the active account UI before upload/send, otherwise the run fails closed.
 
 If the next ChatGPT run after an unexplained failure should inspect the
 Yoetz-owned tab without resubmitting, use

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -137,6 +137,7 @@ pub struct ManagedExtensionUpdateResult {
     pub status: &'static str,
     pub source_dir: PathBuf,
     pub extension_dir: PathBuf,
+    pub loaded_extension_dirs: Vec<PathBuf>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub manifest_version: Option<String>,
     pub copied_files: usize,
@@ -287,12 +288,29 @@ pub fn managed_chatgpt_extension_dir() -> Result<PathBuf> {
     Ok(yoetz_state_dir()?.join("chatgpt-native-extension"))
 }
 
+fn legacy_loaded_chatgpt_extension_dir() -> Result<PathBuf> {
+    Ok(yoetz_state_dir()?
+        .join("chrome-extension-native")
+        .join("unpacked"))
+}
+
 pub fn prepare_managed_chatgpt_extension() -> Result<ManagedExtensionUpdateResult> {
     let source_dir = chatgpt_extension_source_dir().with_context(|| {
         format!("could not find ChatGPT native extension source; set {CHATGPT_EXTENSION_DIR_ENV}")
     })?;
     let extension_dir = managed_chatgpt_extension_dir()?;
-    sync_managed_chatgpt_extension_from(&source_dir, &extension_dir)
+    let mut result = sync_managed_chatgpt_extension_from(&source_dir, &extension_dir)?;
+    let legacy_dir = legacy_loaded_chatgpt_extension_dir()?;
+    if legacy_dir.exists() && !paths_refer_to_same_location(&legacy_dir, &extension_dir) {
+        sync_managed_chatgpt_extension_from(&source_dir, &legacy_dir).with_context(|| {
+            format!(
+                "sync legacy loaded ChatGPT native extension directory {}",
+                legacy_dir.display()
+            )
+        })?;
+        result.loaded_extension_dirs.push(legacy_dir);
+    }
+    Ok(result)
 }
 
 fn sync_managed_chatgpt_extension_from(
@@ -310,6 +328,7 @@ fn sync_managed_chatgpt_extension_from(
             status: "current",
             source_dir: source_dir.to_path_buf(),
             extension_dir: extension_dir.to_path_buf(),
+            loaded_extension_dirs: vec![extension_dir.to_path_buf()],
             manifest_version: extension_manifest_version(extension_dir),
             copied_files: count_regular_files(extension_dir)?,
         });
@@ -325,6 +344,7 @@ fn sync_managed_chatgpt_extension_from(
             status: "current",
             source_dir: source_dir.to_path_buf(),
             extension_dir: extension_dir.to_path_buf(),
+            loaded_extension_dirs: vec![extension_dir.to_path_buf()],
             manifest_version: extension_manifest_version(extension_dir),
             copied_files: 0,
         });
@@ -384,6 +404,7 @@ fn sync_managed_chatgpt_extension_from(
         status: "updated",
         source_dir: source_dir.to_path_buf(),
         extension_dir: extension_dir.to_path_buf(),
+        loaded_extension_dirs: vec![extension_dir.to_path_buf()],
         manifest_version: extension_manifest_version(extension_dir),
         copied_files,
     })
@@ -849,6 +870,7 @@ pub fn update_extension(selector: ExtensionInstanceSelector<'_>) -> Result<Value
         "transport": TRANSPORT_NAME,
         "extension_dir": update.extension_dir,
         "source_dir": update.source_dir,
+        "loaded_extension_dirs": update.loaded_extension_dirs,
         "manifest_version": update.manifest_version,
         "copy_status": update.status,
         "copied_files": update.copied_files,
@@ -1331,14 +1353,10 @@ fn auto_heal_extension_version_skew(
     paths: &ExtensionPaths,
     selector: ExtensionInstanceSelector<'_>,
 ) -> Result<Option<ExtensionInstanceStatus>> {
-    let source_dir = match chatgpt_extension_source_dir() {
-        Some(path) => path,
-        None => return Ok(None),
-    };
-    let extension_dir = managed_chatgpt_extension_dir()?;
-    if managed_chatgpt_extension_needs_sync(&source_dir, &extension_dir)? {
-        sync_managed_chatgpt_extension_from(&source_dir, &extension_dir)?;
+    if chatgpt_extension_source_dir().is_none() {
+        return Ok(None);
     }
+    prepare_managed_chatgpt_extension()?;
     reload_extension(selector)?;
     wait_for_extension_version(paths, selector, YOETZ_CLI_VERSION).map(Some)
 }
@@ -3512,6 +3530,33 @@ mod tests {
         assert_eq!(result.source_dir, source.canonicalize().unwrap());
         assert_eq!(result.extension_dir, state.join("chatgpt-native-extension"));
         assert!(is_chatgpt_extension_source_dir(&result.extension_dir));
+    }
+
+    #[test]
+    #[serial]
+    fn prepare_managed_extension_refreshes_legacy_loaded_unpacked_dir_when_present() {
+        let dir = TempDir::new().unwrap();
+        let source = dir.path().join("source");
+        write_extension_source_fixture(&source, "fresh");
+        let state = dir.path().join("state");
+        let legacy_loaded = state.join("chrome-extension-native").join("unpacked");
+        write_extension_source_fixture(&legacy_loaded, "stale");
+        let _source_guard = EnvGuard::set(CHATGPT_EXTENSION_DIR_ENV, &source);
+        let _state_guard = EnvGuard::set("YOETZ_DIR", &state);
+
+        let result = prepare_managed_chatgpt_extension().unwrap();
+
+        assert_eq!(result.extension_dir, state.join("chatgpt-native-extension"));
+        assert!(result.loaded_extension_dirs.contains(&result.extension_dir));
+        assert!(result.loaded_extension_dirs.contains(&legacy_loaded));
+        assert_eq!(
+            fs::read_to_string(legacy_loaded.join("manifest.json")).unwrap(),
+            r#"{"version":"fresh"}"#
+        );
+        assert_eq!(
+            fs::read_to_string(legacy_loaded.join("src").join("service-worker.js")).unwrap(),
+            "service-worker:fresh"
+        );
     }
 
     #[test]

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -84,6 +84,9 @@ export function findSendButton(root = document) {
 }
 
 export function findModelButton(root = document) {
+  // ChatGPT serves at least two picker families: Enterprise exposes a global
+  // model-switcher button, while personal ChatGPT can render a composer-scoped
+  // model chip. Keep both paths because either account type may back Pro.
   const enterpriseButton = firstVisible(root, [
     'button[data-testid="model-switcher-dropdown-button"]',
     'button:has([data-testid="selected-model"])',
@@ -92,7 +95,7 @@ export function findModelButton(root = document) {
     'button[aria-controls*="model" i]',
     'button[id*="model" i]'
   ]);
-  return enterpriseButton ?? findComposerModelControl(root);
+  return enterpriseButton ?? findComposerModelControl(root) ?? findStandaloneProExtendedModelControl(root);
 }
 
 export function getPageText(root = document) {
@@ -225,7 +228,7 @@ function isActionableElement(node) {
 }
 
 function findComposerModelControl(root) {
-  for (const scope of composerScopes(root, { includeRoot: false })) {
+  for (const scope of modelControlScopes(root)) {
     const candidates = uniqueElements(Array.from(scope.querySelectorAll([
       "button",
       '[role="button"]',
@@ -253,6 +256,37 @@ function findComposerModelControl(root) {
     }
   }
   return null;
+}
+
+function findStandaloneProExtendedModelControl(root) {
+  const requested = proExtendedModelRequest();
+  const candidates = uniqueElements(Array.from(root.querySelectorAll([
+    "button",
+    '[role="button"]',
+    "[aria-haspopup]"
+  ].join(","))));
+  return candidates.find((node) => {
+    if (!isVisible(node, { allowDisabled: true })) {
+      return false;
+    }
+    const haystack = modelCandidateText(node);
+    if (!modelTextMatchesRequest(haystack, requested)) {
+      return false;
+    }
+    return !/\b(send|stop|copy|share|new chat|attach|upload|search|history|dictation|voice|microphone|account|profile|settings|upgrade)\b/.test(haystack);
+  }) ?? null;
+}
+
+function modelControlScopes(root) {
+  const composer = findComposer(root);
+  const scopes = [...composerScopes(root, { includeRoot: false })];
+  const add = (scope) => {
+    if (scope && !scopes.includes(scope)) {
+      scopes.push(scope);
+    }
+  };
+  add(composer?.closest("main, [role=\"main\"]"));
+  return scopes;
 }
 
 function modelClickTarget(node, stopAt) {
@@ -320,23 +354,57 @@ function isModelChipLike(node) {
 }
 
 export async function selectRequestedModel(root, requested) {
-  let modelButton = null;
-  try {
-    modelButton = await waitForElement(root, findModelButton, "ChatGPT model selector", {
-      timeoutMs: 5000,
-      intervalMs: 250
-    });
-  } catch {
+  const readiness = await waitForModelSelectionTarget(root, requested);
+  if (readiness.selection.selected) {
+    return {
+      status: "selected",
+      model_used: readiness.selection.model_used,
+      available_options: []
+    };
+  }
+
+  const modelButton = readiness.modelButton;
+  if (!modelButton) {
     return {
       status: "unavailable",
-      model_used: currentModelLabel(root),
+      model_used: readiness.selection.model_used,
       warning: "ChatGPT model selector button not found"
     };
   }
-  modelButton.click();
 
-  const { option, availableOptions } = await waitForRequestedModelOption(root, requested);
-  if (!option) {
+  const currentSelection = currentRequestedModelSelection(root, requested);
+  if (currentSelection.selected) {
+    return {
+      status: "selected",
+      model_used: currentSelection.model_used,
+      available_options: []
+    };
+  }
+
+  let selectedOption = null;
+  let availableOptions = [];
+  const openAttempts = 3;
+  for (let attempt = 0; attempt < openAttempts; attempt += 1) {
+    await openModelPicker(root, modelButton);
+    const result = await waitForRequestedModelOption(root, requested, {
+      timeoutMs: attempt === openAttempts - 1 ? 7000 : 2500,
+      stableForMs: attempt === openAttempts - 1 ? 0 : 600
+    });
+    selectedOption = result.option;
+    availableOptions = result.availableOptions;
+    if (selectedOption) {
+      break;
+    }
+  }
+  if (!selectedOption) {
+    const verification = await waitForRequestedModelSelected(root, requested, null);
+    if (verification.selected) {
+      return {
+        status: "selected",
+        model_used: verification.model_used,
+        available_options: availableOptions
+      };
+    }
     return {
       status: "unavailable",
       model_used: currentModelLabel(root),
@@ -344,22 +412,174 @@ export async function selectRequestedModel(root, requested) {
       warning: "ChatGPT Pro Extended was not visible in the model picker"
     };
   }
-  option.click();
+  realClick(selectedOption);
 
-  const verification = await waitForRequestedModelSelected(root, requested, option);
+  const verification = await waitForRequestedModelSelected(root, requested, selectedOption);
   if (verification.selected) {
     return {
       status: "selected",
-      model_used: verification.model_used || textOf(option),
+      model_used: verification.model_used || textOf(selectedOption),
       available_options: availableOptions
     };
   }
   return {
     status: "mismatch",
-    model_used: verification.model_used || textOf(option),
+    model_used: verification.model_used || "unknown",
     available_options: availableOptions,
     warning: `ChatGPT Pro Extended was clicked but selected label is ${verification.model_used || "unknown"}`
   };
+}
+
+async function waitForModelSelectionTarget(root, requested, options = {}) {
+  const timeoutMs = Number(options.timeoutMs ?? 30000);
+  const intervalMs = Number(options.intervalMs ?? 250);
+  const startedAt = Date.now();
+  let selection = currentRequestedModelSelection(root, requested);
+  let modelButton = findModelButton(root);
+
+  while (Date.now() - startedAt < timeoutMs) {
+    selection = currentRequestedModelSelection(root, requested);
+    if (selection.selected) {
+      return { selection, modelButton: findModelButton(root) };
+    }
+    modelButton = findModelButton(root);
+    if (modelButton) {
+      return { selection, modelButton };
+    }
+    await sleep(intervalMs);
+  }
+
+  return { selection, modelButton };
+}
+
+function currentRequestedModelSelection(root, requested) {
+  const modelUsed = currentModelLabel(root);
+  return {
+    selected: modelTextMatchesRequest(modelUsed, requested),
+    model_used: modelUsed
+  };
+}
+
+async function openModelPicker(root, modelButton, options = {}) {
+  const settleMs = Number(options.settleMs ?? 150);
+  if (visibleModelOptions(root).length > 0) {
+    return true;
+  }
+  const activators = [openWithPointerEvents, pressEnter, pressSpace];
+  for (const activate of activators) {
+    try {
+      if (await activate(root, modelButton, { settleMs })) {
+        return true;
+      }
+    } catch {
+      // Try the next activation path; ChatGPT changes this control frequently.
+    }
+  }
+  return false;
+}
+
+async function openWithPointerEvents(root, element, options = {}) {
+  element?.focus?.();
+  const settleMs = Number(options.settleMs ?? 150);
+  const phases = [
+    ["pointerdown", "PointerEvent", {
+      button: 0,
+      buttons: 1,
+      pointerId: 1,
+      pointerType: "mouse",
+      isPrimary: true
+    }],
+    ["mousedown", "MouseEvent", { button: 0, buttons: 1 }],
+    ["pointerup", "PointerEvent", {
+      button: 0,
+      buttons: 0,
+      pointerId: 1,
+      pointerType: "mouse",
+      isPrimary: true
+    }],
+    ["mouseup", "MouseEvent", { button: 0, buttons: 0 }],
+    ["click", "MouseEvent", { button: 0, buttons: 0, detail: 1 }]
+  ];
+  for (const [type, constructorName, init] of phases) {
+    dispatchSyntheticEvent(element, type, constructorName, init);
+    await sleep(settleMs);
+    if (visibleModelOptions(root).length > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function pressEnter(root, element, options = {}) {
+  pressActivationKey(element, "Enter");
+  await sleep(Number(options.settleMs ?? 150));
+  return visibleModelOptions(root).length > 0;
+}
+
+async function pressSpace(root, element, options = {}) {
+  pressActivationKey(element, " ");
+  await sleep(Number(options.settleMs ?? 150));
+  return visibleModelOptions(root).length > 0;
+}
+
+function realClick(element) {
+  element?.focus?.();
+  dispatchSyntheticEvent(element, "pointerdown", "PointerEvent", {
+    button: 0,
+    buttons: 1,
+    pointerId: 1,
+    pointerType: "mouse",
+    isPrimary: true
+  });
+  dispatchSyntheticEvent(element, "mousedown", "MouseEvent", {
+    button: 0,
+    buttons: 1
+  });
+  dispatchSyntheticEvent(element, "pointerup", "PointerEvent", {
+    button: 0,
+    buttons: 0,
+    pointerId: 1,
+    pointerType: "mouse",
+    isPrimary: true
+  });
+  dispatchSyntheticEvent(element, "mouseup", "MouseEvent", {
+    button: 0,
+    buttons: 0
+  });
+  dispatchSyntheticEvent(element, "click", "MouseEvent", {
+    button: 0,
+    buttons: 0,
+    detail: 1
+  });
+}
+
+function pressActivationKey(element, key) {
+  const code = key === " " ? "Space" : key;
+  element?.focus?.();
+  dispatchSyntheticEvent(element, "keydown", "KeyboardEvent", { key, code });
+  dispatchSyntheticEvent(element, "keyup", "KeyboardEvent", { key, code });
+}
+
+function dispatchSyntheticEvent(element, type, constructorName, init = {}) {
+  const win = element?.ownerDocument?.defaultView ?? globalThis;
+  const EventConstructor = win?.[constructorName] ?? globalThis[constructorName] ?? win?.Event ?? globalThis.Event;
+  if (typeof EventConstructor !== "function") {
+    return false;
+  }
+  const eventInit = {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+    view: win,
+    ...init
+  };
+  let event = null;
+  try {
+    event = new EventConstructor(type, eventInit);
+  } catch {
+    event = new Event(type, eventInit);
+  }
+  return element.dispatchEvent?.(event) ?? false;
 }
 
 export async function clickSend(root, options = {}) {
@@ -1006,7 +1226,7 @@ async function waitForRequestedModelOption(root, requested, options = {}) {
       stableSince = signature ? now : 0;
     }
 
-    if (signature && stableSince > 0 && now - stableSince >= stableForMs) {
+    if (stableForMs > 0 && signature && stableSince > 0 && now - stableSince >= stableForMs) {
       return { option: null, availableOptions };
     }
     await sleep(intervalMs);
@@ -1015,7 +1235,7 @@ async function waitForRequestedModelOption(root, requested, options = {}) {
   return { option: null, availableOptions };
 }
 
-async function waitForRequestedModelSelected(root, requested, option, options = {}) {
+async function waitForRequestedModelSelected(root, requested, _option, options = {}) {
   const timeoutMs = Number(options.timeoutMs ?? 4000);
   const intervalMs = Number(options.intervalMs ?? 100);
   const startedAt = Date.now();
@@ -1026,27 +1246,10 @@ async function waitForRequestedModelSelected(root, requested, option, options = 
     if (modelTextMatchesRequest(modelUsed, requested)) {
       return { selected: true, model_used: modelUsed };
     }
-    if (modelOptionIsSelected(option)) {
-      return { selected: true, model_used: textOf(option) };
-    }
     await sleep(intervalMs);
   }
 
   return { selected: false, model_used: modelUsed };
-}
-
-function modelOptionIsSelected(node) {
-  const truthy = ["true", "checked", "selected", "active"];
-  return [
-    node?.getAttribute?.("aria-checked"),
-    node?.getAttribute?.("aria-selected"),
-    node?.getAttribute?.("aria-current"),
-    node?.getAttribute?.("data-state"),
-    node?.getAttribute?.("data-selected"),
-    node?.getAttribute?.("data-current")
-  ]
-    .map((value) => String(value ?? "").trim().toLowerCase())
-    .some((value) => truthy.includes(value));
 }
 
 function optionSlugs(node) {
@@ -1554,15 +1757,31 @@ function uniqueElements(nodes) {
 
 function currentModelLabel(root) {
   const selected = firstVisible(root, [
-    '[data-testid="model-switcher-selected-model"]',
-    '[aria-checked="true"]',
-    '[aria-selected="true"]'
+    '[data-testid="model-switcher-selected-model"]'
   ]);
   const selectedText = normalizeText(selected?.innerText ?? selected?.textContent ?? "");
   if (selectedText) {
     return selectedText;
   }
+  if (visibleModelOptions(root).length > 0) {
+    return "";
+  }
   return modelControlLabel(findModelButton(root));
+}
+
+export function modelSelectionDiagnostics(root = document) {
+  const requested = proExtendedModelRequest();
+  const modelButton = findModelButton(root);
+  const modelUsed = currentModelLabel(root);
+  return {
+    requested_model: requested.raw,
+    current_model_label: modelUsed,
+    current_matches_requested: modelTextMatchesRequest(modelUsed, requested),
+    model_button: modelButton ? elementSummary(modelButton) : null,
+    visible_options: visibleModelOptionLabels(root).slice(0, 20),
+    composer: elementSummary(findComposer(root)),
+    model_control_scopes: modelControlScopes(root).slice(0, 5).map(elementSummary)
+  };
 }
 
 function proExtendedModelRequest() {

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -167,7 +167,7 @@ async function extractJobResponse(job) {
 }
 
 async function inspectPage(runId, options = {}) {
-  const { extractResponse, getPageText, parseOwnedWindowName } = await domHelpers();
+  const { extractResponse, getPageText, modelSelectionDiagnostics, parseOwnedWindowName } = await domHelpers();
   const parsed = parseOwnedWindowName(window.name);
   const urlRunId = runIdFromUrl(location.href);
   const conversationId = conversationIdFromUrl(location.href);
@@ -187,6 +187,7 @@ async function inspectPage(runId, options = {}) {
     ownership: parsed,
     active_job_ids: Array.from(activeJobs.keys()),
     extraction,
+    model_selection: modelSelectionDiagnostics(document),
     page_text_chars: pageText.length
   };
   if (options.include_page_text) {

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -1422,7 +1422,15 @@ function nonNegativeFiniteNumber(value) {
 }
 
 function isAcceptableModelSelection(selection) {
-  return selection?.status === "selected";
+  return selection?.status === "selected"
+    && selection?.requested_model === "extended-pro"
+    && selection?.extended_status === "required"
+    && modelUsedLooksLikeProExtended(selection?.model_used);
+}
+
+function modelUsedLooksLikeProExtended(value) {
+  const folded = String(value ?? "").toLowerCase();
+  return /\bpro\b/.test(folded) && /\bextended\b/.test(folded);
 }
 
 function hasFinalAssistantAffordance(extraction) {

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -6,6 +6,7 @@ import {
   configureModelState,
   ensureFreshChat,
   extractResponse,
+  findModelButton,
   insertPrompt,
   sendAcceptanceBaseline,
   uploadFile,
@@ -28,9 +29,11 @@ class FakeElement {
     this.textContent = text;
     this.innerText = text;
     this.onClick = attrs.onClick;
+    this.onPointerDown = attrs.onPointerDown;
     this.hidden = Boolean(attrs.hidden);
     this.onChange = attrs.onChange;
     delete this.attrs.onClick;
+    delete this.attrs.onPointerDown;
     delete this.attrs.onChange;
   }
 
@@ -56,13 +59,23 @@ class FakeElement {
   }
 
   click() {
-    this.clicked = true;
-    this.attrs["aria-checked"] = "true";
+    this.recordClick();
     this.onClick?.();
+  }
+
+  recordClick() {
+    this.clicked = true;
   }
 
   dispatchEvent(event) {
     this.events.push(event.type);
+    if (event.type === "pointerdown") {
+      this.onPointerDown?.(event);
+    }
+    if (event.type === "click") {
+      this.recordClick();
+      this.onClick?.(event);
+    }
     if (event.type === "change") {
       this.onChange?.();
     }
@@ -1393,7 +1406,13 @@ test("fake ChatGPT model controls always select Pro Extended", async () => {
   const modelButton = new FakeElement("button", {
     "data-testid": "model-switcher-dropdown-button",
     "aria-haspopup": "menu",
-    onClick: () => delete modelButton.attrs["aria-checked"]
+    onClick: () => {
+      for (const option of [instantOption, thinkingOption, extendedProOption]) {
+        if (!body.children.includes(option)) {
+          body.append(option);
+        }
+      }
+    }
   }, "Instant");
   const extended = new FakeElement("button", { "aria-label": "click to remove Extended" }, "Extended");
   const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Instant");
@@ -1408,8 +1427,8 @@ test("fake ChatGPT model controls always select Pro Extended", async () => {
     }
   }, "Pro • Extended");
   const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
-  const body = new FakeElement("body", {}, "Ask anything Instant Thinking Pro Extended")
-    .append(extended, form, selected, instantOption, thinkingOption, extendedProOption);
+  const body = new FakeElement("body", {}, "Ask anything Instant")
+    .append(extended, form, selected);
   const doc = new FakeDocument(body);
 
   const result = await configureModelState(doc, {});
@@ -1466,21 +1485,393 @@ test("fake ChatGPT waits for late Pro Extended option before selecting", async (
   assert.equal(result.model_used, "Pro • Extended");
 });
 
+test("fake ChatGPT keeps waiting when non-Pro options render before Pro Extended", async () => {
+  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Instant");
+  const instantOption = new FakeElement("div", {
+    role: "menuitemradio",
+    "data-testid": "model-switcher-gpt-5-5"
+  }, "Instant");
+  const thinkingOption = new FakeElement("div", {
+    role: "menuitemradio",
+    "data-testid": "model-switcher-gpt-5-5-thinking"
+  }, "Thinking");
+  const proOption = new FakeElement("div", {
+    role: "menuitemradio",
+    "data-testid": "model-switcher-gpt-5-5-pro",
+    onClick: () => {
+      selected.innerText = "Pro • Extended";
+      selected.textContent = "Pro • Extended";
+    }
+  }, "Pro • Extended");
+  const modelButton = new FakeElement("button", {
+    "data-testid": "model-switcher-dropdown-button",
+    "aria-haspopup": "menu",
+    onClick: () => {
+      if (!body.children.includes(instantOption)) {
+        body.append(instantOption, thinkingOption);
+        setTimeout(() => body.append(proOption), 900);
+      }
+    }
+  }, "Instant");
+  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
+  const body = new FakeElement("body", {}, "Ask anything Instant Thinking").append(form, selected);
+  const doc = new FakeDocument(body);
+
+  const result = await configureModelState(doc, {});
+
+  assert.equal(proOption.clicked, true);
+  assert.equal(result.status, "selected");
+  assert.equal(result.model_used, "Pro • Extended");
+});
+
+test("fake ChatGPT opens model menu with pointer events when DOM click does not open it", async () => {
+  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Thinking");
+  const proOption = new FakeElement("div", {
+    role: "menuitemradio",
+    "data-testid": "model-switcher-gpt-5-5-pro",
+    onClick: () => {
+      selected.innerText = "Pro • Extended";
+      selected.textContent = "Pro • Extended";
+    }
+  }, "Pro • Extended");
+  const modelButton = new FakeElement("button", {
+    "data-testid": "model-switcher-dropdown-button",
+    "aria-haspopup": "menu",
+    onPointerDown: () => {
+      if (!body.children.includes(proOption)) {
+        body.append(proOption);
+      }
+    }
+  }, "Thinking");
+  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
+  const body = new FakeElement("body", {}, "Ask anything Thinking").append(form, selected);
+  const doc = new FakeDocument(body);
+
+  const result = await configureModelState(doc, {});
+
+  assert.ok(modelButton.events.includes("pointerdown"));
+  assert.equal(modelButton.clicked, false);
+  assert.equal(proOption.clicked, true);
+  assert.equal(result.status, "selected");
+  assert.equal(result.model_used, "Pro • Extended");
+});
+
+test("fake ChatGPT stops opening sequence when pointerdown opens the menu", async () => {
+  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Thinking");
+  const proOption = new FakeElement("div", {
+    role: "menuitemradio",
+    "data-testid": "model-switcher-gpt-5-5-pro",
+    onClick: () => {
+      selected.innerText = "Pro • Extended";
+      selected.textContent = "Pro • Extended";
+    }
+  }, "Pro • Extended");
+  const modelButton = new FakeElement("button", {
+    "data-testid": "model-switcher-dropdown-button",
+    "aria-haspopup": "menu",
+    onPointerDown: () => {
+      if (!body.children.includes(proOption)) {
+        body.append(proOption);
+      }
+    },
+    onClick: () => {
+      body.children = body.children.filter((child) => child !== proOption);
+    }
+  }, "Thinking");
+  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
+  const body = new FakeElement("body", {}, "Ask anything Thinking").append(form, selected);
+  const doc = new FakeDocument(body);
+
+  const result = await configureModelState(doc, {});
+
+  assert.ok(modelButton.events.includes("pointerdown"));
+  assert.equal(modelButton.events.includes("click"), false);
+  assert.equal(proOption.clicked, true);
+  assert.equal(result.status, "selected");
+  assert.equal(result.model_used, "Pro • Extended");
+});
+
+test("fake personal ChatGPT composer model chip selects Pro Extended", async () => {
+  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Thinking");
+  const proOption = new FakeElement("div", {
+    role: "menuitemradio",
+    "data-testid": "model-switcher-gpt-5-5-pro",
+    onClick: () => {
+      selected.innerText = "Pro • Extended";
+      selected.textContent = "Pro • Extended";
+    }
+  }, "Pro • Extended");
+  const modelChip = new FakeElement("button", {
+    class: "model-chip",
+    "aria-haspopup": "menu",
+    onPointerDown: () => {
+      if (!body.children.includes(proOption)) {
+        body.append(proOption);
+      }
+    }
+  }, "Thinking");
+  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelChip);
+  const body = new FakeElement("body", {}, "Ask anything Thinking").append(form, selected);
+  const doc = new FakeDocument(body);
+
+  const result = await configureModelState(doc, {});
+
+  assert.ok(modelChip.events.includes("pointerdown"));
+  assert.equal(modelChip.clicked, false);
+  assert.equal(proOption.clicked, true);
+  assert.equal(result.status, "selected");
+  assert.equal(result.model_used, "Pro • Extended");
+  assert.equal(result.extended_status, "required");
+});
+
+test("fake personal ChatGPT composer model chip verifies the chip label after the menu closes", async () => {
+  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+  const proOption = new FakeElement("div", {
+    role: "menuitemradio",
+    "data-testid": "model-switcher-gpt-5-5-pro",
+    onClick: () => {
+      modelChip.innerText = "Pro Extended";
+      modelChip.textContent = "Pro Extended";
+      body.children = body.children.filter((child) => child !== proOption);
+    }
+  }, "Pro Extended");
+  const modelChip = new FakeElement("button", {
+    class: "model-chip",
+    "aria-haspopup": "menu",
+    onPointerDown: () => {
+      if (!body.children.includes(proOption)) {
+        body.append(proOption);
+      }
+    }
+  }, "Thinking");
+  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelChip);
+  const body = new FakeElement("body", {}, "Ask anything Thinking").append(form);
+  const doc = new FakeDocument(body);
+
+  const result = await configureModelState(doc, {});
+
+  assert.ok(modelChip.events.includes("pointerdown"));
+  assert.equal(proOption.clicked, true);
+  assert.equal(result.status, "selected");
+  assert.equal(result.model_used, "Pro Extended");
+  assert.equal(result.extended_status, "required");
+});
+
+test("fake personal ChatGPT composer model chip accepts already selected Extended Pro", async () => {
+  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+  const modelChip = new FakeElement("button", {
+    class: "model-chip",
+    "aria-haspopup": "menu",
+    onPointerDown: () => {
+      throw new Error("already selected Pro Extended should not open the picker");
+    }
+  }, "Extended Pro");
+  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelChip);
+  const body = new FakeElement("body", {}, "Ask anything Extended Pro").append(form);
+  const doc = new FakeDocument(body);
+
+  const result = await configureModelState(doc, {});
+
+  assert.equal(modelChip.events.includes("pointerdown"), false);
+  assert.equal(modelChip.clicked, false);
+  assert.equal(result.status, "selected");
+  assert.equal(result.model_used, "Extended Pro");
+  assert.equal(result.extended_status, "required");
+});
+
+test("fake ChatGPT finds visible Extended Pro control before composer scope exists", () => {
+  const modelChip = new FakeElement("button", {
+    class: "__composer-pill __composer-pill--neutral group/pill",
+    "aria-haspopup": "menu"
+  }, "Extended Pro");
+  const body = new FakeElement("body", {}, "Extended Pro").append(modelChip);
+  const doc = new FakeDocument(body);
+
+  assert.equal(findModelButton(doc), modelChip);
+});
+
+test("fake ChatGPT accepts hydrated already selected Extended Pro before selector exists", async () => {
+  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+  const body = new FakeElement("body", {}, "Ask anything").append(composer);
+  const doc = new FakeDocument(body);
+  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Extended Pro");
+  setTimeout(() => body.append(selected), 250);
+
+  const result = await configureModelState(doc, {});
+
+  assert.equal(result.status, "selected");
+  assert.equal(result.model_used, "Extended Pro");
+  assert.equal(result.extended_status, "required");
+});
+
+test("fake personal ChatGPT composer pill can live outside the inner composer scope", async () => {
+  const composer = new FakeElement("div", { id: "prompt-textarea", role: "textbox" }, "");
+  const innerComposer = new FakeElement("div", { class: "deep-research-composer-shell" }, "").append(composer);
+  const modelPill = new FakeElement("button", {
+    class: "__composer-pill __composer-pill--neutral group/pill",
+    "aria-haspopup": "menu",
+    onPointerDown: () => {
+      throw new Error("already selected Pro Extended should not open the picker");
+    }
+  }, "Extended Pro");
+  const trailingControls = new FakeElement("div", { class: "composer-trailing-controls" }, "").append(modelPill);
+  const main = new FakeElement("main", {}, "Ask anything Extended Pro").append(innerComposer, trailingControls);
+  const body = new FakeElement("body", {}, "Ask anything Extended Pro").append(main);
+  const doc = new FakeDocument(body);
+
+  const result = await configureModelState(doc, {});
+
+  assert.equal(modelPill.events.includes("pointerdown"), false);
+  assert.equal(modelPill.clicked, false);
+  assert.equal(result.status, "selected");
+  assert.equal(result.model_used, "Extended Pro");
+  assert.equal(result.extended_status, "required");
+});
+
+test("fake ChatGPT accepts Pro Extended label that appears after the picker stays empty", async () => {
+  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Thinking");
+  const modelButton = new FakeElement("button", {
+    "data-testid": "model-switcher-dropdown-button",
+    "aria-haspopup": "menu",
+    onPointerDown: () => {
+      setTimeout(() => {
+        selected.innerText = "Extended Pro";
+        selected.textContent = "Extended Pro";
+      }, 500);
+    }
+  }, "Thinking");
+  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
+  const body = new FakeElement("body", {}, "Ask anything Thinking").append(form, selected);
+  const doc = new FakeDocument(body);
+
+  const result = await configureModelState(doc, {});
+
+  assert.ok(modelButton.events.includes("pointerdown"));
+  assert.equal(result.status, "selected");
+  assert.equal(result.model_used, "Extended Pro");
+  assert.equal(result.extended_status, "required");
+});
+
+test("fake ChatGPT reports mismatch when option checks but selected label stays Thinking", async () => {
+  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Thinking");
+  const proOption = new FakeElement("div", {
+    role: "menuitemradio",
+    "data-testid": "model-switcher-gpt-5-5-pro",
+    onClick: () => {
+      proOption.attrs["aria-checked"] = "true";
+    }
+  }, "Pro • Extended");
+  const modelButton = new FakeElement("button", {
+    "data-testid": "model-switcher-dropdown-button",
+    "aria-haspopup": "menu",
+    onClick: () => {
+      if (!body.children.includes(proOption)) {
+        body.append(proOption);
+      }
+    }
+  }, "Thinking");
+  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
+  const body = new FakeElement("body", {}, "Ask anything Thinking").append(form, selected);
+  const doc = new FakeDocument(body);
+
+  const result = await configureModelState(doc, {});
+
+  assert.equal(proOption.clicked, true);
+  assert.equal(result.status, "mismatch");
+  assert.equal(result.model_used, "Thinking");
+  assert.match(result.warning, /selected label is Thinking/);
+});
+
+test("fake ChatGPT does not certify transient Pro text on an open dropdown", async () => {
+  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+  const proOption = new FakeElement("div", {
+    role: "menuitemradio",
+    "data-testid": "model-switcher-gpt-5-5-pro",
+    onClick: () => {
+      modelButton.innerText = "Pro • Extended";
+      modelButton.textContent = "Pro • Extended";
+      modelButton.attrs["aria-selected"] = "true";
+    }
+  }, "Pro • Extended");
+  const modelButton = new FakeElement("button", {
+    "data-testid": "model-switcher-dropdown-button",
+    "aria-haspopup": "menu",
+    onClick: () => {
+      if (!body.children.includes(proOption)) {
+        body.append(proOption);
+      }
+    }
+  }, "Thinking");
+  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
+  const body = new FakeElement("body", {}, "Ask anything Thinking").append(form);
+  const doc = new FakeDocument(body);
+
+  const result = await configureModelState(doc, {});
+
+  assert.equal(proOption.clicked, true);
+  assert.equal(result.status, "mismatch");
+  assert.equal(result.model_used, "unknown");
+  assert.match(result.warning, /selected label is unknown/);
+});
+
 test("fake ChatGPT fails when Pro Extended is absent", async () => {
   const modelButton = new FakeElement("button", {
     "data-testid": "model-switcher-dropdown-button",
-    "aria-haspopup": "menu"
+    "aria-haspopup": "menu",
+    onClick: () => {
+      for (const option of [instantOption, thinkingOption]) {
+        if (!body.children.includes(option)) {
+          body.append(option);
+        }
+      }
+    }
   }, "ChatGPT");
   const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Instant");
   const instantOption = new FakeElement("div", { role: "menuitemradio" }, "Instant");
   const thinkingOption = new FakeElement("div", { role: "menuitemradio" }, "Thinking");
   const body = new FakeElement("body", {}, "ChatGPT Instant Thinking")
-    .append(modelButton, selected, instantOption, thinkingOption);
+    .append(modelButton, selected);
   const doc = new FakeDocument(body);
 
   const result = await configureModelState(doc, {});
 
   assert.equal(modelButton.clicked, true);
+  assert.equal(instantOption.clicked, false);
+  assert.equal(thinkingOption.clicked, false);
+  assert.equal(result.status, "unavailable");
+  assert.equal(result.extended_status, "required");
+  assert.match(result.warning, /Pro Extended was not visible/);
+});
+
+test("fake personal ChatGPT composer model chip fails when Pro Extended is absent", async () => {
+  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Thinking");
+  const instantOption = new FakeElement("div", { role: "menuitemradio" }, "Instant");
+  const thinkingOption = new FakeElement("div", { role: "menuitemradio" }, "Thinking");
+  const modelChip = new FakeElement("button", {
+    class: "model-chip",
+    "aria-haspopup": "menu",
+    onPointerDown: () => {
+      for (const option of [instantOption, thinkingOption]) {
+        if (!body.children.includes(option)) {
+          body.append(option);
+        }
+      }
+    }
+  }, "Thinking");
+  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelChip);
+  const body = new FakeElement("body", {}, "Ask anything Thinking").append(form, selected);
+  const doc = new FakeDocument(body);
+
+  const result = await configureModelState(doc, {});
+
+  assert.ok(modelChip.events.includes("pointerdown"));
   assert.equal(instantOption.clicked, false);
   assert.equal(thinkingOption.clicked, false);
   assert.equal(result.status, "unavailable");
@@ -1511,6 +1902,10 @@ function matchesSimpleSelector(element, selector) {
   const attr = (name) => element.attrs[name];
   const text = String(element.innerText ?? element.textContent ?? "");
 
+  if (selector.startsWith("button:has(")) {
+    const inner = selector.slice("button:has(".length, -1);
+    return tag === "button" && element.querySelectorAll(inner).length > 0;
+  }
   if (selector === '[data-message-author-role="assistant"] [class*="markdown"]') {
     return String(attr("class") ?? "").includes("markdown")
       && Boolean(element.closest('[data-message-author-role="assistant"]'));

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -51,7 +51,7 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro • Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro • Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -183,7 +183,7 @@ test("service worker fails fast on metadata manual handoff detected while waitin
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -385,6 +385,56 @@ test("service worker fails closed when Pro Extended selection fails", async () =
   }
 });
 
+test("service worker fails closed when selected model proof is incomplete", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const sentToTabs = [];
+  let tabId = 0;
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        sentToTabs.push(message.type);
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return {
+              ok: true,
+              payload: {
+                status: "selected",
+                model_used: "Pro Extended"
+              }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?model_selected_incomplete=${Date.now()}`);
+    port.emit(envelope("job_start", "job_model_selected_incomplete", {
+      prompt: "prompt",
+    }));
+    await eventually(() => port.messages.some((message) => message.type === "job_error"));
+    const error = port.messages.find((message) => message.type === "job_error");
+    assert.equal(error.payload.code, "model_selection_failed");
+    assert.equal(error.payload.phase, "model_selection");
+    assert.equal(error.payload.side_effect_started, false);
+    assert.equal(error.payload.model_selection_status, "selected");
+    assert.equal(sentToTabs.includes("yoetz_upload_file"), false);
+    assert.equal(sentToTabs.includes("yoetz_send_prompt"), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker rejects duplicate active job starts before opening another tab", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
@@ -401,7 +451,7 @@ test("service worker rejects duplicate active job starts before opening another 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           default:
             throw new Error(`unexpected tab message ${message.type}`);
         }
@@ -439,7 +489,7 @@ test("service worker rejects follow-on messages with the wrong capability token"
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           default:
             throw new Error(`unexpected tab message ${message.type}`);
         }
@@ -606,7 +656,7 @@ test("service worker allows matching extension instance id when profile identity
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           default:
             throw new Error(`unexpected tab message ${message.type}`);
         }
@@ -682,7 +732,7 @@ test("service worker allows matching profile email before opening a tab", async 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           default:
             throw new Error(`unexpected tab message ${message.type}`);
         }
@@ -894,7 +944,7 @@ test("service worker times out stale pre-send assistant text as job_error", asyn
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -953,7 +1003,7 @@ test("service worker classifies final affordance without scoped assistant text",
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1037,7 +1087,7 @@ test("service worker fails extraction when final affordance page text alternates
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1122,7 +1172,7 @@ test("service worker completes post-send response when preceding user count is u
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1194,7 +1244,7 @@ test("service worker does not complete on brief stable assistant text without a 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1267,7 +1317,7 @@ test("service worker emits low-noise waiting progress while ChatGPT is quiet", a
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1351,7 +1401,7 @@ test("service worker completion is structural and does not classify response tex
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1421,7 +1471,7 @@ test("service worker accepts a scoped single-letter assistant markdown response"
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1497,7 +1547,7 @@ test("service worker reports oversized completed responses before native deliver
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1582,7 +1632,7 @@ test("service worker latches a completed scoped response when later ChatGPT DOM 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1662,7 +1712,7 @@ test("service worker preserves the best final response across a transient genera
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1773,7 +1823,7 @@ test("service worker settles same-length post-final text churn instead of timing
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1851,7 +1901,7 @@ test("service worker waits for scoped response text bytes to stabilize after fin
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1936,7 +1986,7 @@ test("service worker waits for streaming one-letter prefix to reach final assist
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2027,7 +2077,7 @@ test("service worker does not complete when ChatGPT idles before final assistant
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2115,7 +2165,7 @@ test("service worker rejects stale copy-button extraction from a pre-send assist
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2191,7 +2241,7 @@ test("service worker does not complete on copy button while response is still ge
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2260,7 +2310,7 @@ test("service worker completes when a generating response becomes idle without t
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2333,7 +2383,7 @@ test("service worker does not complete only because post-send copy controls incr
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2406,7 +2456,7 @@ test("service worker rebinds owned tab after content script reload during respon
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2476,7 +2526,7 @@ test("service worker preserves content-script committed-send error metadata", as
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_extract_response":
@@ -2635,7 +2685,7 @@ test("service worker stops before upload when final chunk ack cannot reach nativ
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           default:
             throw new Error(`unexpected tab message ${message.type}`);
         }
@@ -2686,7 +2736,7 @@ test("service worker shards storage by job id so concurrent jobs do not clobber 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2770,7 +2820,7 @@ test("service worker caps last_response_progress_text on disk while keeping the 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2892,7 +2942,7 @@ test("service worker does not persist on every in-flight chunk", async () => {
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 16 } };
           case "yoetz_send_prompt":
@@ -3073,7 +3123,7 @@ test("service worker cancelJob clicks stop, removes tab, and evicts the in-memor
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -3177,7 +3227,7 @@ test("service worker cancelJob still removes the tab when the content script is 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended" } };
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -20,6 +20,9 @@ name: chatgpt
 # Variables:
 #   This recipe supports exactly one ChatGPT target: Pro with Extended enabled.
 #   `model` and `extended` overrides are intentionally unsupported.
+#   The Pro Extended selector must work against both ChatGPT Enterprise and
+#              personal ChatGPT accounts. Their picker DOM differs, but both
+#              are fail-closed if Pro Extended cannot be proven selected.
 #   prompt   — prompt text to send with the attachment. For Yoetz bundle
 #              sessions, typed ChatGPT transports default this to bundle.json's
 #              stored user prompt unless --var prompt=... explicitly overrides.

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -180,6 +180,9 @@ Chrome remote-debugging approval friction, recommend the opt-in
 `chrome-extension-native` transport as the robust path. Keep it explicit:
 install the native host, load/update the extension in Chrome, run `doctor`, then
 target the stable `extension_instance_id` when multiple profiles are open.
+The recipe supports both ChatGPT Enterprise and personal ChatGPT account UIs;
+their model pickers differ, but Yoetz still targets only Pro with Extended
+enabled and fails closed if that selection cannot be proven.
 
 Do not silently switch transports after upload/send/wait side effects. If the
 extension reports a terminal ChatGPT phase, preserve the manual-recovery tab and
@@ -336,7 +339,9 @@ by Yoetz. `setup --chatgpt` copies packaged extension source into the stable
 `$YOETZ_DIR/chatgpt-native-extension` directory; load that directory once from
 `chrome://extensions` with Developer mode enabled. After Yoetz upgrades, run
 `yoetz browser extension update --chatgpt` to refresh the managed copy, reload
-Chrome, and verify the loaded version.
+Chrome, and verify the loaded version. If an older install has Chrome loading
+`$YOETZ_DIR/chrome-extension-native/unpacked`, update refreshes that loaded
+directory too.
 For agent-driven setup, prefer `yoetz browser extension setup --chatgpt
 --open-chrome`; it installs the host, opens Chrome's extension page, and prints
 the exact folder to select. Chrome still requires the **Load unpacked** UI
@@ -358,7 +363,10 @@ Requires Node >= 24.4. If macOS shows a Keychain prompt for `Chrome Safe Storage
 ### Use ChatGPT Pro via recipe
 
 The built-in ChatGPT recipe always targets Pro with Extended enabled. Do not pass
-`model` or `extended` overrides; the CLI rejects them.
+`model` or `extended` overrides; the CLI rejects them. This applies to both
+ChatGPT Enterprise and personal ChatGPT accounts. Different picker layouts are
+handled by the transport, but an unproven Pro Extended selection is a hard
+failure before upload/send.
 
 ```bash
 # Create bundle and get bundle.md path


### PR DESCRIPTION
## Summary
- Replace the native ChatGPT model-picker DOM `.click()` path with pointer/mouse activation plus Enter/Space fallback, then select options with the same real-click sequence.
- Keep the target strictly Pro Extended-only: accept already-selected Extended Pro, verify the selected label after choosing, and fail closed for plain Pro/current/Thinking/Instant or incomplete proof.
- Cover both ChatGPT Enterprise/global picker and personal composer-pill layouts, including a standalone visible Extended Pro control before composer scoping stabilizes.
- Make extension update refresh the legacy loaded `$YOETZ_DIR/chrome-extension-native/unpacked` directory when present, in addition to the canonical managed directory.
- Update README, recipe comments, and skill docs to state Enterprise + personal UI support and Pro Extended-only behavior.

## Verification
- `npm test` in `extensions/chatgpt-native`: 159/159 passed
- `cargo test -p yoetz chatgpt_recipe`: 18/18 passed
- `cargo test -p yoetz prepare_managed_extension`: 2/2 passed
- `cargo fmt --all`
- `git diff --check`
- `./scripts/build-chatgpt-native-extension.sh --check`
- `./target/debug/yoetz browser extension update --chatgpt --extension-instance-id ext_5b65fe4ea80c7dd073a5722e --format json` reports both loaded dirs refreshed
- live canary after branch reload: `model_selection_status=selected`, `model_used=Extended Pro`, `response=OK`

## Remaining release gate
Claude code-reviewed the branch as passing. The final force-non-Pro live proof should be run after this lands in a 0.5.18 release and `yoetz browser extension update --chatgpt` is executed from the 0.5.18 binary, so Chrome reloads a version-distinct packaged extension instead of an in-memory 0.5.17 script.