### PR TITLE
docs(changelog): resume hardening fast-follows for v0.5.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- Further hardened ChatGPT conversation resume against tab/conversation drift.
+  The `_yoetz` run marker is now re-verified immediately before claiming tab
+  ownership (not only before loading the conversation), so a marker change
+  during the conversation-load wait fails closed before ownership is marked.
+  `clickSend` now takes the expected conversation id and re-checks it in the
+  same tick as the actual send click, so a conversation change between the
+  ownership assertion and the click fails closed with `side_effect_started:
+  false` and the prompt is never sent to the wrong conversation. Resume-mode
+  model detection is now scoped positively to the live header/composer model
+  switcher instead of merely excluding transcript containers, so a stale model
+  chip rendered inside the conversation transcript can no longer be mistaken for
+  the current model; an unfound live control fails closed to `unavailable`.
 
 ## [0.5.21] - 2026-06-02
 ### Added


### PR DESCRIPTION
Populates `CHANGELOG.md` `[Unreleased]` for the two merged fast-follow PRs ahead of 0.5.22:
- #261 — re-verify `_yoetz` before ownership + re-check conversation inside `clickSend`
- #262 — positive model-control scoping (resume mode)

Docs-only. `./scripts/release.sh 0.5.22` will move these into `[0.5.22]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)