### PR TITLE
chore(release): v0.5.18

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.5.17",
+  "version": "0.5.18",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.5.17",
+  "version": "0.5.18",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+## [0.5.18] - 2026-05-29
 ### Fixed
 
 - The ChatGPT native extension now reliably opens the model picker and selects
@@ -21,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   addition to the canonical `$YOETZ_DIR/chatgpt-native-extension` directory, so
   an extension loaded from the legacy path actually receives the update instead
   of silently running stale code.
+
 
 ## [0.5.17] - 2026-05-29
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3227,7 +3227,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoetz"
-version = "0.5.17"
+version = "0.5.18"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "yoetz-core"
-version = "0.5.17"
+version = "0.5.18"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/yoetz-core", "crates/yoetz-cli"]
 
 [workspace.package]
-version = "0.5.17"
+version = "0.5.18"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/extensions/chatgpt-native/manifest.json
+++ b/extensions/chatgpt-native/manifest.json
@@ -3,7 +3,7 @@
   "name": "Yoetz ChatGPT Native Transport",
   "short_name": "Yoetz ChatGPT",
   "description": "Experimental Yoetz native transport for ChatGPT recipe jobs.",
-  "version": "0.5.17",
+  "version": "0.5.18",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAujviQNA7EjHnfqpn3TM5IfgmHzOnvtu5pXg3Y1rS5koNJBT2PSG7FTGi9wD4oqNLVFehKm5h46vq1u1ACsMjAUrqMMUVvf7RUeqieUmfbtKRmx24N2blfz4b8KYpMlNUhf8IZ5TAFbvzy9NEO2KHAHCV6pP84E4lLBW2OQIDhqJd0FfS3Ecn91pbsH3tcsU6Gu+WiPEHLXZjPj85KcgQ+8qL0Xz83V5hEXIocMlCQ0RnMOfQIp5qUEIKgZ7qKqEjW2czNz48s5Fdgzbv95Lf09vat1NWiDHXZtDPWIa6TRjlKAAXIwsz5A/DJibzWiCgKiuOWmCgQPJgDidoyj/7RQIDAQAB",
   "icons": {
     "16": "icons/icon-16.png",

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yoetz
-version: 0.5.17
+version: 0.5.18
 description: >
   Fast CLI-first LLM council, bundler, and multimodal gateway. Use ONLY when user
   explicitly mentions "yoetz", "yoetz ask", "yoetz council", "yoetz review",


### PR DESCRIPTION
## Release

- updates `CHANGELOG.md` for `v0.5.18`
- bumps workspace version to `0.5.18`
- aligns skill/plugin metadata to `0.5.18`
- merge triggers .github/workflows/release.yml, which creates the tag and
  publishes the release
- GitHub release notes come from the committed `CHANGELOG.md` entry