### PR TITLE
fix(browser): cancel actually stops ChatGPT generation before closing the tab

### DIFF
--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -1193,6 +1193,54 @@ export function clickStopGenerating(root = document) {
   }
 }
 
+// Click stop, then WAIT for ChatGPT to actually go idle before reporting back.
+// A bare clickStopGenerating only *initiates* ChatGPT's client-side abort to
+// OpenAI; the service worker tearing the tab down microseconds later races that
+// request and frequently never stops server-side generation. Polling
+// isResponseGenerating until it clears both proves the abort registered in the
+// UI and gives the abort request time to flush before the tab is removed.
+//
+// Bounded loop (default ≤5s, 250ms interval) with ONE extra re-click if the
+// stop control is still present after the first interval (covers a click that
+// landed on a stale/transitional button). Returns { stopped, confirmed_idle,
+// waited_ms }. Never throws — cancel is best-effort and a torn-down or
+// navigated page must not turn into a hard error.
+export async function confirmGenerationStopped(root = document, options = {}) {
+  const timeoutMs = Number(options.timeoutMs ?? 5000);
+  const intervalMs = Number(options.intervalMs ?? 250);
+  const startedAt = Date.now();
+  let stopped = false;
+  let reclicked = false;
+  try {
+    // Already idle (no stop control) → confirmed_idle without waiting.
+    if (!isResponseGenerating(root)) {
+      return { stopped: false, confirmed_idle: true, waited_ms: 0 };
+    }
+    stopped = clickStopGenerating(root);
+    while (Date.now() - startedAt < timeoutMs) {
+      await sleep(intervalMs);
+      if (!isResponseGenerating(root)) {
+        return { stopped, confirmed_idle: true, waited_ms: Date.now() - startedAt };
+      }
+      // Still generating after the first interval: re-click once in case the
+      // first click hit a transitional control, then keep polling.
+      if (!reclicked) {
+        reclicked = true;
+        if (clickStopGenerating(root)) {
+          stopped = true;
+        }
+      }
+    }
+    // Timed out still generating: report not-idle so the caller can warn the
+    // user the run may still be live server-side.
+    return { stopped, confirmed_idle: false, waited_ms: Date.now() - startedAt };
+  } catch {
+    // Page torn down / navigated mid-poll. Treat as best-effort: we clicked
+    // (maybe), we cannot confirm idle.
+    return { stopped, confirmed_idle: false, waited_ms: Date.now() - startedAt };
+  }
+}
+
 export function normalizeText(value) {
   return String(value ?? "")
     .replace(/\r\n/g, "\n")

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -36,16 +36,26 @@ async function handleMessage(message) {
   }
 }
 
-// Best-effort cancel: click ChatGPT's stop control if visible, then return.
+// Best-effort cancel: click ChatGPT's stop control, then WAIT for generation to
+// actually go idle before returning so the service worker does not remove the
+// tab while the abort request to OpenAI is still in flight (closing the tab
+// early lets the server keep generating). Returns confirmed_idle so the worker
+// can report a truthful stop status to the CLI.
+//
 // Intentionally does NOT call assertJobOwnership — the cancel may arrive after
 // the tab has navigated, lost its window.name marker, or after the content
 // script reloaded (in which case activeJobs is empty). Cancel is a kill, not a
 // safe-tab-only operation; the service worker is already going to remove the
-// tab right after this regardless of outcome.
+// tab right after this regardless of outcome. confirmGenerationStopped never
+// throws, so cancel stays best-effort.
 async function cancelSend(_job) {
-  const { clickStopGenerating } = await domHelpers();
-  const stopped = clickStopGenerating(document);
-  return { stopped: Boolean(stopped) };
+  const { confirmGenerationStopped } = await domHelpers();
+  const result = await confirmGenerationStopped(document);
+  return {
+    stopped: Boolean(result?.stopped),
+    confirmed_idle: Boolean(result?.confirmed_idle),
+    waited_ms: Number(result?.waited_ms ?? 0)
+  };
 }
 
 async function prepareJob(job) {

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -539,28 +539,43 @@ async function cancelJob(message) {
   chunks.discard(job.job_id);
   await persistJob(job);
 
-  // Best-effort: tell the content script to click ChatGPT's stop control so we
-  // do not keep consuming the user's ChatGPT quota for a generation they
-  // cancelled. The content script's cancelSend handler does NOT require the
-  // ownership marker — cancel is a kill, and the tab may have navigated away,
-  // lost its window.name marker, or had its content script reloaded. We never
-  // let a content-script failure block the rest of the cancel teardown.
+  // Best-effort: tell the content script to click ChatGPT's stop control AND
+  // wait for generation to actually go idle before we tear the tab down — a bare
+  // stop click only initiates ChatGPT's abort to OpenAI, and removing the tab
+  // microseconds later races/drops that request so the server keeps generating.
+  // We await cancelSend so chrome.tabs.remove below runs only AFTER the stop is
+  // confirmed (or its bounded ~5s idle-wait elapses). The content script's
+  // cancelSend handler does NOT require the ownership marker — cancel is a kill,
+  // and the tab may have navigated away, lost its window.name marker, or had its
+  // content script reloaded. We never let a content-script failure block the
+  // rest of the cancel teardown.
   let stopClicked = false;
+  // stopConfirmed === false means we could not confirm generation halted (timed
+  // out still generating, or the content script was unreachable). The CLI uses
+  // it to warn the user the run may still be live server-side. null = unknown
+  // (no tab to ask).
+  let stopConfirmed = job.tab_id ? false : null;
   if (job.tab_id) {
     try {
       const stopResult = await sendToTab(job.tab_id, { type: "yoetz_cancel_send", job });
       stopClicked = Boolean(stopResult?.stopped);
+      stopConfirmed = Boolean(stopResult?.confirmed_idle);
     } catch {
       // Tab may already be gone / content script unreachable; cancel proceeds.
+      // Leave stopConfirmed false so the CLI can warn it may still be running.
     }
   }
+  // True when we asked a tab to stop but could not confirm it went idle.
+  const cancelMayStillBeRunning = job.tab_id ? stopConfirmed === false : false;
 
   // Close the tab so generation cannot continue in the background. V1 chooses
   // hard removal over chrome.tabGroups.update({ collapsed: true }) into a
   // "yoetz-cancelled" group — removal is the simpler contract (no group cleanup
   // to manage, no risk of a collapsed-but-still-streaming tab consuming quota).
   // If a future revision wants to preserve the tab for forensics, route that
-  // here through the tabGroups API instead of chrome.tabs.remove.
+  // here through the tabGroups API instead of chrome.tabs.remove. This runs only
+  // after the awaited cancelSend above resolves, so we never destroy the page
+  // mid-abort.
   if (job.tab_id && chrome.tabs?.remove) {
     try {
       await chrome.tabs.remove(job.tab_id);
@@ -569,14 +584,26 @@ async function cancelJob(message) {
     }
   }
 
-  postNative(progress(job, "cancelled", { tab_id: job.tab_id, stop_clicked: stopClicked }));
+  postNative(progress(job, "cancelled", {
+    tab_id: job.tab_id,
+    stop_clicked: stopClicked,
+    stop_confirmed: stopConfirmed,
+    generation_idle: stopConfirmed,
+    may_still_be_running: cancelMayStillBeRunning
+  }));
   postNative(makeEnvelope("job_cancel", {
     request_id: message.request_id,
     job_id: job.job_id,
     run_id: job.run_id,
     workspace_id: job.workspace_id,
     capability_token: job.capability_token,
-    payload: { cancelled: true, stop_clicked: stopClicked }
+    payload: {
+      cancelled: true,
+      stop_clicked: stopClicked,
+      stop_confirmed: stopConfirmed,
+      generation_idle: stopConfirmed,
+      may_still_be_running: cancelMayStillBeRunning
+    }
   }));
   // Mark terminal and evict from the in-memory map AFTER the cancel envelope is
   // posted and the job's terminal status is persisted. Subsequent extract /

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -4,11 +4,13 @@ import {
   clickSend,
   clickStopGenerating,
   configureModelState,
+  confirmGenerationStopped,
   ensureConversationLoaded,
   ensureFreshChat,
   extractResponse,
   findModelButton,
   insertPrompt,
+  isResponseGenerating,
   sendAcceptanceBaseline,
   uploadFile,
   waitForSendAccepted
@@ -230,6 +232,96 @@ test("clickStopGenerating ignores hidden stop controls", () => {
 
   assert.equal(clickStopGenerating(doc), false);
   assert.equal(stop.clicked, false);
+});
+
+test("confirmGenerationStopped reports confirmed_idle immediately when already idle", async () => {
+  const body = new FakeElement("body", {}, "ChatGPT settled");
+  const doc = new FakeDocument(body);
+
+  const result = await confirmGenerationStopped(doc, { timeoutMs: 1000, intervalMs: 10 });
+  assert.deepEqual(result, { stopped: false, confirmed_idle: true, waited_ms: 0 });
+});
+
+test("confirmGenerationStopped clicks stop then waits until generation goes idle", async () => {
+  // Clicking stop hides the control on the next poll, mirroring ChatGPT removing
+  // the Stop button once it accepts the abort.
+  const stop = new FakeElement("button", {
+    "aria-label": "Stop streaming",
+    onClick: () => {
+      stop.attrs.style = "display:none";
+    }
+  }, "Stop");
+  const body = new FakeElement("body", {}, "Stop").append(stop);
+  const doc = new FakeDocument(body);
+
+  assert.equal(isResponseGenerating(doc), true);
+  const result = await confirmGenerationStopped(doc, { timeoutMs: 1000, intervalMs: 10 });
+  assert.equal(stop.clicked, true);
+  assert.equal(result.stopped, true);
+  assert.equal(result.confirmed_idle, true);
+  assert.equal(isResponseGenerating(doc), false);
+});
+
+test("confirmGenerationStopped re-clicks once when generation persists after the first interval", async () => {
+  // First click is ignored (transitional control); the SECOND click halts.
+  let clicks = 0;
+  const stop = new FakeElement("button", {
+    "aria-label": "Stop streaming",
+    onClick: () => {
+      clicks += 1;
+      if (clicks >= 2) {
+        stop.attrs.style = "display:none";
+      }
+    }
+  }, "Stop");
+  const body = new FakeElement("body", {}, "Stop").append(stop);
+  const doc = new FakeDocument(body);
+
+  const result = await confirmGenerationStopped(doc, { timeoutMs: 1000, intervalMs: 10 });
+  assert.equal(clicks, 2, "expected exactly one re-click after the first interval");
+  assert.equal(result.stopped, true);
+  assert.equal(result.confirmed_idle, true);
+});
+
+test("confirmGenerationStopped re-clicks at most once and reports not idle on timeout", async () => {
+  // Generation never stops no matter how many times we click → timeout path.
+  let clicks = 0;
+  const stop = new FakeElement("button", {
+    "aria-label": "Stop streaming",
+    onClick: () => {
+      clicks += 1;
+    }
+  }, "Stop");
+  const body = new FakeElement("body", {}, "Stop").append(stop);
+  const doc = new FakeDocument(body);
+
+  const result = await confirmGenerationStopped(doc, { timeoutMs: 80, intervalMs: 10 });
+  assert.equal(result.stopped, true);
+  assert.equal(result.confirmed_idle, false, "must report not-idle when generation outlasts the timeout");
+  assert.ok(result.waited_ms >= 0);
+  // Initial click + exactly one re-click, never more (re-click is bounded to once).
+  assert.equal(clicks, 2, "re-click must fire at most once even across many poll cycles");
+});
+
+test("confirmGenerationStopped never throws when the page tears down mid-poll", async () => {
+  let polls = 0;
+  const stop = new FakeElement("button", { "aria-label": "Stop streaming" }, "Stop");
+  const body = new FakeElement("body", {}, "Stop").append(stop);
+  const doc = new FakeDocument(body);
+  // Simulate the document being torn down (navigated/removed) after the stop
+  // click, so a later querySelectorAll throws.
+  const realQuery = doc.querySelectorAll.bind(doc);
+  doc.querySelectorAll = (selector) => {
+    polls += 1;
+    if (polls > 1) {
+      throw new Error("document detached");
+    }
+    return realQuery(selector);
+  };
+
+  const result = await confirmGenerationStopped(doc, { timeoutMs: 200, intervalMs: 10 });
+  assert.equal(result.confirmed_idle, false);
+  assert.equal(typeof result.stopped, "boolean");
 });
 
 test("extractResponse ignores user prompt articles and copy controls", () => {

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -3874,6 +3874,276 @@ test("service worker cancelJob still removes the tab when the content script is 
     const cancelEnvelope = port.messages.find((m) => m.type === "job_cancel" && m.job_id === "job_cancel_b");
     assert.equal(cancelEnvelope.payload.cancelled, true);
     assert.equal(cancelEnvelope.payload.stop_clicked, false);
+    // Content script unreachable → we cannot confirm generation stopped, so the
+    // CLI must be told the run may still be live server-side.
+    assert.equal(cancelEnvelope.payload.stop_confirmed, false);
+    assert.equal(cancelEnvelope.payload.generation_idle, false);
+    assert.equal(cancelEnvelope.payload.may_still_be_running, true);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker cancelJob waits for cancelSend to resolve before removing the tab and reports confirmed idle", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const removedTabs = [];
+  let createdTabId = 0;
+  let sent = false;
+  // Gate the yoetz_cancel_send response so the test can observe ordering: the
+  // tab must NOT be removed while cancelSend is still in flight.
+  let releaseCancel;
+  const cancelGate = new Promise((resolve) => {
+    releaseCancel = resolve;
+  });
+  let cancelSendStarted = false;
+  let extracted = false;
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++createdTabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      remove: async (id) => {
+        removedTabs.push(id);
+      },
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true } };
+          case "yoetz_extract_response":
+            extracted = true;
+            return {
+              ok: true,
+              payload: sent
+                ? { method: "assistant_dom_fallback", text: "partial...", is_generating: true, assistant_count: 1, copy_button_count: 0, has_copy_button: false, turn_index: 0 }
+                : { method: "none", text: "", is_generating: false, assistant_count: 0, turn_index: -1 }
+            };
+          case "yoetz_cancel_send":
+            cancelSendStarted = true;
+            // Block until the test releases us, mimicking confirmGenerationStopped
+            // polling for idle.
+            await cancelGate;
+            return { ok: true, payload: { stopped: true, confirmed_idle: true, waited_ms: 250 } };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?cancel_waits=${Date.now()}`);
+    await eventually(() => port.messages.some((m) => m.type === "hello"));
+
+    port.emit(envelope("job_start", "job_cancel_wait", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 60000
+    }));
+    await eventually(() => port.messages.some((m) => m.payload?.phase === "ready_for_file"));
+
+    port.emit(envelope("job_file_chunk", "job_cancel_wait", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_cancel_wait.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+    await eventually(() => sent);
+    await eventually(() => extracted);
+
+    port.emit(envelope("job_cancel", "job_cancel_wait"));
+
+    // cancelSend is in flight (gated). The tab must NOT be removed yet.
+    await eventually(() => cancelSendStarted);
+    assert.deepEqual(removedTabs, [], "tab must not be removed while cancelSend is still awaited");
+
+    // Release cancelSend; only now may the tab be removed and the envelope post.
+    releaseCancel();
+    await eventually(() => port.messages.some((m) => m.type === "job_cancel" && m.job_id === "job_cancel_wait"));
+    assert.deepEqual(removedTabs, [createdTabId], "tab removal must happen after cancelSend resolves");
+
+    const cancelEnvelope = port.messages.find((m) => m.type === "job_cancel" && m.job_id === "job_cancel_wait");
+    assert.equal(cancelEnvelope.payload.cancelled, true);
+    assert.equal(cancelEnvelope.payload.stop_clicked, true);
+    assert.equal(cancelEnvelope.payload.stop_confirmed, true);
+    assert.equal(cancelEnvelope.payload.generation_idle, true);
+    assert.equal(cancelEnvelope.payload.may_still_be_running, false);
+
+    const cancelledProgress = port.messages.find((m) => m.type === "job_progress" && m.job_id === "job_cancel_wait" && m.payload?.phase === "cancelled");
+    assert.equal(cancelledProgress.payload.stop_confirmed, true);
+    assert.equal(cancelledProgress.payload.generation_idle, true);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker cancelJob removes the tab but warns may_still_be_running when stop is not confirmed", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const removedTabs = [];
+  let createdTabId = 0;
+  let sent = false;
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++createdTabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      remove: async (id) => {
+        removedTabs.push(id);
+      },
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true } };
+          case "yoetz_extract_response":
+            return {
+              ok: true,
+              payload: sent
+                ? { method: "assistant_dom_fallback", text: "partial...", is_generating: true, assistant_count: 1, copy_button_count: 0, has_copy_button: false, turn_index: 0 }
+                : { method: "none", text: "", is_generating: false, assistant_count: 0, turn_index: -1 }
+            };
+          case "yoetz_cancel_send":
+            // Generation outlasted the bounded wait: clicked but not confirmed idle.
+            return { ok: true, payload: { stopped: true, confirmed_idle: false, waited_ms: 5000 } };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?cancel_unconfirmed=${Date.now()}`);
+    await eventually(() => port.messages.some((m) => m.type === "hello"));
+
+    port.emit(envelope("job_start", "job_cancel_warn", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 60000
+    }));
+    await eventually(() => port.messages.some((m) => m.payload?.phase === "ready_for_file"));
+
+    port.emit(envelope("job_file_chunk", "job_cancel_warn", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_cancel_warn.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+    await eventually(() => sent);
+
+    port.emit(envelope("job_cancel", "job_cancel_warn"));
+    await eventually(() => port.messages.some((m) => m.type === "job_cancel" && m.job_id === "job_cancel_warn"));
+
+    // Can't block forever: tab is still removed even when stop is unconfirmed.
+    assert.deepEqual(removedTabs, [createdTabId]);
+    const cancelEnvelope = port.messages.find((m) => m.type === "job_cancel" && m.job_id === "job_cancel_warn");
+    assert.equal(cancelEnvelope.payload.stop_clicked, true);
+    assert.equal(cancelEnvelope.payload.stop_confirmed, false);
+    assert.equal(cancelEnvelope.payload.generation_idle, false);
+    assert.equal(cancelEnvelope.payload.may_still_be_running, true);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker cancelJob on an already-idle response removes the tab and reports confirmed_idle", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const removedTabs = [];
+  let createdTabId = 0;
+  let sent = false;
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++createdTabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      remove: async (id) => {
+        removedTabs.push(id);
+      },
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true } };
+          case "yoetz_extract_response":
+            return {
+              ok: true,
+              payload: sent
+                ? { method: "assistant_dom_fallback", text: "partial...", is_generating: true, assistant_count: 1, copy_button_count: 0, has_copy_button: false, turn_index: 0 }
+                : { method: "none", text: "", is_generating: false, assistant_count: 0, turn_index: -1 }
+            };
+          case "yoetz_cancel_send":
+            // Response had already settled: no stop button, so nothing clicked
+            // but idle is confirmed.
+            return { ok: true, payload: { stopped: false, confirmed_idle: true, waited_ms: 0 } };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?cancel_idle=${Date.now()}`);
+    await eventually(() => port.messages.some((m) => m.type === "hello"));
+
+    port.emit(envelope("job_start", "job_cancel_idle", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 60000
+    }));
+    await eventually(() => port.messages.some((m) => m.payload?.phase === "ready_for_file"));
+
+    port.emit(envelope("job_file_chunk", "job_cancel_idle", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_cancel_idle.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+    await eventually(() => sent);
+
+    port.emit(envelope("job_cancel", "job_cancel_idle"));
+    await eventually(() => port.messages.some((m) => m.type === "job_cancel" && m.job_id === "job_cancel_idle"));
+
+    assert.deepEqual(removedTabs, [createdTabId], "already-idle cancel must still remove the tab");
+    const cancelEnvelope = port.messages.find((m) => m.type === "job_cancel" && m.job_id === "job_cancel_idle");
+    assert.equal(cancelEnvelope.payload.cancelled, true);
+    assert.equal(cancelEnvelope.payload.stop_clicked, false);
+    assert.equal(cancelEnvelope.payload.stop_confirmed, true);
+    assert.equal(cancelEnvelope.payload.generation_idle, true);
+    assert.equal(cancelEnvelope.payload.may_still_be_running, false);
   } finally {
     globalThis.chrome = originalChrome;
   }


### PR DESCRIPTION
## Bug (reported by Ben S.)
Stopping a GPT Pro session "just closed the tab… and OAI kept running… it didn't really stop."

## Root cause
Cancel fires on local-client disconnect → `cancelJob` sent `yoetz_cancel_send` (a fire-and-forget `clickStopGenerating`) then **immediately** `chrome.tabs.remove`. The stop click only *initiates* ChatGPT's client-side abort to OpenAI; destroying the tab microseconds later raced/dropped that request, and closing a tab does not stop server-side generation (esp. Pro/Extended reasoning).

## Fix (extension only)
- `confirmGenerationStopped`: click stop, then poll `isResponseGenerating` until idle (bounded ~5s, one re-click), returns `{stopped, confirmed_idle, waited_ms}`; never throws.
- `cancelSend` awaits it; `cancelJob` removes the tab only AFTER the awaited stop is confirmed (or times out).
- Truthful reporting: `stop_confirmed` / `generation_idle` / `may_still_be_running` on the `cancelled` progress + `job_cancel` payload (if not confirmed, tab is still removed but the run is flagged as possibly still live).

Rust untouched (the `job_cancel` payload is an opaque `Value`; new fields are additive).

## Tests
Extension suite 172 passing, incl. a gated test proving `chrome.tabs.remove` does not run until `cancelSend` resolves. Reviewed + approved by codex.

## Follow-up
CLI-side rendering of `may_still_be_running` as a user-visible warning (separate small PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)