### PR TITLE
fix(chatgpt-native): harden resume ownership before send

### DIFF
--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -709,6 +709,7 @@ export async function clickSend(root, options = {}) {
   while (Date.now() - startedAt < timeoutMs) {
     const button = findSendButtonControl(root, { requireEnabled: true });
     if (button) {
+      assertExpectedConversationBeforeSendClick(root, options.expectedConversationId);
       button.click();
       return true;
     }
@@ -720,6 +721,32 @@ export async function clickSend(root, options = {}) {
     throw new Error(`ChatGPT send button remained disabled (${describeElement(lastCandidate)}; ${sendReadinessDiagnostics(root)})`);
   }
   throw new Error(`ChatGPT send button not found (${sendReadinessDiagnostics(root)})`);
+}
+
+function assertExpectedConversationBeforeSendClick(root, expectedConversationId) {
+  const expected = String(expectedConversationId ?? "").trim();
+  if (!expected) {
+    return;
+  }
+  const win = root.defaultView ?? globalThis;
+  const pathname = String(win.location?.pathname ?? "");
+  const currentConversationId = conversationIdFromPathname(pathname);
+  if (currentConversationId === expected) {
+    return;
+  }
+  const code = currentConversationId ? "conversation_changed" : "conversation_not_loaded";
+  throw chatgptCommandError(
+    code,
+    `ChatGPT conversation changed before send click; expected ${expected}, current ${currentConversationId ?? "(none)"}`,
+    {
+      phase: "send",
+      side_effect_started: false,
+      requested_conversation_id: expected,
+      current_conversation_id: currentConversationId,
+      current_url: currentLocationForError(win),
+      current_pathname: pathname
+    }
+  );
 }
 
 export function sendAcceptanceBaseline(root = document) {

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -130,7 +130,12 @@ async function sendPrompt(job, prompt) {
   const baseline = sendAcceptanceBaseline(document);
   await insertPrompt(document, prompt, { timeoutMs: 20000 });
   assertJobOwnership(job, parseOwnedWindowName, ownershipOptionsForJob(job, "send"));
-  await clickSend(document, { timeoutMs: Number(job.send_timeout_ms) || 120000 });
+  const clickOptions = { timeoutMs: Number(job.send_timeout_ms) || 120000 };
+  const expectedConversationId = expectedConversationIdForJob(job);
+  if (expectedConversationId) {
+    clickOptions.expectedConversationId = expectedConversationId;
+  }
+  await clickSend(document, clickOptions);
   let accepted;
   try {
     accepted = await waitForSendAccepted(document, baseline, {

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -75,13 +75,7 @@ async function prepareJob(job) {
   });
   const conversationId = conversationIdForJob(job);
   if (!handoff && conversationId) {
-    const urlRunId = runIdFromUrl(location.href);
-    if (urlRunId !== job.run_id) {
-      throw commandError("run_mismatch", `tab is not owned by Yoetz run ${job.run_id}`, {
-        phase: "upload",
-        side_effect_started: false
-      });
-    }
+    assertUrlRunMarker(job);
   }
   const conversation = !handoff && conversationId
     ? await ensureConversationLoaded(document, conversationId, conversationLoadOptionsForJob(job))
@@ -90,6 +84,9 @@ async function prepareJob(job) {
     ? await ensureFreshChat(document, job)
     : null;
   if (!handoff) {
+    if (conversationId) {
+      assertUrlRunMarker(job);
+    }
     window.name = ownedWindowName(job);
     markOwnership(document, job);
     activeJobs.set(job.job_id, { ...job, prepare_complete: true });
@@ -329,6 +326,16 @@ function ownershipOptionsForJob(job, phase) {
   return conversationId
     ? { requireConversation: conversationId, phase }
     : { requireFresh: true, phase };
+}
+
+function assertUrlRunMarker(job) {
+  const urlRunId = runIdFromUrl(location.href);
+  if (urlRunId !== job.run_id) {
+    throw commandError("run_mismatch", `tab is not owned by Yoetz run ${job.run_id}`, {
+      phase: "upload",
+      side_effect_started: false
+    });
+  }
 }
 
 function conversationIdForJob(job) {

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -59,6 +59,7 @@ export async function ensureConversationLoaded(_document, conversationId, option
     }
     throw error;
   }
+  hooks.afterEnsureConversationLoaded?.();
   return { status: "loaded", conversation_id: conversationId, pathname: globalThis.location.pathname };
 }
 
@@ -218,6 +219,26 @@ test("content script resume prepare rejects an unowned resume URL marker", async
     assert.equal(response.phase, "upload");
     assert.equal(response.side_effect_started, false);
     assert.deepEqual(hooks.ensureConversationLoadedCalls, []);
+    assert.deepEqual(hooks.markOwnershipCalls, []);
+  } finally {
+    restore();
+  }
+});
+
+test("content script resume prepare rejects marker drift during conversation loading before ownership mark", async () => {
+  const { send, hooks, restore, location } = await loadContentScript("resume_marker_drift_during_load", "https://chatgpt.com/c/conv-123?_yoetz=run_resume");
+  try {
+    hooks.afterEnsureConversationLoaded = () => {
+      location.href = "https://chatgpt.com/c/conv-123?_yoetz=other_run";
+    };
+
+    const response = await send({ type: "yoetz_prepare_job", job: resumeJob() });
+
+    assert.equal(response.ok, false);
+    assert.equal(response.code, "run_mismatch");
+    assert.equal(response.phase, "upload");
+    assert.equal(response.side_effect_started, false);
+    assert.equal(hooks.ensureConversationLoadedCalls.length, 1);
     assert.deepEqual(hooks.markOwnershipCalls, []);
   } finally {
     restore();

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -139,6 +139,7 @@ test("content script resume path skips fresh enforcement and completes on reques
     const sent = await send({ type: "yoetz_send_prompt", job, prompt: "continue" });
     assert.equal(sent.ok, true);
     assert.equal(sent.payload.conversation_id, "conv-123");
+    assert.equal(hooks.clickSendCalls[0].expectedConversationId, "conv-123");
 
     const extracted = await send({ type: "yoetz_extract_response", job });
     assert.equal(extracted.ok, true);

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -1635,6 +1635,39 @@ test("hidden ancestors make controls invisible", async () => {
   );
 });
 
+test("clickSend rejects conversation drift immediately before clicking send", async () => {
+  const composer = new FakeElement("div", { id: "prompt-textarea", role: "textbox" }, "Review this");
+  const send = new FakeElement("button", { "aria-label": "Send prompt", "aria-disabled": "true" }, "");
+  const body = new FakeElement("body", {}, "Review this").append(composer, send);
+  const doc = new FakeDocument(body);
+  doc.defaultView.location.href = "https://chatgpt.com/c/conv-123?_yoetz=run_resume";
+  doc.defaultView.location.pathname = "/c/conv-123";
+
+  setTimeout(() => {
+    doc.defaultView.location.href = "https://chatgpt.com/c/other?_yoetz=run_resume";
+    doc.defaultView.location.pathname = "/c/other";
+    delete send.attrs["aria-disabled"];
+  }, 20);
+
+  await assert.rejects(
+    () => clickSend(doc, {
+      expectedConversationId: "conv-123",
+      timeoutMs: 250,
+      intervalMs: 10,
+      minTimeoutMs: 0
+    }),
+    (error) => {
+      assert.equal(error.code, "conversation_changed");
+      assert.equal(error.phase, "send");
+      assert.equal(error.side_effect_started, false);
+      assert.equal(error.requested_conversation_id, "conv-123");
+      assert.equal(error.current_conversation_id, "other");
+      return true;
+    }
+  );
+  assert.equal(send.clicked, false);
+});
+
 test("clickSend waits for a visible ChatGPT send control to become enabled", async () => {
   const composer = new FakeElement("div", { id: "prompt-textarea", role: "textbox" }, "Review this");
   const send = new FakeElement("button", { "aria-label": "Send prompt", "aria-disabled": "true" }, "");


### PR DESCRIPTION
## Summary
- Recheck the `_yoetz` run marker after `ensureConversationLoaded` and immediately before writing ownership markers for resumed ChatGPT conversations.
- Pass the expected conversation id into `clickSend` and fail closed immediately before the DOM click if the conversation drifted.
- Add targeted coverage for marker drift during load and pre-click conversation drift.

## Verification
- `node --test extensions/chatgpt-native/tests/content-script.test.js`
- `node --test extensions/chatgpt-native/tests/fake-chatgpt.test.js`
- `npm test` in `extensions/chatgpt-native`
- `./scripts/build-chatgpt-native-extension.sh --check`
- `git diff --check origin/main..HEAD`
- `cargo test --workspace`

AMQ: PR A fast-follow for H6 + B2.