### PR TITLE
Fail closed on ChatGPT native extension

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ recipe flows, treat `dev-browser` as a QuickJS/WASM runner, not Node.js:
 
 Yoetz browser integrations are extension-free by default unless the Yoetz
 Chrome extension is installed and connected, in which case the `chatgpt`
-recipe auto-promotes it.
+recipe selects it as the only default transport.
 
 - Treat yoetz as a thin wrapper over the underlying browser transport unless
   yoetz must own behavior for correctness or UX.
@@ -113,8 +113,11 @@ recipe auto-promotes it.
   stack extension-free.
 - For the `chatgpt` recipe specifically, when `yoetz browser extension
   status --chatgpt` reports `connected`, `chrome-extension-native` is
-  auto-promoted to the front of the default transport funnel; pass
-  `--transport <other>` or pin `transports:` in the recipe yaml to opt out.
+  auto-selected as the only default transport and fails closed instead of
+  falling through to CDP/dev-browser transports; pass `--transport <other>` or
+  pin `transports:` in the recipe yaml to opt out. CDP fallback after a native
+  extension failure requires the explicit
+  `--transport chrome-extension-native --allow-cdp-fallback` opt-in.
   Non-ChatGPT recipes and unhealthy/missing extensions are not affected.
 - The `chrome-extension-native` path stays the explicit choice when callers
   want it regardless of detection, via

--- a/README.md
+++ b/README.md
@@ -217,11 +217,15 @@ yoetz browser recipe --recipe recipes/chatgpt.yaml --bundle bundle.md
 yoetz --format json browser recipe --recipe recipes/chatgpt.yaml --bundle bundle.md
 ```
 
-The default browser stack remains extension-free: ChatGPT recipes use
-`chrome-devtools-mcp`, then `dev-browser`, then `agent-browser` / cookie
-fallbacks as needed. The experimental `chrome-extension-native` transport is an
-explicit opt-in exception for ChatGPT Pro runs that need install-once native
-messaging instead of CDP approval prompts. This native-host path is currently
+The default browser stack remains extension-free unless the ChatGPT native
+extension is installed and connected. Without a connected extension, ChatGPT
+recipes use `chrome-devtools-mcp`, then `dev-browser`, then `agent-browser` /
+cookie fallbacks as needed. With a connected extension, the built-in ChatGPT
+recipe auto-selects `chrome-extension-native` as the only default transport and
+fails closed instead of falling through to CDP/dev-browser transports. Pass
+`--transport <other>` to opt out, or
+`--transport chrome-extension-native --allow-cdp-fallback` to explicitly permit
+CDP fallback after a native-extension failure. This native-host path is currently
 macOS/Linux-only; Windows CLI artifacts still ship, but Windows native-host
 registration is not implemented yet.
 
@@ -317,8 +321,8 @@ The recipe never auto-falls-back to another transport once a side effect has
 landed in the user's tab. If the run fails after upload/send, the error
 includes a manual recovery hint (`window.name` marker, `_yoetz` URL marker,
 extension marker prefix) so an agent can decide whether to reuse the tab or
-abort. Pass `--allow-cdp-fallback` only if you understand that explicitly
-permits a second submission via CDP.
+abort. Pass `--transport chrome-extension-native --allow-cdp-fallback` only if
+you understand that this explicitly permits a second submission via CDP.
 
 The built-in ChatGPT recipe supports exactly one target: ChatGPT Pro with
 Extended enabled. `model` and `extended` recipe overrides are rejected. This is

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -245,12 +245,12 @@ pub fn recipe_transports(recipe: &Recipe, is_chatgpt: bool) -> Vec<RecipeTranspo
     })
 }
 
-/// Prepend `chrome-extension-native` to the ChatGPT recipe transport list when
+/// Select `chrome-extension-native` as the only ChatGPT recipe transport when
 /// the Yoetz Chrome extension is installed and connected and the recipe author
 /// did not pin their own transport order. The list is returned unchanged for
-/// any other recipe, when the recipe pinned `transports:`, when the extension
-/// is unhealthy, or when the list already contains `chrome-extension-native`.
-pub fn maybe_prefer_extension_native_for_chatgpt(
+/// any other recipe, when the recipe pinned `transports:`, or when the extension
+/// is unhealthy.
+pub fn maybe_select_extension_native_for_chatgpt(
     transports: Vec<RecipeTransport>,
     is_chatgpt: bool,
     recipe_transports_pinned: bool,
@@ -259,13 +259,7 @@ pub fn maybe_prefer_extension_native_for_chatgpt(
     if !is_chatgpt || recipe_transports_pinned || !extension_connected {
         return transports;
     }
-    if transports.contains(&RecipeTransport::ChromeExtensionNative) {
-        return transports;
-    }
-    let mut promoted = Vec::with_capacity(transports.len() + 1);
-    promoted.push(RecipeTransport::ChromeExtensionNative);
-    promoted.extend(transports);
-    promoted
+    vec![RecipeTransport::ChromeExtensionNative]
 }
 
 /// Returns (program, extra_prefix_args) for launching agent-browser.
@@ -7346,59 +7340,50 @@ steps:
     }
 
     #[test]
-    fn maybe_prefer_extension_native_prepends_for_chatgpt_when_connected() {
+    fn maybe_select_extension_native_requires_native_only_for_chatgpt_when_connected() {
         let base = vec![
             RecipeTransport::ChromeDevtoolsMcp,
             RecipeTransport::DevBrowser,
             RecipeTransport::AgentBrowser,
             RecipeTransport::Manual,
         ];
-        let promoted = maybe_prefer_extension_native_for_chatgpt(base, true, false, true);
-        assert_eq!(
-            promoted,
-            vec![
-                RecipeTransport::ChromeExtensionNative,
-                RecipeTransport::ChromeDevtoolsMcp,
-                RecipeTransport::DevBrowser,
-                RecipeTransport::AgentBrowser,
-                RecipeTransport::Manual,
-            ]
-        );
+        let promoted = maybe_select_extension_native_for_chatgpt(base, true, false, true);
+        assert_eq!(promoted, vec![RecipeTransport::ChromeExtensionNative]);
     }
 
     #[test]
-    fn maybe_prefer_extension_native_noop_when_extension_disconnected() {
+    fn maybe_select_extension_native_noop_when_extension_disconnected() {
         let base = vec![
             RecipeTransport::ChromeDevtoolsMcp,
             RecipeTransport::DevBrowser,
         ];
-        let result = maybe_prefer_extension_native_for_chatgpt(base.clone(), true, false, false);
+        let result = maybe_select_extension_native_for_chatgpt(base.clone(), true, false, false);
         assert_eq!(result, base);
     }
 
     #[test]
-    fn maybe_prefer_extension_native_noop_when_recipe_pinned_transports() {
+    fn maybe_select_extension_native_noop_when_recipe_pinned_transports() {
         let base = vec![RecipeTransport::ChromeDevtoolsMcp, RecipeTransport::Manual];
-        let result = maybe_prefer_extension_native_for_chatgpt(base.clone(), true, true, true);
+        let result = maybe_select_extension_native_for_chatgpt(base.clone(), true, true, true);
         assert_eq!(result, base);
     }
 
     #[test]
-    fn maybe_prefer_extension_native_noop_for_non_chatgpt() {
+    fn maybe_select_extension_native_noop_for_non_chatgpt() {
         let base = vec![RecipeTransport::AgentBrowser];
-        let result = maybe_prefer_extension_native_for_chatgpt(base.clone(), false, false, true);
+        let result = maybe_select_extension_native_for_chatgpt(base.clone(), false, false, true);
         assert_eq!(result, base);
     }
 
     #[test]
-    fn maybe_prefer_extension_native_noop_when_already_present() {
+    fn maybe_select_extension_native_keeps_native_only_when_already_present() {
         let base = vec![
             RecipeTransport::ChromeDevtoolsMcp,
             RecipeTransport::ChromeExtensionNative,
             RecipeTransport::Manual,
         ];
-        let result = maybe_prefer_extension_native_for_chatgpt(base.clone(), true, false, true);
-        assert_eq!(result, base);
+        let result = maybe_select_extension_native_for_chatgpt(base, true, false, true);
+        assert_eq!(result, vec![RecipeTransport::ChromeExtensionNative]);
     }
 
     #[test]
@@ -7462,7 +7447,7 @@ steps:
     }
 
     #[test]
-    fn builtin_chatgpt_recipe_does_not_pin_transports_so_auto_promotion_can_fire() {
+    fn builtin_chatgpt_recipe_does_not_pin_transports_so_native_selection_can_fail_closed() {
         let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../recipes/chatgpt.yaml");
         let content = fs::read_to_string(&path).expect("read recipes/chatgpt.yaml");
         let recipe: Recipe = serde_yaml_ng::from_str(&content).expect("parse chatgpt.yaml");
@@ -7470,31 +7455,22 @@ steps:
         assert!(
             recipe.transports.is_none(),
             "built-in chatgpt.yaml must not pin `transports:` so that \
-             chrome-extension-native auto-promotion gates correctly"
+             chrome-extension-native auto-selection gates correctly"
         );
 
         let base = recipe_transports(&recipe, true);
-        let promoted = maybe_prefer_extension_native_for_chatgpt(
+        let promoted = maybe_select_extension_native_for_chatgpt(
             base,
             true,
             recipe.transports.is_some(),
             true,
         );
         assert_eq!(
-            promoted.first(),
-            Some(&RecipeTransport::ChromeExtensionNative),
+            promoted,
+            vec![RecipeTransport::ChromeExtensionNative],
             "with extension connected, the built-in chatgpt recipe must \
-             auto-promote chrome-extension-native to the front of the funnel"
-        );
-        assert_eq!(
-            &promoted[1..],
-            &[
-                RecipeTransport::ChromeDevtoolsMcp,
-                RecipeTransport::DevBrowser,
-                RecipeTransport::AgentBrowser,
-                RecipeTransport::Manual,
-            ],
-            "auto-promotion must preserve the existing extension-free funnel order behind it"
+             auto-select chrome-extension-native and fail closed instead of \
+             silently falling through to CDP/dev-browser transports"
         );
     }
 

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -261,7 +261,7 @@ struct BrowserRecipeArgs {
     recipe: PathBuf,
 
     /// Explicitly select one browser recipe transport. When omitted, the
-    /// chatgpt recipe auto-promotes `chrome-extension-native` if the Yoetz
+    /// chatgpt recipe selects only `chrome-extension-native` if the Yoetz
     /// Chrome extension is installed and reports `connected`; otherwise the
     /// default funnel stays extension-free.
     #[arg(long, value_parser = parse_recipe_transport_flag)]
@@ -1147,6 +1147,16 @@ fn recipe_transports_with_explicit_override(
     Ok(vec![requested])
 }
 
+fn recipe_should_auto_discover_cdp_target(
+    managed_profile_only: bool,
+    requested_extension_native: bool,
+    extension_native_will_route: bool,
+    allow_cdp_fallback: bool,
+) -> bool {
+    !managed_profile_only
+        && (!extension_native_will_route || (requested_extension_native && allow_cdp_fallback))
+}
+
 fn manual_browser_recipe_fallback(recipe_path: &Path, bundle: Option<&Path>) -> String {
     let bundle_hint = bundle
         .map(|path| format!(" Upload or paste `{}` manually.", path.display()))
@@ -1415,28 +1425,28 @@ fn maybe_print_running_profile_auto_connect_preference(
 /// Returns true when the locally installed Yoetz Chrome extension reports
 /// `connected`. Any other status (`disconnected`, `missing_extension`,
 /// `manual_handoff`, `version_mismatch`, `not_installed`) or I/O error is
-/// treated as not available for auto-promotion. The probe is filesystem-local
+/// treated as not available for auto-selection. The probe is filesystem-local
 /// (status file + Unix socket reachability) and is cheap enough to run on
 /// every `yoetz browser recipe` invocation.
-fn extension_status_connected_for_auto_promotion() -> bool {
+fn extension_status_connected_for_auto_selection() -> bool {
     browser_extension_native::status()
         .map(|status| status.status == "connected")
         .unwrap_or(false)
 }
 
-fn maybe_print_auto_promoted_extension_native_transport(
-    auto_promoted: bool,
+fn maybe_print_auto_selected_extension_native_transport(
+    auto_selected: bool,
     transports: &[browser::RecipeTransport],
     format: OutputFormat,
 ) {
-    if !auto_promoted
+    if !auto_selected
         || transports.first() != Some(&browser::RecipeTransport::ChromeExtensionNative)
     {
         return;
     }
     if matches!(format, OutputFormat::Text | OutputFormat::Markdown) {
         eprintln!(
-            "info: auto-selected chrome-extension-native transport because the Yoetz Chrome extension is installed and connected (pass --transport <other> or pin `transports:` in the recipe to opt out)"
+            "info: auto-selected chrome-extension-native as the only transport because the Yoetz Chrome extension is installed and connected (pass --transport <other> to opt out, or --transport chrome-extension-native --allow-cdp-fallback to opt into CDP fallback)"
         );
     }
 }
@@ -3294,12 +3304,12 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 Some(browser::RecipeTransport::ChromeExtensionNative)
             );
             let recipe_transports_pinned = recipe.transports.is_some();
-            let extension_auto_promotion_eligible = recipe_args.transport.is_none()
+            let extension_auto_selection_eligible = recipe_args.transport.is_none()
                 && is_chatgpt
                 && !recipe_transports_pinned
-                && extension_status_connected_for_auto_promotion();
+                && extension_status_connected_for_auto_selection();
             let extension_native_will_route =
-                requested_extension_native || extension_auto_promotion_eligible;
+                requested_extension_native || extension_auto_selection_eligible;
             if recipe_uses_extension_instance_selector(&recipe_vars) && !extension_native_will_route
             {
                 bail!(
@@ -3317,17 +3327,21 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 recipe_args.cdp.as_deref(),
                 recipe_args.browser_id.as_deref(),
                 &ctx.browser_defaults,
-                !managed_profile_only
-                    && (!requested_extension_native || recipe_args.allow_cdp_fallback),
+                recipe_should_auto_discover_cdp_target(
+                    managed_profile_only,
+                    requested_extension_native,
+                    extension_native_will_route,
+                    recipe_args.allow_cdp_fallback,
+                ),
             )?;
             maybe_print_auto_selected_cdp_target(resolved_cdp_target.as_ref(), format);
-            let base_transports = browser::maybe_prefer_extension_native_for_chatgpt(
+            let base_transports = browser::maybe_select_extension_native_for_chatgpt(
                 browser::recipe_transports(&recipe, is_chatgpt),
                 is_chatgpt,
                 recipe_transports_pinned,
-                extension_auto_promotion_eligible,
+                extension_auto_selection_eligible,
             );
-            let extension_native_auto_promoted = extension_auto_promotion_eligible
+            let extension_native_auto_selected = extension_auto_selection_eligible
                 && base_transports.first()
                     == Some(&browser::RecipeTransport::ChromeExtensionNative);
             let transports = recipe_transports_with_explicit_override(
@@ -3361,8 +3375,8 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 &recipe_vars,
                 is_chatgpt,
             )?;
-            maybe_print_auto_promoted_extension_native_transport(
-                extension_native_auto_promoted,
+            maybe_print_auto_selected_extension_native_transport(
+                extension_native_auto_selected,
                 &transports,
                 format,
             );
@@ -4659,6 +4673,28 @@ mod tests {
         assert!(err
             .to_string()
             .contains("--allow-cdp-fallback is only valid"));
+    }
+
+    #[test]
+    fn cdp_auto_discovery_is_disabled_for_native_only_routes() {
+        assert!(recipe_should_auto_discover_cdp_target(
+            false, false, false, false
+        ));
+        assert!(!recipe_should_auto_discover_cdp_target(
+            true, false, false, false
+        ));
+        assert!(!recipe_should_auto_discover_cdp_target(
+            false, false, true, false
+        ));
+        assert!(!recipe_should_auto_discover_cdp_target(
+            false, false, true, true
+        ));
+        assert!(!recipe_should_auto_discover_cdp_target(
+            false, true, true, false
+        ));
+        assert!(recipe_should_auto_discover_cdp_target(
+            false, true, true, true
+        ));
     }
 
     #[test]

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -4,13 +4,19 @@ name: chatgpt
 # `crates/yoetz-cli/src/chatgpt_recipe.rs`. This YAML still defines the
 # generic agent-browser action sequence, but MCP/dev-browser consume the same
 # typed Rust contract even when they do not execute these steps literally.
-# Transport order:
+# Transport order when the native extension is missing or unhealthy:
 #   1. chrome-devtools-mcp — direct CDP client against running Chrome 147+
 #      (uses vendored `headless_chrome`; NOT a bridge to the chrome-devtools-mcp
 #      MCP server, despite the name — the module name is historical)
 #   2. dev-browser (fallback for Chrome <= 146 / Chrome for Testing)
 #   3. agent-browser (managed browser fallback)
 #   4. manual (last resort; upload the bundle yourself)
+#
+# When `yoetz browser extension status --chatgpt` reports `connected`, the
+# built-in recipe auto-selects `chrome-extension-native` as the only default
+# transport and fails closed. Use `--transport <other>` to opt out, or
+# `--transport chrome-extension-native --allow-cdp-fallback` to explicitly allow
+# CDP fallback after a native-extension failure.
 #
 # Recommended: enable chrome://inspect/#remote-debugging (Chrome 144+) for auto-connect.
 # Note: Chrome 136+ ignores --remote-debugging-port on the default profile.


### PR DESCRIPTION
## Summary
- auto-select chrome-extension-native as the only default ChatGPT transport when the native extension is connected
- require explicit operator intent for CDP fallback via --transport chrome-extension-native --allow-cdp-fallback
- disable CDP auto-discovery for native-only routes so the default path avoids Chrome approval prompts
- update README, CLAUDE.md, and the built-in ChatGPT recipe docs to match the new policy

## Verification
- cargo fmt
- git diff --check
- cargo test -p yoetz cdp_auto_discovery_is_disabled_for_native_only_routes --quiet
- cargo test -p yoetz maybe_select_extension_native --quiet
- cargo test -p yoetz allow_cdp_fallback --quiet
- cargo test -p yoetz --quiet
- cargo clippy --workspace --all-targets -- -D warnings

Claude reviewed over AMQ and approved committed fix 053aec0 with no further findings.