### PR TITLE
fix(chatgpt-native): scope resume model controls to live regions

### DIFF
--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -93,7 +93,7 @@ export function findModelButton(root = document, options = {}) {
   // ChatGPT serves at least two picker families: Enterprise exposes a global
   // model-switcher button, while personal ChatGPT can render a composer-scoped
   // model chip. Keep both paths because either account type may back Pro.
-  const enterpriseButton = firstVisibleModelControl(root, [
+  const enterpriseButton = firstVisibleModelControlInScopes(modelHeaderScopes(root, options), [
     'button[data-testid="model-switcher-dropdown-button"]',
     'button:has([data-testid="selected-model"])',
     'button:has([data-testid="model-switcher-selected-model"])',
@@ -341,7 +341,7 @@ function isActionableElement(node) {
 }
 
 function findComposerModelControl(root, options = {}) {
-  for (const scope of modelControlScopes(root)) {
+  for (const scope of modelControlScopes(root, options)) {
     const candidates = uniqueElements(Array.from(scope.querySelectorAll([
       "button",
       '[role="button"]',
@@ -374,6 +374,16 @@ function findComposerModelControl(root, options = {}) {
   return null;
 }
 
+function firstVisibleModelControlInScopes(scopes, selectors, options = {}) {
+  for (const scope of scopes) {
+    const control = firstVisibleModelControl(scope, selectors, options);
+    if (control) {
+      return control;
+    }
+  }
+  return null;
+}
+
 function findStandaloneProExtendedModelControl(root) {
   const requested = proExtendedModelRequest();
   const candidates = uniqueElements(Array.from(root.querySelectorAll([
@@ -393,16 +403,69 @@ function findStandaloneProExtendedModelControl(root) {
   }) ?? null;
 }
 
-function modelControlScopes(root) {
+function modelHeaderScopes(root, options = {}) {
+  if (options.allowStandaloneFallback !== false) {
+    return [root];
+  }
+  return uniqueElements(Array.from(root.querySelectorAll([
+    "header",
+    '[role="banner"]'
+  ].join(","))));
+}
+
+function modelControlScopes(root, options = {}) {
   const composer = findComposer(root);
-  const scopes = [...composerScopes(root, { includeRoot: false })];
+  const scopes = [];
   const add = (scope) => {
     if (scope && !scopes.includes(scope)) {
       scopes.push(scope);
     }
   };
-  add(composer?.closest("main, [role=\"main\"]"));
+  add(composer?.closest("form"));
+  add(composer?.closest('[data-testid*="composer"], [class*="composer"]'));
+  const parent = composer?.parentElement;
+  if (options.allowStandaloneFallback !== false || isLocalComposerScope(parent)) {
+    add(parent);
+  }
+  for (const scope of [...scopes]) {
+    addAdjacentComposerControlScopes(scope, add);
+  }
+  if (options.allowStandaloneFallback !== false) {
+    add(composer?.closest("main, [role=\"main\"]"));
+  }
   return scopes;
+}
+
+function addAdjacentComposerControlScopes(scope, add) {
+  const parent = scope?.parentElement;
+  if (!parent) {
+    return;
+  }
+  for (const sibling of Array.from(parent.children ?? [])) {
+    if (sibling !== scope && looksLikeComposerControlScope(sibling)) {
+      add(sibling);
+    }
+  }
+}
+
+function isLocalComposerScope(node) {
+  if (!node) {
+    return false;
+  }
+  const tag = String(node.tagName ?? "").toLowerCase();
+  const role = String(node.getAttribute?.("role") ?? "").toLowerCase();
+  return !["html", "body", "main"].includes(tag) && role !== "main";
+}
+
+function looksLikeComposerControlScope(node) {
+  const marker = normalizeText([
+    node?.getAttribute?.("data-testid"),
+    node?.getAttribute?.("class"),
+    node?.getAttribute?.("aria-label"),
+    node?.getAttribute?.("role")
+  ].filter(Boolean).join(" ")).toLowerCase();
+  return /\b(composer|model|switcher|toolbar|controls|pill)\b/.test(marker)
+    && !/\b(conversation|transcript|message|turn|assistant|user)\b/.test(marker);
 }
 
 function modelClickTarget(node, stopAt) {

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -2090,6 +2090,105 @@ test("fake ChatGPT accepts Pro Extended label that appears after the picker stay
   assert.equal(result.extended_status, "required");
 });
 
+test("fake ChatGPT resume selects Enterprise header model switcher", async () => {
+  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Thinking");
+  const proOption = new FakeElement("div", {
+    role: "menuitemradio",
+    "data-testid": "model-switcher-gpt-5-5-pro",
+    onClick: () => {
+      selected.innerText = "Pro Extended";
+      selected.textContent = "Pro Extended";
+    }
+  }, "Pro Extended");
+  const modelButton = new FakeElement("button", {
+    "data-testid": "model-switcher-dropdown-button",
+    "aria-haspopup": "menu",
+    onPointerDown: () => {
+      if (!body.children.includes(proOption)) {
+        body.append(proOption);
+      }
+    }
+  }, "Thinking").append(selected);
+  const header = new FakeElement("header", {}, "Thinking").append(modelButton);
+  const main = new FakeElement("main", {}, "Ask anything").append(composer);
+  const body = new FakeElement("body", {}, "Thinking Ask anything").append(header, main);
+  const doc = new FakeDocument(body);
+  doc.defaultView.location.pathname = "/c/conv-123";
+
+  const result = await configureModelState(doc, { conversation_id: "conv-123" });
+
+  assert.ok(modelButton.events.includes("pointerdown"));
+  assert.equal(proOption.clicked, true);
+  assert.equal(result.status, "selected");
+  assert.equal(result.model_used, "Pro Extended");
+  assert.equal(result.extended_status, "required");
+});
+
+test("fake ChatGPT resume selects personal composer model picker", async () => {
+  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+  const proOption = new FakeElement("div", {
+    role: "menuitemradio",
+    "data-testid": "model-switcher-gpt-5-5-pro",
+    onClick: () => {
+      modelChip.innerText = "Pro Extended";
+      modelChip.textContent = "Pro Extended";
+      body.children = body.children.filter((child) => child !== proOption);
+    }
+  }, "Pro Extended");
+  const modelChip = new FakeElement("button", {
+    class: "model-chip",
+    "aria-haspopup": "menu",
+    onPointerDown: () => {
+      if (!body.children.includes(proOption)) {
+        body.append(proOption);
+      }
+    }
+  }, "Thinking");
+  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelChip);
+  const body = new FakeElement("body", {}, "Ask anything Thinking").append(form);
+  const doc = new FakeDocument(body);
+  doc.defaultView.location.pathname = "/c/conv-123";
+
+  const result = await configureModelState(doc, { conversation_id: "conv-123" });
+
+  assert.ok(modelChip.events.includes("pointerdown"));
+  assert.equal(proOption.clicked, true);
+  assert.equal(result.status, "selected");
+  assert.equal(result.model_used, "Pro Extended");
+  assert.equal(result.extended_status, "required");
+});
+
+test("fake ChatGPT resume treats stale transcript model chip as unavailable", async () => {
+  const staleModelChip = new FakeElement("button", {
+    class: "model-chip",
+    "aria-haspopup": "menu",
+    onPointerDown: () => {
+      throw new Error("stale transcript model chip should not be opened");
+    }
+  }, "Extended Pro");
+  const staleTranscript = new FakeElement("section", { class: "old-transcript-row" }, "Earlier model Extended Pro")
+    .append(staleModelChip);
+  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+  const main = new FakeElement("main", {}, "Earlier model Extended Pro Ask anything")
+    .append(staleTranscript, composer);
+  const body = new FakeElement("body", {}, "Earlier model Extended Pro Ask anything").append(main);
+  const doc = new FakeDocument(body);
+  doc.defaultView.location.pathname = "/c/conv-123";
+
+  const result = await configureModelState(doc, {
+    conversation_id: "conv-123",
+    model_selection_timeout_ms: 30,
+    model_selection_interval_ms: 10
+  });
+
+  assert.equal(staleModelChip.events.includes("pointerdown"), false);
+  assert.equal(staleModelChip.clicked, false);
+  assert.equal(result.status, "unavailable");
+  assert.equal(result.extended_status, "required");
+  assert.match(result.warning, /model selector button not found/);
+});
+
 test("fake ChatGPT resume does not accept stale conversation Pro Extended labels as current model", async () => {
   const staleConversationControl = new FakeElement("button", {}, "Pro Extended");
   const staleSelectedLabel = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Pro Extended");
@@ -2317,6 +2416,7 @@ function matchesSimpleSelector(element, selector) {
   if (selector === "#prompt-textarea") return attr("id") === "prompt-textarea";
   if (selector === "button") return tag === "button";
   if (selector === "div") return tag === "div";
+  if (selector === "header") return tag === "header";
   if (selector === "article") return tag === "article";
   if (selector === "pre") return tag === "pre";
   if (selector === "code") return tag === "code";
@@ -2387,6 +2487,9 @@ function matchesSimpleSelector(element, selector) {
   }
   if (selector.includes('[role="main"]')) {
     return attr("role") === "main";
+  }
+  if (selector.includes('[role="banner"]')) {
+    return attr("role") === "banner";
   }
   if (selector.includes('[data-testid="model-switcher-dropdown-button"]')) {
     return attr("data-testid") === "model-switcher-dropdown-button";


### PR DESCRIPTION
## Summary
- Scope resume-mode model-control discovery to known live regions: header/banner switchers plus composer-local controls.
- Remove resume-mode reliance on broad transcript/main scanning for model buttons while preserving fresh-mode fallback behavior.
- Add fixtures for Enterprise header switcher, personal composer picker, and stale transcript model chip fail-closed behavior.

## Verification
- `node --test --test-name-pattern "fake ChatGPT resume (selects Enterprise header model switcher|selects personal composer model picker|treats stale transcript model chip as unavailable|does not accept stale conversation Pro Extended labels as current model|ignores stale transcript model switcher buttons)" extensions/chatgpt-native/tests/fake-chatgpt.test.js`
- `node --test extensions/chatgpt-native/tests/fake-chatgpt.test.js`
- `npm test` in `extensions/chatgpt-native`
- `./scripts/build-chatgpt-native-extension.sh --check`
- `git diff --check origin/main..HEAD`
- `cargo test --workspace`

Post-A sequencing: rebased on #261 merge commit 4bebbaf before push.

AMQ: PR B fast-follow for H4 positive model-control scoping.