### PR TITLE
[codex] Add doctor-only ChatGPT auth probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Changed
+
+- `yoetz browser extension doctor --chatgpt` now performs a doctor-only
+  ChatGPT auth probe through the native extension. It reports whether the
+  bridge is up and the selected Chrome profile is ChatGPT-authenticated, while
+  keeping `yoetz browser check --transport chrome-extension-native`
+  transport-only.
 
 ## [0.5.25] - 2026-06-05
 ### Changed

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -832,6 +832,74 @@ pub fn doctor() -> Result<DoctorReport> {
     Ok(DoctorReport { ok, checks })
 }
 
+pub fn doctor_with_auth_probe(selector: ExtensionInstanceSelector<'_>) -> Result<DoctorReport> {
+    let mut report = doctor()?;
+    report.checks.push(chatgpt_auth_doctor_check(selector));
+    report.ok = report.checks.iter().all(|check| check.ok);
+    Ok(report)
+}
+
+fn chatgpt_auth_doctor_check(selector: ExtensionInstanceSelector<'_>) -> DoctorCheck {
+    match chatgpt_auth_probe(selector) {
+        Ok(payload) => chatgpt_auth_doctor_check_from_payload(&payload),
+        Err(error) => DoctorCheck {
+            name: "chatgpt_auth",
+            ok: true,
+            detail: format!("status=probe_unavailable, auth probe unavailable: {error}"),
+        },
+    }
+}
+
+fn chatgpt_auth_doctor_check_from_payload(payload: &Value) -> DoctorCheck {
+    let status = payload
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let authenticated = payload
+        .get("authenticated")
+        .and_then(Value::as_bool)
+        .unwrap_or(status == "authenticated");
+    let mut detail = vec![format!("status={status}")];
+    if let Some(message) = payload.get("message").and_then(Value::as_str) {
+        detail.push(message.to_string());
+    }
+    if let Some(tab_id) = payload.get("tab_id").and_then(Value::as_u64) {
+        detail.push(format!("tab_id={tab_id}"));
+    }
+    if let Some(selection) = payload.get("selection").and_then(Value::as_str) {
+        detail.push(format!("selection={selection}"));
+    }
+    if let Some(url) = payload
+        .get("url")
+        .or_else(|| payload.get("tab_url"))
+        .and_then(Value::as_str)
+    {
+        detail.push(format!("url={url}"));
+    }
+    DoctorCheck {
+        name: "chatgpt_auth",
+        ok: authenticated || !is_confirmed_unusable_chatgpt_auth_status(status),
+        detail: detail.join(", "),
+    }
+}
+
+fn is_confirmed_unusable_chatgpt_auth_status(status: &str) -> bool {
+    // Only hard-fail doctor on statuses that prove ChatGPT cannot be used in the profile.
+    matches!(
+        status,
+        "login_required" | "challenge_required" | "rate_limited"
+    )
+}
+
+pub fn chatgpt_auth_probe(selector: ExtensionInstanceSelector<'_>) -> Result<Value> {
+    let response = send_control_job(
+        "reconnect",
+        json!({ "intent": "doctor_auth_probe" }),
+        selector,
+    )?;
+    Ok(response.payload)
+}
+
 pub fn reconnect(selector: ExtensionInstanceSelector<'_>) -> Result<Value> {
     let response = send_control_job("reconnect", json!({ "intent": "reconnect" }), selector)?;
     Ok(json!({
@@ -1353,7 +1421,7 @@ fn select_extension_instance(
         1 => Ok(instances[0].clone()),
         0 => connect_legacy_socket_instance(paths),
         _ => bail!(
-            "chrome-extension-native found multiple connected extension profiles; pass --var profile_email=<chrome-profile-email> or --var extension_instance_id=<id> so Yoetz can route the job safely. Connected instances: {}",
+            "chrome-extension-native found multiple connected extension profiles; pass --profile-email=<chrome-profile-email> or --extension-instance-id=<id> (recipe callers can use --var profile_email=<chrome-profile-email> or --var extension_instance_id=<id>) so Yoetz can route the job safely. Connected instances: {}",
             observed_extension_profiles(&instances)
         ),
     }
@@ -3456,6 +3524,56 @@ mod tests {
         assert_eq!(payload.status, "not_installed");
         assert!(!payload.manifest_installed);
         assert!(!payload.token_present);
+    }
+
+    #[test]
+    fn chatgpt_auth_doctor_check_reports_login_required_probe() {
+        let check = chatgpt_auth_doctor_check_from_payload(&json!({
+            "status": "login_required",
+            "authenticated": false,
+            "message": "ChatGPT login required in this Chrome profile",
+            "tab_id": 7,
+            "selection": "active_non_yoetz_chatgpt_tab",
+            "url": "https://chatgpt.com/auth/login"
+        }));
+
+        assert_eq!(check.name, "chatgpt_auth");
+        assert!(!check.ok);
+        assert!(check.detail.contains("login_required"));
+        assert!(check.detail.contains("tab_id=7"));
+        assert!(check.detail.contains("active_non_yoetz_chatgpt_tab"));
+    }
+
+    #[test]
+    fn chatgpt_auth_doctor_check_accepts_authenticated_probe() {
+        let check = chatgpt_auth_doctor_check_from_payload(&json!({
+            "status": "authenticated",
+            "authenticated": true,
+            "message": "ChatGPT authenticated in this Chrome profile",
+            "tab_id": 7,
+            "selection": "active_non_yoetz_chatgpt_tab",
+            "url": "https://chatgpt.com/"
+        }));
+
+        assert_eq!(check.name, "chatgpt_auth");
+        assert!(check.ok);
+        assert!(check.detail.contains("authenticated"));
+        assert!(check.detail.contains("tab_id=7"));
+    }
+
+    #[test]
+    fn chatgpt_auth_doctor_check_keeps_no_tab_probe_informational() {
+        let check = chatgpt_auth_doctor_check_from_payload(&json!({
+            "status": "no_chatgpt_tab",
+            "authenticated": false,
+            "message": "No ChatGPT tab is open in this Chrome profile; open https://chatgpt.com/ and rerun doctor",
+            "inspected_tabs": 0
+        }));
+
+        assert_eq!(check.name, "chatgpt_auth");
+        assert!(check.ok);
+        assert!(check.detail.contains("no_chatgpt_tab"));
+        assert!(check.detail.contains("open https://chatgpt.com/"));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -363,7 +363,7 @@ enum BrowserExtensionCommand {
     /// Install the ChatGPT native messaging host. Currently macOS/Linux only.
     InstallHost(BrowserExtensionScopeArgs),
     Status(BrowserExtensionScopeArgs),
-    Doctor(BrowserExtensionScopeArgs),
+    Doctor(BrowserExtensionMaintenanceArgs),
     Reconnect(BrowserExtensionMaintenanceArgs),
     Reload(BrowserExtensionMaintenanceArgs),
     /// Copy the packaged extension into Yoetz state, reload Chrome, and verify the version.
@@ -2495,7 +2495,12 @@ fn handle_browser_extension(
         }
         BrowserExtensionCommand::Doctor(args) => {
             ensure_chatgpt_extension_scope(args.chatgpt)?;
-            let report = browser_extension_native::doctor()?;
+            let selector = extension_selector_from_parts(
+                args.profile_email.as_ref(),
+                args.extension_instance_id.as_ref(),
+                args.extension_profile_id.as_ref(),
+            );
+            let report = browser_extension_native::doctor_with_auth_probe(selector)?;
             text_output = Some(format_extension_doctor(&report));
             ("browser.extension.doctor", serde_json::to_value(report)?)
         }

--- a/crates/yoetz-cli/tests/cli.rs
+++ b/crates/yoetz-cli/tests/cli.rs
@@ -326,6 +326,14 @@ fn browser_extension_setup_help_shows_open_chrome() {
 #[test]
 fn browser_extension_maintenance_help_shows_instance_selectors() {
     yoetz()
+        .args(["browser", "extension", "doctor", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--profile-email"))
+        .stdout(predicate::str::contains("--extension-instance-id"))
+        .stdout(predicate::str::contains("--extension-profile-id"));
+
+    yoetz()
         .args(["browser", "extension", "reconnect", "--help"])
         .assert()
         .success()

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -29,6 +29,8 @@ async function handleMessage(message) {
         conversation_id: message.conversation_id,
         include_page_text: Boolean(message.include_page_text)
       });
+    case "yoetz_auth_probe":
+      return authProbe();
     case "yoetz_probe":
       return probe();
     default:
@@ -233,6 +235,28 @@ async function inspectPage(runId, options = {}) {
     result.page_text_tail = pageText.slice(-500);
   }
   return result;
+}
+
+async function authProbe() {
+  const { classifyManualHandoff, getPageText } = await domHelpers();
+  const text = getPageText(document);
+  const handoff = classifyManualHandoff({
+    url: location.href,
+    title: document.title,
+    text
+  });
+  const authenticated = !handoff;
+  return {
+    status: authenticated ? "authenticated" : handoff.state,
+    authenticated,
+    manual_handoff: handoff,
+    message: authenticated
+      ? "ChatGPT authenticated in this Chrome profile"
+      : handoff.message,
+    url: location.href,
+    title: document.title,
+    text_chars: text.length
+  };
 }
 
 async function probe() {

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -647,7 +647,91 @@ async function handleReconnect(message) {
     setTimeout(() => chrome.runtime.reload(), 50);
     return;
   }
+  if (message.payload?.intent === "doctor_auth_probe") {
+    await handleDoctorAuthProbe(message);
+    return;
+  }
   await recoverJobs(message);
+}
+
+async function handleDoctorAuthProbe(message) {
+  postNative(makeEnvelope("job_complete", {
+    request_id: message.request_id,
+    job_id: message.job_id,
+    run_id: message.run_id,
+    workspace_id: message.workspace_id,
+    payload: await probeChatgptAuthentication()
+  }));
+}
+
+async function probeChatgptAuthentication() {
+  const tabs = await chrome.tabs.query({ url: "https://chatgpt.com/*" });
+  const selected = selectChatgptAuthProbeTab(tabs);
+  if (!selected) {
+    return {
+      status: "no_chatgpt_tab",
+      authenticated: false,
+      message: "No ChatGPT tab is open in this Chrome profile; open https://chatgpt.com/ and rerun doctor",
+      inspected_tabs: 0
+    };
+  }
+  try {
+    const probe = await sendToTab(selected.tab.id, { type: "yoetz_auth_probe" });
+    return {
+      ...probe,
+      tab_id: selected.tab.id,
+      tab_url: selected.tab.url ?? null,
+      tab_title: selected.tab.title ?? null,
+      selection: selected.selection,
+      inspected_tabs: selected.total
+    };
+  } catch (error) {
+    return {
+      status: "content_script_unavailable",
+      authenticated: false,
+      message: `Yoetz content script is not ready in selected ChatGPT tab: ${String(error?.message ?? error)}`,
+      tab_id: selected.tab.id,
+      tab_url: selected.tab.url ?? null,
+      tab_title: selected.tab.title ?? null,
+      selection: selected.selection,
+      inspected_tabs: selected.total
+    };
+  }
+}
+
+function selectChatgptAuthProbeTab(tabs) {
+  const candidates = (tabs ?? [])
+    .filter((tab) => tab?.id && String(tab.url ?? "").startsWith("https://chatgpt.com/"))
+    .map((tab) => ({
+      tab,
+      yoetzOwned: new URL(tab.url).searchParams.has("_yoetz")
+    }));
+  if (candidates.length === 0) {
+    return null;
+  }
+  const candidate =
+    candidates.find((item) => item.tab.active && !item.yoetzOwned)
+    ?? candidates.find((item) => !item.yoetzOwned)
+    ?? candidates.find((item) => item.tab.active)
+    ?? candidates[0];
+  return {
+    tab: candidate.tab,
+    selection: chatgptAuthProbeSelection(candidate),
+    total: candidates.length
+  };
+}
+
+function chatgptAuthProbeSelection(candidate) {
+  if (candidate.tab.active && !candidate.yoetzOwned) {
+    return "active_non_yoetz_chatgpt_tab";
+  }
+  if (!candidate.yoetzOwned) {
+    return "non_yoetz_chatgpt_tab";
+  }
+  if (candidate.tab.active) {
+    return "active_yoetz_job_tab";
+  }
+  return "yoetz_job_tab";
 }
 
 async function handleInspectRun(message) {

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -149,6 +149,30 @@ test("content script resume path skips fresh enforcement and completes on reques
   }
 });
 
+test("content script auth probe reports manual handoff without job side effects", async () => {
+  const { send, hooks, restore } = await loadContentScript("auth_probe_login", "https://chatgpt.com/auth/login");
+  try {
+    hooks.manualHandoff = {
+      state: "login_required",
+      message: "ChatGPT login required in this Chrome profile"
+    };
+    hooks.pageText = "Log in to ChatGPT";
+
+    const response = await send({ type: "yoetz_auth_probe" });
+
+    assert.equal(response.ok, true);
+    assert.equal(response.payload.status, "login_required");
+    assert.equal(response.payload.authenticated, false);
+    assert.deepEqual(response.payload.manual_handoff, hooks.manualHandoff);
+    assert.equal(response.payload.text_chars, "Log in to ChatGPT".length);
+    assert.deepEqual(hooks.ensureFreshChatCalls, []);
+    assert.deepEqual(hooks.ensureConversationLoadedCalls, []);
+    assert.deepEqual(hooks.markOwnershipCalls, []);
+  } finally {
+    restore();
+  }
+});
+
 test("content script resume prepare rejects a different conversation before send", async () => {
   const { send, restore } = await loadContentScript("resume_mismatch", "https://chatgpt.com/c/other?_yoetz=run_resume");
   try {

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -145,6 +145,66 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
   }
 });
 
+test("service worker doctor auth probe prefers active non-owned ChatGPT tab and surfaces login", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const sentToTabs = [];
+  globalThis.chrome = chromeStub({
+    port,
+    profileEmail: "work@example.com",
+    tabs: {
+      query: async () => [
+        { id: 1, url: "https://chatgpt.com/?_yoetz=run_job", title: "Yoetz job", active: true },
+        { id: 2, url: "https://chatgpt.com/", title: "ChatGPT", active: true },
+        { id: 3, url: "https://chatgpt.com/c/older", title: "Older ChatGPT", active: false }
+      ],
+      create: async () => {
+        throw new Error("doctor auth probe must not open a tab");
+      },
+      get: async () => {
+        throw new Error("doctor auth probe must not poll tab loading");
+      },
+      sendMessage: async (id, message) => {
+        sentToTabs.push({ id, message });
+        assert.equal(message.type, "yoetz_auth_probe");
+        return {
+          ok: true,
+          payload: {
+            status: "login_required",
+            authenticated: false,
+            manual_handoff: {
+              state: "login_required",
+              message: "ChatGPT login required in this Chrome profile"
+            },
+            url: "https://chatgpt.com/auth/login",
+            title: "Log in | ChatGPT"
+          }
+        };
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?doctor_auth=${Date.now()}`);
+    await eventually(() => port.messages.some((message) => message.type === "hello"));
+    port.messages.length = 0;
+
+    port.emit(envelope("reconnect", "job_auth_probe", { intent: "doctor_auth_probe" }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_complete"));
+    const complete = port.messages.find((message) => message.type === "job_complete");
+    assert.equal(complete.job_id, "job_auth_probe");
+    assert.equal(complete.payload.status, "login_required");
+    assert.equal(complete.payload.authenticated, false);
+    assert.equal(complete.payload.manual_handoff.state, "login_required");
+    assert.equal(complete.payload.tab_id, 2);
+    assert.equal(complete.payload.selection, "active_non_yoetz_chatgpt_tab");
+    assert.deepEqual(sentToTabs.map((item) => item.id), [2]);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker opens fresh and resume jobs in new owned tabs", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();


### PR DESCRIPTION
## What changed

Adds a doctor-only ChatGPT authentication probe for the native extension path.

- `yoetz browser extension doctor --chatgpt` now reports the static bridge checks plus a `chatgpt_auth` check.
- The auth probe uses an existing ChatGPT tab and classifies manual handoff states without sending a ChatGPT message, opening tabs, or running job recovery.
- `yoetz browser check --transport chrome-extension-native` remains transport-only.
- Doctor auth gating only fails on confirmed unusable states: `login_required`, `challenge_required`, and `rate_limited`; no-tab and probe-unavailable states stay informational.
- Adds selector help coverage for doctor and JS/Rust tests for the content-script probe, service-worker tab selection, and doctor gating semantics.

## Why

ChatGPT Pro readiness should be visible in `doctor --chatgpt`, but regular transport checks should not run live canaries or interfere with how the host agent builds/sends bundles.

## Validation

- `npm test` in `extensions/chatgpt-native`
- `cargo fmt --all -- --check`
- `cargo test -p yoetz browser_extension -- --nocapture`
- `cargo test -p yoetz chatgpt_auth_doctor_check -- --nocapture`
- `git diff --cached --check`

Claude adversarial review cleared the staged change over AMQ before commit; he will re-confirm on the PR before merge.