### PR TITLE
Fix ChatGPT long Pro completion finality

### DIFF
--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -24,6 +24,10 @@ const MAX_FINAL_AFFORDANCE_IDLE_MS = Math.max(
   MIN_STABLE_IDLE_MS,
   Number(globalThis.__YOETZ_MAX_FINAL_AFFORDANCE_IDLE_MS ?? 5 * 60 * 1000) || 5 * 60 * 1000
 );
+const MIN_UNSCOPED_COPY_STABLE_TEXT_CHARS = Math.max(
+  1,
+  Number(globalThis.__YOETZ_MIN_UNSCOPED_COPY_STABLE_TEXT_CHARS ?? 4096) || 4096
+);
 // Once ChatGPT has exposed a final assistant affordance (copy control) AND scoped
 // text is extractable AND generation has stopped, the response is structurally
 // complete. Confirm it over a SHORT stable window at a FAST cadence instead of
@@ -1280,6 +1284,9 @@ async function waitForResponse(job) {
   let finalAffordanceCandidate = null;
   let bestFinalAffordanceCandidate = null;
   let finalAffordanceCandidateSinceMs = 0;
+  let unscopedCopyCandidate = null;
+  let bestUnscopedCopyCandidate = null;
+  let unscopedCopyCandidateSinceMs = 0;
   let extractionFailureSinceMs = 0;
   let lastWaitingProgressAt = startedAt;
   const timeoutMs = responseWaitTimeoutMs(job);
@@ -1327,7 +1334,13 @@ async function waitForResponse(job) {
       && !extraction?.is_generating
       && hasFinalAssistantAffordance(extraction)
     );
+    const stableIdleUnscopedCopy = Boolean(
+      scopedExtractionCandidate
+      && !finalAffordance
+      && hasStableIdleUnscopedCopyAffordance(job, extraction)
+    );
     let stableForMs = 0;
+    let unscopedCopyStableForMs = 0;
     if (finalAffordance) {
       // Once ChatGPT exposes final assistant controls, scope and turn checks
       // have already ruled out pre-send content. From here we track the best
@@ -1356,13 +1369,47 @@ async function waitForResponse(job) {
       if (stableForMs >= affordanceConfirmMs) {
         return completedExtraction(finalAffordanceCandidate, "copy_button", stableForMs);
       }
+      unscopedCopyCandidate = null;
+      bestUnscopedCopyCandidate = null;
+      unscopedCopyCandidateSinceMs = 0;
     } else if (extraction?.is_generating) {
       finalAffordanceCandidate = null;
       finalAffordanceCandidateSinceMs = 0;
+      unscopedCopyCandidate = null;
+      unscopedCopyCandidateSinceMs = 0;
     } else if (!postSendAssistantActivity) {
       finalAffordanceCandidate = null;
       bestFinalAffordanceCandidate = null;
       finalAffordanceCandidateSinceMs = 0;
+      unscopedCopyCandidate = null;
+      bestUnscopedCopyCandidate = null;
+      unscopedCopyCandidateSinceMs = 0;
+    }
+    if (stableIdleUnscopedCopy) {
+      const bestSelection = selectFinalAffordanceCandidate(bestUnscopedCopyCandidate, extraction);
+      bestUnscopedCopyCandidate = bestSelection.candidate;
+      const candidateSelection = selectFinalAffordanceCandidate(
+        unscopedCopyCandidate ?? bestUnscopedCopyCandidate,
+        extraction
+      );
+      if (!unscopedCopyCandidate || candidateSelection.candidate !== unscopedCopyCandidate) {
+        if (!unscopedCopyCandidate || candidateSelection.resetTimer) {
+          unscopedCopyCandidateSinceMs = Date.now();
+        }
+        unscopedCopyCandidate = candidateSelection.candidate;
+      } else if (!unscopedCopyCandidateSinceMs) {
+        unscopedCopyCandidateSinceMs = Date.now();
+      }
+      unscopedCopyStableForMs = Date.now() - unscopedCopyCandidateSinceMs;
+      if (unscopedCopyStableForMs >= finalAffordanceIdleMs) {
+        return completedExtraction(unscopedCopyCandidate, "stable_idle_unscoped_copy_button", unscopedCopyStableForMs);
+      }
+    } else if (!finalAffordance) {
+      unscopedCopyCandidate = null;
+      unscopedCopyCandidateSinceMs = 0;
+      if (!postSendAssistantActivity) {
+        bestUnscopedCopyCandidate = null;
+      }
     }
     const awaitingFinalAffordance = Boolean(scopedExtractionCandidate && !finalAffordance);
     if (finalAffordanceWithoutScopedText) {
@@ -1402,8 +1449,9 @@ async function waitForResponse(job) {
         elapsed_ms: elapsedMs,
         timeout_ms: timeoutMs,
         next_poll_ms: nextDelay,
-        stable_for_ms: stableForMs,
+        stable_for_ms: Math.max(stableForMs, unscopedCopyStableForMs),
         final_affordance: finalAffordance,
+        stable_idle_unscoped_copy_candidate: stableIdleUnscopedCopy,
         extraction_failure_candidate: finalAffordanceWithoutScopedText
       };
       if (awaitingFinalAffordance) {
@@ -1617,6 +1665,28 @@ function hasFinalAssistantAffordance(extraction) {
   // ChatGPT shows assistant copy controls when a turn is externally complete.
   // Pair this with the scoped extraction and !is_generating checks above.
   return Boolean(!extraction?.is_generating && extraction?.has_copy_button);
+}
+
+function hasStableIdleUnscopedCopyAffordance(job, extraction) {
+  if (hasFinalAssistantAffordance(extraction)) {
+    return false;
+  }
+  if (!hasNoVisibleStopControls(extraction)) {
+    return false;
+  }
+  if (normalizedResponseText(extraction?.text).length < MIN_UNSCOPED_COPY_STABLE_TEXT_CHARS) {
+    return false;
+  }
+  const baselineCopyButtonCount = nonNegativeFiniteNumber(job.response_baseline?.copy_button_count);
+  const copyButtonCount = nonNegativeFiniteNumber(extraction?.copy_button_count);
+  return baselineCopyButtonCount !== null
+    && copyButtonCount !== null
+    && copyButtonCount > baselineCopyButtonCount;
+}
+
+function hasNoVisibleStopControls(extraction) {
+  const stopControlCount = nonNegativeFiniteNumber(extraction?.diagnostics?.counts?.stop_controls);
+  return stopControlCount === null || stopControlCount === 0;
 }
 
 function responseStableIdleThresholdMs(intervalMs) {

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -769,6 +769,31 @@ test("extractResponse does not use an unscoped transcript copy button when multi
   assert.equal(extraction.has_copy_button, false);
 });
 
+test("extractResponse reports long idle assistant text with an unscoped copy affordance", () => {
+  const longAnswer = "Final Pro review paragraph with concrete evidence.\n".repeat(160);
+  const user = new FakeElement("article", { "data-message-author-role": "user", class: "user-turn" }, "Review bundle");
+  const oldMarker = new FakeElement("div", { "data-message-author-role": "assistant" }, "");
+  const oldMarkdown = new FakeElement("div", { class: "markdown prose" }, "Old answer");
+  const oldTurn = new FakeElement("div", { class: "turn-messages" }, "Old answer").append(oldMarker, oldMarkdown);
+  const copy = new FakeElement("button", { "aria-label": "Copy", noLayout: true }, "Copy");
+  const detachedActionRow = new FakeElement("div", { class: "agent-turn" }, "Copy").append(copy);
+  const newMarker = new FakeElement("div", { "data-message-author-role": "assistant" }, "");
+  const newMarkdown = new FakeElement("div", { class: "markdown prose" }, longAnswer);
+  const newTurn = new FakeElement("div", { class: "turn-messages" }, longAnswer).append(newMarker, newMarkdown);
+  const conversation = new FakeElement("main", { role: "main" }, `Review bundle Old answer Copy ${longAnswer}`)
+    .append(user, oldTurn, detachedActionRow, newTurn);
+  const body = new FakeElement("body", {}, `Review bundle Old answer Copy ${longAnswer}`).append(conversation);
+  const doc = new FakeDocument(body);
+
+  const extraction = extractResponse(doc);
+
+  assert.equal(extraction.method, "assistant_dom_fallback");
+  assert.equal(extraction.text, longAnswer.trim());
+  assert.equal(extraction.is_generating, false);
+  assert.equal(extraction.copy_button_count, 1);
+  assert.equal(extraction.has_copy_button, false);
+});
+
 test("extractResponse associates a copy button after the assistant markdown text node", () => {
   const user = new FakeElement("article", { "data-message-author-role": "user", class: "user-turn" }, "Review bundle");
   const marker = new FakeElement("div", { "data-message-author-role": "assistant" }, "");

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -1892,6 +1892,168 @@ test("service worker does not complete on brief stable assistant text without a 
   }
 });
 
+test("service worker completes long stable assistant text with an unscoped copy affordance", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const longAnswer = "Final Pro review paragraph with concrete evidence.\n".repeat(160).trim();
+  let tabId = 0;
+  let sent = false;
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true } };
+          case "yoetz_extract_response":
+            return {
+              ok: true,
+              payload: sent
+                ? {
+                    method: "assistant_dom_fallback",
+                    text: longAnswer,
+                    is_generating: false,
+                    assistant_count: 1,
+                    user_count: 1,
+                    preceding_user_count: 1,
+                    copy_button_count: 1,
+                    has_copy_button: false,
+                    turn_index: 0,
+                    diagnostics: {
+                      counts: { stop_controls: 0, copy_buttons: 1 }
+                    }
+                  }
+                : { method: "none", text: "", is_generating: false, assistant_count: 0, user_count: 0, copy_button_count: 0, has_copy_button: false, turn_index: -1 }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?long_unscoped_copy=${Date.now()}`);
+    port.emit(envelope("job_start", "job_long_unscoped_copy", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 2000
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_long_unscoped_copy", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_long_unscoped_copy.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_complete"));
+    const complete = port.messages.find((message) => message.type === "job_complete");
+    assert.equal(complete.payload.response, longAnswer);
+    assert.equal(complete.payload.extraction_method, "assistant_dom_fallback");
+    assert.equal(complete.payload.completion_reason, "stable_idle_unscoped_copy_button");
+    assert.ok(complete.payload.stable_for_ms >= 100);
+    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker does not complete long idle assistant text with only baseline copy controls", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const longAnswer = "Final Pro review paragraph with concrete evidence.\n".repeat(160).trim();
+  let tabId = 0;
+  let sent = false;
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true } };
+          case "yoetz_extract_response":
+            return {
+              ok: true,
+              payload: sent
+                ? {
+                    method: "assistant_dom_fallback",
+                    text: longAnswer,
+                    is_generating: false,
+                    assistant_count: 2,
+                    user_count: 2,
+                    preceding_user_count: 2,
+                    copy_button_count: 1,
+                    has_copy_button: false,
+                    turn_index: 1
+                  }
+                : {
+                    method: "copy_scope_dom_fallback",
+                    text: "old answer",
+                    is_generating: false,
+                    assistant_count: 1,
+                    user_count: 1,
+                    preceding_user_count: 1,
+                    copy_button_count: 1,
+                    has_copy_button: true,
+                    turn_index: 0
+                  }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?long_baseline_copy_only=${Date.now()}`);
+    port.emit(envelope("job_start", "job_long_baseline_copy_only", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 1200
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_long_baseline_copy_only", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_long_baseline_copy_only.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_error" && message.payload.code === "response_timeout"));
+    assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker emits low-noise waiting progress while ChatGPT is quiet", async () => {
   const originalChrome = globalThis.chrome;
   const previousWaitingProgressInterval = globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS;
@@ -2881,6 +3043,81 @@ test("service worker does not complete on copy button while response is still ge
       mime_type: "text/markdown",
       bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
     }));
+    await eventually(() => port.messages.some((message) => message.type === "job_error" && message.payload.code === "response_timeout"));
+    assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker does not complete long unscoped-copy text while response is still generating", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const longPartial = "Streaming Pro review paragraph that is still changing.\n".repeat(160).trim();
+  let tabId = 0;
+  let sent = false;
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true } };
+          case "yoetz_extract_response":
+            return {
+              ok: true,
+              payload: sent
+                ? {
+                    method: "assistant_dom_fallback",
+                    text: longPartial,
+                    is_generating: true,
+                    assistant_count: 1,
+                    user_count: 1,
+                    preceding_user_count: 1,
+                    copy_button_count: 1,
+                    has_copy_button: false,
+                    turn_index: 0,
+                    diagnostics: {
+                      counts: { stop_controls: 1, copy_buttons: 1 }
+                    }
+                  }
+                : { method: "none", text: "", is_generating: false, assistant_count: 0, user_count: 0, copy_button_count: 0, has_copy_button: false, turn_index: -1 }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?long_unscoped_copy_generating=${Date.now()}`);
+    port.emit(envelope("job_start", "job_long_unscoped_copy_generating", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 1200
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_long_unscoped_copy_generating", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_long_unscoped_copy_generating.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
     await eventually(() => port.messages.some((message) => message.type === "job_error" && message.payload.code === "response_timeout"));
     assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
   } finally {

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -375,19 +375,23 @@ BUNDLE=$(yoetz bundle -p "Review this code" -f src/*.rs --format json | jq -r .a
 # Send to ChatGPT
 yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE"
 
-# Every request opens a fresh, yoetz-owned ChatGPT tab marked with ?_yoetz=<run-id>
-# so your own ChatGPT conversations are never touched. `--var thread=reuse` is
-# rejected — yoetz is always a fresh-tab consumer.
+# By default, every request opens a fresh, yoetz-owned ChatGPT tab marked with
+# ?_yoetz=<run-id> so your own ChatGPT tabs are not touched. `--var thread=reuse`
+# is rejected. To resume, pass `--var conversation=<id|url>`; yoetz still opens a
+# new owned tab for that conversation.
 ```
 
 The wait loop reports `completion_reason` in its JSON output:
 - `copy_button` — the strong signal: a copy control rendered on the new
   assistant message (response is fully streamed).
+- `stable_idle_unscoped_copy_button` — guarded recovery for long responses when
+  scoped assistant text is stable, generation is idle, and a new copy control is
+  visible but cannot be scoped to the latest assistant turn.
 
 There is no generic "stable text" completion fallback for the extension
 transport. If ChatGPT text is visible but final controls have not appeared yet,
-Yoetz keeps waiting and prints the inspect command so the owning agent can
-debug the live tab instead of accepting a partial prefix.
+Yoetz keeps waiting and prints the inspect command unless the long-response
+copy-control recovery above is satisfied.
 
 ### Combined workflow: API + Browser
 


### PR DESCRIPTION
## Summary

Fix native ChatGPT completion finality for long Pro Extended reasoning runs where the final answer is stable and idle, a copy control is visible, but the DOM extractor cannot scope that copy control to the latest assistant turn.

## Changes

- Add a guarded service-worker recovery path for long stable `assistant_dom_fallback` answers with unscoped copy controls.
- Require idle generation, no visible stop controls when diagnostics are present, long text, copy-count growth after the pre-send baseline, and the existing stable idle window before completing.
- Add fake ChatGPT DOM coverage for the mis-scoped long-answer extraction state.
- Add service-worker regressions for the support-positive case, baseline-only copy controls, and long text that is still generating.
- Correct `skills/yoetz/SKILL.md` wording for fresh tabs vs `--var conversation=<id|url>` resume tabs, and document the new completion reason.

## Testing

- [ ] `cargo test` passes (not run; change is native-extension JS + skill docs only)
- [ ] `cargo clippy` passes without warnings (not run; change is native-extension JS + skill docs only)
- [ ] `cargo fmt` applied (not run; no Rust changes)
- [x] New tests added for new functionality
- [x] `npm test` in `extensions/chatgpt-native` passes (205 tests)
- [x] `git diff --check` passes

## Release Impact

- [x] This change needs a release entry / next `chore(release): vX.Y.Z`
- [x] This change affects packaged binaries, Homebrew/Scoop, or skill metadata

## Related Issues

Support-important AMQ handoff: completion-finality gap for long ChatGPT Pro Extended reasoning.