### PR TITLE
feat(browser): ChatGPT recipe conversation resume (caller-owned, native-only)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,10 @@ recipe selects it as the only default transport.
   `inspect --chatgpt --run-id <id>`, and `grant-identity --chatgpt`. Use
   `yoetz browser check --transport chrome-extension-native` for extension
   readiness; plain `yoetz browser check` verifies the default CDP/browser stack.
+- ChatGPT conversation resume uses `--var conversation=<id|url>` with the
+  `conversation_id` / `conversation_url` fields returned by earlier runs. It is
+  native-extension only and does not manage context automatically; callers own
+  the decision to resume a saved conversation or start fresh.
 - For multiple loaded Chrome extension profiles, route extension-native jobs by
   `profile_email` when Chrome exposes it, or by the stable
   `extension_instance_id` shown in `status --chatgpt` when it does not.

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -996,6 +996,8 @@ fn chatgpt_recipe_payload_from_steps(steps: &[Value], fallback_used: bool) -> Va
         fallback_used,
         delivery_mode: chatgpt_recipe::ChatgptDeliveryMode::FileUpload,
         auto_paste_fallback: false,
+        conversation_id: None,
+        conversation_url: None,
     };
     let mut payload = output.to_value();
     if let Some(object) = payload.as_object_mut() {

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -130,6 +130,8 @@ pub struct ExtensionRecipeResult {
     pub model_used: Option<String>,
     pub model_selection_status: ChatgptModelSelectionStatus,
     pub warnings: Vec<String>,
+    pub conversation_id: Option<String>,
+    pub conversation_url: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -1927,11 +1929,23 @@ fn parse_recipe_result(envelope: ProtocolEnvelope) -> Result<ExtensionRecipeResu
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
+    let conversation_id = envelope
+        .payload
+        .get("conversation_id")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let conversation_url = envelope
+        .payload
+        .get("conversation_url")
+        .and_then(Value::as_str)
+        .map(str::to_string);
     Ok(ExtensionRecipeResult {
         response,
         model_used,
         model_selection_status,
         warnings,
+        conversation_id,
+        conversation_url,
     })
 }
 
@@ -3052,6 +3066,38 @@ mod tests {
         let decoded = read_json_frame(&mut &buf[..]).unwrap();
         assert_eq!(decoded.kind, "job_progress");
         assert_eq!(decoded.payload["message"], "uploading");
+    }
+
+    #[test]
+    fn parse_recipe_result_carries_conversation_fields() {
+        let envelope = ProtocolEnvelope::new(
+            "job_complete",
+            Some("job_1".to_string()),
+            Some("run_1".to_string()),
+            json!({
+                "response": "done",
+                "model_used": "Pro Extended",
+                "model_selection_status": "selected",
+                "warnings": ["kept current"],
+                "conversation_id": "conv-123",
+                "conversation_url": "https://chatgpt.com/c/conv-123",
+            }),
+        );
+
+        let result = parse_recipe_result(envelope).unwrap();
+
+        assert_eq!(result.response, "done");
+        assert_eq!(result.model_used.as_deref(), Some("Pro Extended"));
+        assert_eq!(
+            result.model_selection_status,
+            ChatgptModelSelectionStatus::Selected
+        );
+        assert_eq!(result.warnings, vec!["kept current"]);
+        assert_eq!(result.conversation_id.as_deref(), Some("conv-123"));
+        assert_eq!(
+            result.conversation_url.as_deref(),
+            Some("https://chatgpt.com/c/conv-123")
+        );
     }
 
     #[test]

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -999,23 +999,7 @@ pub fn run_chatgpt_recipe(
         "job_start",
         Some(job_id.clone()),
         Some(spec.run_id.clone()),
-        json!({
-            "recipe": "chatgpt",
-            "bundle_path": bundle.path,
-            "file_name": bundle.file_name,
-            "bundle_size": bundle.size,
-            "mime": bundle.mime,
-            "prompt": spec.prompt,
-            "model": spec.model,
-            "browser_context_id": spec.browser_context_id,
-            "profile_email": spec.profile_email,
-            "extension_instance_id": spec.extension_instance_id,
-            "extension_profile_id": spec.extension_profile_id,
-            "wait_timeout_ms": spec.wait_timeout_ms,
-            "wait_interval_ms": spec.wait_interval_ms,
-            "upload_timeout_ms": spec.upload_timeout_ms,
-            "send_timeout_ms": spec.send_timeout_ms,
-        }),
+        chatgpt_job_start_payload(spec, &bundle),
     )
     .with_token(token);
     write_json_frame(&mut stream, &start)?;
@@ -1045,6 +1029,27 @@ pub fn serve_native_host_chatgpt() -> Result<()> {
     {
         bail!("chrome-extension-native native host is currently supported on macOS/Linux only")
     }
+}
+
+fn chatgpt_job_start_payload(spec: &ChatgptRecipeSpec, bundle: &BundleInfo) -> Value {
+    json!({
+        "recipe": "chatgpt",
+        "bundle_path": bundle.path,
+        "file_name": bundle.file_name,
+        "bundle_size": bundle.size,
+        "mime": bundle.mime,
+        "prompt": spec.prompt,
+        "model": spec.model,
+        "browser_context_id": spec.browser_context_id,
+        "profile_email": spec.profile_email,
+        "extension_instance_id": spec.extension_instance_id,
+        "extension_profile_id": spec.extension_profile_id,
+        "conversation_id": spec.conversation_id,
+        "wait_timeout_ms": spec.wait_timeout_ms,
+        "wait_interval_ms": spec.wait_interval_ms,
+        "upload_timeout_ms": spec.upload_timeout_ms,
+        "send_timeout_ms": spec.send_timeout_ms,
+    })
 }
 
 #[derive(Clone, Debug)]
@@ -3067,6 +3072,35 @@ mod tests {
         let decoded = read_json_frame(&mut &buf[..]).unwrap();
         assert_eq!(decoded.kind, "job_progress");
         assert_eq!(decoded.payload["message"], "uploading");
+    }
+
+    #[test]
+    fn chatgpt_job_start_payload_carries_conversation_id() {
+        let bundle = BundleInfo {
+            path: PathBuf::from("/tmp/yoetz-bundle.md"),
+            file_name: "yoetz-bundle.md".to_string(),
+            size: 42,
+            mime: "text/markdown".to_string(),
+        };
+        let spec = ChatgptRecipeSpec {
+            bundle_path: Some(bundle.path.clone()),
+            model: "extended-pro".to_string(),
+            prompt: "continue".to_string(),
+            browser_context_id: None,
+            profile_email: None,
+            extension_instance_id: None,
+            extension_profile_id: None,
+            conversation_id: Some("conv-123".to_string()),
+            run_id: "run-123".to_string(),
+            wait_timeout_ms: 10_000,
+            wait_interval_ms: 1_000,
+            upload_timeout_ms: 2_000,
+            send_timeout_ms: 3_000,
+        };
+
+        let payload = chatgpt_job_start_payload(&spec, &bundle);
+
+        assert_eq!(payload["conversation_id"], "conv-123");
     }
 
     #[test]

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -904,6 +904,7 @@ pub fn canary(live: bool, selector: ExtensionInstanceSelector<'_>) -> Result<Val
         profile_email: selector.profile_email.map(str::to_string),
         extension_instance_id: selector.extension_instance_id.map(str::to_string),
         extension_profile_id: selector.extension_profile_id.map(str::to_string),
+        conversation_id: None,
         run_id: new_id("canary"),
         wait_timeout_ms: 180_000,
         wait_interval_ms: 1_000,

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -1976,11 +1976,7 @@ fn parse_model_selection_status(value: Option<&str>) -> ChatgptModelSelectionSta
 }
 
 fn job_error(envelope: ProtocolEnvelope) -> anyhow::Error {
-    let message = envelope
-        .payload
-        .get("message")
-        .and_then(Value::as_str)
-        .unwrap_or("chrome-extension-native job failed");
+    let message = job_error_message(&envelope.payload);
     let phase = envelope.payload.get("phase").and_then(Value::as_str);
     let side_effect_started = envelope
         .payload
@@ -2006,6 +2002,63 @@ fn job_error(envelope: ProtocolEnvelope) -> anyhow::Error {
             crate::chatgpt_recipe::mark_terminal_fallback_phase(err, ChatgptTransportPhase::Upload)
         }
     }
+}
+
+fn job_error_message(payload: &Value) -> String {
+    let mut message = payload
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or("chrome-extension-native job failed")
+        .to_string();
+    let code = payload.get("code").and_then(Value::as_str).unwrap_or("");
+    if !code.starts_with("conversation_") {
+        return message;
+    }
+
+    let mut detail = Vec::new();
+    if let Some(requested) = payload
+        .get("requested_conversation_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        if !message.contains(requested) {
+            detail.push(format!("requested conversation {requested}"));
+        }
+    }
+    if let Some(current_url) = payload
+        .get("current_url")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        if !message.contains(current_url) {
+            detail.push(format!("current URL {current_url}"));
+        }
+    }
+    if let Some(phase) = payload
+        .get("phase")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        let phase_text = format!("phase {phase}");
+        if !message.contains(&phase_text) {
+            detail.push(phase_text);
+        }
+    }
+    if let Some(inspect_command) = payload
+        .get("inspect_command")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        if !message.contains(inspect_command) {
+            detail.push(format!("inspect with: {inspect_command}"));
+        }
+    }
+
+    if !detail.is_empty() {
+        message.push_str(". ");
+        message.push_str(&detail.join("; "));
+    }
+    message
 }
 
 fn emit_progress(format: OutputFormat, envelope: &ProtocolEnvelope) -> Result<()> {
@@ -3962,5 +4015,29 @@ mod tests {
             crate::chatgpt_recipe::terminal_fallback_phase(&post_effect),
             Some(ChatgptTransportPhase::Send)
         );
+    }
+
+    #[test]
+    fn job_error_conversation_failures_surface_actionable_context() {
+        let err = job_error(ProtocolEnvelope::new(
+            "job_error",
+            Some("job_conv".to_string()),
+            Some("run_conv".to_string()),
+            json!({
+                "code": "conversation_unavailable",
+                "message": "ChatGPT conversation is unavailable",
+                "phase": "upload",
+                "side_effect_started": false,
+                "requested_conversation_id": "conv-404",
+                "current_url": "https://chatgpt.com/c/conv-404?_yoetz=run_conv",
+                "inspect_command": "yoetz browser extension inspect --chatgpt --run-id run_conv",
+            }),
+        ));
+        let text = err.to_string();
+
+        assert!(text.contains("requested conversation conv-404"));
+        assert!(text.contains("current URL https://chatgpt.com/c/conv-404?_yoetz=run_conv"));
+        assert!(text.contains("phase upload"));
+        assert!(text.contains("yoetz browser extension inspect --chatgpt --run-id run_conv"));
     }
 }

--- a/crates/yoetz-cli/src/chatgpt_recipe.rs
+++ b/crates/yoetz-cli/src/chatgpt_recipe.rs
@@ -159,6 +159,7 @@ pub struct ChatgptRecipeSpec {
     pub profile_email: Option<String>,
     pub extension_instance_id: Option<String>,
     pub extension_profile_id: Option<String>,
+    pub conversation_id: Option<String>,
     pub run_id: String,
     pub wait_timeout_ms: u64,
     pub wait_interval_ms: u64,

--- a/crates/yoetz-cli/src/chatgpt_recipe.rs
+++ b/crates/yoetz-cli/src/chatgpt_recipe.rs
@@ -177,6 +177,8 @@ pub struct ChatgptRecipeOutput {
     pub fallback_used: bool,
     pub delivery_mode: ChatgptDeliveryMode,
     pub auto_paste_fallback: bool,
+    pub conversation_id: Option<String>,
+    pub conversation_url: Option<String>,
 }
 
 impl ChatgptRecipeOutput {
@@ -192,6 +194,8 @@ impl ChatgptRecipeOutput {
             "fallback_used": self.fallback_used,
             "delivery_mode": self.delivery_mode.as_str(),
             "auto_paste_fallback": self.auto_paste_fallback,
+            "conversation_id": self.conversation_id,
+            "conversation_url": self.conversation_url,
         })
     }
 
@@ -207,6 +211,8 @@ impl ChatgptRecipeOutput {
             "fallback_used": self.fallback_used,
             "delivery_mode": self.delivery_mode.as_str(),
             "auto_paste_fallback": self.auto_paste_fallback,
+            "conversation_id": self.conversation_id,
+            "conversation_url": self.conversation_url,
         })
     }
 }
@@ -228,6 +234,8 @@ mod tests {
             fallback_used: true,
             delivery_mode: ChatgptDeliveryMode::Paste,
             auto_paste_fallback: true,
+            conversation_id: Some("conv-123".to_string()),
+            conversation_url: Some("https://chatgpt.com/c/conv-123".to_string()),
         };
 
         let payload = output.to_value();
@@ -241,6 +249,15 @@ mod tests {
         assert_eq!(payload["fallback_used"], true);
         assert_eq!(payload["delivery_mode"], "paste");
         assert_eq!(payload["auto_paste_fallback"], true);
+        assert_eq!(payload["conversation_id"], "conv-123");
+        assert_eq!(
+            payload["conversation_url"],
+            "https://chatgpt.com/c/conv-123"
+        );
+
+        let event = output.to_recipe_complete_event();
+        assert_eq!(event["conversation_id"], "conv-123");
+        assert_eq!(event["conversation_url"], "https://chatgpt.com/c/conv-123");
     }
 
     #[test]

--- a/crates/yoetz-cli/src/chatgpt_web.rs
+++ b/crates/yoetz-cli/src/chatgpt_web.rs
@@ -9,6 +9,8 @@ use time::{format_description::FormatItem, macros::format_description, OffsetDat
 use crate::chatgpt_recipe::ChatgptModelSelectionStatus;
 
 pub const CHATGPT_URL: &str = "https://chatgpt.com/";
+const CHATGPT_LEGACY_HOST: &str = "chat.openai.com";
+const CHATGPT_HOST: &str = "chatgpt.com";
 pub const COMPOSER_SELECTOR: &str =
     "#prompt-textarea, div[contenteditable='true'][role='textbox'], [role='textbox']";
 pub const MODEL_SELECTOR_BUTTON_SELECTOR: &str = "[data-testid='model-switcher-dropdown-button'], button[aria-label='Model selector'], button[aria-label='Model selector menu'], button:has([data-testid='selected-model']), button:has([data-testid='model-switcher-selected-model'])";
@@ -96,6 +98,12 @@ const LOGIN_MARKERS: &[&str] = &[
     "continue with apple",
 ];
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChatgptConversation {
+    pub id: String,
+    pub url: String,
+}
+
 pub fn stable_idle_threshold_ms(interval_ms: u64) -> u64 {
     interval_ms
         .saturating_mul(STABLE_IDLE_INTERVAL_MULTIPLIER)
@@ -137,6 +145,74 @@ pub fn validate_thread_mode(raw: Option<&str>) -> Result<()> {
     }
 }
 
+pub fn normalize_conversation(raw: &str) -> Result<ChatgptConversation> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!(
+            "invalid `conversation`: expected a ChatGPT conversation id or /c/<id> URL"
+        ));
+    }
+    let id = if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        conversation_id_from_url(trimmed)?
+    } else {
+        trimmed.to_string()
+    };
+    validate_conversation_id(&id)?;
+    Ok(ChatgptConversation {
+        url: chatgpt_conversation_url(&id),
+        id,
+    })
+}
+
+pub fn chatgpt_conversation_url(conversation_id: &str) -> String {
+    format!(
+        "{CHATGPT_URL}c/{}",
+        percent_encode_path_segment(conversation_id)
+    )
+}
+
+fn conversation_id_from_url(raw: &str) -> Result<String> {
+    let without_scheme = raw.strip_prefix("https://").ok_or_else(|| {
+        anyhow!("invalid `conversation` URL: expected https://chatgpt.com/c/<id>")
+    })?;
+    let (host, path_and_more) = without_scheme.split_once('/').ok_or_else(|| {
+        anyhow!("invalid `conversation` URL: expected https://chatgpt.com/c/<id>")
+    })?;
+    let host = host.to_ascii_lowercase();
+    if host != CHATGPT_HOST && host != CHATGPT_LEGACY_HOST {
+        return Err(anyhow!(
+            "invalid `conversation` URL host `{host}`; expected chatgpt.com or chat.openai.com"
+        ));
+    }
+    let path = path_and_more.split(['?', '#']).next().unwrap_or_default();
+    let id = path
+        .strip_prefix("c/")
+        .ok_or_else(|| anyhow!("invalid `conversation` URL path: expected /c/<id>"))?;
+    if id.contains('/') {
+        return Err(anyhow!(
+            "invalid `conversation` URL path: expected a single /c/<id> path segment"
+        ));
+    }
+    Ok(id.to_string())
+}
+
+fn validate_conversation_id(id: &str) -> Result<()> {
+    let valid = !id.is_empty()
+        && id != "."
+        && id != ".."
+        && id.len() <= 256
+        && id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'));
+    if valid {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "invalid `conversation`: expected 1-256 ASCII letters, digits, `_`, `-`, or `.`"
+        ))
+    }
+}
+
 pub fn mark_chatgpt_url(run_id: &str) -> String {
     format!("{CHATGPT_URL}?{}", chatgpt_run_url_marker(run_id))
 }
@@ -146,6 +222,18 @@ pub(crate) fn chatgpt_run_url_marker(run_id: &str) -> String {
 }
 
 fn percent_encode_query_component(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}
+
+fn percent_encode_path_segment(value: &str) -> String {
     let mut encoded = String::new();
     for byte in value.bytes() {
         if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
@@ -1925,6 +2013,54 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("unsupported `thread` value `sideways`"));
         assert!(msg.contains("fresh"));
+    }
+
+    #[test]
+    fn normalize_conversation_accepts_ids_and_chatgpt_urls() {
+        let cases = [
+            (
+                "6a0228a7-4994-832d-8bb0-ea6b35d1b7af",
+                "6a0228a7-4994-832d-8bb0-ea6b35d1b7af",
+            ),
+            (
+                "https://chatgpt.com/c/6a0228a7-4994-832d-8bb0-ea6b35d1b7af?_yoetz=run-1",
+                "6a0228a7-4994-832d-8bb0-ea6b35d1b7af",
+            ),
+            ("https://chat.openai.com/c/legacy_123#thread", "legacy_123"),
+        ];
+
+        for (raw, expected_id) in cases {
+            let conversation = normalize_conversation(raw).unwrap();
+            assert_eq!(conversation.id, expected_id);
+            assert_eq!(
+                conversation.url,
+                format!("https://chatgpt.com/c/{expected_id}")
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_conversation_rejects_unsafe_or_wrong_targets() {
+        for raw in [
+            "",
+            "   ",
+            "https://example.com/c/conv-123",
+            "http://chatgpt.com/c/conv-123",
+            "https://chatgpt.com/",
+            "https://chatgpt.com/g/g-123",
+            "https://chatgpt.com/c/conv-123/extra",
+            "conv/123",
+            "conv?123",
+            "conv 123",
+            "conv%20123",
+            ".",
+            "..",
+        ] {
+            assert!(
+                normalize_conversation(raw).is_err(),
+                "expected {raw:?} to be rejected"
+            );
+        }
     }
 
     #[test]

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -1147,6 +1147,14 @@ fn recipe_transports_with_explicit_override(
     Ok(vec![requested])
 }
 
+fn recipe_effective_allow_cdp_fallback(
+    allow_cdp_fallback: bool,
+    recipe_vars: &BTreeMap<String, String>,
+    is_chatgpt: bool,
+) -> bool {
+    allow_cdp_fallback && !(is_chatgpt && recipe_uses_conversation_selector(recipe_vars))
+}
+
 fn recipe_should_auto_discover_cdp_target(
     managed_profile_only: bool,
     requested_extension_native: bool,
@@ -1319,6 +1327,12 @@ fn recipe_uses_extension_instance_selector(
         || recipe_var_present(recipe_vars)("extension_profile_id")
 }
 
+fn recipe_uses_conversation_selector(
+    recipe_vars: &std::collections::BTreeMap<String, String>,
+) -> bool {
+    recipe_var_present(recipe_vars)("conversation")
+}
+
 #[cfg(test)]
 fn recipe_uses_chatgpt_browser_context_selector(
     recipe_vars: &std::collections::BTreeMap<String, String>,
@@ -1366,6 +1380,20 @@ fn constrain_chatgpt_transports_for_browser_context_selector(
     transports
 }
 
+fn constrain_chatgpt_transports_for_conversation(
+    transports: Vec<browser::RecipeTransport>,
+    recipe_vars: &std::collections::BTreeMap<String, String>,
+    is_chatgpt: bool,
+) -> Vec<browser::RecipeTransport> {
+    if !is_chatgpt || !recipe_uses_conversation_selector(recipe_vars) {
+        return transports;
+    }
+    transports
+        .into_iter()
+        .filter(|transport| matches!(transport, browser::RecipeTransport::ChromeExtensionNative))
+        .collect()
+}
+
 fn ensure_chatgpt_transport_constraints_allow_any(
     transports: &[browser::RecipeTransport],
     requested: Option<browser::RecipeTransport>,
@@ -1380,6 +1408,12 @@ fn ensure_chatgpt_transport_constraints_allow_any(
         .map(recipe_transport_name)
         .map(|name| format!("requested transport `{name}`"))
         .unwrap_or_else(|| "configured transports".to_string());
+
+    if recipe_uses_conversation_selector(recipe_vars) {
+        bail!(
+            "conversation requires chrome-extension-native; {requested} is not compatible. Install the Yoetz Chrome extension (`yoetz browser extension setup --chatgpt`) or pass --transport chrome-extension-native."
+        );
+    }
 
     if recipe_uses_exact_browser_context_selector(recipe_vars) {
         bail!(
@@ -3323,6 +3357,11 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 && extension_status_connected_for_auto_selection();
             let extension_native_will_route =
                 requested_extension_native || extension_auto_selection_eligible;
+            let effective_allow_cdp_fallback = recipe_effective_allow_cdp_fallback(
+                recipe_args.allow_cdp_fallback,
+                &recipe_vars,
+                is_chatgpt,
+            );
             if recipe_uses_extension_instance_selector(&recipe_vars) && !extension_native_will_route
             {
                 bail!(
@@ -3344,7 +3383,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                     managed_profile_only,
                     requested_extension_native,
                     extension_native_will_route,
-                    recipe_args.allow_cdp_fallback,
+                    effective_allow_cdp_fallback,
                 ),
             )?;
             maybe_print_auto_selected_cdp_target(resolved_cdp_target.as_ref(), format);
@@ -3360,7 +3399,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             let transports = recipe_transports_with_explicit_override(
                 base_transports,
                 recipe_args.transport,
-                recipe_args.allow_cdp_fallback,
+                effective_allow_cdp_fallback,
                 is_chatgpt,
             )?;
             let live_attach_owner_is_present =
@@ -3382,6 +3421,8 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 &recipe_vars,
                 is_chatgpt,
             );
+            let transports =
+                constrain_chatgpt_transports_for_conversation(transports, &recipe_vars, is_chatgpt);
             ensure_chatgpt_transport_constraints_allow_any(
                 &transports,
                 recipe_args.transport,
@@ -3509,7 +3550,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                             skip_remaining_live_cdp = true;
                         }
                         if matches!(transport, browser::RecipeTransport::ChromeExtensionNative)
-                            && !recipe_args.allow_cdp_fallback
+                            && !effective_allow_cdp_fallback
                             && chatgpt_recipe::terminal_fallback_phase(&err).is_none()
                             && matches!(format, OutputFormat::Text | OutputFormat::Markdown)
                         {
@@ -4689,6 +4730,21 @@ mod tests {
     }
 
     #[test]
+    fn conversation_disables_cdp_fallback_even_when_requested() {
+        let vars = std::collections::BTreeMap::from([(
+            "conversation".to_string(),
+            "conv-123".to_string(),
+        )]);
+        assert!(!recipe_effective_allow_cdp_fallback(true, &vars, true));
+        assert!(recipe_effective_allow_cdp_fallback(
+            true,
+            &std::collections::BTreeMap::new(),
+            true
+        ));
+        assert!(recipe_effective_allow_cdp_fallback(true, &vars, false));
+    }
+
+    #[test]
     fn cdp_auto_discovery_is_disabled_for_native_only_routes() {
         assert!(recipe_should_auto_discover_cdp_target(
             false, false, false, false
@@ -4736,6 +4792,84 @@ mod tests {
         vars.insert("extension_instance_id".to_string(), "ext-work".to_string());
         assert!(recipe_uses_extension_instance_selector(&vars));
         assert!(!recipe_uses_chatgpt_browser_context_selector(&vars));
+
+        vars.clear();
+        vars.insert("conversation".to_string(), "conv-123".to_string());
+        assert!(recipe_uses_conversation_selector(&vars));
+    }
+
+    #[test]
+    fn conversation_selector_keeps_only_chrome_extension_native() {
+        let vars = std::collections::BTreeMap::from([(
+            "conversation".to_string(),
+            "conv-123".to_string(),
+        )]);
+        let transports = constrain_chatgpt_transports_for_conversation(
+            vec![
+                browser::RecipeTransport::ChromeDevtoolsMcp,
+                browser::RecipeTransport::DevBrowser,
+                browser::RecipeTransport::ChromeExtensionNative,
+                browser::RecipeTransport::AgentBrowser,
+                browser::RecipeTransport::Manual,
+            ],
+            &vars,
+            true,
+        );
+        assert_eq!(
+            transports,
+            vec![browser::RecipeTransport::ChromeExtensionNative]
+        );
+    }
+
+    #[test]
+    fn conversation_selector_rejects_non_native_transport_routes() {
+        let vars = std::collections::BTreeMap::from([(
+            "conversation".to_string(),
+            "conv-123".to_string(),
+        )]);
+        for transport in [
+            browser::RecipeTransport::ChromeDevtoolsMcp,
+            browser::RecipeTransport::DevBrowser,
+            browser::RecipeTransport::AgentBrowser,
+            browser::RecipeTransport::Manual,
+        ] {
+            let transports =
+                constrain_chatgpt_transports_for_conversation(vec![transport], &vars, true);
+            let err = ensure_chatgpt_transport_constraints_allow_any(
+                &transports,
+                Some(transport),
+                &vars,
+                true,
+            )
+            .unwrap_err();
+            let message = err.to_string();
+            assert!(message.contains("conversation requires chrome-extension-native"));
+            assert!(message.contains("yoetz browser extension setup --chatgpt"));
+        }
+    }
+
+    #[test]
+    fn conversation_selector_rejects_default_routes_when_extension_is_not_selected() {
+        let vars = std::collections::BTreeMap::from([(
+            "conversation".to_string(),
+            "conv-123".to_string(),
+        )]);
+        let transports = constrain_chatgpt_transports_for_conversation(
+            vec![
+                browser::RecipeTransport::ChromeDevtoolsMcp,
+                browser::RecipeTransport::DevBrowser,
+                browser::RecipeTransport::AgentBrowser,
+                browser::RecipeTransport::Manual,
+            ],
+            &vars,
+            true,
+        );
+        let err = ensure_chatgpt_transport_constraints_allow_any(&transports, None, &vars, true)
+            .unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("conversation requires chrome-extension-native"));
+        assert!(message.contains("configured transports"));
+        assert!(message.contains("yoetz browser extension setup --chatgpt"));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -1907,6 +1907,8 @@ async fn run_recipe_via_chrome_devtools_mcp(
         fallback_used,
         delivery_mode: chatgpt_recipe::ChatgptDeliveryMode::FileUpload,
         auto_paste_fallback: false,
+        conversation_id: None,
+        conversation_url: None,
     }
     .to_value();
     maybe_write_output(ctx, &payload)?;
@@ -1935,6 +1937,8 @@ async fn run_recipe_via_chrome_devtools_mcp(
                 fallback_used,
                 delivery_mode: chatgpt_recipe::ChatgptDeliveryMode::FileUpload,
                 auto_paste_fallback: false,
+                conversation_id: payload["conversation_id"].as_str().map(str::to_owned),
+                conversation_url: payload["conversation_url"].as_str().map(str::to_owned),
             }
             .to_recipe_complete_event();
             write_jsonl("browser.recipe", &event)?;
@@ -2115,6 +2119,8 @@ fn run_recipe_via_chrome_extension_native(
         fallback_used,
         delivery_mode: chatgpt_recipe::ChatgptDeliveryMode::FileUpload,
         auto_paste_fallback: false,
+        conversation_id: response.conversation_id,
+        conversation_url: response.conversation_url,
     };
     let mut payload = output.to_value();
     attach_browser_recipe_artifacts(&mut payload, recipe_args.bundle.as_deref())?;
@@ -2262,6 +2268,8 @@ fn run_recipe_via_dev_browser(
             chatgpt_recipe::ChatgptDeliveryMode::FileUpload
         },
         auto_paste_fallback,
+        conversation_id: None,
+        conversation_url: None,
     };
     let payload = output.to_value();
     maybe_write_output(ctx, &payload)?;
@@ -5679,6 +5687,8 @@ mod tests {
             fallback_used: true,
             delivery_mode: crate::chatgpt_recipe::ChatgptDeliveryMode::Paste,
             auto_paste_fallback: true,
+            conversation_id: Some("conv-123".to_string()),
+            conversation_url: Some("https://chatgpt.com/c/conv-123".to_string()),
         };
 
         let event = output.to_recipe_complete_event();
@@ -5688,6 +5698,8 @@ mod tests {
         assert_eq!(event["delivery_mode"], "paste");
         assert_eq!(event["auto_paste_fallback"], true);
         assert_eq!(event["warnings"], json!(["clipboard fallback"]));
+        assert_eq!(event["conversation_id"], "conv-123");
+        assert_eq!(event["conversation_url"], "https://chatgpt.com/c/conv-123");
     }
 
     #[test]

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -1961,6 +1961,10 @@ fn build_chatgpt_recipe_spec(
         dev_browser::resolve_chatgpt_upload_timeout_ms(recipe_vars, recipe_args.bundle.as_deref())?;
     let send_timeout_ms = dev_browser::resolve_chatgpt_send_timeout_ms(recipe_vars)?;
     chrome_devtools_mcp::RecipeThreadMode::parse(recipe_vars.get("thread").map(String::as_str))?;
+    let conversation = recipe_vars
+        .get("conversation")
+        .map(|value| chatgpt_web::normalize_conversation(value))
+        .transpose()?;
     Ok(chatgpt_recipe::ChatgptRecipeSpec {
         bundle_path: recipe_args.bundle.clone(),
         model: chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL.to_string(),
@@ -1984,6 +1988,7 @@ fn build_chatgpt_recipe_spec(
             .get("extension_profile_id")
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty()),
+        conversation_id: conversation.map(|value| value.id),
         run_id: recipe_vars
             .get("run_id")
             .cloned()
@@ -5434,6 +5439,10 @@ mod tests {
             ("profile_email".to_string(), "user@example.com".to_string()),
             ("extension_instance_id".to_string(), "ext-work".to_string()),
             ("extension_profile_id".to_string(), "gaia-work".to_string()),
+            (
+                "conversation".to_string(),
+                "https://chat.openai.com/c/conv-123?model=gpt-4".to_string(),
+            ),
             ("run_id".to_string(), "run-123".to_string()),
             ("wait_timeout_ms".to_string(), "2400000".to_string()),
             ("wait_interval_ms".to_string(), "45000".to_string()),
@@ -5449,6 +5458,7 @@ mod tests {
         assert_eq!(spec.profile_email.as_deref(), Some("user@example.com"));
         assert_eq!(spec.extension_instance_id.as_deref(), Some("ext-work"));
         assert_eq!(spec.extension_profile_id.as_deref(), Some("gaia-work"));
+        assert_eq!(spec.conversation_id.as_deref(), Some("conv-123"));
         assert_eq!(spec.run_id, "run-123");
         assert_eq!(spec.wait_timeout_ms, 2_400_000);
         assert_eq!(spec.wait_interval_ms, 45_000);

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -4822,6 +4822,21 @@ mod tests {
     }
 
     #[test]
+    fn conversation_selector_allows_native_transport_route() {
+        let vars = std::collections::BTreeMap::from([(
+            "conversation".to_string(),
+            "conv-123".to_string(),
+        )]);
+        ensure_chatgpt_transport_constraints_allow_any(
+            &[browser::RecipeTransport::ChromeExtensionNative],
+            Some(browser::RecipeTransport::ChromeExtensionNative),
+            &vars,
+            true,
+        )
+        .unwrap();
+    }
+
+    #[test]
     fn conversation_selector_rejects_non_native_transport_routes() {
         let vars = std::collections::BTreeMap::from([(
             "conversation".to_string(),

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -1785,12 +1785,7 @@ function hasConversationResidue(root) {
 }
 
 function conversationUnavailableState(root, win) {
-  // Avoid treating quoted prior transcript text as a page-level unavailable
-  // marker on legitimate resumed conversations.
-  if (hasConversationResidue(root)) {
-    return null;
-  }
-  const text = normalizeText(`${String(win.document?.title ?? "")}\n${getPageText(root)}`).toLowerCase();
+  const text = normalizeText(`${String(win.document?.title ?? "")}\n${conversationUnavailableSurfaceText(root)}`).toLowerCase();
   if (!text) {
     return null;
   }
@@ -1805,6 +1800,50 @@ function conversationUnavailableState(root, win) {
   ];
   const matched = unavailablePatterns.find((pattern) => pattern.test(text));
   return matched ? { reason: matched.source } : null;
+}
+
+function conversationUnavailableSurfaceText(root) {
+  // Prior transcript text can quote "conversation not found" / "no access" phrases.
+  // When transcript residue exists, keep page-level banners and other non-turn UI
+  // text, but drop message containers so quoted assistant/user content cannot
+  // mask a valid resumed conversation or create a false unavailable state.
+  if (!hasConversationResidue(root)) {
+    return getPageText(root);
+  }
+  const start = root.body ?? root.documentElement ?? root;
+  const chunks = [];
+  collectConversationUnavailableSurfaceText(start, chunks);
+  return chunks.join("\n");
+}
+
+function collectConversationUnavailableSurfaceText(node, chunks) {
+  if (!node || isConversationTurnSurface(node)) {
+    return;
+  }
+  const children = Array.from(node.children ?? []);
+  if (children.length === 0) {
+    if (isVisible(node, { allowDisabled: true })) {
+      const text = textOf(node);
+      if (text) {
+        chunks.push(text);
+      }
+    }
+    return;
+  }
+  for (const child of children) {
+    collectConversationUnavailableSurfaceText(child, chunks);
+  }
+}
+
+function isConversationTurnSurface(node) {
+  return Boolean(node?.closest?.([
+    "[data-message-author-role]",
+    "article",
+    '[data-testid*="conversation-turn"]',
+    '[class*="turn-messages"]',
+    '[class*="agent-turn"]',
+    '[class*="user-turn"]'
+  ].join(",")));
 }
 
 function conversationResidue(root) {

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -93,15 +93,15 @@ export function findModelButton(root = document, options = {}) {
   // ChatGPT serves at least two picker families: Enterprise exposes a global
   // model-switcher button, while personal ChatGPT can render a composer-scoped
   // model chip. Keep both paths because either account type may back Pro.
-  const enterpriseButton = firstVisible(root, [
+  const enterpriseButton = firstVisibleModelControl(root, [
     'button[data-testid="model-switcher-dropdown-button"]',
     'button:has([data-testid="selected-model"])',
     'button:has([data-testid="model-switcher-selected-model"])',
     'button[aria-label*="model" i]',
     'button[aria-controls*="model" i]',
     'button[id*="model" i]'
-  ]);
-  const composerButton = findComposerModelControl(root);
+  ], options);
+  const composerButton = findComposerModelControl(root, options);
   if (options.allowStandaloneFallback === false) {
     return enterpriseButton ?? composerButton;
   }
@@ -340,7 +340,7 @@ function isActionableElement(node) {
     || node?.getAttribute?.("tabindex") !== null;
 }
 
-function findComposerModelControl(root) {
+function findComposerModelControl(root, options = {}) {
   for (const scope of modelControlScopes(root)) {
     const candidates = uniqueElements(Array.from(scope.querySelectorAll([
       "button",
@@ -356,6 +356,9 @@ function findComposerModelControl(root) {
     for (const node of candidates) {
       const target = modelClickTarget(node, scope);
       if (!target || !isVisible(target, { allowDisabled: true })) {
+        continue;
+      }
+      if (isTranscriptModelControl(target, options)) {
         continue;
       }
       const haystack = modelCandidateText(node, target);
@@ -520,7 +523,7 @@ export async function selectRequestedModel(root, requested, options = {}) {
     }
     return {
       status: "unavailable",
-      model_used: currentModelLabel(root),
+      model_used: currentModelLabel(root, options),
       available_options: availableOptions,
       warning: "ChatGPT Pro Extended was not visible in the model picker"
     };
@@ -1200,6 +1203,33 @@ export function normalizeText(value) {
 
 function firstVisible(root, selectors) {
   return firstMatching(root, selectors, { allowHidden: false });
+}
+
+function firstVisibleModelControl(root, selectors, options = {}) {
+  for (const selector of selectors) {
+    const nodes = Array.from(root.querySelectorAll(selector));
+    const visible = nodes.find((node) =>
+      isVisible(node, options) && !isTranscriptModelControl(node, options)
+    );
+    if (visible) {
+      return visible;
+    }
+  }
+  return null;
+}
+
+function isTranscriptModelControl(node, options = {}) {
+  if (options.allowStandaloneFallback !== false) {
+    return false;
+  }
+  return Boolean(node?.closest?.([
+    "[data-message-author-role]",
+    "article",
+    '[data-testid*="conversation-turn"]',
+    '[class*="turn-messages"]',
+    '[class*="agent-turn"]',
+    '[class*="user-turn"]'
+  ].join(",")));
 }
 
 function firstMatching(root, selectors, options = {}) {

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -235,6 +235,10 @@ export async function ensureConversationLoaded(root = document, conversationId, 
       }
     );
   }
+  const unavailable = conversationUnavailableState(root, win);
+  if (unavailable) {
+    throw conversationUnavailableError(conversationId, loadedConversationId, win, pathname, unavailable);
+  }
   try {
     await waitForElement(root, findComposer, "ChatGPT composer", options);
   } catch (error) {
@@ -251,11 +255,50 @@ export async function ensureConversationLoaded(root = document, conversationId, 
       }
     );
   }
+  const currentPathname = String(win.location?.pathname ?? "");
+  const currentConversationId = conversationIdFromPathname(currentPathname);
+  if (currentConversationId !== conversationId) {
+    const code = currentConversationId ? "conversation_not_loaded" : "conversation_unavailable";
+    throw chatgptCommandError(
+      code,
+      code === "conversation_unavailable"
+        ? `ChatGPT conversation ${conversationId} is unavailable; current URL is ${currentLocationForError(win)}`
+        : `ChatGPT conversation ${conversationId} did not load; current URL is ${currentLocationForError(win)}`,
+      {
+        phase: "upload",
+        side_effect_started: false,
+        requested_conversation_id: conversationId,
+        current_conversation_id: currentConversationId,
+        current_url: currentLocationForError(win),
+        current_pathname: currentPathname
+      }
+    );
+  }
+  const postComposerUnavailable = conversationUnavailableState(root, win);
+  if (postComposerUnavailable) {
+    throw conversationUnavailableError(conversationId, currentConversationId, win, currentPathname, postComposerUnavailable);
+  }
   return {
     status: "loaded",
     conversation_id: conversationId,
-    pathname
+    pathname: currentPathname
   };
+}
+
+function conversationUnavailableError(conversationId, currentConversationId, win, pathname, unavailable) {
+  return chatgptCommandError(
+    "conversation_unavailable",
+    `ChatGPT conversation ${conversationId} is unavailable at ${currentLocationForError(win)}${unavailable.reason ? `: ${unavailable.reason}` : ""}`,
+    {
+      phase: "upload",
+      side_effect_started: false,
+      requested_conversation_id: conversationId,
+      current_conversation_id: currentConversationId,
+      current_url: currentLocationForError(win),
+      current_pathname: pathname,
+      unavailable_reason: unavailable.reason
+    }
+  );
 }
 
 export async function configureModelState(root, job = {}) {
@@ -1709,6 +1752,29 @@ function hasAssistantRoleDescendant(node) {
 function hasConversationResidue(root) {
   const residue = conversationResidue(root);
   return residue.user_count > 0 || residue.assistant_count > 0 || residue.copy_button_count > 0;
+}
+
+function conversationUnavailableState(root, win) {
+  // Avoid treating quoted prior transcript text as a page-level unavailable
+  // marker on legitimate resumed conversations.
+  if (hasConversationResidue(root)) {
+    return null;
+  }
+  const text = normalizeText(`${String(win.document?.title ?? "")}\n${getPageText(root)}`).toLowerCase();
+  if (!text) {
+    return null;
+  }
+  const unavailablePatterns = [
+    /\bconversation not found\b/,
+    /\bchat not found\b/,
+    /\bconversation (?:is )?unavailable\b/,
+    /\byou (?:do not|don't) have access to (?:this )?(?:conversation|chat)\b/,
+    /\b(?:cannot|can't|could not) access (?:this )?(?:conversation|chat)\b/,
+    /\bthis (?:conversation|chat) (?:has been )?archived\b/,
+    /\barchived (?:conversation|chat)\b/
+  ];
+  const matched = unavailablePatterns.find((pattern) => pattern.test(text));
+  return matched ? { reason: matched.source } : null;
 }
 
 function conversationResidue(root) {

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -219,12 +219,19 @@ export async function ensureConversationLoaded(root = document, conversationId, 
   const pathname = String(win.location?.pathname ?? "");
   const loadedConversationId = conversationIdFromPathname(pathname);
   if (loadedConversationId !== conversationId) {
+    const code = loadedConversationId ? "conversation_not_loaded" : "conversation_unavailable";
     throw chatgptCommandError(
-      "conversation_not_loaded",
-      `ChatGPT conversation ${conversationId} did not load; current path is ${pathname || "(unknown)"}`,
+      code,
+      code === "conversation_unavailable"
+        ? `ChatGPT conversation ${conversationId} is unavailable; current URL is ${currentLocationForError(win)}`
+        : `ChatGPT conversation ${conversationId} did not load; current URL is ${currentLocationForError(win)}`,
       {
         phase: "upload",
-        side_effect_started: false
+        side_effect_started: false,
+        requested_conversation_id: conversationId,
+        current_conversation_id: loadedConversationId,
+        current_url: currentLocationForError(win),
+        current_pathname: pathname
       }
     );
   }
@@ -232,11 +239,15 @@ export async function ensureConversationLoaded(root = document, conversationId, 
     await waitForElement(root, findComposer, "ChatGPT composer", options);
   } catch (error) {
     throw chatgptCommandError(
-      "conversation_not_loaded",
-      `ChatGPT conversation ${conversationId} did not load a composer: ${String(error?.message ?? error)}`,
+      "conversation_unavailable",
+      `ChatGPT conversation ${conversationId} is unavailable; composer did not load at ${currentLocationForError(win)}: ${String(error?.message ?? error)}`,
       {
         phase: "upload",
-        side_effect_started: false
+        side_effect_started: false,
+        requested_conversation_id: conversationId,
+        current_conversation_id: loadedConversationId,
+        current_url: currentLocationForError(win),
+        current_pathname: pathname
       }
     );
   }
@@ -2001,7 +2012,16 @@ function chatgptCommandError(code, message, detail = {}) {
   if (typeof detail.side_effect_started === "boolean") {
     error.side_effect_started = detail.side_effect_started;
   }
+  for (const [key, value] of Object.entries(detail)) {
+    if (!(key in error) && value !== undefined) {
+      error[key] = value;
+    }
+  }
   return error;
+}
+
+function currentLocationForError(win) {
+  return String(win.location?.href ?? win.location?.pathname ?? "(unknown)") || "(unknown)";
 }
 
 function sleep(ms) {

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -29,6 +29,12 @@ export function chatgptJobUrl(runId) {
   return url.toString();
 }
 
+export function chatgptConversationJobUrl(conversationId, runId) {
+  const url = new URL(`https://chatgpt.com/c/${encodeURIComponent(conversationId)}`);
+  url.searchParams.set("_yoetz", runId);
+  return url.toString();
+}
+
 export function classifyManualHandoff({ url = "", title = "", text = "" } = {}) {
   const haystack = `${url}\n${title}\n${text}`.toLowerCase();
   if (/\/auth\/login|log in|sign in/.test(haystack)) {

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -210,6 +210,39 @@ export async function ensureFreshChat(root = document, job = {}, options = {}) {
   };
 }
 
+export async function ensureConversationLoaded(root = document, conversationId, options = {}) {
+  const win = options.window ?? root.defaultView ?? globalThis;
+  const pathname = String(win.location?.pathname ?? "");
+  const loadedConversationId = conversationIdFromPathname(pathname);
+  if (loadedConversationId !== conversationId) {
+    throw chatgptCommandError(
+      "conversation_not_loaded",
+      `ChatGPT conversation ${conversationId} did not load; current path is ${pathname || "(unknown)"}`,
+      {
+        phase: "upload",
+        side_effect_started: false
+      }
+    );
+  }
+  try {
+    await waitForElement(root, findComposer, "ChatGPT composer", options);
+  } catch (error) {
+    throw chatgptCommandError(
+      "conversation_not_loaded",
+      `ChatGPT conversation ${conversationId} did not load a composer: ${String(error?.message ?? error)}`,
+      {
+        phase: "upload",
+        side_effect_started: false
+      }
+    );
+  }
+  return {
+    status: "loaded",
+    conversation_id: conversationId,
+    pathname
+  };
+}
+
 export async function configureModelState(root) {
   const requested = proExtendedModelRequest();
   const selection = await selectRequestedModel(root, requested);
@@ -1924,6 +1957,30 @@ function describeElement(node) {
     .filter(Boolean)
     .join(" ");
   return `${node.tagName?.toLowerCase?.() ?? "element"}${attrs ? ` ${attrs}` : ""}`;
+}
+
+function conversationIdFromPathname(pathname) {
+  const match = String(pathname ?? "").match(/^\/c\/([^/?#]+)$/);
+  if (!match) {
+    return null;
+  }
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return null;
+  }
+}
+
+function chatgptCommandError(code, message, detail = {}) {
+  const error = new Error(message);
+  error.code = code;
+  if (detail.phase) {
+    error.phase = detail.phase;
+  }
+  if (typeof detail.side_effect_started === "boolean") {
+    error.side_effect_started = detail.side_effect_started;
+  }
+  return error;
 }
 
 function sleep(ms) {

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -89,7 +89,7 @@ export function findSendButton(root = document) {
   return findSendButtonControl(root, { requireEnabled: true });
 }
 
-export function findModelButton(root = document) {
+export function findModelButton(root = document, options = {}) {
   // ChatGPT serves at least two picker families: Enterprise exposes a global
   // model-switcher button, while personal ChatGPT can render a composer-scoped
   // model chip. Keep both paths because either account type may back Pro.
@@ -101,7 +101,11 @@ export function findModelButton(root = document) {
     'button[aria-controls*="model" i]',
     'button[id*="model" i]'
   ]);
-  return enterpriseButton ?? findComposerModelControl(root) ?? findStandaloneProExtendedModelControl(root);
+  const composerButton = findComposerModelControl(root);
+  if (options.allowStandaloneFallback === false) {
+    return enterpriseButton ?? composerButton;
+  }
+  return enterpriseButton ?? composerButton ?? findStandaloneProExtendedModelControl(root);
 }
 
 export function getPageText(root = document) {
@@ -243,9 +247,9 @@ export async function ensureConversationLoaded(root = document, conversationId, 
   };
 }
 
-export async function configureModelState(root) {
+export async function configureModelState(root, job = {}) {
   const requested = proExtendedModelRequest();
-  const selection = await selectRequestedModel(root, requested);
+  const selection = await selectRequestedModel(root, requested, modelSelectionOptionsForJob(job));
   const warnings = selection.warning ? [selection.warning] : [];
   return {
     status: selection.status,
@@ -256,6 +260,22 @@ export async function configureModelState(root) {
     warning: warnings[0] ?? null,
     warnings
   };
+}
+
+function modelSelectionOptionsForJob(job = {}) {
+  const options = {};
+  if (String(job?.conversation_id ?? "").trim()) {
+    options.allowStandaloneFallback = false;
+  }
+  const timeoutMs = Number(job?.model_selection_timeout_ms);
+  if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
+    options.timeoutMs = timeoutMs;
+  }
+  const intervalMs = Number(job?.model_selection_interval_ms);
+  if (Number.isFinite(intervalMs) && intervalMs > 0) {
+    options.intervalMs = intervalMs;
+  }
+  return options;
 }
 
 function isActionableElement(node) {
@@ -392,8 +412,8 @@ function isModelChipLike(node) {
   return /\b(model|model-switcher)\b/.test(marker) && /\b(chip|pill|token|button|menu|dropdown|switcher)\b/.test(marker);
 }
 
-export async function selectRequestedModel(root, requested) {
-  const readiness = await waitForModelSelectionTarget(root, requested);
+export async function selectRequestedModel(root, requested, options = {}) {
+  const readiness = await waitForModelSelectionTarget(root, requested, options);
   if (readiness.selection.selected) {
     return {
       status: "selected",
@@ -411,7 +431,7 @@ export async function selectRequestedModel(root, requested) {
     };
   }
 
-  const currentSelection = currentRequestedModelSelection(root, requested);
+  const currentSelection = currentRequestedModelSelection(root, requested, options);
   if (currentSelection.selected) {
     return {
       status: "selected",
@@ -436,7 +456,7 @@ export async function selectRequestedModel(root, requested) {
     }
   }
   if (!selectedOption) {
-    const verification = await waitForRequestedModelSelected(root, requested, null);
+    const verification = await waitForRequestedModelSelected(root, requested, null, options);
     if (verification.selected) {
       return {
         status: "selected",
@@ -453,7 +473,7 @@ export async function selectRequestedModel(root, requested) {
   }
   realClick(selectedOption);
 
-  const verification = await waitForRequestedModelSelected(root, requested, selectedOption);
+  const verification = await waitForRequestedModelSelected(root, requested, selectedOption, options);
   if (verification.selected) {
     return {
       status: "selected",
@@ -473,15 +493,15 @@ async function waitForModelSelectionTarget(root, requested, options = {}) {
   const timeoutMs = Number(options.timeoutMs ?? 30000);
   const intervalMs = Number(options.intervalMs ?? 250);
   const startedAt = Date.now();
-  let selection = currentRequestedModelSelection(root, requested);
-  let modelButton = findModelButton(root);
+  let selection = currentRequestedModelSelection(root, requested, options);
+  let modelButton = findModelButton(root, options);
 
   while (Date.now() - startedAt < timeoutMs) {
-    selection = currentRequestedModelSelection(root, requested);
+    selection = currentRequestedModelSelection(root, requested, options);
     if (selection.selected) {
-      return { selection, modelButton: findModelButton(root) };
+      return { selection, modelButton: findModelButton(root, options) };
     }
-    modelButton = findModelButton(root);
+    modelButton = findModelButton(root, options);
     if (modelButton) {
       return { selection, modelButton };
     }
@@ -491,8 +511,8 @@ async function waitForModelSelectionTarget(root, requested, options = {}) {
   return { selection, modelButton };
 }
 
-function currentRequestedModelSelection(root, requested) {
-  const modelUsed = currentModelLabel(root);
+function currentRequestedModelSelection(root, requested, options = {}) {
+  const modelUsed = currentModelLabel(root, options);
   return {
     selected: modelTextMatchesRequest(modelUsed, requested),
     model_used: modelUsed
@@ -1314,10 +1334,10 @@ async function waitForRequestedModelSelected(root, requested, _option, options =
   const timeoutMs = Number(options.timeoutMs ?? 4000);
   const intervalMs = Number(options.intervalMs ?? 100);
   const startedAt = Date.now();
-  let modelUsed = currentModelLabel(root);
+  let modelUsed = currentModelLabel(root, options);
 
   while (Date.now() - startedAt < timeoutMs) {
-    modelUsed = currentModelLabel(root);
+    modelUsed = currentModelLabel(root, options);
     if (modelTextMatchesRequest(modelUsed, requested)) {
       return { selected: true, model_used: modelUsed };
     }
@@ -1844,10 +1864,11 @@ function uniqueElements(nodes) {
   return nodes.filter((node, index) => node && nodes.indexOf(node) === index);
 }
 
-function currentModelLabel(root) {
-  const selected = firstVisible(root, [
-    '[data-testid="model-switcher-selected-model"]'
-  ]);
+function currentModelLabel(root, options = {}) {
+  const modelButton = findModelButton(root, options);
+  const selected = options.allowStandaloneFallback === false
+    ? (modelButton ? firstVisible(modelButton, ['[data-testid="model-switcher-selected-model"]']) : null)
+    : firstVisible(root, ['[data-testid="model-switcher-selected-model"]']);
   const selectedText = normalizeText(selected?.innerText ?? selected?.textContent ?? "");
   if (selectedText) {
     return selectedText;
@@ -1855,7 +1876,7 @@ function currentModelLabel(root) {
   if (visibleModelOptions(root).length > 0) {
     return "";
   }
-  return modelControlLabel(findModelButton(root));
+  return modelControlLabel(modelButton);
 }
 
 export function modelSelectionDiagnostics(root = document) {

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -51,6 +51,7 @@ async function cancelSend(_job) {
 async function prepareJob(job) {
   const {
     classifyManualHandoff,
+    ensureConversationLoaded,
     ensureFreshChat,
     getPageText,
     markOwnership,
@@ -62,7 +63,13 @@ async function prepareJob(job) {
     title: document.title,
     text: getPageText(document)
   });
-  const freshChat = handoff ? null : await ensureFreshChat(document, job);
+  const conversationId = conversationIdForJob(job);
+  const conversation = !handoff && conversationId
+    ? await ensureConversationLoaded(document, conversationId)
+    : null;
+  const freshChat = !handoff && !conversationId
+    ? await ensureFreshChat(document, job)
+    : null;
   if (!handoff) {
     window.name = ownedWindowName(job);
     markOwnership(document, job);
@@ -72,6 +79,7 @@ async function prepareJob(job) {
     url: location.href,
     title: document.title,
     window_name: window.name,
+    conversation,
     fresh_chat: freshChat,
     manual_handoff: handoff
   };
@@ -79,7 +87,7 @@ async function prepareJob(job) {
 
 async function uploadJobFile(job, filePayload) {
   const { parseOwnedWindowName, uploadFile } = await domHelpers();
-  assertJobOwnership(job, parseOwnedWindowName, { requireFresh: true });
+  assertJobOwnership(job, parseOwnedWindowName, ownershipOptionsForJob(job, "upload"));
   const bytes = base64ToUint8Array(filePayload.bytes_base64);
   const file = new File([bytes], filePayload.filename || "yoetz-bundle.md", {
     type: filePayload.mime_type || "text/markdown"
@@ -90,7 +98,7 @@ async function uploadJobFile(job, filePayload) {
 
 async function configureModel(job) {
   const { configureModelState, parseOwnedWindowName } = await domHelpers();
-  assertJobOwnership(job, parseOwnedWindowName, { requireFresh: true });
+  assertJobOwnership(job, parseOwnedWindowName, ownershipOptionsForJob(job, "model_selection"));
   return configureModelState(document, job);
 }
 
@@ -102,7 +110,7 @@ async function sendPrompt(job, prompt) {
     sendAcceptanceBaseline,
     waitForSendAccepted
   } = await domHelpers();
-  assertJobOwnership(job, parseOwnedWindowName, { requireFresh: true });
+  assertJobOwnership(job, parseOwnedWindowName, ownershipOptionsForJob(job, "send"));
   const baseline = sendAcceptanceBaseline(document);
   await insertPrompt(document, prompt, { timeoutMs: 20000 });
   await clickSend(document, { timeoutMs: Number(job.send_timeout_ms) || 120000 });
@@ -140,10 +148,11 @@ async function extractJobResponse(job) {
   } = await domHelpers();
   assertJobOwnership(job, parseOwnedWindowName);
   const conversationId = conversationIdFromUrl(location.href);
-  if (job.submitted_conversation_id && conversationId && job.submitted_conversation_id !== conversationId) {
+  const expectedConversationId = expectedConversationIdForJob(job);
+  if (expectedConversationId && conversationId !== expectedConversationId) {
     throw commandError(
       "conversation_changed",
-      `tab moved from ChatGPT conversation ${job.submitted_conversation_id} to ${conversationId}`,
+      `tab moved from ChatGPT conversation ${expectedConversationId} to ${conversationId ?? "(none)"}`,
       {
         phase: "wait_response",
         side_effect_started: true
@@ -236,10 +245,11 @@ async function bindJob(job) {
     );
   }
   const conversationId = conversationIdFromUrl(location.href);
-  if (job.submitted_conversation_id && conversationId && job.submitted_conversation_id !== conversationId) {
+  const expectedConversationId = expectedConversationIdForJob(job);
+  if (expectedConversationId && conversationId !== expectedConversationId) {
     throw commandError(
       "conversation_changed",
-      `tab moved from ChatGPT conversation ${job.submitted_conversation_id} to ${conversationId}`,
+      `tab moved from ChatGPT conversation ${expectedConversationId} to ${conversationId ?? "(none)"}`,
       {
         phase: "wait_response",
         side_effect_started: true
@@ -265,12 +275,42 @@ function assertJobOwnership(job, parseOwnedWindowName, options = {}) {
   if (parsed?.job_id !== job.job_id || parsed?.run_id !== job.run_id) {
     throw new Error(`tab ownership marker mismatch for job ${job.job_id}`);
   }
+  if (options.requireConversation) {
+    const actualConversationId = conversationIdFromUrl(location.href);
+    if (actualConversationId === options.requireConversation) {
+      return;
+    }
+    const code = actualConversationId ? "conversation_changed" : "conversation_not_loaded";
+    throw commandError(
+      code,
+      `job ${job.job_id} expected ChatGPT conversation ${options.requireConversation}, current conversation is ${actualConversationId ?? "(none)"}`,
+      {
+        phase: options.phase ?? "upload",
+        side_effect_started: false
+      }
+    );
+  }
   if (options.requireFresh && String(location.pathname ?? "").startsWith("/c/")) {
     throw commandError("fresh_chat_lost", `job ${job.job_id} is no longer on a fresh ChatGPT page`, {
       phase: "upload",
       side_effect_started: false
     });
   }
+}
+
+function ownershipOptionsForJob(job, phase) {
+  const conversationId = conversationIdForJob(job);
+  return conversationId
+    ? { requireConversation: conversationId, phase }
+    : { requireFresh: true, phase };
+}
+
+function conversationIdForJob(job) {
+  return String(job?.conversation_id ?? "").trim() || null;
+}
+
+function expectedConversationIdForJob(job) {
+  return String(job?.expected_conversation_id ?? job?.submitted_conversation_id ?? "").trim() || null;
 }
 
 async function domHelpers() {
@@ -316,7 +356,7 @@ function runIdFromUrl(value) {
 function conversationIdFromUrl(value) {
   try {
     const pathname = new URL(value, location.href).pathname;
-    const match = pathname.match(/^\/c\/([^/?#]+)/);
+    const match = pathname.match(/^\/c\/([^/?#]+)$/);
     return match ? decodeURIComponent(match[1]) : null;
   } catch {
     return null;

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -155,7 +155,9 @@ async function extractJobResponse(job) {
       `tab moved from ChatGPT conversation ${expectedConversationId} to ${conversationId ?? "(none)"}`,
       {
         phase: "wait_response",
-        side_effect_started: true
+        side_effect_started: true,
+        requested_conversation_id: expectedConversationId,
+        current_conversation_id: conversationId
       }
     );
   }
@@ -252,7 +254,9 @@ async function bindJob(job) {
       `tab moved from ChatGPT conversation ${expectedConversationId} to ${conversationId ?? "(none)"}`,
       {
         phase: "wait_response",
-        side_effect_started: true
+        side_effect_started: true,
+        requested_conversation_id: expectedConversationId,
+        current_conversation_id: conversationId
       }
     );
   }
@@ -286,7 +290,9 @@ function assertJobOwnership(job, parseOwnedWindowName, options = {}) {
       `job ${job.job_id} expected ChatGPT conversation ${options.requireConversation}, current conversation is ${actualConversationId ?? "(none)"}`,
       {
         phase: options.phase ?? "upload",
-        side_effect_started: false
+        side_effect_started: false,
+        requested_conversation_id: options.requireConversation,
+        current_conversation_id: actualConversationId
       }
     );
   }
@@ -334,7 +340,25 @@ function commandError(code, message, detail = {}) {
   error.code = code;
   error.phase = detail.phase;
   error.side_effect_started = detail.side_effect_started;
+  for (const [key, value] of Object.entries({
+    ...conversationLocationDetail(code),
+    ...detail
+  })) {
+    if (!(key in error) && value !== undefined) {
+      error[key] = value;
+    }
+  }
   return error;
+}
+
+function conversationLocationDetail(code) {
+  if (!String(code ?? "").startsWith("conversation_")) {
+    return {};
+  }
+  return {
+    current_url: String(location.href ?? ""),
+    current_pathname: String(location.pathname ?? "")
+  };
 }
 
 function contentScriptBuild() {
@@ -376,6 +400,16 @@ function errorResponse(error) {
   }
   if (typeof error?.side_effect_started === "boolean") {
     response.side_effect_started = error.side_effect_started;
+  }
+  for (const key of [
+    "requested_conversation_id",
+    "current_conversation_id",
+    "current_url",
+    "current_pathname"
+  ]) {
+    if (error?.[key] !== undefined) {
+      response[key] = error[key];
+    }
   }
   return response;
 }

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -64,8 +64,17 @@ async function prepareJob(job) {
     text: getPageText(document)
   });
   const conversationId = conversationIdForJob(job);
+  if (!handoff && conversationId) {
+    const urlRunId = runIdFromUrl(location.href);
+    if (urlRunId !== job.run_id) {
+      throw commandError("run_mismatch", `tab is not owned by Yoetz run ${job.run_id}`, {
+        phase: "upload",
+        side_effect_started: false
+      });
+    }
+  }
   const conversation = !handoff && conversationId
-    ? await ensureConversationLoaded(document, conversationId)
+    ? await ensureConversationLoaded(document, conversationId, conversationLoadOptionsForJob(job))
     : null;
   const freshChat = !handoff && !conversationId
     ? await ensureFreshChat(document, job)
@@ -316,7 +325,20 @@ function conversationIdForJob(job) {
 }
 
 function expectedConversationIdForJob(job) {
-  return String(job?.expected_conversation_id ?? job?.submitted_conversation_id ?? "").trim() || null;
+  return String(job?.expected_conversation_id ?? job?.submitted_conversation_id ?? job?.conversation_id ?? "").trim() || null;
+}
+
+function conversationLoadOptionsForJob(job) {
+  const options = {};
+  const timeoutMs = Number(job?.upload_timeout_ms);
+  if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
+    options.timeoutMs = timeoutMs;
+  }
+  const intervalMs = Number(job?.upload_interval_ms);
+  if (Number.isFinite(intervalMs) && intervalMs > 0) {
+    options.intervalMs = intervalMs;
+  }
+  return options;
 }
 
 async function domHelpers() {

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -122,6 +122,7 @@ async function sendPrompt(job, prompt) {
   assertJobOwnership(job, parseOwnedWindowName, ownershipOptionsForJob(job, "send"));
   const baseline = sendAcceptanceBaseline(document);
   await insertPrompt(document, prompt, { timeoutMs: 20000 });
+  assertJobOwnership(job, parseOwnedWindowName, ownershipOptionsForJob(job, "send"));
   await clickSend(document, { timeoutMs: Number(job.send_timeout_ms) || 120000 });
   let accepted;
   try {

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -213,6 +213,14 @@ async function startJob(message) {
   job.updated_at = Date.now();
   job.connection_generation = connectionGeneration;
 
+  if (job.conversation_error) {
+    await failJob(job, "invalid_conversation", job.conversation_error.message, {
+      phase: "upload",
+      side_effect_started: false
+    });
+    return;
+  }
+
   const targetProfile = await validateTargetProfile(job);
   if (!targetProfile.ok) {
     await failJob(job, targetProfile.code, targetProfile.message, targetProfile.detail);
@@ -875,6 +883,7 @@ function canResumeWaitingResponseAfterWorkerRestart(job) {
 
 function normalizeJob(message) {
   const payload = message.payload ?? {};
+  const conversation = normalizeConversationId(payload.conversation_id);
   return {
     job_id: message.job_id,
     run_id: message.run_id,
@@ -891,7 +900,8 @@ function normalizeJob(message) {
     profile_email: payload.profile_email ?? null,
     extension_instance_id: payload.extension_instance_id ?? null,
     extension_profile_id: payload.extension_profile_id ?? null,
-    conversation_id: payload.conversation_id ?? null,
+    conversation_id: conversation.ok ? conversation.id : null,
+    conversation_error: conversation.ok ? null : conversation,
     bundle_size: payload.bundle_size ?? 0,
     file_name: payload.file_name ?? "yoetz-bundle.md",
     model_selection_status: "unavailable",
@@ -899,6 +909,26 @@ function normalizeJob(message) {
     warnings: [],
     status: "starting"
   };
+}
+
+function normalizeConversationId(value) {
+  if (value == null) {
+    return { ok: true, id: null };
+  }
+  if (typeof value !== "string") {
+    return { ok: false, message: "invalid `conversation_id`: expected a string ChatGPT conversation id" };
+  }
+  const id = value.trim();
+  if (!id || id === "." || id === "..") {
+    return { ok: false, message: "invalid `conversation_id`: expected a non-empty ChatGPT conversation id" };
+  }
+  if (id.length > 256) {
+    return { ok: false, message: "invalid `conversation_id`: expected at most 256 characters" };
+  }
+  if (!/^[A-Za-z0-9_.-]+$/.test(id)) {
+    return { ok: false, message: "invalid `conversation_id`: expected ASCII letters, digits, `_`, `.`, or `-`" };
+  }
+  return { ok: true, id };
 }
 
 function requireJob(jobId) {
@@ -1648,7 +1678,7 @@ function assertJobConnectionCurrent(job) {
 }
 
 function assertJobConversationCurrent(job, extraction) {
-  const expectedConversationId = job.expected_conversation_id ?? job.submitted_conversation_id;
+  const expectedConversationId = job.expected_conversation_id ?? job.submitted_conversation_id ?? job.conversation_id;
   if (!expectedConversationId || !extraction?.conversation_id) {
     return;
   }

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -1702,16 +1702,23 @@ function assertSubmittedConversationCurrent(job, sendResult) {
 
 function assertJobConversationCurrent(job, extraction) {
   const expectedConversationId = job.expected_conversation_id ?? job.submitted_conversation_id ?? job.conversation_id;
-  if (!expectedConversationId || !extraction?.conversation_id) {
+  if (!expectedConversationId) {
     return;
   }
-  if (expectedConversationId === extraction.conversation_id) {
+  const currentConversationId = extraction?.conversation_id ?? null;
+  if (expectedConversationId === currentConversationId) {
     return;
   }
-  throw commandError("conversation_changed", `job ${job.job_id} moved from ChatGPT conversation ${expectedConversationId} to ${extraction.conversation_id}`, {
-    phase: "wait_response",
-    side_effect_started: true
-  });
+  throw commandError(
+    "conversation_changed",
+    `job ${job.job_id} moved from ChatGPT conversation ${expectedConversationId} to ${currentConversationId ?? "(none)"}`,
+    {
+      phase: "wait_response",
+      side_effect_started: true,
+      requested_conversation_id: expectedConversationId,
+      current_conversation_id: currentConversationId
+    }
+  );
 }
 
 function commandError(code, message, detail = {}) {

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -886,6 +886,7 @@ function normalizeJob(message) {
     profile_email: payload.profile_email ?? null,
     extension_instance_id: payload.extension_instance_id ?? null,
     extension_profile_id: payload.extension_profile_id ?? null,
+    conversation_id: payload.conversation_id ?? null,
     bundle_size: payload.bundle_size ?? 0,
     file_name: payload.file_name ?? "yoetz-bundle.md",
     model_selection_status: "unavailable",

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -182,11 +182,13 @@ async function handleNativeMessage(message) {
   } catch (error) {
     const job = message?.job_id ? jobs.get(message.job_id) : null;
     if (job) {
+      const code = error?.code ?? "extension_error";
+      const detail = errorContextForJob(job, error);
       await failJob(
         job,
-        error?.code ?? "extension_error",
-        String(error?.message ?? error),
-        errorContextForJob(job, error)
+        code,
+        jobErrorMessage(job, error, code, detail),
+        detail
       );
     } else {
       postNative(errorEnvelope(message, "extension_error", String(error?.message ?? error), {
@@ -912,12 +914,41 @@ function errorContextForJob(job, error = null) {
     return {};
   }
   const phase = phaseForStatus(job.status) ?? (job.tab_id ? "upload" : undefined);
-  return {
+  const detail = {
     phase: error?.phase ?? phase,
     side_effect_started: typeof error?.side_effect_started === "boolean"
       ? error.side_effect_started
       : Boolean(job.tab_id)
   };
+  if (job.run_id) {
+    detail.inspect_command = inspectCommandForJob(job);
+  }
+  if (isConversationFailureCode(error?.code)) {
+    detail.requested_conversation_id = error?.requested_conversation_id
+      ?? job.expected_conversation_id
+      ?? job.conversation_id
+      ?? null;
+    detail.current_conversation_id = error?.current_conversation_id ?? null;
+    detail.current_url = error?.current_url ?? job.submitted_url ?? null;
+    detail.current_pathname = error?.current_pathname ?? null;
+  }
+  return detail;
+}
+
+function jobErrorMessage(job, error, code, detail = {}) {
+  const base = String(error?.message ?? error);
+  if (!isConversationFailureCode(code)) {
+    return base;
+  }
+  const requested = detail.requested_conversation_id ?? job?.expected_conversation_id ?? job?.conversation_id ?? "(unknown)";
+  const currentUrl = detail.current_url ?? "(unknown)";
+  const phase = detail.phase ?? phaseForStatus(job?.status) ?? "upload";
+  const inspect = detail.inspect_command ?? inspectCommandForJob(job);
+  return `${base}. requested conversation ${requested}; current URL ${currentUrl}; phase ${phase}; inspect with: ${inspect}`;
+}
+
+function isConversationFailureCode(code) {
+  return String(code ?? "").startsWith("conversation_");
 }
 
 function postHello() {
@@ -1146,6 +1177,16 @@ function tabCommandError(response) {
   }
   if (typeof response?.side_effect_started === "boolean") {
     error.side_effect_started = response.side_effect_started;
+  }
+  for (const key of [
+    "requested_conversation_id",
+    "current_conversation_id",
+    "current_url",
+    "current_pathname"
+  ]) {
+    if (response?.[key] !== undefined) {
+      error[key] = response[key];
+    }
   }
   return error;
 }

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -396,6 +396,7 @@ async function runJobWithFile(job, file) {
     job.submitted_assistant_count = Number.isFinite(Number(sendResult?.submitted_assistant_count))
       ? Number(sendResult.submitted_assistant_count)
       : null;
+    assertSubmittedConversationCurrent(job, sendResult);
     assertJobConnectionCurrent(job);
     if (job.cancelled) return;
     const inspectCommand = inspectCommandForJob(job);
@@ -1677,6 +1678,28 @@ function assertJobConnectionCurrent(job) {
   });
 }
 
+function assertSubmittedConversationCurrent(job, sendResult) {
+  const expectedConversationId = job.expected_conversation_id ?? job.conversation_id;
+  if (!expectedConversationId) {
+    return;
+  }
+  const currentConversationId = sendResult?.conversation_id ?? null;
+  if (currentConversationId === expectedConversationId) {
+    return;
+  }
+  throw commandError(
+    "conversation_changed",
+    `job ${job.job_id} sent in ChatGPT conversation ${currentConversationId ?? "(none)"} instead of ${expectedConversationId}`,
+    {
+      phase: "send",
+      side_effect_started: true,
+      requested_conversation_id: expectedConversationId,
+      current_conversation_id: currentConversationId,
+      current_url: job.submitted_url ?? null
+    }
+  );
+}
+
 function assertJobConversationCurrent(job, extraction) {
   const expectedConversationId = job.expected_conversation_id ?? job.submitted_conversation_id ?? job.conversation_id;
   if (!expectedConversationId || !extraction?.conversation_id) {
@@ -1699,6 +1722,11 @@ function commandError(code, message, detail = {}) {
   }
   if (typeof detail.side_effect_started === "boolean") {
     error.side_effect_started = detail.side_effect_started;
+  }
+  for (const [key, value] of Object.entries(detail)) {
+    if (!(key in error) && value !== undefined) {
+      error[key] = value;
+    }
   }
   return error;
 }

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -9,7 +9,7 @@ import {
   progress,
   validateEnvelope
 } from "./protocol.js";
-import { chatgptJobUrl } from "./chatgpt-dom.js";
+import { chatgptConversationJobUrl, chatgptJobUrl } from "./chatgpt-dom.js";
 
 const DEFAULT_WAIT_TIMEOUT_MS = 90 * 60 * 1000;
 const JOB_TTL_MS = 3 * 60 * 60 * 1000;
@@ -217,11 +217,14 @@ async function startJob(message) {
     return;
   }
 
+  job.expected_conversation_id = job.conversation_id ?? null;
   job.status = "opening_tab";
   jobs.set(job.job_id, job);
   await persistJob(job);
 
-  const url = chatgptJobUrl(job.run_id);
+  const url = job.expected_conversation_id
+    ? chatgptConversationJobUrl(job.expected_conversation_id, job.run_id)
+    : chatgptJobUrl(job.run_id);
   const tab = await chrome.tabs.create({ url, active: false });
   job.tab_id = tab.id;
   job.updated_at = Date.now();
@@ -1604,13 +1607,14 @@ function assertJobConnectionCurrent(job) {
 }
 
 function assertJobConversationCurrent(job, extraction) {
-  if (!job.submitted_conversation_id || !extraction?.conversation_id) {
+  const expectedConversationId = job.expected_conversation_id ?? job.submitted_conversation_id;
+  if (!expectedConversationId || !extraction?.conversation_id) {
     return;
   }
-  if (job.submitted_conversation_id === extraction.conversation_id) {
+  if (expectedConversationId === extraction.conversation_id) {
     return;
   }
-  throw commandError("conversation_changed", `job ${job.job_id} moved from ChatGPT conversation ${job.submitted_conversation_id} to ${extraction.conversation_id}`, {
+  throw commandError("conversation_changed", `job ${job.job_id} moved from ChatGPT conversation ${expectedConversationId} to ${extraction.conversation_id}`, {
     phase: "wait_response",
     side_effect_started: true
   });

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -391,6 +391,8 @@ async function runJobWithFile(job, file) {
       inspect_command: inspectCommand,
       yoetz_url: chatgptJobUrl(job.run_id),
       submitted_url: job.submitted_url,
+      conversation_id: conversationIdForJob(job),
+      conversation_url: conversationUrlForId(conversationIdForJob(job)),
       message: `prompt sent; waiting for ChatGPT response (timeout ${formatDurationForMessage(responseWaitTimeoutMs(job))}); inspect with: ${inspectCommand}`
     }))) {
       await recordTerminalDeliveryLost(job, "send");
@@ -418,6 +420,7 @@ async function runJobWithFile(job, file) {
 }
 
 async function completeJobWithExtraction(job, extraction) {
+  const conversationId = conversationIdForJob(job, extraction);
   const completeEnvelope = makeEnvelope("job_complete", {
     job_id: job.job_id,
     run_id: job.run_id,
@@ -431,6 +434,8 @@ async function completeJobWithExtraction(job, extraction) {
       stable_for_ms: extraction.stable_for_ms,
       assistant_turn_count: extraction.assistant_turn_count ?? extraction.assistant_count ?? 0,
       copy_button_count: extraction.copy_button_count ?? 0,
+      conversation_id: conversationId,
+      conversation_url: conversationUrlForId(conversationId),
       model_used: job.model_used ?? null,
       model_selection_status: job.model_selection_status ?? "unavailable",
       warnings: [
@@ -471,6 +476,17 @@ async function completeJobWithExtraction(job, extraction) {
   rememberTerminalJob(job.job_id);
   jobs.delete(job.job_id);
   chunks.discard(job.job_id);
+}
+
+function conversationIdForJob(job, extraction = null) {
+  return job?.submitted_conversation_id ?? extraction?.conversation_id ?? job?.conversation_id ?? null;
+}
+
+function conversationUrlForId(conversationId) {
+  if (!conversationId) {
+    return null;
+  }
+  return `https://chatgpt.com/c/${encodeURIComponent(conversationId)}`;
 }
 
 async function resumeWaitingResponseJob(job) {

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -83,6 +83,7 @@ export function sendAcceptanceBaseline() {
 
 export async function insertPrompt(_document, prompt, options) {
   hooks.insertPromptCalls.push({ prompt, options });
+  hooks.afterInsertPrompt?.();
 }
 
 export async function clickSend(_document, options) {
@@ -246,6 +247,30 @@ test("content script resume follow-on commands reject conversation drift", async
     assert.equal(response.code, "conversation_changed");
     assert.equal(response.phase, "upload");
     assert.equal(response.side_effect_started, false);
+  } finally {
+    restore();
+  }
+});
+
+test("content script resume send rechecks conversation drift after prompt insertion before clicking send", async () => {
+  const { send, hooks, restore, location } = await loadContentScript("resume_send_drift", "https://chatgpt.com/c/conv-123?_yoetz=run_resume");
+  try {
+    const job = resumeJob();
+    const prepared = await send({ type: "yoetz_prepare_job", job });
+    assert.equal(prepared.ok, true);
+    hooks.afterInsertPrompt = () => {
+      location.href = "https://chatgpt.com/c/other?_yoetz=run_resume";
+      location.pathname = "/c/other";
+    };
+
+    const response = await send({ type: "yoetz_send_prompt", job, prompt: "continue" });
+
+    assert.equal(response.ok, false);
+    assert.equal(response.code, "conversation_changed");
+    assert.equal(response.phase, "send");
+    assert.equal(response.side_effect_started, false);
+    assert.equal(hooks.insertPromptCalls.length, 1);
+    assert.equal(hooks.clickSendCalls.length, 0);
   } finally {
     restore();
   }

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -1,0 +1,289 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { uint8ArrayToBase64 } from "../src/chunks.js";
+
+const helperModule = `const hooks = globalThis.__contentScriptTestHooks;
+
+export function ownedWindowName(job) {
+  return \`yoetz-chatgpt-native:\${job.run_id}:\${job.job_id}\`;
+}
+
+export function parseOwnedWindowName(value) {
+  if (typeof value !== "string" || !value.startsWith("yoetz-chatgpt-native:")) {
+    return null;
+  }
+  const rest = value.slice("yoetz-chatgpt-native:".length);
+  const separator = rest.lastIndexOf(":");
+  return separator > 0 ? {
+    run_id: rest.slice(0, separator),
+    job_id: rest.slice(separator + 1)
+  } : null;
+}
+
+export function getPageText() {
+  return hooks.pageText ?? "";
+}
+
+export function classifyManualHandoff() {
+  return hooks.manualHandoff ?? null;
+}
+
+export function classifyWaitManualHandoff() {
+  return hooks.waitManualHandoff ?? null;
+}
+
+export async function ensureFreshChat(_document, job) {
+  hooks.ensureFreshChatCalls.push(job);
+  if (hooks.failFreshChat) {
+    throw new Error(hooks.failFreshChat);
+  }
+  return { status: "fresh", pathname: globalThis.location.pathname };
+}
+
+export async function ensureConversationLoaded(_document, conversationId) {
+  hooks.ensureConversationLoadedCalls.push(conversationId);
+  const actual = conversationIdFromLocation();
+  if (actual !== conversationId) {
+    const error = new Error(\`ChatGPT conversation \${conversationId} did not load\`);
+    error.code = "conversation_not_loaded";
+    error.phase = "upload";
+    error.side_effect_started = false;
+    throw error;
+  }
+  if (hooks.failConversationLoaded) {
+    const error = new Error(hooks.failConversationLoaded.message);
+    error.code = hooks.failConversationLoaded.code;
+    error.phase = hooks.failConversationLoaded.phase;
+    error.side_effect_started = hooks.failConversationLoaded.side_effect_started;
+    throw error;
+  }
+  return { status: "loaded", conversation_id: conversationId, pathname: globalThis.location.pathname };
+}
+
+export function markOwnership(_document, job) {
+  hooks.markOwnershipCalls.push(job);
+}
+
+export async function uploadFile(_document, file, options) {
+  hooks.uploadFileCalls.push({ file_name: file.name, size: file.size, options });
+  return true;
+}
+
+export function configureModelState(_document, job) {
+  hooks.configureModelCalls.push(job);
+  return { status: "selected", model_used: "Pro • Extended", requested_model: "extended-pro", extended_status: "required" };
+}
+
+export function sendAcceptanceBaseline() {
+  hooks.sendAcceptanceBaselineCalls += 1;
+  return { user_count: 1, assistant_count: 2 };
+}
+
+export async function insertPrompt(_document, prompt, options) {
+  hooks.insertPromptCalls.push({ prompt, options });
+}
+
+export async function clickSend(_document, options) {
+  hooks.clickSendCalls.push(options);
+}
+
+export async function waitForSendAccepted() {
+  return hooks.sendAccepted ?? { accepted: true };
+}
+
+export function extractResponse() {
+  return hooks.extraction ?? { method: "assistant_dom_fallback", text: "answer", conversation_id: conversationIdFromLocation() };
+}
+
+export function modelSelectionDiagnostics() {
+  return {};
+}
+
+function conversationIdFromLocation() {
+  const match = String(globalThis.location.pathname ?? "").match(/^\\/c\\/([^/?#]+)$/);
+  return match ? decodeURIComponent(match[1]) : null;
+}`;
+
+test("content script resume path skips fresh enforcement and completes on requested conversation", async () => {
+  const { send, hooks, restore } = await loadContentScript("resume_happy", "https://chatgpt.com/c/conv-123?_yoetz=run_resume");
+  try {
+    const job = resumeJob();
+
+    const prepared = await send({ type: "yoetz_prepare_job", job });
+    assert.equal(prepared.ok, true);
+    assert.equal(prepared.payload.manual_handoff, null);
+    assert.equal(prepared.payload.fresh_chat, null);
+    assert.deepEqual(hooks.ensureFreshChatCalls, []);
+    assert.deepEqual(hooks.ensureConversationLoadedCalls, ["conv-123"]);
+    assert.equal(globalThis.window.name, "yoetz-chatgpt-native:run_resume:job_resume");
+
+    const uploaded = await send({
+      type: "yoetz_upload_file",
+      job,
+      file: {
+        filename: "bundle.md",
+        mime_type: "text/markdown",
+        bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+      }
+    });
+    assert.equal(uploaded.ok, true);
+    assert.equal(hooks.uploadFileCalls.length, 1);
+
+    const configured = await send({ type: "yoetz_configure_model", job });
+    assert.equal(configured.ok, true);
+
+    const sent = await send({ type: "yoetz_send_prompt", job, prompt: "continue" });
+    assert.equal(sent.ok, true);
+    assert.equal(sent.payload.conversation_id, "conv-123");
+
+    const extracted = await send({ type: "yoetz_extract_response", job });
+    assert.equal(extracted.ok, true);
+    assert.equal(extracted.payload.conversation_id, "conv-123");
+  } finally {
+    restore();
+  }
+});
+
+test("content script resume prepare rejects a different conversation before send", async () => {
+  const { send, restore } = await loadContentScript("resume_mismatch", "https://chatgpt.com/c/other?_yoetz=run_resume");
+  try {
+    const response = await send({ type: "yoetz_prepare_job", job: resumeJob() });
+
+    assert.equal(response.ok, false);
+    assert.equal(response.code, "conversation_not_loaded");
+    assert.equal(response.phase, "upload");
+    assert.equal(response.side_effect_started, false);
+  } finally {
+    restore();
+  }
+});
+
+test("content script resume follow-on commands reject conversation drift", async () => {
+  const { send, restore, location } = await loadContentScript("resume_drift", "https://chatgpt.com/c/conv-123?_yoetz=run_resume");
+  try {
+    const job = resumeJob();
+    const prepared = await send({ type: "yoetz_prepare_job", job });
+    assert.equal(prepared.ok, true);
+
+    location.href = "https://chatgpt.com/c/other?_yoetz=run_resume";
+    location.pathname = "/c/other";
+    const response = await send({
+      type: "yoetz_upload_file",
+      job,
+      file: {
+        filename: "bundle.md",
+        mime_type: "text/markdown",
+        bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+      }
+    });
+
+    assert.equal(response.ok, false);
+    assert.equal(response.code, "conversation_changed");
+    assert.equal(response.phase, "upload");
+    assert.equal(response.side_effect_started, false);
+  } finally {
+    restore();
+  }
+});
+
+test("content script fresh path still requires a fresh page after prepare", async () => {
+  const { send, hooks, restore, location } = await loadContentScript("fresh_guard", "https://chatgpt.com/?_yoetz=run_fresh");
+  try {
+    const job = {
+      job_id: "job_fresh",
+      run_id: "run_fresh",
+      upload_timeout_ms: 1000
+    };
+    const prepared = await send({ type: "yoetz_prepare_job", job });
+    assert.equal(prepared.ok, true);
+    assert.equal(hooks.ensureFreshChatCalls.length, 1);
+    assert.deepEqual(hooks.ensureConversationLoadedCalls, []);
+
+    location.href = "https://chatgpt.com/c/late?_yoetz=run_fresh";
+    location.pathname = "/c/late";
+    const response = await send({
+      type: "yoetz_upload_file",
+      job,
+      file: {
+        filename: "bundle.md",
+        mime_type: "text/markdown",
+        bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+      }
+    });
+
+    assert.equal(response.ok, false);
+    assert.equal(response.code, "fresh_chat_lost");
+  } finally {
+    restore();
+  }
+});
+
+async function loadContentScript(label, href) {
+  const originalChrome = globalThis.chrome;
+  const originalWindow = globalThis.window;
+  const originalDocument = globalThis.document;
+  const originalLocation = globalThis.location;
+  const location = locationState(href);
+  let listener = null;
+  const hooks = {
+    ensureFreshChatCalls: [],
+    ensureConversationLoadedCalls: [],
+    markOwnershipCalls: [],
+    uploadFileCalls: [],
+    configureModelCalls: [],
+    insertPromptCalls: [],
+    clickSendCalls: [],
+    sendAcceptanceBaselineCalls: 0
+  };
+  globalThis.__contentScriptTestHooks = hooks;
+  globalThis.window = { name: "", location };
+  globalThis.document = { title: "ChatGPT", defaultView: globalThis.window };
+  globalThis.location = location;
+  const helperUrl = `data:text/javascript,${encodeURIComponent(helperModule)}#${label}`;
+  globalThis.chrome = {
+    runtime: {
+      getURL: () => helperUrl,
+      getManifest: () => ({ version: "test" }),
+      onMessage: {
+        addListener: (fn) => {
+          listener = fn;
+        }
+      }
+    }
+  };
+
+  await import(`../src/content-script.js?test=${label}-${Date.now()}`);
+  assert.equal(typeof listener, "function");
+
+  return {
+    hooks,
+    location,
+    send: (message) => new Promise((resolve) => listener(message, {}, resolve)),
+    restore: () => {
+      globalThis.chrome = originalChrome;
+      globalThis.window = originalWindow;
+      globalThis.document = originalDocument;
+      globalThis.location = originalLocation;
+      delete globalThis.__contentScriptTestHooks;
+    }
+  };
+}
+
+function locationState(href) {
+  const url = new URL(href);
+  return {
+    href: url.href,
+    pathname: url.pathname
+  };
+}
+
+function resumeJob() {
+  return {
+    job_id: "job_resume",
+    run_id: "run_resume",
+    conversation_id: "conv-123",
+    expected_conversation_id: "conv-123",
+    upload_timeout_ms: 1000,
+    send_timeout_ms: 1000
+  };
+}

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -52,9 +52,11 @@ export async function ensureConversationLoaded(_document, conversationId) {
   }
   if (hooks.failConversationLoaded) {
     const error = new Error(hooks.failConversationLoaded.message);
-    error.code = hooks.failConversationLoaded.code;
-    error.phase = hooks.failConversationLoaded.phase;
-    error.side_effect_started = hooks.failConversationLoaded.side_effect_started;
+    for (const [key, value] of Object.entries(hooks.failConversationLoaded)) {
+      if (key !== "message") {
+        error[key] = value;
+      }
+    }
     throw error;
   }
   return { status: "loaded", conversation_id: conversationId, pathname: globalThis.location.pathname };
@@ -153,6 +155,32 @@ test("content script resume prepare rejects a different conversation before send
     assert.equal(response.code, "conversation_not_loaded");
     assert.equal(response.phase, "upload");
     assert.equal(response.side_effect_started, false);
+  } finally {
+    restore();
+  }
+});
+
+test("content script resume prepare preserves conversation unavailable details", async () => {
+  const currentUrl = "https://chatgpt.com/c/conv-123?_yoetz=run_resume";
+  const { send, hooks, restore } = await loadContentScript("resume_unavailable", currentUrl);
+  try {
+    hooks.failConversationLoaded = {
+      message: "ChatGPT conversation conv-123 is unavailable",
+      code: "conversation_unavailable",
+      phase: "upload",
+      side_effect_started: false,
+      requested_conversation_id: "conv-123",
+      current_url: currentUrl
+    };
+
+    const response = await send({ type: "yoetz_prepare_job", job: resumeJob() });
+
+    assert.equal(response.ok, false);
+    assert.equal(response.code, "conversation_unavailable");
+    assert.equal(response.phase, "upload");
+    assert.equal(response.side_effect_started, false);
+    assert.equal(response.requested_conversation_id, "conv-123");
+    assert.equal(response.current_url, currentUrl);
   } finally {
     restore();
   }

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -40,8 +40,8 @@ export async function ensureFreshChat(_document, job) {
   return { status: "fresh", pathname: globalThis.location.pathname };
 }
 
-export async function ensureConversationLoaded(_document, conversationId) {
-  hooks.ensureConversationLoadedCalls.push(conversationId);
+export async function ensureConversationLoaded(_document, conversationId, options) {
+  hooks.ensureConversationLoadedCalls.push({ conversationId, options });
   const actual = conversationIdFromLocation();
   if (actual !== conversationId) {
     const error = new Error(\`ChatGPT conversation \${conversationId} did not load\`);
@@ -116,7 +116,7 @@ test("content script resume path skips fresh enforcement and completes on reques
     assert.equal(prepared.payload.manual_handoff, null);
     assert.equal(prepared.payload.fresh_chat, null);
     assert.deepEqual(hooks.ensureFreshChatCalls, []);
-    assert.deepEqual(hooks.ensureConversationLoadedCalls, ["conv-123"]);
+    assert.deepEqual(hooks.ensureConversationLoadedCalls.map((call) => call.conversationId), ["conv-123"]);
     assert.equal(globalThis.window.name, "yoetz-chatgpt-native:run_resume:job_resume");
 
     const uploaded = await send({
@@ -181,6 +181,43 @@ test("content script resume prepare preserves conversation unavailable details",
     assert.equal(response.side_effect_started, false);
     assert.equal(response.requested_conversation_id, "conv-123");
     assert.equal(response.current_url, currentUrl);
+  } finally {
+    restore();
+  }
+});
+
+test("content script resume prepare passes job load timing into conversation loading", async () => {
+  const { send, hooks, restore } = await loadContentScript("resume_timing", "https://chatgpt.com/c/conv-123?_yoetz=run_resume");
+  try {
+    const job = {
+      ...resumeJob(),
+      upload_timeout_ms: 4321,
+      upload_interval_ms: 123
+    };
+
+    const prepared = await send({ type: "yoetz_prepare_job", job });
+
+    assert.equal(prepared.ok, true);
+    assert.equal(hooks.ensureConversationLoadedCalls.length, 1);
+    assert.equal(hooks.ensureConversationLoadedCalls[0].conversationId, "conv-123");
+    assert.equal(hooks.ensureConversationLoadedCalls[0].options.timeoutMs, 4321);
+    assert.equal(hooks.ensureConversationLoadedCalls[0].options.intervalMs, 123);
+  } finally {
+    restore();
+  }
+});
+
+test("content script resume prepare rejects an unowned resume URL marker", async () => {
+  const { send, hooks, restore } = await loadContentScript("resume_wrong_marker", "https://chatgpt.com/c/conv-123?_yoetz=other_run");
+  try {
+    const response = await send({ type: "yoetz_prepare_job", job: resumeJob() });
+
+    assert.equal(response.ok, false);
+    assert.equal(response.code, "run_mismatch");
+    assert.equal(response.phase, "upload");
+    assert.equal(response.side_effect_started, false);
+    assert.deepEqual(hooks.ensureConversationLoadedCalls, []);
+    assert.deepEqual(hooks.markOwnershipCalls, []);
   } finally {
     restore();
   }

--- a/extensions/chatgpt-native/tests/dom.test.js
+++ b/extensions/chatgpt-native/tests/dom.test.js
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  chatgptConversationJobUrl,
   chatgptJobUrl,
   classifyManualHandoff,
   classifyWaitManualHandoff,
@@ -17,6 +18,13 @@ test("ownedWindowName round trips run and job ids", () => {
 
 test("chatgptJobUrl scopes jobs to chatgpt.com with a Yoetz marker", () => {
   assert.equal(chatgptJobUrl("run 1"), "https://chatgpt.com/?_yoetz=run+1");
+});
+
+test("chatgptConversationJobUrl scopes resume jobs to a canonical conversation with a Yoetz marker", () => {
+  assert.equal(
+    chatgptConversationJobUrl("conv-123", "run 1"),
+    "https://chatgpt.com/c/conv-123?_yoetz=run+1"
+  );
 });
 
 test("classifyManualHandoff detects login, challenge, and rate limits", () => {

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -1300,6 +1300,44 @@ test("ensureConversationLoaded reports unavailable when an error page still rend
   );
 });
 
+test("ensureConversationLoaded reports unavailable from page banner even with prior transcript residue", async () => {
+  const priorAssistant = new FakeElement("article", { "data-message-author-role": "assistant" }, "Earlier assistant answer");
+  const banner = new FakeElement("div", { role: "alert" }, "This conversation has been archived");
+  const composer = new FakeElement("textarea", { placeholder: "Message ChatGPT" });
+  const body = new FakeElement("body", {}, "Earlier assistant answer This conversation has been archived Message ChatGPT")
+    .append(priorAssistant, banner, composer);
+  const doc = new FakeDocument(body);
+  doc.defaultView.location.pathname = "/c/conv-archived";
+  doc.defaultView.location.href = "https://chatgpt.com/c/conv-archived?_yoetz=run_resume";
+
+  await assert.rejects(
+    () => ensureConversationLoaded(doc, "conv-archived", { timeoutMs: 30, intervalMs: 10 }),
+    (error) => {
+      assert.equal(error.code, "conversation_unavailable");
+      assert.equal(error.phase, "upload");
+      assert.equal(error.side_effect_started, false);
+      assert.equal(error.requested_conversation_id, "conv-archived");
+      assert.equal(error.current_conversation_id, "conv-archived");
+      assert.equal(error.current_url, "https://chatgpt.com/c/conv-archived?_yoetz=run_resume");
+      return true;
+    }
+  );
+});
+
+test("ensureConversationLoaded ignores unavailable text quoted inside prior transcript residue", async () => {
+  const priorAssistant = new FakeElement("article", { "data-message-author-role": "assistant" }, "Example text: you do not have access to this conversation");
+  const composer = new FakeElement("textarea", { placeholder: "Message ChatGPT" });
+  const body = new FakeElement("body", {}, "Example text: you do not have access to this conversation Message ChatGPT")
+    .append(priorAssistant, composer);
+  const doc = new FakeDocument(body);
+  doc.defaultView.location.pathname = "/c/conv-123";
+
+  const loaded = await ensureConversationLoaded(doc, "conv-123", { timeoutMs: 30, intervalMs: 10 });
+
+  assert.equal(loaded.status, "loaded");
+  assert.equal(loaded.conversation_id, "conv-123");
+});
+
 test("uploadFile accepts hidden composer-scoped file inputs", async () => {
   const previousDataTransfer = globalThis.DataTransfer;
   globalThis.DataTransfer = FakeDataTransfer;

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -1279,6 +1279,27 @@ test("ensureConversationLoaded reports unavailable when the requested conversati
   );
 });
 
+test("ensureConversationLoaded reports unavailable when an error page still renders a composer", async () => {
+  const composer = new FakeElement("textarea", { placeholder: "Message ChatGPT" });
+  const body = new FakeElement("body", {}, "Conversation not found Message ChatGPT").append(composer);
+  const doc = new FakeDocument(body);
+  doc.defaultView.location.pathname = "/c/conv-404";
+  doc.defaultView.location.href = "https://chatgpt.com/c/conv-404?_yoetz=run_resume";
+
+  await assert.rejects(
+    () => ensureConversationLoaded(doc, "conv-404", { timeoutMs: 30, intervalMs: 10 }),
+    (error) => {
+      assert.equal(error.code, "conversation_unavailable");
+      assert.equal(error.phase, "upload");
+      assert.equal(error.side_effect_started, false);
+      assert.equal(error.requested_conversation_id, "conv-404");
+      assert.equal(error.current_conversation_id, "conv-404");
+      assert.equal(error.current_url, "https://chatgpt.com/c/conv-404?_yoetz=run_resume");
+      return true;
+    }
+  );
+});
+
 test("uploadFile accepts hidden composer-scoped file inputs", async () => {
   const previousDataTransfer = globalThis.DataTransfer;
   globalThis.DataTransfer = FakeDataTransfer;

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -4,6 +4,7 @@ import {
   clickSend,
   clickStopGenerating,
   configureModelState,
+  ensureConversationLoaded,
   ensureFreshChat,
   extractResponse,
   findModelButton,
@@ -1231,6 +1232,31 @@ test("ensureFreshChat rejects old transcript residue on a fresh-looking path", a
   await assert.rejects(
     () => ensureFreshChat(doc, { run_id: "run_dirty" }, { timeoutMs: 30, intervalMs: 10 }),
     /old conversation transcript did not clear|not a clean fresh chat/
+  );
+});
+
+test("ensureConversationLoaded accepts the requested conversation with a composer", async () => {
+  const composer = new FakeElement("textarea", { placeholder: "Message ChatGPT" });
+  const body = new FakeElement("body", {}, "").append(composer);
+  const doc = new FakeDocument(body);
+  doc.defaultView.location.pathname = "/c/conv-123";
+
+  const loaded = await ensureConversationLoaded(doc, "conv-123", { timeoutMs: 30, intervalMs: 10 });
+
+  assert.equal(loaded.status, "loaded");
+  assert.equal(loaded.conversation_id, "conv-123");
+  assert.equal(loaded.pathname, "/c/conv-123");
+});
+
+test("ensureConversationLoaded rejects the wrong conversation before send", async () => {
+  const composer = new FakeElement("textarea", { placeholder: "Message ChatGPT" });
+  const body = new FakeElement("body", {}, "").append(composer);
+  const doc = new FakeDocument(body);
+  doc.defaultView.location.pathname = "/c/other";
+
+  await assert.rejects(
+    () => ensureConversationLoaded(doc, "conv-123", { timeoutMs: 30, intervalMs: 10 }),
+    (error) => error.code === "conversation_not_loaded"
   );
 });
 

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -1951,6 +1951,37 @@ test("fake ChatGPT resume does not accept stale conversation Pro Extended labels
   assert.match(result.warning, /model selector button not found/);
 });
 
+test("fake ChatGPT resume ignores stale transcript model switcher buttons", async () => {
+  const staleSelectedLabel = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Pro Extended");
+  const staleConversationControl = new FakeElement("button", {
+    "data-testid": "model-switcher-dropdown-button",
+    "aria-haspopup": "menu",
+    onPointerDown: () => {
+      throw new Error("stale transcript model button should not be opened");
+    }
+  }, "Pro Extended").append(staleSelectedLabel);
+  const priorAssistant = new FakeElement("article", { "data-message-author-role": "assistant" }, "")
+    .append(staleConversationControl);
+  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer);
+  const body = new FakeElement("body", {}, "Pro Extended Ask anything")
+    .append(priorAssistant, form);
+  const doc = new FakeDocument(body);
+  doc.defaultView.location.pathname = "/c/conv-123";
+
+  const result = await configureModelState(doc, {
+    conversation_id: "conv-123",
+    model_selection_timeout_ms: 30,
+    model_selection_interval_ms: 10
+  });
+
+  assert.equal(staleConversationControl.clicked, false);
+  assert.equal(staleConversationControl.events.includes("pointerdown"), false);
+  assert.equal(result.status, "unavailable");
+  assert.equal(result.extended_status, "required");
+  assert.match(result.warning, /model selector button not found/);
+});
+
 test("fake ChatGPT reports mismatch when option checks but selected label stays Thinking", async () => {
   const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
   const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Thinking");

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -1887,6 +1887,30 @@ test("fake ChatGPT accepts Pro Extended label that appears after the picker stay
   assert.equal(result.extended_status, "required");
 });
 
+test("fake ChatGPT resume does not accept stale conversation Pro Extended labels as current model", async () => {
+  const staleConversationControl = new FakeElement("button", {}, "Pro Extended");
+  const staleSelectedLabel = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Pro Extended");
+  const priorAssistant = new FakeElement("article", { "data-message-author-role": "assistant" }, "")
+    .append(staleConversationControl, staleSelectedLabel);
+  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer);
+  const body = new FakeElement("body", {}, "Pro Extended Ask anything")
+    .append(priorAssistant, form);
+  const doc = new FakeDocument(body);
+  doc.defaultView.location.pathname = "/c/conv-123";
+
+  const result = await configureModelState(doc, {
+    conversation_id: "conv-123",
+    model_selection_timeout_ms: 30,
+    model_selection_interval_ms: 10
+  });
+
+  assert.equal(staleConversationControl.clicked, false);
+  assert.equal(result.status, "unavailable");
+  assert.equal(result.extended_status, "required");
+  assert.match(result.warning, /model selector button not found/);
+});
+
 test("fake ChatGPT reports mismatch when option checks but selected label stays Thinking", async () => {
   const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
   const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Thinking");

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -1260,6 +1260,25 @@ test("ensureConversationLoaded rejects the wrong conversation before send", asyn
   );
 });
 
+test("ensureConversationLoaded reports unavailable when the requested conversation has no composer", async () => {
+  const body = new FakeElement("body", {}, "Conversation not found");
+  const doc = new FakeDocument(body);
+  doc.defaultView.location.pathname = "/c/conv-123";
+  doc.defaultView.location.href = "https://chatgpt.com/c/conv-123?_yoetz=run_resume";
+
+  await assert.rejects(
+    () => ensureConversationLoaded(doc, "conv-123", { timeoutMs: 30, intervalMs: 10 }),
+    (error) => {
+      assert.equal(error.code, "conversation_unavailable");
+      assert.equal(error.phase, "upload");
+      assert.equal(error.side_effect_started, false);
+      assert.equal(error.requested_conversation_id, "conv-123");
+      assert.equal(error.current_url, "https://chatgpt.com/c/conv-123?_yoetz=run_resume");
+      return true;
+    }
+  );
+});
+
 test("uploadFile accepts hidden composer-scoped file inputs", async () => {
   const previousDataTransfer = globalThis.DataTransfer;
   globalThis.DataTransfer = FakeDataTransfer;

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -231,6 +231,102 @@ test("service worker opens fresh and resume jobs in new owned tabs", async () =>
   }
 });
 
+test("service worker rejects invalid conversation ids before opening a tab", async () => {
+  const invalidCases = [
+    ".",
+    "..",
+    "a/b",
+    "conv%2F123",
+    "",
+    "x".repeat(257),
+    42
+  ];
+
+  for (const [index, invalid] of invalidCases.entries()) {
+    const originalChrome = globalThis.chrome;
+    const port = makePort();
+    const createdTabs = [];
+    globalThis.chrome = chromeStub({
+      port,
+      tabs: {
+        create: async (opts) => {
+          createdTabs.push(opts);
+          return { id: createdTabs.length, ...opts };
+        },
+        get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+        sendMessage: async () => {
+          throw new Error("invalid conversation must fail before tab messaging");
+        }
+      }
+    });
+
+    try {
+      await import(`../src/service-worker.js?invalid_conversation=${Date.now()}_${index}`);
+      port.emit(envelope("job_start", `job_invalid_${index}`, {
+        prompt: "resume",
+        conversation_id: invalid,
+        wait_interval_ms: 50,
+        wait_timeout_ms: 1000
+      }));
+
+      await eventually(() => port.messages.some((message) => message.type === "job_error"));
+      const error = port.messages.find((message) => message.type === "job_error");
+      assert.equal(error.payload.code, "invalid_conversation");
+      assert.equal(error.payload.phase, "upload");
+      assert.equal(error.payload.side_effect_started, false);
+      assert.deepEqual(createdTabs, []);
+    } finally {
+      globalThis.chrome = originalChrome;
+    }
+  }
+});
+
+test("service worker trims a valid conversation id before opening the resume tab", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const createdTabs = [];
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => {
+        const tab = { id: createdTabs.length + 1, ...opts };
+        createdTabs.push(tab);
+        return tab;
+      },
+      get: async (id) => ({ id, status: "complete", url: createdTabs.find((item) => item.id === id)?.url ?? "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: { status: "selected", model_used: "Pro • Extended", requested_model: "extended-pro", extended_status: "required" } };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?trim_conversation=${Date.now()}`);
+    port.emit(envelope("job_start", "job_trim_conversation", {
+      prompt: "resume",
+      conversation_id: " conv-123 ",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 1000
+    }));
+
+    await eventually(() => port.messages.some((message) =>
+      message.type === "job_progress" && message.payload?.phase === "ready_for_file"
+    ));
+    assert.equal(createdTabs[0].url, "https://chatgpt.com/c/conv-123?_yoetz=run_job_trim_conversation");
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker fails unavailable conversations with inspectable terminal error", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -398,6 +398,77 @@ test("service worker fails immediately when send reports the wrong resumed conve
   }
 });
 
+test("service worker fails resumed jobs when post-send extraction omits the conversation id", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const sentToTabs = [];
+  let tabId = 0;
+  let sent = false;
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/c/conv-123?_yoetz=run_job_missing_extract_conversation" }),
+      sendMessage: async (_id, message) => {
+        sentToTabs.push(message.type);
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: { status: "selected", model_used: "Pro • Extended", requested_model: "extended-pro", extended_status: "required" } };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true, conversation_id: "conv-123" } };
+          case "yoetz_extract_response":
+            return sent
+              ? { ok: true, payload: { method: "assistant_dom_fallback", text: "answer without identity", is_generating: false, assistant_count: 1, copy_button_count: 1, has_copy_button: true, turn_index: 0 } }
+              : { ok: true, payload: { method: "none", text: "", is_generating: false, assistant_count: 0, turn_index: -1, conversation_id: "conv-123" } };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?missing_extract_conversation=${Date.now()}`);
+    port.emit(envelope("job_start", "job_missing_extract_conversation", {
+      prompt: "resume",
+      conversation_id: "conv-123",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 1000
+    }));
+    await eventually(() => port.messages.some((message) =>
+      message.type === "job_progress" && message.payload?.phase === "ready_for_file"
+    ));
+    port.emit(envelope("job_file_chunk", "job_missing_extract_conversation", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_missing_extract_conversation.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) =>
+      message.type === "job_error" && message.payload?.code === "conversation_changed"
+    ));
+    const error = port.messages.find((message) => message.type === "job_error");
+    assert.equal(error.payload.phase, "wait_response");
+    assert.equal(error.payload.side_effect_started, true);
+    assert.equal(error.payload.requested_conversation_id, "conv-123");
+    assert.equal(error.payload.current_conversation_id, null);
+    assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
+    assert.equal(sentToTabs.includes("yoetz_send_prompt"), true);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker fails unavailable conversations with inspectable terminal error", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
@@ -623,6 +694,70 @@ test("service worker fails closed when Pro Extended is unavailable", async () =>
     assert.equal(error.payload.model_selection_status, "unavailable");
     assert.equal(sentToTabs.includes("yoetz_upload_file"), false);
     assert.equal(sentToTabs.includes("yoetz_send_prompt"), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker fails resumed jobs before upload when Pro Extended is unavailable", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const createdTabs = [];
+  const sentToTabs = [];
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => {
+        const tab = { id: createdTabs.length + 1, ...opts };
+        createdTabs.push(tab);
+        return tab;
+      },
+      get: async (id) => ({ id, status: "complete", url: createdTabs.find((tab) => tab.id === id)?.url ?? "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        sentToTabs.push(message.type);
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return {
+              ok: true,
+              payload: {
+                status: "unavailable",
+                model_used: "Default",
+                requested_model: "extended-pro",
+                extended_status: "required",
+                available_options: ["Default"],
+                warning: "ChatGPT model selector button not found"
+              }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?resume_model_unavailable=${Date.now()}`);
+    port.emit(envelope("job_start", "job_resume_model_fail", {
+      prompt: "resume",
+      conversation_id: "conv-123",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 1000
+    }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_error"));
+    const error = port.messages.find((message) => message.type === "job_error");
+    assert.equal(createdTabs[0].url, "https://chatgpt.com/c/conv-123?_yoetz=run_job_resume_model_fail");
+    assert.equal(error.payload.code, "model_selection_failed");
+    assert.equal(error.payload.phase, "model_selection");
+    assert.equal(error.payload.side_effect_started, false);
+    assert.equal(error.payload.model_selection_status, "unavailable");
+    assert.equal(sentToTabs.includes("yoetz_upload_file"), false);
+    assert.equal(sentToTabs.includes("yoetz_send_prompt"), false);
+    assert.equal(port.messages.some((message) => message.payload?.phase === "ready_for_file"), false);
   } finally {
     globalThis.chrome = originalChrome;
   }

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -327,6 +327,77 @@ test("service worker trims a valid conversation id before opening the resume tab
   }
 });
 
+test("service worker fails immediately when send reports the wrong resumed conversation", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const sentToTabs = [];
+  let tabId = 0;
+  let sent = false;
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/c/conv-123?_yoetz=run_job_send_drift" }),
+      sendMessage: async (_id, message) => {
+        sentToTabs.push(message.type);
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: { status: "selected", model_used: "Pro • Extended", requested_model: "extended-pro", extended_status: "required" } };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_extract_response":
+            return sent
+              ? { ok: true, payload: { method: "assistant_dom_fallback", text: "wrong answer", is_generating: false, assistant_count: 1, copy_button_count: 1, has_copy_button: true, turn_index: 0, conversation_id: "other" } }
+              : { ok: true, payload: { method: "none", text: "", is_generating: false, assistant_count: 0, turn_index: -1, conversation_id: "conv-123" } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true, conversation_id: "other" } };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?send_wrong_conversation=${Date.now()}`);
+    port.emit(envelope("job_start", "job_send_drift", {
+      prompt: "resume",
+      conversation_id: "conv-123",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 1000
+    }));
+    await eventually(() => port.messages.some((message) =>
+      message.type === "job_progress" && message.payload?.phase === "ready_for_file"
+    ));
+    port.emit(envelope("job_file_chunk", "job_send_drift", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_send_drift.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) =>
+      message.type === "job_error" && message.payload?.code === "conversation_changed"
+    ));
+    const error = port.messages.find((message) => message.type === "job_error");
+    assert.equal(error.payload.phase, "send");
+    assert.equal(error.payload.side_effect_started, true);
+    assert.equal(error.payload.requested_conversation_id, "conv-123");
+    assert.equal(error.payload.current_conversation_id, "other");
+    assert.equal(port.messages.some((message) => message.payload?.phase === "prompt_sent"), false);
+    assert.equal(sentToTabs.filter((type) => type === "yoetz_extract_response").length, 1);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker fails unavailable conversations with inspectable terminal error", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -56,12 +56,18 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
             sentJobs.add(message.job.job_id);
-            return { ok: true, payload: { sent: true } };
+            return {
+              ok: true,
+              payload: {
+                sent: true,
+                conversation_id: `conv-${message.job.job_id}`
+              }
+            };
           case "yoetz_extract_response":
             return {
               ok: true,
               payload: sentJobs.has(message.job.job_id)
-                ? { method: "assistant_dom_fallback", text: `answer ${message.job.job_id}`, is_generating: false, assistant_count: 1, copy_button_count: 1, has_copy_button: true, turn_index: 0 }
+                ? { method: "assistant_dom_fallback", text: `answer ${message.job.job_id}`, is_generating: false, assistant_count: 1, copy_button_count: 1, has_copy_button: true, turn_index: 0, conversation_id: `conv-${message.job.job_id}` }
                 : { method: "none", text: "", is_generating: false, assistant_count: 0, turn_index: -1 }
             };
           default:
@@ -118,6 +124,14 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
     assert.equal(
       port.messages.find((message) => message.type === "job_complete" && message.job_id === "job_a")?.payload.completion_reason,
       "copy_button"
+    );
+    assert.equal(
+      port.messages.find((message) => message.type === "job_complete" && message.job_id === "job_a")?.payload.conversation_id,
+      "conv-job_a"
+    );
+    assert.equal(
+      port.messages.find((message) => message.type === "job_complete" && message.job_id === "job_a")?.payload.conversation_url,
+      "https://chatgpt.com/c/conv-job_a"
     );
     assert.equal(sentToTabs.filter((item) => item.message.type === "yoetz_upload_file").length, 2);
     assert.equal(
@@ -1450,12 +1464,12 @@ test("service worker emits low-noise waiting progress while ChatGPT is quiet", a
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
             sent = true;
-            return { ok: true, payload: { sent: true } };
+            return { ok: true, payload: { sent: true, conversation_id: "conv-waiting-progress" } };
           case "yoetz_extract_response":
             return {
               ok: true,
               payload: sent
-                ? { method: "none", text: "", is_generating: true, assistant_count: 0, copy_button_count: 0, has_copy_button: false, turn_index: -1 }
+                ? { method: "none", text: "", is_generating: true, assistant_count: 0, copy_button_count: 0, has_copy_button: false, turn_index: -1, conversation_id: "conv-waiting-progress" }
                 : { method: "none", text: "", is_generating: false, assistant_count: 0, copy_button_count: 0, has_copy_button: false, turn_index: -1 }
             };
           default:
@@ -1494,6 +1508,8 @@ test("service worker emits low-noise waiting progress while ChatGPT is quiet", a
     assert.match(sentProgress?.payload.message, /waiting for ChatGPT response/);
     assert.equal(sentProgress?.payload.inspect_command, "yoetz browser extension inspect --chatgpt --run-id run_job_waiting_progress");
     assert.equal(sentProgress?.payload.yoetz_url, "https://chatgpt.com/?_yoetz=run_job_waiting_progress");
+    assert.equal(sentProgress?.payload.conversation_id, "conv-waiting-progress");
+    assert.equal(sentProgress?.payload.conversation_url, "https://chatgpt.com/c/conv-waiting-progress");
     assert.match(sentProgress?.payload.message, /inspect with: yoetz browser extension inspect --chatgpt --run-id run_job_waiting_progress/);
     assert.match(waiting?.payload.message, /waiting for ChatGPT response/);
     assert.equal(waiting.payload.inspect_command, "yoetz browser extension inspect --chatgpt --run-id run_job_waiting_progress");

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -96,6 +96,7 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
     for (const jobId of jobs) {
       port.emit(envelope("job_start", jobId, {
         prompt: `prompt ${jobId}`,
+        ...(jobId === "job_a" ? { conversation_id: "conv-resume-a" } : {}),
         wait_interval_ms: 500,
         wait_timeout_ms: 2500
       }));
@@ -132,6 +133,14 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
     assert.equal(
       port.messages.find((message) => message.type === "job_complete" && message.job_id === "job_a")?.payload.conversation_url,
       "https://chatgpt.com/c/conv-job_a"
+    );
+    assert.equal(
+      sentToTabs.find((item) => item.message.type === "yoetz_prepare_job" && item.message.job.job_id === "job_a")?.message.job.conversation_id,
+      "conv-resume-a"
+    );
+    assert.equal(
+      sentToTabs.find((item) => item.message.type === "yoetz_prepare_job" && item.message.job.job_id === "job_b")?.message.job.conversation_id,
+      null
     );
     assert.equal(sentToTabs.filter((item) => item.message.type === "yoetz_upload_file").length, 2);
     assert.equal(

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -231,6 +231,70 @@ test("service worker opens fresh and resume jobs in new owned tabs", async () =>
   }
 });
 
+test("service worker fails unavailable conversations with inspectable terminal error", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const sentToTabs = [];
+  let tabId = 0;
+  const currentUrl = "https://chatgpt.com/c/conv-404?_yoetz=run_job_unavailable";
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: currentUrl }),
+      sendMessage: async (_id, message) => {
+        sentToTabs.push(message.type);
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return {
+              ok: false,
+              code: "conversation_unavailable",
+              error: "ChatGPT conversation conv-404 is unavailable",
+              phase: "upload",
+              side_effect_started: false,
+              requested_conversation_id: "conv-404",
+              current_url: currentUrl
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?conversation_unavailable=${Date.now()}`);
+    port.emit(envelope("job_start", "job_unavailable", {
+      prompt: "resume",
+      conversation_id: "conv-404",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 1000
+    }));
+
+    await eventually(() => port.messages.some((message) =>
+      message.type === "job_error" && message.payload.code === "conversation_unavailable"
+    ));
+
+    const error = port.messages.find((message) => message.type === "job_error");
+    assert.equal(error.payload.phase, "upload");
+    assert.equal(error.payload.side_effect_started, false);
+    assert.equal(error.payload.requested_conversation_id, "conv-404");
+    assert.equal(error.payload.current_url, currentUrl);
+    assert.equal(error.payload.inspect_command, "yoetz browser extension inspect --chatgpt --run-id run_job_unavailable");
+    assert.match(error.payload.message, /requested conversation conv-404/);
+    assert.match(error.payload.message, /current URL https:\/\/chatgpt\.com\/c\/conv-404\?_yoetz=run_job_unavailable/);
+    assert.match(error.payload.message, /phase upload/);
+    assert.match(error.payload.message, /yoetz browser extension inspect --chatgpt --run-id run_job_unavailable/);
+    assert.equal(sentToTabs.includes("yoetz_upload_file"), false);
+    assert.equal(sentToTabs.includes("yoetz_send_prompt"), false);
+    assert.equal(port.messages.some((message) => message.payload?.phase === "ready_for_file"), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker marks manual handoff as terminal after tab side effects", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -96,7 +96,6 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
     for (const jobId of jobs) {
       port.emit(envelope("job_start", jobId, {
         prompt: `prompt ${jobId}`,
-        ...(jobId === "job_a" ? { conversation_id: "conv-resume-a" } : {}),
         wait_interval_ms: 500,
         wait_timeout_ms: 2500
       }));
@@ -134,14 +133,6 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
       port.messages.find((message) => message.type === "job_complete" && message.job_id === "job_a")?.payload.conversation_url,
       "https://chatgpt.com/c/conv-job_a"
     );
-    assert.equal(
-      sentToTabs.find((item) => item.message.type === "yoetz_prepare_job" && item.message.job.job_id === "job_a")?.message.job.conversation_id,
-      "conv-resume-a"
-    );
-    assert.equal(
-      sentToTabs.find((item) => item.message.type === "yoetz_prepare_job" && item.message.job.job_id === "job_b")?.message.job.conversation_id,
-      null
-    );
     assert.equal(sentToTabs.filter((item) => item.message.type === "yoetz_upload_file").length, 2);
     assert.equal(
       sentToTabs.find((item) => item.message.type === "yoetz_configure_model" && item.message.job.job_id === "job_b")?.message.job.model,
@@ -151,6 +142,92 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
     globalThis.chrome = originalChrome;
     globalThis.setInterval = originalSetInterval;
     globalThis.clearInterval = originalClearInterval;
+  }
+});
+
+test("service worker opens fresh and resume jobs in new owned tabs", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const createdTabs = [];
+  const sentToTabs = [];
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => {
+        const tab = { id: createdTabs.length + 1, ...opts };
+        createdTabs.push(tab);
+        return tab;
+      },
+      query: async () => {
+        throw new Error("resume jobs must not discover or reuse existing tabs");
+      },
+      get: async (id) => {
+        const tab = createdTabs.find((item) => item.id === id);
+        return { id, status: "complete", url: tab?.url ?? "https://chatgpt.com/" };
+      },
+      sendMessage: async (id, message) => {
+        sentToTabs.push({ id, message });
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: { status: "selected", model_used: "Pro • Extended", requested_model: "extended-pro", extended_status: "required" } };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?resume_url=${Date.now()}`);
+    await eventually(() => port.messages.some((message) => message.type === "hello"));
+    port.messages.length = 0;
+
+    port.emit(envelope("job_start", "job_fresh_url", {
+      prompt: "fresh",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 1000
+    }));
+    port.emit(envelope("job_start", "job_resume_url", {
+      prompt: "resume",
+      conversation_id: "conv-123",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 1000
+    }));
+
+    await eventually(() => port.messages.filter((message) =>
+      message.type === "job_progress" && message.payload?.phase === "ready_for_file"
+    ).length === 2);
+
+    assert.deepEqual(
+      createdTabs.map((tab) => ({ url: tab.url, active: tab.active })),
+      [
+        { url: "https://chatgpt.com/?_yoetz=run_job_fresh_url", active: false },
+        { url: "https://chatgpt.com/c/conv-123?_yoetz=run_job_resume_url", active: false }
+      ]
+    );
+    assert.equal(createdTabs.length, 2);
+    assert.equal(
+      sentToTabs.find((item) => item.message.type === "yoetz_prepare_job" && item.message.job.job_id === "job_resume_url")?.message.job.expected_conversation_id,
+      "conv-123"
+    );
+    assert.equal(
+      sentToTabs.find((item) => item.message.type === "yoetz_prepare_job" && item.message.job.job_id === "job_resume_url")?.message.job.conversation_id,
+      "conv-123"
+    );
+    assert.equal(
+      sentToTabs.find((item) => item.message.type === "yoetz_prepare_job" && item.message.job.job_id === "job_fresh_url")?.message.job.expected_conversation_id,
+      null
+    );
+    assert.equal(
+      sentToTabs.find((item) => item.message.type === "yoetz_prepare_job" && item.message.job.job_id === "job_fresh_url")?.message.job.conversation_id,
+      null
+    );
+  } finally {
+    globalThis.chrome = originalChrome;
   }
 });
 

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -18,6 +18,31 @@ name: chatgpt
 # `--transport chrome-extension-native --allow-cdp-fallback` to explicitly allow
 # CDP fallback after a native-extension failure.
 #
+# Conversation resume:
+#   Use `--var conversation=<id|url>` to continue a caller-owned ChatGPT
+#   conversation by id or by `https://chatgpt.com/c/<id>` URL. Conversation
+#   runs are supported only through `chrome-extension-native`; non-native
+#   transports and CDP fallback are rejected so Yoetz cannot silently switch to
+#   a transport that lacks conversation ownership checks. This is not context
+#   management: the caller decides whether to pass a saved conversation for a
+#   follow-up turn or omit it for a fresh run.
+#
+# Result fields:
+#   Successful ChatGPT recipe runs echo `conversation_id` and
+#   `conversation_url`. Capture these from the first run if you want a later
+#   `--var conversation=<id|url>` run to resume the same ChatGPT conversation.
+#
+# Conversation failure taxonomy:
+#   conversation_unavailable - the requested conversation could not be loaded
+#              at prepare time, including never reaching `/c/<id>`, landing on
+#              the right `/c/<id>` with no composer, or 404 / archived /
+#              wrong-profile style ChatGPT states.
+#   conversation_not_loaded  - a ChatGPT page loaded but not the requested
+#              conversation, such as wrong `/c/<other>` during prepare or
+#              moving off `/c/` after a successful prepare at ownership time.
+#   conversation_changed     - the owned tab drifted to a different
+#              `/c/<other>` after prepare or after send.
+#
 # Recommended: enable chrome://inspect/#remote-debugging (Chrome 144+) for auto-connect.
 # Note: Chrome 136+ ignores --remote-debugging-port on the default profile.
 # Note: yoetz CLI cannot proxy through a parent agent's MCP server; all
@@ -44,6 +69,10 @@ name: chatgpt
 #              Use this when Chrome profile email is unavailable or ambiguous.
 #   extension_profile_id — chrome-extension-native-only Chrome identity profile
 #              id from extension status. Optional secondary selector.
+#   conversation — ChatGPT conversation id or `https://chatgpt.com/c/<id>` URL
+#              for caller-owned resume. Native-extension only; rejected for
+#              CDP/dev-browser/agent-browser/manual transports and rejected even
+#              when `--allow-cdp-fallback` is present.
 #   thread   — "fresh" (default). Every yoetz request opens a new ChatGPT tab
 #              marked with `?_yoetz=<run-id>` so the user's own ChatGPT tabs
 #              are never touched. Passing `thread=reuse` is rejected; parallel


### PR DESCRIPTION
## What
Adds **conversation resume** to the `chatgpt` browser recipe. A caller can pass `--var conversation=<id|url>` to continue an existing ChatGPT conversation (so prior context carries over for follow-ups) instead of always opening a fresh tab. Requested by Ben S. ("very important").

## Design (agreed)
- **Caller owns the session lifecycle** — yoetz does NOT manage/trim context; the caller decides resume vs fresh and passes the id/url. Every run echoes `conversation_id`/`conversation_url` so the caller can capture it on run 1 and resume on run 2.
- **Native-extension only.** A conversation run fails closed on dev-browser/chrome-devtools-mcp/agent-browser/manual and disables CDP fallback even with `--allow-cdp-fallback`.
- **Controlled re-introduction of session reuse** (the old `thread=reuse` stays rejected): resume opens a NEW yoetz-owned tab via `chrome.tabs.create` to the specific `/c/<id>?_yoetz=<run_id>` — never hijacks an arbitrary open tab.

## Invariants held
- **No-hijack:** owned-tab creation + `_yoetz=run_id` ownership check on resume.
- **Fresh path untouched:** resume is a distinct ownership mode (`requireConversation`) alongside `requireFresh`/`fresh_chat_lost`.
- **Hard-fail, no silent fresh fallback:** terminal `conversation_unavailable` / `conversation_not_loaded` / `conversation_changed`; model-selection fails closed on stale Pro/Extended labels in an old conversation.

## Review trail
- 9 incrementally-reviewed tasks (T1–T9), each commit + tests.
- Adversarial ChatGPT Pro pre-merge review (dogfooded via this very native-extension path) across two passes → hardening waves A/B + B1; all blockers/highs resolved and re-reviewed.
- Security: conversation id/URL normalizer rejects open-redirect (host/userinfo/port), URL/path injection, percent-decode bypass, traversal; mirrored JS-side in the extension before tab creation.

## Tests
Extension suite 188 passing; `cargo test -p yoetz` 522 + cli 37 + daemon_policy 3.

## Fast-follow (tracked, not in this PR)
- PR A: last-moment ownership/conversation rechecks (H6 `_yoetz` re-check before markOwnership; B2 residual `clickSend`-internal guard).
- PR B: positive live-control scoping for model detection (H4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)