### PR TITLE
fix(extension): mark ChatGPT progress non-final so interim Pro turns aren't misread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- ChatGPT native progress no longer lets an in-progress, multi-turn Pro
+  "Extended" response be misread as the final answer. ChatGPT Pro now streams
+  the answer as several short interim turns ("I'll review…", "I've narrowed…")
+  before the real answer arrives minutes later, and the first interim turn's
+  streaming head is a single "I". The waiter already never *completes* on an
+  interim turn (generation stays active across them), but its progress and
+  `inspect` output surfaced the interim partial text, which a calling agent
+  could mistake for the verdict and abort the run early. Every `job_progress`
+  event now carries `is_final: false` (enforced — callers cannot override it),
+  the terminal `job_complete` carries `is_final: true` as the only
+  authoritative answer, and progress/`inspect` now label interim turns
+  (`response_in_progress`, `interim_assistant_turn`,
+  `assistant_turns_since_send`). Completion behavior is unchanged.
+
 ### Changed
 
 - `yoetz browser extension doctor --chatgpt` now performs a doctor-only

--- a/extensions/chatgpt-native/src/protocol.js
+++ b/extensions/chatgpt-native/src/protocol.js
@@ -82,6 +82,14 @@ export function validateEnvelope(message, options = {}) {
 }
 
 export function progress(job, phase, detail = {}) {
+  // INVARIANT: every job_progress event is non-final. The authoritative answer is only ever
+  // delivered in the terminal job_complete envelope (payload.is_final=true). A machine consumer
+  // (inspect/JSONL stream) must be able to trust is_final to never mistake a streaming/interim
+  // turn's partial text for the final response — ChatGPT Pro Extended streams the answer as several
+  // interim end_turn turns before the real one, so any progress text may be an interim turn's head
+  // (observed live as a single "I"). Strip any caller-supplied is_final and force false LAST so no
+  // call site can ever emit a final-looking progress event, now or in the future.
+  const { is_final: _ignoredIsFinal, ...rest } = detail;
   return makeEnvelope("job_progress", {
     job_id: job.job_id,
     run_id: job.run_id,
@@ -89,7 +97,8 @@ export function progress(job, phase, detail = {}) {
     capability_token: job.capability_token,
     payload: {
       phase,
-      ...detail
+      ...rest,
+      is_final: false
     }
   });
 }

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -446,6 +446,10 @@ async function completeJobWithExtraction(job, extraction) {
     capability_token: job.capability_token,
     payload: {
       tab_id: job.tab_id,
+      // The authoritative answer. This is the ONLY surface that carries is_final=true; every
+      // job_progress event is is_final=false. A consumer must treat job_complete.response as the
+      // response and never a progress event's interim/partial text.
+      is_final: true,
       response: extraction.text,
       extraction_method: extraction.method,
       completion_reason: extraction.completion_reason,
@@ -755,10 +759,18 @@ async function handleInspectRun(message) {
         run_id: runId,
         conversation_id: runId
       }));
+      const responseInProgress = Boolean(inspection?.extraction?.is_generating);
       matches.push({
         tab_id: tab.id,
         url: tab.url ?? inspection?.url ?? null,
         title: tab.title ?? inspection?.title ?? null,
+        // Non-final marker for inspect read mid-stream. ChatGPT Pro Extended streams several interim
+        // turns before the answer; while generating, inspection.extraction.text is a partial/interim
+        // turn's body (observed live as a single "I"), NOT the verdict. Wait for generation to stop.
+        response_in_progress: responseInProgress,
+        note: responseInProgress
+          ? "response still generating; extraction.text is a partial/interim assistant turn, not the final answer"
+          : undefined,
         inspection
       });
     } catch (error) {
@@ -1578,6 +1590,24 @@ async function waitForResponse(job) {
   return null;
 }
 
+// How many assistant turns have appeared since the prompt was sent. The post-send baseline is
+// captured before send; the first turn beyond it is the response's first turn, and any turn beyond
+// THAT (while still generating) means the earlier turns were interim Pro-Extended status posts.
+function assistantTurnsSinceSend(job, extraction) {
+  const baseline = Number(job.response_baseline?.assistant_count ?? 0);
+  const current = Number(extraction?.assistant_count ?? 0);
+  return Math.max(0, current - baseline);
+}
+
+// Single source of truth for "is this progress an interim Pro-Extended turn, not the answer?".
+// A second-or-later assistant turn appearing while generation is still active proves the earlier
+// turn(s) were interim status posts ("I'll review...", "I've narrowed..."), not the final answer.
+function interimTurnState(job, extraction) {
+  const generating = Boolean(extraction?.is_generating);
+  const turnsSinceSend = assistantTurnsSinceSend(job, extraction);
+  return { generating, turnsSinceSend, interimAssistantTurn: generating && turnsSinceSend > 1 };
+}
+
 function postResponseProgress(job, extraction) {
   const text = String(extraction?.text ?? "");
   if (!text || text === job.last_response_progress_text) {
@@ -1586,13 +1616,19 @@ function postResponseProgress(job, extraction) {
   const previous = String(job.last_response_progress_text ?? "");
   const delta = text.startsWith(previous) ? text.slice(previous.length) : text;
   job.last_response_progress_text = text;
+  const { generating, turnsSinceSend, interimAssistantTurn } = interimTurnState(job, extraction);
   postNative(progress(job, "response_observed", {
-    message: `response observed (${text.length} chars${extraction?.is_generating ? ", still generating" : ""})`,
+    message: interimAssistantTurn
+      ? `interim assistant turn observed (${text.length} chars, turn ${turnsSinceSend} since send, still generating — not the final response)`
+      : `response observed (${text.length} chars${generating ? ", still generating" : ""})`,
+    response_in_progress: generating,
+    interim_assistant_turn: interimAssistantTurn,
+    assistant_turns_since_send: turnsSinceSend,
     response_delta: delta,
     response_length: text.length,
     response_tail: text.slice(-500),
     extraction_method: extraction.method,
-    is_generating: Boolean(extraction.is_generating),
+    is_generating: generating,
     assistant_count: extraction.assistant_count ?? 0,
     turn_index: extraction.turn_index ?? -1,
     copy_button_count: extraction.copy_button_count ?? 0,
@@ -1605,12 +1641,17 @@ function postWaitingResponseProgress(job, extraction, detail = {}) {
   const timeoutMs = Number(detail.timeout_ms ?? responseWaitTimeoutMs(job));
   const finalityStatus = detail.awaiting_final_affordance ? ", waiting for final assistant controls" : "";
   const scopedCopyStatus = extraction?.has_copy_button ? ", scoped_copy_button=true" : ", scoped_copy_button=false";
+  const { generating, turnsSinceSend, interimAssistantTurn } = interimTurnState(job, extraction);
+  const interimStatus = interimAssistantTurn ? `, interim assistant turn ${turnsSinceSend} (response not final)` : "";
   postNative(progress(job, "waiting_response", {
     ...detail,
     inspect_command: detail.inspect_command ?? inspectCommandForJob(job),
-    message: `waiting for ChatGPT response (${formatDurationForMessage(elapsedMs)} elapsed of ${formatDurationForMessage(timeoutMs)} timeout; method=${extraction?.method ?? "none"}, assistant_count=${extraction?.assistant_count ?? 0}, copy_buttons=${extraction?.copy_button_count ?? 0}${scopedCopyStatus}${extraction?.is_generating ? ", generating" : ""}${finalityStatus})`,
+    message: `waiting for ChatGPT response (${formatDurationForMessage(elapsedMs)} elapsed of ${formatDurationForMessage(timeoutMs)} timeout; method=${extraction?.method ?? "none"}, assistant_count=${extraction?.assistant_count ?? 0}, copy_buttons=${extraction?.copy_button_count ?? 0}${scopedCopyStatus}${generating ? ", generating" : ""}${interimStatus}${finalityStatus})`,
     extraction_method: extraction?.method ?? "none",
-    is_generating: Boolean(extraction?.is_generating),
+    response_in_progress: generating,
+    interim_assistant_turn: interimAssistantTurn,
+    assistant_turns_since_send: turnsSinceSend,
+    is_generating: generating,
     assistant_count: extraction?.assistant_count ?? 0,
     turn_index: extraction?.turn_index ?? -1,
     copy_button_count: extraction?.copy_button_count ?? 0,

--- a/extensions/chatgpt-native/tests/protocol.test.js
+++ b/extensions/chatgpt-native/tests/protocol.test.js
@@ -6,8 +6,21 @@ import {
   PROTOCOL_VERSION,
   TRANSPORT,
   makeEnvelope,
+  progress,
   validateEnvelope
 } from "../src/protocol.js";
+
+const PROGRESS_JOB = { job_id: "job_test", run_id: "run_test", workspace_id: "ws_test", capability_token: "cap_test" };
+
+test("progress events are always non-final and the invariant cannot be overridden by the caller", () => {
+  assert.equal(progress(PROGRESS_JOB, "response_observed").payload.is_final, false);
+  // Even a caller that explicitly passes is_final:true must not be able to emit a final-looking
+  // progress event — the authoritative answer is only ever job_complete.
+  const forced = progress(PROGRESS_JOB, "response_observed", { is_final: true, response_tail: "I" });
+  assert.equal(forced.type, "job_progress");
+  assert.equal(forced.payload.is_final, false);
+  assert.equal(forced.payload.response_tail, "I");
+});
 
 test("protocol exports the pinned extension id", () => {
   assert.equal(EXTENSION_ID, "njdakhppfigmloihiikbjmheejfndbfa");

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -2623,6 +2623,112 @@ test("service worker preserves the best final response across a transient genera
   }
 });
 
+test("service worker labels interim Pro-Extended turns as non-final and completes on the later real answer", async () => {
+  // RC4 regression: ChatGPT Pro Extended streams the answer as MULTIPLE interim end_turn turns
+  // ("I'll review...", "I've narrowed...") before the real answer arrives minutes later. The first
+  // interim turn's streaming head is a single "I" (observed live in conv 6a23a3a6). The waiter must
+  // NOT surface that interim "I" as if it were the final response, and must complete on the later
+  // real answer. is_generating stays TRUE across interim turns (verified live), so the gate never
+  // completes early; progress events must mark non-finality so a consumer cannot misread "I".
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  let tabId = 0;
+  let sent = false;
+  let extractCount = 0;
+  const FINAL = "No P0 found. I found two P1 proof-integrity issues and several P2 residual risks.";
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true } };
+          case "yoetz_extract_response": {
+            if (!sent) {
+              // Pre-send baseline (assistant_count 0).
+              return { ok: true, payload: { method: "none", text: "", is_generating: false, assistant_count: 0, copy_button_count: 0, has_copy_button: false, turn_index: -1 } };
+            }
+            extractCount += 1;
+            const base = { user_count: 1, preceding_user_count: 1 };
+            if (extractCount === 1) {
+              // Interim turn #1, streaming head = "I", still generating, no copy button yet.
+              return { ok: true, payload: { ...base, method: "assistant_dom_fallback", text: "I", is_generating: true, assistant_count: 1, copy_button_count: 0, has_copy_button: false, turn_index: 0 } };
+            }
+            if (extractCount === 2) {
+              return { ok: true, payload: { ...base, method: "assistant_dom_fallback", text: "I'll review the bundled diff as the source of truth", is_generating: true, assistant_count: 1, copy_button_count: 0, has_copy_button: false, turn_index: 0 } };
+            }
+            if (extractCount === 3) {
+              // Interim turn #2 now streaming while still generating -> proves turn #1 was interim.
+              return { ok: true, payload: { ...base, method: "assistant_dom_fallback", text: "I've narrowed review to a few possible proof-binding gaps", is_generating: true, assistant_count: 2, copy_button_count: 0, has_copy_button: false, turn_index: 1 } };
+            }
+            // Real final answer: generation stopped, scoped copy button present, stable -> completes.
+            return { ok: true, payload: { ...base, method: "copy_scope_dom_fallback", text: FINAL, is_generating: false, assistant_count: 3, copy_button_count: 1, has_copy_button: true, turn_index: 2 } };
+          }
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?interim_turn_labeling=${Date.now()}`);
+    port.emit(envelope("job_start", "job_interim_turn_labeling", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 4000
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_interim_turn_labeling", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_interim_turn_labeling.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_complete"), 6000);
+    const complete = port.messages.find((message) => message.type === "job_complete");
+
+    // Completion: the later real answer, explicitly marked final.
+    assert.equal(complete.payload.response, FINAL);
+    assert.equal(complete.payload.is_final, true);
+    assert.equal(complete.payload.completion_reason, "copy_button");
+    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
+
+    const progressEvents = port.messages.filter((message) => message.type === "job_progress");
+    // EVERY progress event is non-final by construction -> a consumer cannot mistake interim text for the answer.
+    assert.ok(progressEvents.length > 0);
+    assert.equal(progressEvents.every((message) => message.payload.is_final === false), true);
+
+    const observed = progressEvents.filter((message) => message.payload.phase === "response_observed");
+    // The interim "I" was surfaced in progress but clearly marked in-progress / non-final.
+    const iEvent = observed.find((message) => message.payload.response_length === 1);
+    assert.ok(iEvent, "expected a response_observed event for the single-char interim head 'I'");
+    assert.equal(iEvent.payload.is_final, false);
+    assert.equal(iEvent.payload.response_in_progress, true);
+    // Once a second assistant turn streams while generating, it is labeled an interim assistant turn.
+    const interim = observed.find((message) => message.payload.interim_assistant_turn === true);
+    assert.ok(interim, "expected an interim_assistant_turn=true progress event for the 2nd streaming turn");
+    assert.equal(interim.payload.assistant_turns_since_send, 2);
+    assert.equal(interim.payload.response_in_progress, true);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker settles same-length post-final text churn instead of timing out", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();


### PR DESCRIPTION
## Problem (the "I bug")

A ChatGPT Pro review returned only the single char `I`. Root-caused with live evidence (the actual run in ChatGPT conv `6a23a3a6` + a fresh 1.5s-resolution streaming capture on Extended Pro):

- ChatGPT Pro **Extended now streams the answer as multiple interim `end_turn` turns** ("I'll review…", "I've narrowed…") before the real answer arrives ~10 min later. The first interim turn's streaming head is a single `I`.
- The completion gate is **sound**: `is_generating` (stop button) stays continuously true across all interim turns (verified live — the only idle window is at whole-response completion, when the latest turn is the real answer with its copy button). So yoetz **never completes on an interim turn**.
- The failure was operational: the run was killed ~9–11 min early, and the waiter's **progress / `inspect` output surfaced the interim turn's partial text (`I`)**, which a calling agent misread as the final verdict.

Ruled out (this machine is fully current, v0.5.25 binary + loaded extension): the v0.5.20 `innerText` virtualization bug (RC1) and version/extension skew (RC3). `telclaude` confirmed the `I` was genuine (both `text_chars` and `text_content_chars` tiny).

## Fix (progress/observability only — completion logic unchanged)

- `protocol.js`: every `job_progress` event carries `is_final: false`, **enforced** — any caller-supplied `is_final` is stripped, so no call site can emit a final-looking progress event now or later.
- `service-worker.js`: terminal `job_complete` carries `is_final: true` as the only authoritative answer; `response_observed` / `waiting_response` / `inspect` label interim turns (`response_in_progress`, `interim_assistant_turn`, `assistant_turns_since_send`), and `inspect` warns when read mid-stream.

## Tests

- `protocol.test.js`: invariant — `is_final` cannot be overridden by the caller.
- `service-worker.test.js`: multi-turn Pro scenario — interim `I` streams, a 2nd interim turn streams while generating, then the real answer; asserts every progress event is non-final, the interim turns are labeled, and `job_complete` is the real answer with `is_final: true`.
- **209/209 JS tests pass.**

## Notes

- Reviewed by codex (required `is_final` override hole fixed + enforcement test added).
- Dropped a candidate identity-reset idea that regressed the v0.5.14 anti-artifact latch tests and was moot given `is_generating` stays true across interim turns.
- JS extension only; the Rust CLI passes these payloads through unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)