### PR TITLE
fix(browser): native ChatGPT completion finality + inspect diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- The ChatGPT native extension no longer hangs after a completed Pro review.
+  When a large bundle produced a long assistant turn, the wait loop could keep
+  waiting for final assistant controls even though generation had finished and
+  the response was complete. Assistant body text is now read from
+  `textContent` (layout-independent) instead of `innerText` (which returns only
+  the rendered head of a virtualized/clipped long answer), so the real answer
+  node is selected, the existing same-turn copy-button binding fires, and the
+  turn completes normally and promptly. The 955 KB Pro-review bundle that
+  previously hung now returns the full review with no fallback.
+- Native ChatGPT response extraction no longer falls back to whole-page text
+  (and then stalls) when the assistant turn's container class embeds a CSS
+  keyword such as `var(--header-height)`. Conversation-chrome detection now
+  matches keywords like `header`/`nav`/`aside` as whole class tokens instead of
+  substrings, so a styled answer turn is correctly recognized as the response.
+
+### Added
+
+- `yoetz browser extension inspect --chatgpt` now reports `page_text_content_chars`
+  and per-snippet `text_content_chars` (textContent lengths) alongside the
+  existing innerText-based `page_text_chars`/`text_chars`, so the
+  innerText-vs-textContent gap on a completed turn is observable from a single
+  native inspect. Inspect output also carries `service_worker_build` and
+  `content_script_build` markers so the loaded extension build can be verified
+  against the CLI.
+
+### Changed
+
+- The native ChatGPT response-wait loop confirms a copy-button-final turn over a
+  short fast-poll window (~8s) instead of the previous ~90s stable-idle floor,
+  so short responses (and the transport canary) return promptly without
+  weakening the completion latch.
 
 ## [0.5.19] - 2026-05-31
 

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -888,14 +888,39 @@ function isTurnLikeScope(node) {
   return /\b(user|assistant|conversation-turn|turn-messages|user-turn|agent-turn)\b/i.test(marker);
 }
 
+const CHROME_KEYWORD = /^(aside|nav|header|footer|complementary|navigation|dialog|sidebar|side-panel|popover|modal)$/i;
+
 function isNonConversationChrome(node) {
   for (let current = node; current; current = current.parentElement) {
-    const marker = nodeMarker(current, ["tag", "role", "data-testid", "class", "aria-label"]);
-    if (/\b(aside|nav|header|footer|complementary|navigation|dialog|sidebar|side-panel|popover|modal)\b/i.test(marker)) {
+    // tag / role / data-testid / aria-label are semantic identifiers — match chrome keywords
+    // as whole words there. The class attribute is NOT semantic: ChatGPT uses Tailwind utility
+    // tokens that embed arbitrary CSS expressions (e.g. scroll-mt-[calc(var(--header-height)+...)]
+    // on the conversation-turn <section>), so a substring \bheader\b inside var(--header-height)
+    // would mis-flag a real answer turn as chrome and drop it to page_text_fallback. Match class
+    // chrome keywords only as whole space-separated tokens so genuine chrome classes still match
+    // while CSS-expression substrings do not.
+    const semanticMarker = nodeMarker(current, ["tag", "role", "data-testid", "aria-label"]);
+    if (/\b(aside|nav|header|footer|complementary|navigation|dialog|sidebar|side-panel|popover|modal)\b/i.test(semanticMarker)) {
+      return true;
+    }
+    if (classTokensSignalChrome(current)) {
       return true;
     }
   }
   return false;
+}
+
+function classTokensSignalChrome(node) {
+  const className = node?.getAttribute?.("class");
+  if (!className) {
+    return false;
+  }
+  // Match a chrome keyword only as a WHOLE space-separated class token (e.g. "popover", "modal",
+  // "sidebar", "side-panel"). A Tailwind utility such as scroll-mt-[calc(var(--header-height)+...)]
+  // is a single token that is not equal to any chrome keyword, so it no longer false-positives.
+  return String(className)
+    .split(/\s+/)
+    .some((token) => CHROME_KEYWORD.test(token));
 }
 
 function nodeMarker(node, fields) {

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -978,7 +978,13 @@ function leafNodes(nodes) {
 }
 
 function cleanAssistantText(node, options = {}) {
-  const lines = textOf(node)
+  // Body text MUST come from textContent, not innerText: a virtualized/clipped long answer node
+  // returns only its rendered head via innerText (observed live as a single "I"). textContent
+  // returns the full DOM text regardless of layout. Per-line control/status stripping below then
+  // removes any code-block "Copy code", sr-only, thought/status, and control lines that
+  // textContent may surface. Fall back to innerText only if textContent is empty (defensive).
+  const source = bodyTextOf(node) || textOf(node);
+  const lines = source
     .split(/\n+/)
     .map((line) => normalizeText(line))
     .filter((line) => line && !isAssistantControlLine(line, options));
@@ -988,6 +994,11 @@ function cleanAssistantText(node, options = {}) {
 function isAssistantControlLine(line, options = {}) {
   const value = normalizeText(line);
   return /^(copy|copied|read aloud|share|regenerate|retry|edit|like|dislike)$/i.test(value)
+    // Code-block affordances: textContent (unlike innerText) surfaces the code-block toolbar
+    // button labels, which ChatGPT renders as "Copy code"/"Copy"/"Edit"/"Copy code button text".
+    // Strip them as standalone lines so a fenced code block in the answer doesn't leak its
+    // toolbar text. Anchored to a standalone line so it never eats real answer prose.
+    || /^copy code$/i.test(value)
     || /^(thought|reasoned)\s+for\s+\S.*$/i.test(value)
     || /^show\s+(more|reasoning)$/i.test(value)
     || (!options.preserveContentStatusText && (isThoughtStatusLine(line) || isModelStatusText(line)));
@@ -1718,8 +1729,17 @@ function looksLikeUserTurn(turn) {
 
 function extractionDiagnostics(root, assistantTurns, copyButtons) {
   const pageText = normalizeText(getPageText(root));
+  // page_text_chars is innerText-derived (getPageText = body.innerText) and therefore
+  // UNDER-reports when ChatGPT virtualizes/clips long turns. page_text_content_chars is the
+  // textContent length, which is layout-independent. A large gap between the two on a completed
+  // turn is the discriminator for the "extracted only a single char" failure mode: if
+  // textContent >> innerText, the answer is present but innerText-truncated (extraction bug,
+  // recovered by the textContent body reader); if both are tiny, the model genuinely produced
+  // little text.
+  const pageTextContentChars = normalizeText(root.body?.textContent ?? root.documentElement?.textContent ?? "").length;
   return {
     page_text_chars: pageText.length,
+    page_text_content_chars: pageTextContentChars,
     body_text_tail: pageText.slice(-500),
     counts: {
       articles: root.querySelectorAll("article").length,
@@ -1747,6 +1767,11 @@ function elementSummary(node) {
     class: String(node?.getAttribute?.("class") ?? "").slice(0, 160),
     aria: String(node?.getAttribute?.("aria-label") ?? "").slice(0, 160),
     text_chars: textOf(node).length,
+    // text_content_chars exposes the layout-independent textContent length next to the
+    // innerText-derived text_chars. On the truncation failure mode this node will show
+    // text_chars=1 ("I") while text_content_chars holds the full answer length — a single
+    // native inspect then settles whether "I" is an extraction artifact or genuine output.
+    text_content_chars: bodyTextOf(node).length,
     text: textOf(node).slice(0, 240)
   };
 }
@@ -1810,6 +1835,18 @@ function includesFolded(value, needle) {
 function textOf(node) {
   const inner = normalizeText(node?.innerText ?? "");
   return inner || normalizeText(node?.textContent ?? "");
+}
+
+// Body-text reader for assistant ANSWER content nodes (markdown leaves), NOT control/label
+// nodes. Uses textContent, not innerText, on purpose: ChatGPT virtualizes/clips long assistant
+// turns, so innerText (layout-dependent) returns only the rendered head — observed live as a
+// single "I" for a completed 955 KB Pro review while the full answer sat in textContent. Because
+// callers pass markdown LEAF nodes (the [class*="markdown"] answer content, never the turn
+// container) and the result is still run through cleanAssistantText's per-line control/status
+// stripping, this recovers the full answer without pulling in reasoning/thinking-block text or
+// code-block "Copy code"/sr-only control lines (those are separate nodes and/or stripped lines).
+function bodyTextOf(node) {
+  return normalizeText(node?.textContent ?? "");
 }
 
 function editableText(node) {

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -188,6 +188,12 @@ async function inspectPage(runId, options = {}) {
     active_job_ids: Array.from(activeJobs.keys()),
     extraction,
     model_selection: modelSelectionDiagnostics(document),
+    // Runtime build marker for the CONTENT SCRIPT specifically. Content scripts already injected
+    // into open tabs do NOT refresh when the extension is reloaded (only the service worker
+    // does), so a stale content script can emit old diagnostics (e.g. snippets without
+    // text_content_chars) even when the SW build is current. Surfacing the content-script
+    // manifest version here lets an operator detect that stale-injected-script case directly.
+    content_script_build: contentScriptBuild(),
     page_text_chars: pageText.length
   };
   if (options.include_page_text) {
@@ -289,6 +295,14 @@ function commandError(code, message, detail = {}) {
   error.phase = detail.phase;
   error.side_effect_started = detail.side_effect_started;
   return error;
+}
+
+function contentScriptBuild() {
+  try {
+    return chrome.runtime?.getManifest?.().version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
 }
 
 function runIdFromUrl(value) {

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -1382,6 +1382,13 @@ function diagnosticPayload(diagnostics) {
     return null;
   }
   return {
+    // page_text_content_chars (textContent length) is surfaced alongside the snippet
+    // text_content_chars so an operator running `yoetz browser extension inspect` can compare it
+    // to the innerText-derived page_text_chars and settle the innerText-vs-textContent truncation
+    // fork. Snippets are passed through verbatim below, so each already carries text_content_chars
+    // from elementSummary; this only had to re-add the page-level field that the projection dropped.
+    page_text_chars: diagnostics.page_text_chars ?? null,
+    page_text_content_chars: diagnostics.page_text_content_chars ?? null,
     counts: diagnostics.counts ?? {},
     assistant_turn_snippets: (diagnostics.assistant_turn_snippets ?? []).slice(-3),
     article_snippets: (diagnostics.article_snippets ?? []).slice(-3),

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -648,10 +648,21 @@ async function handleInspectRun(message) {
       // missing P2 fields are a reload problem, not a code bug. Each inspected tab also carries
       // content_script_build (see inspectPage) since content scripts in already-open tabs do not
       // refresh on extension reload even when the SW does.
-      service_worker_build: EXTENSION_VERSION,
+      service_worker_build: serviceWorkerBuild(),
       tabs: matches
     }
   }));
+}
+
+// Runtime build marker for the service worker (manifest version of the LIVE SW). Used in the
+// inspect payload so an operator can confirm the running SW is the expected build before
+// trusting/distrusting the diagnostics fields. Defensive: never throws inside handleInspectRun.
+function serviceWorkerBuild() {
+  try {
+    return chrome.runtime?.getManifest?.().version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
 }
 
 function sanitizeInspection(inspection) {

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -642,6 +642,13 @@ async function handleInspectRun(message) {
     run_id: runId,
     payload: {
       run_id: runId,
+      // Runtime build marker for the SERVICE WORKER. Lets an operator confirm the live SW is the
+      // expected build before trusting (or distrusting) the diagnostics fields below — if this
+      // does not match the shipped version, Chrome is running a stale service worker and any
+      // missing P2 fields are a reload problem, not a code bug. Each inspected tab also carries
+      // content_script_build (see inspectPage) since content scripts in already-open tabs do not
+      // refresh on extension reload even when the SW does.
+      service_worker_build: EXTENSION_VERSION,
       tabs: matches
     }
   }));

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -44,20 +44,6 @@ const AFFORDANCE_CONFIRM_POLL_MS = Math.max(
   250,
   Number(globalThis.__YOETZ_AFFORDANCE_CONFIRM_POLL_MS ?? 1500) || 1500
 );
-// Weak-signal terminal path (the "dead zone" fix): generation has provably stopped (no stop
-// controls) and scoped assistant text is present, but ChatGPT did NOT render a scoped copy
-// button for this turn (e.g. a reasoning/thinking block sits between the answer node and the copy
-// control so the copy button fails scoping). Without a terminal path here the loop polls until
-// the full wait timeout (~20 min) — the observed Pro-review hang. Because "no copy button" is a
-// WEAKER completion signal than the copy button, require a LONG quiet window (default = the old
-// conservative idle floor) so we never return mid-stream on a merely-paused turn, but DO
-// eventually return instead of hanging forever. Structural only — NO content/length guard, so
-// even a degenerate single-char answer returns after the quiet window (the wrapper decides
-// usability). Env-tunable for tests + ops.
-const MIN_NO_AFFORDANCE_IDLE_MS = Math.max(
-  0,
-  Number(globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS ?? MIN_STABLE_IDLE_MS)
-);
 const MAX_NATIVE_OUTBOUND_BYTES = Math.max(
   1024,
   Number(globalThis.__YOETZ_MAX_NATIVE_OUTBOUND_BYTES ?? 64 * 1024 * 1024) || 64 * 1024 * 1024
@@ -1157,9 +1143,6 @@ async function waitForResponse(job) {
   let finalAffordanceCandidate = null;
   let bestFinalAffordanceCandidate = null;
   let finalAffordanceCandidateSinceMs = 0;
-  // Weak-signal (no scoped copy button) terminal-path latch, parallel to the copy-button latch.
-  let noAffordanceCandidate = null;
-  let noAffordanceCandidateSinceMs = 0;
   let extractionFailureSinceMs = 0;
   let lastWaitingProgressAt = startedAt;
   const timeoutMs = responseWaitTimeoutMs(job);
@@ -1243,40 +1226,6 @@ async function waitForResponse(job) {
       finalAffordanceCandidate = null;
       bestFinalAffordanceCandidate = null;
       finalAffordanceCandidateSinceMs = 0;
-    }
-    // Weak-signal terminal path: scoped text present, generation provably stopped, but no scoped
-    // copy button. page_text_fallback can never reach here because scopedExtractionCandidate
-    // already excludes it. stop_controls is the independent cross-check that generation truly
-    // ended (mirrors isResponseGenerating's selectors, counted in extraction diagnostics).
-    const stopControls = Number(extraction?.diagnostics?.counts?.stop_controls ?? 0);
-    const deadZoneCandidate = Boolean(
-      scopedExtractionCandidate
-      && !finalAffordance
-      && extraction?.text
-      && !extraction?.has_copy_button
-      && stopControls === 0
-    );
-    if (deadZoneCandidate) {
-      // Reuse the same growth-aware selection so text growth re-arms the long quiet window and a
-      // settled response is required to hold byte-stable across it before we accept it.
-      const noAffSelection = selectFinalAffordanceCandidate(noAffordanceCandidate, extraction);
-      if (!noAffordanceCandidate || noAffSelection.candidate !== noAffordanceCandidate) {
-        if (!noAffordanceCandidate || noAffSelection.resetTimer) {
-          noAffordanceCandidateSinceMs = Date.now();
-        }
-        noAffordanceCandidate = noAffSelection.candidate;
-      } else if (!noAffordanceCandidateSinceMs) {
-        noAffordanceCandidateSinceMs = Date.now();
-      }
-      const noAffordanceStableForMs = Date.now() - noAffordanceCandidateSinceMs;
-      if (noAffordanceStableForMs >= MIN_NO_AFFORDANCE_IDLE_MS) {
-        return completedExtraction(noAffordanceCandidate, "stable_idle_no_copy_button", noAffordanceStableForMs);
-      }
-    } else {
-      // Predicate false (generation resumed, copy button appeared, page_text_fallback, or no
-      // text) — drop the weak-signal latch so it can only fire on a continuously-stable window.
-      noAffordanceCandidate = null;
-      noAffordanceCandidateSinceMs = 0;
     }
     const awaitingFinalAffordance = Boolean(scopedExtractionCandidate && !finalAffordance);
     if (finalAffordanceWithoutScopedText) {

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -24,6 +24,40 @@ const MAX_FINAL_AFFORDANCE_IDLE_MS = Math.max(
   MIN_STABLE_IDLE_MS,
   Number(globalThis.__YOETZ_MAX_FINAL_AFFORDANCE_IDLE_MS ?? 5 * 60 * 1000) || 5 * 60 * 1000
 );
+// Once ChatGPT has exposed a final assistant affordance (copy control) AND scoped
+// text is extractable AND generation has stopped, the response is structurally
+// complete. Confirm it over a SHORT stable window at a FAST cadence instead of
+// waiting out the full MIN_STABLE_IDLE_MS late-hydration floor. The dual-candidate
+// latch still re-arms this window on any text growth (selectFinalAffordanceCandidate
+// -> resetTimer), so a still-hydrating response cannot complete early; this only
+// removes the dead wall-clock wait after the text has genuinely settled. This is the
+// post-affordance confirm window and is always clamped to the slower idle floor so it
+// can only ever shorten the wait, never lengthen it.
+const MIN_AFFORDANCE_CONFIRM_MS = Math.max(
+  0,
+  Number(globalThis.__YOETZ_MIN_AFFORDANCE_CONFIRM_MS ?? 8000)
+);
+// Fast poll cadence used only while a final affordance is latched, so the short
+// confirm window is actually sampled across several polls instead of a single coarse
+// 30s tick overshooting it.
+const AFFORDANCE_CONFIRM_POLL_MS = Math.max(
+  250,
+  Number(globalThis.__YOETZ_AFFORDANCE_CONFIRM_POLL_MS ?? 1500) || 1500
+);
+// Weak-signal terminal path (the "dead zone" fix): generation has provably stopped (no stop
+// controls) and scoped assistant text is present, but ChatGPT did NOT render a scoped copy
+// button for this turn (e.g. a reasoning/thinking block sits between the answer node and the copy
+// control so the copy button fails scoping). Without a terminal path here the loop polls until
+// the full wait timeout (~20 min) — the observed Pro-review hang. Because "no copy button" is a
+// WEAKER completion signal than the copy button, require a LONG quiet window (default = the old
+// conservative idle floor) so we never return mid-stream on a merely-paused turn, but DO
+// eventually return instead of hanging forever. Structural only — NO content/length guard, so
+// even a degenerate single-char answer returns after the quiet window (the wrapper decides
+// usability). Env-tunable for tests + ops.
+const MIN_NO_AFFORDANCE_IDLE_MS = Math.max(
+  0,
+  Number(globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS ?? MIN_STABLE_IDLE_MS)
+);
 const MAX_NATIVE_OUTBOUND_BYTES = Math.max(
   1024,
   Number(globalThis.__YOETZ_MAX_NATIVE_OUTBOUND_BYTES ?? 64 * 1024 * 1024) || 64 * 1024 * 1024
@@ -1113,11 +1147,19 @@ async function waitForResponse(job) {
   job.response_wait_started_at = startedAt;
   const interval = Math.max(500, Math.min(Number(job.wait_interval_ms) || 30000, 30000));
   const finalAffordanceIdleMs = responseStableIdleThresholdMs(interval);
+  // The post-affordance confirm window is clamped to the idle floor so it can only
+  // shorten the wait for a settled response, never extend it past the late-hydration
+  // ceiling (and so test envs that drive MIN_STABLE_IDLE_MS below the confirm default
+  // still complete promptly).
+  const affordanceConfirmMs = Math.min(MIN_AFFORDANCE_CONFIRM_MS, finalAffordanceIdleMs);
   let best = { method: "none", text: "", is_generating: true };
   let last = { method: "none", text: "", is_generating: true };
   let finalAffordanceCandidate = null;
   let bestFinalAffordanceCandidate = null;
   let finalAffordanceCandidateSinceMs = 0;
+  // Weak-signal (no scoped copy button) terminal-path latch, parallel to the copy-button latch.
+  let noAffordanceCandidate = null;
+  let noAffordanceCandidateSinceMs = 0;
   let extractionFailureSinceMs = 0;
   let lastWaitingProgressAt = startedAt;
   const timeoutMs = responseWaitTimeoutMs(job);
@@ -1186,7 +1228,12 @@ async function waitForResponse(job) {
         finalAffordanceCandidateSinceMs = Date.now();
       }
       stableForMs = Date.now() - finalAffordanceCandidateSinceMs;
-      if (stableForMs >= finalAffordanceIdleMs) {
+      // The latch above only re-stamps finalAffordanceCandidateSinceMs on a
+      // timer-resetting candidate change (first candidate or text growth), so
+      // stableForMs is "time since the scoped text last grew". Once that has held
+      // for the short confirm window, the response is settled — emit instead of
+      // burning the full idle floor.
+      if (stableForMs >= affordanceConfirmMs) {
         return completedExtraction(finalAffordanceCandidate, "copy_button", stableForMs);
       }
     } else if (extraction?.is_generating) {
@@ -1196,6 +1243,40 @@ async function waitForResponse(job) {
       finalAffordanceCandidate = null;
       bestFinalAffordanceCandidate = null;
       finalAffordanceCandidateSinceMs = 0;
+    }
+    // Weak-signal terminal path: scoped text present, generation provably stopped, but no scoped
+    // copy button. page_text_fallback can never reach here because scopedExtractionCandidate
+    // already excludes it. stop_controls is the independent cross-check that generation truly
+    // ended (mirrors isResponseGenerating's selectors, counted in extraction diagnostics).
+    const stopControls = Number(extraction?.diagnostics?.counts?.stop_controls ?? 0);
+    const deadZoneCandidate = Boolean(
+      scopedExtractionCandidate
+      && !finalAffordance
+      && extraction?.text
+      && !extraction?.has_copy_button
+      && stopControls === 0
+    );
+    if (deadZoneCandidate) {
+      // Reuse the same growth-aware selection so text growth re-arms the long quiet window and a
+      // settled response is required to hold byte-stable across it before we accept it.
+      const noAffSelection = selectFinalAffordanceCandidate(noAffordanceCandidate, extraction);
+      if (!noAffordanceCandidate || noAffSelection.candidate !== noAffordanceCandidate) {
+        if (!noAffordanceCandidate || noAffSelection.resetTimer) {
+          noAffordanceCandidateSinceMs = Date.now();
+        }
+        noAffordanceCandidate = noAffSelection.candidate;
+      } else if (!noAffordanceCandidateSinceMs) {
+        noAffordanceCandidateSinceMs = Date.now();
+      }
+      const noAffordanceStableForMs = Date.now() - noAffordanceCandidateSinceMs;
+      if (noAffordanceStableForMs >= MIN_NO_AFFORDANCE_IDLE_MS) {
+        return completedExtraction(noAffordanceCandidate, "stable_idle_no_copy_button", noAffordanceStableForMs);
+      }
+    } else {
+      // Predicate false (generation resumed, copy button appeared, page_text_fallback, or no
+      // text) — drop the weak-signal latch so it can only fire on a continuously-stable window.
+      noAffordanceCandidate = null;
+      noAffordanceCandidateSinceMs = 0;
     }
     const awaitingFinalAffordance = Boolean(scopedExtractionCandidate && !finalAffordance);
     if (finalAffordanceWithoutScopedText) {
@@ -1221,7 +1302,13 @@ async function waitForResponse(job) {
     } else {
       extractionFailureSinceMs = 0;
     }
-    const nextDelay = (finalAffordance || finalAffordanceWithoutScopedText) ? Math.min(interval, Math.max(finalAffordanceIdleMs, 500)) : interval;
+    const nextDelay = finalAffordance
+      // Poll fast while confirming a latched final affordance so the short confirm
+      // window is sampled across several ticks rather than overshot by a coarse poll.
+      ? Math.min(interval, AFFORDANCE_CONFIRM_POLL_MS)
+      : (finalAffordanceWithoutScopedText
+          ? Math.min(interval, Math.max(finalAffordanceIdleMs, 500))
+          : interval);
     const nowMs = Date.now();
     const elapsedMs = nowMs - startedAt;
     if (nowMs - lastWaitingProgressAt >= WAITING_RESPONSE_PROGRESS_INTERVAL_MS) {

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -429,6 +429,65 @@ test("extractResponse returns single-letter assistant markdown with a copy affor
   assert.equal(extraction.has_copy_button, true);
 });
 
+test("extractResponse recovers the full answer when innerText is virtualized to a head char (textContent body reader)", () => {
+  // P1 regression guard for the live 955 KB Pro-review failure: ChatGPT virtualized/clipped the
+  // long assistant turn, so the markdown body's innerText collapsed to the rendered head "I" while
+  // textContent still held the full answer. The body reader must use textContent, recover the full
+  // review, and strip a code-block "Copy code" toolbar line without eating the code body or prose.
+  const fullReview = [
+    "## Findings",
+    "1. The cutover gate can be green with fabricated evidence.",
+    "Copy code",
+    "const gate = verify(report);",
+    "2. Rollback transcript verification is sound."
+  ].join("\n");
+  const copy = new FakeElement("button", { "aria-label": "Copy" }, "Copy");
+  const markdownAnswer = new FakeElement("div", { class: "markdown prose" }, fullReview);
+  // Simulate virtualization: layout-derived innerText shows only the rendered head; textContent
+  // (set above via the constructor text) retains the full DOM text.
+  markdownAnswer.innerText = "I";
+  const assistant = new FakeElement("article", { "data-message-author-role": "assistant" }, "Thought for 9m 44s\n\nI")
+    .append(markdownAnswer, copy);
+  const body = new FakeElement("body", {}, "I").append(assistant);
+
+  const extraction = extractResponse(new FakeDocument(body));
+
+  assert.equal(extraction.method, "copy_scope_dom_fallback");
+  assert.equal(extraction.has_copy_button, true);
+  assert.ok(extraction.text.includes("## Findings"), `expected full review, got: ${extraction.text}`);
+  assert.ok(extraction.text.includes("Rollback transcript verification is sound."));
+  assert.ok(extraction.text.includes("const gate = verify(report);"), "code body must survive");
+  assert.ok(!/copy code/i.test(extraction.text), `"Copy code" leaked: ${extraction.text}`);
+  assert.notEqual(extraction.text, "I");
+});
+
+test("extractResponse diagnostics expose textContent length next to innerText length for the truncation fork", () => {
+  // P2: a single native inspect must discriminate innerText-truncation from a genuine short
+  // answer. The selected markdown snippet must report text_chars (innerText) == 1 while
+  // text_content_chars (textContent) reflects the full answer — that per-node gap is the fork
+  // discriminator codex reads live. (The page-level page_text_content_chars field is also added in
+  // code for live inspects; it is not asserted here because this fake DOM stores textContent as a
+  // flat per-node string rather than aggregating descendants like a real DOM, so a page-level
+  // textContent length is not meaningful under the harness.)
+  const fullReview = "## Findings\nThis is a long completed review body with many characters.";
+  const copy = new FakeElement("button", { "aria-label": "Copy" }, "Copy");
+  const markdownAnswer = new FakeElement("div", { class: "markdown prose" }, fullReview);
+  markdownAnswer.innerText = "I";
+  const assistant = new FakeElement("article", { "data-message-author-role": "assistant" }, "I")
+    .append(markdownAnswer, copy);
+  const body = new FakeElement("body", {}, "I").append(assistant);
+  body.innerText = "I";
+
+  const extraction = extractResponse(new FakeDocument(body));
+
+  const snippet = extraction.diagnostics.markdown_snippets.find((s) => s.text_chars === 1);
+  assert.ok(snippet, "expected a markdown snippet whose innerText is the truncated head");
+  assert.equal(snippet.text_chars, 1);
+  assert.ok(snippet.text_content_chars > 10, `text_content_chars should expose full length, got ${snippet.text_content_chars}`);
+  // Field is present on the diagnostics for live inspects to read.
+  assert.equal(typeof extraction.diagnostics.page_text_content_chars, "number");
+});
+
 test("extractResponse preserves one-word assistant markdown answers that look like model status labels", () => {
   for (const answer of ["GPT-5", "Pro", "Thinking"]) {
     const user = new FakeElement("article", { "data-message-author-role": "user", class: "user-turn" }, "One word");

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -461,6 +461,51 @@ test("extractResponse recovers the full answer when innerText is virtualized to 
   assert.notEqual(extraction.text, "I");
 });
 
+test("extractResponse selects the answer turn when its class embeds a chrome keyword inside a Tailwind CSS expression", () => {
+  // Live regression (conversation 6a1d4327, GPT-5.5 Pro "OK" canary on branch tip 03685ec): the
+  // assistant turn <section data-testid="conversation-turn-2"> carries a Tailwind utility token
+  // scroll-mt-[calc(var(--header-height)+min(200px,max(70px,20svh)))]. The old chrome filter ran a
+  // /\bheader\b/i test against the whole class string, so the "header" inside var(--header-height)
+  // mis-flagged the entire answer turn as non-conversation chrome. extractResponse dropped the
+  // "OK" markdown node and fell to page_text_fallback (excluded from completion), so the wait loop
+  // hung (stable_for_ms=90553) even though the answer "OK" + a copy button were present and
+  // is_generating=false. The toggle button "Thought for 16s" is the collapsed reasoning header and
+  // must not be mistaken for the answer. The chrome filter must only treat WHOLE class tokens as
+  // chrome, never substrings of arbitrary CSS expressions.
+  const turnSectionClass = "text-token-text-primary w-full focus:outline-none "
+    + "has-data-writing-block:pointer-events-none "
+    + "scroll-mt-[calc(var(--header-height)+min(200px,max(70px,20svh)))]";
+  const reasoningToggle = new FakeElement("button", { type: "button", class: "text-token-text-tertiary" }, "Thought for 16s");
+  const reasoningHeader = new FakeElement("div", { class: "flex items-center justify-between" }, "Thought for 16s")
+    .append(reasoningToggle);
+  const answerMarkdown = new FakeElement("div", { class: "markdown prose dark:prose-invert markdown-new-styling" }, "OK");
+  const answerWrap = new FakeElement("div", { class: "flex w-full flex-col gap-1 empty:hidden" }, "OK").append(answerMarkdown);
+  const assistantMessage = new FakeElement("div", {
+    "data-message-author-role": "assistant",
+    "data-message-model-slug": "gpt-5-5-pro",
+    class: "min-h-8 text-message"
+  }, "OK").append(answerWrap);
+  const grow = new FakeElement("div", { class: "flex max-w-full flex-col gap-4 grow" }, "Thought for 16s OK")
+    .append(reasoningHeader, assistantMessage);
+  const turnMessages = new FakeElement("div", { class: "mx-auto group/turn-messages flex w-full" }, "Thought for 16s OK").append(grow);
+  const copy = new FakeElement("button", { "aria-label": "Copy response", "data-testid": "copy-turn-action-button" }, "Copy");
+  const actions = new FakeElement("div", { "aria-label": "Response actions", role: "group" }, "Copy").append(copy);
+  const turnSection = new FakeElement("section", { "data-testid": "conversation-turn-2", "data-turn": "assistant", class: turnSectionClass }, "Thought for 16s OK")
+    .append(turnMessages, actions);
+  const user = new FakeElement("section", { "data-testid": "conversation-turn-1" }, "Reply with OK")
+    .append(new FakeElement("div", { "data-message-author-role": "user", class: "user-turn" }, "Reply with OK"));
+  const conversation = new FakeElement("main", { role: "main" }, "Reply with OK Thought for 16s OK").append(user, turnSection);
+  const body = new FakeElement("body", {}, "Reply with OK Thought for 16s OK").append(conversation);
+
+  const extraction = extractResponse(new FakeDocument(body));
+
+  assert.equal(extraction.method, "copy_scope_dom_fallback", `expected scoped extraction, got ${extraction.method} (${JSON.stringify(extraction.text)})`);
+  assert.equal(extraction.text, "OK");
+  assert.equal(extraction.has_copy_button, true);
+  assert.equal(extraction.is_generating, false);
+  assert.notEqual(extraction.turn_index, -1);
+});
+
 test("extractResponse diagnostics expose textContent length next to innerText length for the truncation fork", () => {
   // P2: a single native inspect must discriminate innerText-truncation from a genuine short
   // answer. The selected markdown snippet must report text_chars (innerText) == 1 while

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -1227,17 +1227,8 @@ test("service worker completes post-send response when preceding user count is u
   }
 });
 
-test("service worker completes via the bounded no-copy-button idle path when generation stopped but no scoped copy button appears", async () => {
-  // Dead-zone fix (P3): a turn whose generation has provably stopped (is_generating=false AND
-  // diagnostics stop_controls=0) and whose scoped assistant text is present but for which ChatGPT
-  // rendered NO scoped copy button must NOT hang to the wait timeout. It now completes via the
-  // bounded weak-signal path (completion_reason "stable_idle_no_copy_button") once the text has
-  // held stable for MIN_NO_AFFORDANCE_IDLE_MS. (Previously this hung to response_timeout, which
-  // was the observed Pro-review failure.) Structural only — no content/length guard, so even a
-  // short answer returns after the quiet window.
+test("service worker does not complete on brief stable assistant text without a final affordance", async () => {
   const originalChrome = globalThis.chrome;
-  const previousNoAffordanceIdle = globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS;
-  globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS = 120;
   const port = makePort();
   let tabId = 0;
   let sent = false;
@@ -1265,15 +1256,12 @@ test("service worker completes via the bounded no-copy-button idle path when gen
               payload: sent
                 ? {
                     method: "assistant_dom_fallback",
-                    text: "stable answer without a scoped copy button",
+                    text: "stable but possibly partial",
                     is_generating: false,
                     assistant_count: 1,
-                    user_count: 1,
-                    preceding_user_count: 1,
                     copy_button_count: 0,
                     has_copy_button: false,
-                    turn_index: 0,
-                    diagnostics: { counts: { stop_controls: 0 } }
+                    turn_index: 0
                   }
                 : { method: "none", text: "", is_generating: false, assistant_count: 0, turn_index: -1 }
             };
@@ -1289,7 +1277,7 @@ test("service worker completes via the bounded no-copy-button idle path when gen
     port.emit(envelope("job_start", "job_stable_no_copy", {
       prompt: "prompt",
       wait_interval_ms: 50,
-      wait_timeout_ms: 5000
+      wait_timeout_ms: 1200
     }));
     await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
     port.emit(envelope("job_file_chunk", "job_stable_no_copy", {
@@ -1300,18 +1288,13 @@ test("service worker completes via the bounded no-copy-button idle path when gen
       mime_type: "text/markdown",
       bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
     }));
-    await eventually(() => port.messages.some((message) => message.type === "job_complete"));
-    const complete = port.messages.find((message) => message.type === "job_complete");
-    assert.equal(complete.payload.response, "stable answer without a scoped copy button");
-    assert.equal(complete.payload.completion_reason, "stable_idle_no_copy_button");
-    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
+    await eventually(() => port.messages.some((message) => message.type === "job_error" && message.payload.code === "response_timeout"));
+    assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
+    const observed = port.messages.find((message) => message.type === "job_progress" && message.payload.phase === "response_observed");
+    assert.equal(observed?.payload.response_delta, "stable but possibly partial");
+    assert.equal(observed?.payload.is_generating, false);
   } finally {
     globalThis.chrome = originalChrome;
-    if (previousNoAffordanceIdle === undefined) {
-      delete globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS;
-    } else {
-      globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS = previousNoAffordanceIdle;
-    }
   }
 });
 
@@ -2078,12 +2061,6 @@ test("service worker does not complete when ChatGPT idles before final assistant
   const originalChrome = globalThis.chrome;
   const previousWaitingProgressInterval = globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS;
   globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS = 100;
-  // Keep the weak-signal (no-copy-button) idle window LONG so this test still proves the strong
-  // signal wins: the one-letter "I" prefix (no copy button) must NOT complete via the dead-zone
-  // path before the real copy button + full text arrive. This mirrors production, where the
-  // ~90s no-copy-button window is far longer than the seconds it takes the copy button to render.
-  const previousNoAffordanceIdle = globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS;
-  globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS = 60000;
   const port = makePort();
   let tabId = 0;
   let sent = false;
@@ -2167,11 +2144,6 @@ test("service worker does not complete when ChatGPT idles before final assistant
       delete globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS;
     } else {
       globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS = previousWaitingProgressInterval;
-    }
-    if (previousNoAffordanceIdle === undefined) {
-      delete globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS;
-    } else {
-      globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS = previousNoAffordanceIdle;
     }
   }
 });
@@ -2394,13 +2366,7 @@ test("service worker completes when a generating response becomes idle without t
   }
 });
 
-test("service worker does not complete on a raw copy-count rise while generation is still in progress", async () => {
-  // Guards that a rising RAW copy_button_count (here 2) with NO scoped copy button
-  // (has_copy_button=false) does not by itself complete the job. To keep this focused on the
-  // copy-count signal (and isolated from the bounded no-copy-button idle path), the turn reports
-  // is_generating=true and a stop control present, so neither the copy-button affordance path nor
-  // the dead-zone weak-signal path (which both require generation to have stopped) can fire — the
-  // job must wait, then time out.
+test("service worker does not complete only because post-send copy controls increased", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
   let tabId = 0;
@@ -2430,12 +2396,11 @@ test("service worker does not complete on a raw copy-count rise while generation
                 ? {
                     method: "assistant_dom_fallback",
                     text: "YOETZ_EXTENSION_NATIVE_SMOKE_OK",
-                    is_generating: true,
+                    is_generating: false,
                     assistant_count: 3,
                     copy_button_count: 2,
                     has_copy_button: false,
-                    turn_index: 0,
-                    diagnostics: { counts: { stop_controls: 1 } }
+                    turn_index: 0
                   }
                 : { method: "none", text: "", is_generating: false, assistant_count: 0, copy_button_count: 0, has_copy_button: false, turn_index: -1 }
             };
@@ -2467,92 +2432,6 @@ test("service worker does not complete on a raw copy-count rise while generation
     assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
   } finally {
     globalThis.chrome = originalChrome;
-  }
-});
-
-test("service worker dead-zone path resets on is_generating re-entry and stays excluded for page_text_fallback", async () => {
-  // (e)+(f) combined: the weak-signal no-copy-button completion must NOT fire while generation is
-  // re-entering, and must NEVER fire for page_text_fallback (broad page chrome is not a scoped
-  // answer). Sequence: idle scoped "draft" (no copy button) for a couple polls (arming the
-  // window), then a generating poll (must reset the window), then a page_text_fallback poll (must
-  // not be eligible). The job must therefore time out, never completing via the dead-zone path.
-  const originalChrome = globalThis.chrome;
-  const previousNoAffordanceIdle = globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS;
-  // Window longer than the test's whole runtime: completion here could ONLY happen if the
-  // dead-zone path ignored the is_generating re-entry reset or accepted page_text_fallback. The
-  // job must instead reach response_timeout, proving neither happened.
-  globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS = 60000;
-  const port = makePort();
-  let tabId = 0;
-  let sent = false;
-  let extractCount = 0;
-  globalThis.chrome = chromeStub({
-    port,
-    tabs: {
-      create: async (opts) => ({ id: ++tabId, ...opts }),
-      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
-      sendMessage: async (_id, message) => {
-        switch (message.type) {
-          case "yoetz_probe":
-            return { ok: true, payload: {} };
-          case "yoetz_prepare_job":
-            return { ok: true, payload: { manual_handoff: null } };
-          case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
-          case "yoetz_upload_file":
-            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
-          case "yoetz_send_prompt":
-            sent = true;
-            return { ok: true, payload: { sent: true } };
-          case "yoetz_extract_response": {
-            if (!sent) {
-              return { ok: true, payload: { method: "none", text: "", is_generating: false, assistant_count: 0, copy_button_count: 0, has_copy_button: false, turn_index: -1 } };
-            }
-            extractCount += 1;
-            // Poll 1: idle scoped draft, no copy button (arms the window).
-            // Poll 2: generation re-enters (must reset the window).
-            // Poll 3+: page_text_fallback (never eligible for the dead-zone path).
-            if (extractCount === 1) {
-              return { ok: true, payload: { method: "assistant_dom_fallback", text: "draft", is_generating: false, assistant_count: 1, user_count: 1, preceding_user_count: 1, copy_button_count: 0, has_copy_button: false, turn_index: 0, diagnostics: { counts: { stop_controls: 0 } } } };
-            }
-            if (extractCount === 2) {
-              return { ok: true, payload: { method: "assistant_dom_fallback", text: "draft", is_generating: true, assistant_count: 1, user_count: 1, preceding_user_count: 1, copy_button_count: 0, has_copy_button: false, turn_index: 0, diagnostics: { counts: { stop_controls: 1 } } } };
-            }
-            return { ok: true, payload: { method: "page_text_fallback", text: "whole page text", is_generating: false, assistant_count: 1, user_count: 1, preceding_user_count: 1, copy_button_count: 0, has_copy_button: false, turn_index: -1, diagnostics: { counts: { stop_controls: 0 } } } };
-          }
-          default:
-            throw new Error(`unexpected tab message ${message.type}`);
-        }
-      }
-    }
-  });
-
-  try {
-    await import(`../src/service-worker.js?deadzone_reset=${Date.now()}`);
-    port.emit(envelope("job_start", "job_deadzone_reset", {
-      prompt: "prompt",
-      wait_interval_ms: 50,
-      wait_timeout_ms: 1200
-    }));
-    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
-    port.emit(envelope("job_file_chunk", "job_deadzone_reset", {
-      sequence: 0,
-      total_chunks: 1,
-      total_bytes: 4,
-      filename: "job_deadzone_reset.md",
-      mime_type: "text/markdown",
-      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
-    }));
-
-    await eventually(() => port.messages.some((message) => message.type === "job_error" && message.payload.code === "response_timeout"));
-    assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
-  } finally {
-    globalThis.chrome = originalChrome;
-    if (previousNoAffordanceIdle === undefined) {
-      delete globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS;
-    } else {
-      globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS = previousNoAffordanceIdle;
-    }
   }
 });
 

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -878,6 +878,134 @@ test("service worker inspect_run omits broad page text by default", async () => 
   }
 });
 
+test("service worker inspect_run surfaces the textContent diagnostics and a runtime build marker", async () => {
+  // P2: the innerText-vs-textContent truncation discriminator must reach `yoetz browser extension
+  // inspect` output. This drives the full inspect_run -> sanitizeInspection -> diagnosticPayload
+  // projection and asserts (a) the page-level page_text_chars + page_text_content_chars survive,
+  // (b) per-snippet text_content_chars survives on markdown_snippets/assistant_turn_snippets, and
+  // (c) the service_worker_build runtime marker is present so an operator can confirm the live SW
+  // is the expected build before trusting/distrusting the fields (stale-runtime disambiguation).
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      query: async () => [{ id: 11, url: "https://chatgpt.com/c/run", title: "Yoetz run" }],
+      sendMessage: async (_id, message) => {
+        assert.equal(message.type, "yoetz_inspect_page");
+        return {
+          ok: true,
+          payload: {
+            url: "https://chatgpt.com/c/run",
+            title: "Yoetz run",
+            window_name: "yoetz-chatgpt-native:run_inspect:job_inspect",
+            ownership: { run_id: "run_inspect", job_id: "job_inspect" },
+            active_job_ids: ["job_inspect"],
+            content_script_build: "9.9.9-content",
+            page_text_chars: 42,
+            extraction: {
+              method: "copy_scope_dom_fallback",
+              text: "I",
+              diagnostics: {
+                page_text_chars: 42,
+                page_text_content_chars: 10823,
+                counts: { markdown: 1, assistant_turns: 1 },
+                markdown_snippets: [{ tag: "div", role: "", text: "I", text_chars: 1, text_content_chars: 10823 }],
+                assistant_turn_snippets: [{ tag: "article", role: "assistant", text: "I", text_chars: 1, text_content_chars: 10823 }],
+                article_snippets: [],
+                stop_control_snippets: []
+              }
+            }
+          }
+        };
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?inspect_textcontent=${Date.now()}`);
+    await eventually(() => port.messages.some((message) => message.type === "hello"));
+    port.messages.length = 0;
+
+    port.emit(envelope("inspect_run", "job_inspect", { run_id: "run_inspect" }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_complete"));
+    const complete = port.messages.find((message) => message.type === "job_complete");
+    // (A) service-worker runtime build marker present on the inspect envelope.
+    assert.equal(typeof complete.payload.service_worker_build, "string");
+    assert.ok(complete.payload.service_worker_build.length > 0);
+    const inspection = complete.payload.tabs[0].inspection;
+    // (C) content-script runtime build marker passed through sanitizeInspection's spread.
+    assert.equal(inspection.content_script_build, "9.9.9-content");
+    const diagnostics = inspection.extraction.diagnostics;
+    // (B)+(D) page-level + per-snippet textContent discriminator survives the projection.
+    assert.equal(diagnostics.page_text_chars, 42);
+    assert.equal(diagnostics.page_text_content_chars, 10823);
+    assert.equal(diagnostics.markdown_snippets[0].text_content_chars, 10823);
+    assert.equal(diagnostics.assistant_turn_snippets[0].text_content_chars, 10823);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("diagnosticPayload defensively emits page-level textContent keys even when source omits them", async () => {
+  // Defensiveness guard: the KEY must be present (even as null) when the source diagnostics lack
+  // page_text_content_chars, so the mere presence of the key in live inspect output proves the new
+  // service-worker code is executing (its total absence => stale runtime, not a code bug).
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      query: async () => [{ id: 12, url: "https://chatgpt.com/c/run", title: "Yoetz run" }],
+      sendMessage: async (_id, message) => {
+        assert.equal(message.type, "yoetz_inspect_page");
+        return {
+          ok: true,
+          payload: {
+            url: "https://chatgpt.com/c/run",
+            title: "Yoetz run",
+            window_name: "yoetz-chatgpt-native:run_inspect:job_inspect",
+            ownership: { run_id: "run_inspect", job_id: "job_inspect" },
+            active_job_ids: ["job_inspect"],
+            extraction: {
+              method: "assistant_dom_fallback",
+              text: "answer",
+              // Source diagnostics WITHOUT the page-level textContent field (stale content script).
+              diagnostics: {
+                counts: { assistant_turns: 1 },
+                assistant_turn_snippets: [{ text: "answer" }],
+                article_snippets: [],
+                markdown_snippets: [],
+                stop_control_snippets: []
+              }
+            }
+          }
+        };
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?inspect_defensive=${Date.now()}`);
+    await eventually(() => port.messages.some((message) => message.type === "hello"));
+    port.messages.length = 0;
+
+    port.emit(envelope("inspect_run", "job_inspect", { run_id: "run_inspect" }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_complete"));
+    const complete = port.messages.find((message) => message.type === "job_complete");
+    const diagnostics = complete.payload.tabs[0].inspection.extraction.diagnostics;
+    // Keys present (the diagnostics object literally has the property) even though the value is null.
+    assert.ok(Object.hasOwn(diagnostics, "page_text_content_chars"));
+    assert.ok(Object.hasOwn(diagnostics, "page_text_chars"));
+    assert.equal(diagnostics.page_text_content_chars, null);
+    assert.equal(diagnostics.page_text_chars, null);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker inspect_run can target a ChatGPT conversation id", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -1227,8 +1227,17 @@ test("service worker completes post-send response when preceding user count is u
   }
 });
 
-test("service worker does not complete on brief stable assistant text without a final affordance", async () => {
+test("service worker completes via the bounded no-copy-button idle path when generation stopped but no scoped copy button appears", async () => {
+  // Dead-zone fix (P3): a turn whose generation has provably stopped (is_generating=false AND
+  // diagnostics stop_controls=0) and whose scoped assistant text is present but for which ChatGPT
+  // rendered NO scoped copy button must NOT hang to the wait timeout. It now completes via the
+  // bounded weak-signal path (completion_reason "stable_idle_no_copy_button") once the text has
+  // held stable for MIN_NO_AFFORDANCE_IDLE_MS. (Previously this hung to response_timeout, which
+  // was the observed Pro-review failure.) Structural only — no content/length guard, so even a
+  // short answer returns after the quiet window.
   const originalChrome = globalThis.chrome;
+  const previousNoAffordanceIdle = globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS;
+  globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS = 120;
   const port = makePort();
   let tabId = 0;
   let sent = false;
@@ -1256,12 +1265,15 @@ test("service worker does not complete on brief stable assistant text without a 
               payload: sent
                 ? {
                     method: "assistant_dom_fallback",
-                    text: "stable but possibly partial",
+                    text: "stable answer without a scoped copy button",
                     is_generating: false,
                     assistant_count: 1,
+                    user_count: 1,
+                    preceding_user_count: 1,
                     copy_button_count: 0,
                     has_copy_button: false,
-                    turn_index: 0
+                    turn_index: 0,
+                    diagnostics: { counts: { stop_controls: 0 } }
                   }
                 : { method: "none", text: "", is_generating: false, assistant_count: 0, turn_index: -1 }
             };
@@ -1277,7 +1289,7 @@ test("service worker does not complete on brief stable assistant text without a 
     port.emit(envelope("job_start", "job_stable_no_copy", {
       prompt: "prompt",
       wait_interval_ms: 50,
-      wait_timeout_ms: 1200
+      wait_timeout_ms: 5000
     }));
     await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
     port.emit(envelope("job_file_chunk", "job_stable_no_copy", {
@@ -1288,13 +1300,18 @@ test("service worker does not complete on brief stable assistant text without a 
       mime_type: "text/markdown",
       bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
     }));
-    await eventually(() => port.messages.some((message) => message.type === "job_error" && message.payload.code === "response_timeout"));
-    assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
-    const observed = port.messages.find((message) => message.type === "job_progress" && message.payload.phase === "response_observed");
-    assert.equal(observed?.payload.response_delta, "stable but possibly partial");
-    assert.equal(observed?.payload.is_generating, false);
+    await eventually(() => port.messages.some((message) => message.type === "job_complete"));
+    const complete = port.messages.find((message) => message.type === "job_complete");
+    assert.equal(complete.payload.response, "stable answer without a scoped copy button");
+    assert.equal(complete.payload.completion_reason, "stable_idle_no_copy_button");
+    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
   } finally {
     globalThis.chrome = originalChrome;
+    if (previousNoAffordanceIdle === undefined) {
+      delete globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS;
+    } else {
+      globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS = previousNoAffordanceIdle;
+    }
   }
 });
 
@@ -2061,6 +2078,12 @@ test("service worker does not complete when ChatGPT idles before final assistant
   const originalChrome = globalThis.chrome;
   const previousWaitingProgressInterval = globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS;
   globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS = 100;
+  // Keep the weak-signal (no-copy-button) idle window LONG so this test still proves the strong
+  // signal wins: the one-letter "I" prefix (no copy button) must NOT complete via the dead-zone
+  // path before the real copy button + full text arrive. This mirrors production, where the
+  // ~90s no-copy-button window is far longer than the seconds it takes the copy button to render.
+  const previousNoAffordanceIdle = globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS;
+  globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS = 60000;
   const port = makePort();
   let tabId = 0;
   let sent = false;
@@ -2144,6 +2167,11 @@ test("service worker does not complete when ChatGPT idles before final assistant
       delete globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS;
     } else {
       globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS = previousWaitingProgressInterval;
+    }
+    if (previousNoAffordanceIdle === undefined) {
+      delete globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS;
+    } else {
+      globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS = previousNoAffordanceIdle;
     }
   }
 });
@@ -2366,7 +2394,13 @@ test("service worker completes when a generating response becomes idle without t
   }
 });
 
-test("service worker does not complete only because post-send copy controls increased", async () => {
+test("service worker does not complete on a raw copy-count rise while generation is still in progress", async () => {
+  // Guards that a rising RAW copy_button_count (here 2) with NO scoped copy button
+  // (has_copy_button=false) does not by itself complete the job. To keep this focused on the
+  // copy-count signal (and isolated from the bounded no-copy-button idle path), the turn reports
+  // is_generating=true and a stop control present, so neither the copy-button affordance path nor
+  // the dead-zone weak-signal path (which both require generation to have stopped) can fire — the
+  // job must wait, then time out.
   const originalChrome = globalThis.chrome;
   const port = makePort();
   let tabId = 0;
@@ -2396,11 +2430,12 @@ test("service worker does not complete only because post-send copy controls incr
                 ? {
                     method: "assistant_dom_fallback",
                     text: "YOETZ_EXTENSION_NATIVE_SMOKE_OK",
-                    is_generating: false,
+                    is_generating: true,
                     assistant_count: 3,
                     copy_button_count: 2,
                     has_copy_button: false,
-                    turn_index: 0
+                    turn_index: 0,
+                    diagnostics: { counts: { stop_controls: 1 } }
                   }
                 : { method: "none", text: "", is_generating: false, assistant_count: 0, copy_button_count: 0, has_copy_button: false, turn_index: -1 }
             };
@@ -2432,6 +2467,92 @@ test("service worker does not complete only because post-send copy controls incr
     assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
   } finally {
     globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker dead-zone path resets on is_generating re-entry and stays excluded for page_text_fallback", async () => {
+  // (e)+(f) combined: the weak-signal no-copy-button completion must NOT fire while generation is
+  // re-entering, and must NEVER fire for page_text_fallback (broad page chrome is not a scoped
+  // answer). Sequence: idle scoped "draft" (no copy button) for a couple polls (arming the
+  // window), then a generating poll (must reset the window), then a page_text_fallback poll (must
+  // not be eligible). The job must therefore time out, never completing via the dead-zone path.
+  const originalChrome = globalThis.chrome;
+  const previousNoAffordanceIdle = globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS;
+  // Window longer than the test's whole runtime: completion here could ONLY happen if the
+  // dead-zone path ignored the is_generating re-entry reset or accepted page_text_fallback. The
+  // job must instead reach response_timeout, proving neither happened.
+  globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS = 60000;
+  const port = makePort();
+  let tabId = 0;
+  let sent = false;
+  let extractCount = 0;
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true } };
+          case "yoetz_extract_response": {
+            if (!sent) {
+              return { ok: true, payload: { method: "none", text: "", is_generating: false, assistant_count: 0, copy_button_count: 0, has_copy_button: false, turn_index: -1 } };
+            }
+            extractCount += 1;
+            // Poll 1: idle scoped draft, no copy button (arms the window).
+            // Poll 2: generation re-enters (must reset the window).
+            // Poll 3+: page_text_fallback (never eligible for the dead-zone path).
+            if (extractCount === 1) {
+              return { ok: true, payload: { method: "assistant_dom_fallback", text: "draft", is_generating: false, assistant_count: 1, user_count: 1, preceding_user_count: 1, copy_button_count: 0, has_copy_button: false, turn_index: 0, diagnostics: { counts: { stop_controls: 0 } } } };
+            }
+            if (extractCount === 2) {
+              return { ok: true, payload: { method: "assistant_dom_fallback", text: "draft", is_generating: true, assistant_count: 1, user_count: 1, preceding_user_count: 1, copy_button_count: 0, has_copy_button: false, turn_index: 0, diagnostics: { counts: { stop_controls: 1 } } } };
+            }
+            return { ok: true, payload: { method: "page_text_fallback", text: "whole page text", is_generating: false, assistant_count: 1, user_count: 1, preceding_user_count: 1, copy_button_count: 0, has_copy_button: false, turn_index: -1, diagnostics: { counts: { stop_controls: 0 } } } };
+          }
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?deadzone_reset=${Date.now()}`);
+    port.emit(envelope("job_start", "job_deadzone_reset", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 1200
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_deadzone_reset", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_deadzone_reset.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_error" && message.payload.code === "response_timeout"));
+    assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+    if (previousNoAffordanceIdle === undefined) {
+      delete globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS;
+    } else {
+      globalThis.__YOETZ_MIN_NO_AFFORDANCE_IDLE_MS = previousNoAffordanceIdle;
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- Fixes native ChatGPT completion finality for long Pro review turns by using layout-independent textContent diagnostics/extraction where needed.
- Fixes response extraction when ChatGPT turn classes contain CSS expressions such as var(--header-height) by matching chrome keywords as whole semantic/class tokens.
- Adds inspect diagnostics/build markers for live extension verification and records the v0.5.20 changelog notes.

## Validation
- Co-signed by Codex after live validation of 110df5084056ca57edcd349b14af9887f073e582.
- node --test tests/*.test.js: 164 pass / 0 fail.
- Loaded managed extension path verified: /Users/avivsinai/.yoetz/chatgpt-native-extension.
- Live canary canary_18b4e9756dc522b0_7051ee6e26ff5609 completed OK via copy_scope_dom_fallback.
- Inspect markers live: service_worker_build=0.5.19, content_script_build=0.5.19, page_text_content_chars and per-snippet text_content_chars present.