### PR TITLE
Fix ChatGPT native capture when background rendering freezes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 ### Fixed
 
+- ChatGPT native-extension capture now reads completed answers from ChatGPT's
+  same-origin backend conversation API after the DOM reports generation idle.
+  This is the primary recovery path for backgrounded Pro runs whose rendered
+  transcript freezes on the first token (for example `"I"`): the content script
+  resolves the active `current_node` lineage only, rejects stale/off-branch
+  answers, and returns the full backend answer to the service worker without
+  waiting for final copy controls that may never render while the tab is
+  backgrounded.
 - ChatGPT native-extension runs now refresh the owned conversation tab when a
   background live-stream render freezes on a short idle assistant prefix without
   final scoped copy controls. The refresh is bounded, reloads the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- ChatGPT native-extension runs now refresh the owned conversation tab when a
+  background live-stream render freezes on a short idle assistant prefix without
+  final scoped copy controls. The refresh is bounded, reloads the same
+  conversation URL with the Yoetz run marker, rebinds/revalidates the content
+  script, and then resumes normal final-response polling so completed Pro
+  answers can be captured instead of timing out on a frozen `"I"`.
 
 ## [0.5.26] - 2026-06-06
 ### Fixed

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -314,23 +314,23 @@ function resolveBackendAnswer(job, conversationId, data) {
   if (!mapping) {
     return notReady("backend-api response had no conversation mapping");
   }
-  // Count COMPLETED assistant answer turns addressed to the user (recipient 'all'). This excludes
-  // thoughts/reasoning_recap (content_type != text) and tool turns (recipient like container.exec /
-  // file_search.msearch). Freshness = the count exceeds the pre-send baseline, i.e. a NEW answer
-  // landed for THIS prompt (not a leftover from a resumed conversation).
-  const assistantAnswerCount = Object.values(mapping).filter((node) => isAssistantAnswerNode(node?.message)).length;
-  // Walk current_node UP its parent chain to the latest completed assistant answer node. current_node
-  // may be a tool/reasoning_recap node, so we cannot just read it directly.
-  const answerNode = walkToAnswerNode(mapping, data.current_node);
+  // Freshness MUST be scoped to the ACTIVE current_node lineage, not the whole mapping. ChatGPT
+  // retains off-branch assistant answers (regenerations / abandoned / alternate branches) in the
+  // mapping; a global count could be inflated past the baseline by an off-branch node while the
+  // active lineage still points at a STALE earlier answer — returning that stale answer as fresh.
+  // So walk current_node -> root ONCE: the latest answer node on that path is THE answer, and the
+  // count of answer nodes on that path is what we compare against the pre-send baseline. current_node
+  // may be a tool/reasoning_recap node, so we cannot read it directly.
+  const { answerNode, count: lineageAnswerCount } = collectLineageAnswerNodes(mapping, data.current_node);
   if (!answerNode) {
-    return notReady("no completed assistant answer node yet (still generating / tool-only)");
+    return notReady("no completed assistant answer node on the active lineage yet (still generating / tool-only)");
   }
-  if (assistantAnswerCount <= baseline) {
-    return notReady(`assistant answer not fresh past baseline (${assistantAnswerCount} <= ${baseline})`);
+  if (lineageAnswerCount <= baseline) {
+    return notReady(`assistant answer not fresh past baseline (active-lineage ${lineageAnswerCount} <= ${baseline})`);
   }
   const text = answerTextOf(answerNode.message);
   if (!text) {
-    return notReady("latest assistant answer node had no text parts");
+    return notReady("latest active-lineage assistant answer node had no text parts");
   }
   return {
     method: "backend_api",
@@ -338,8 +338,8 @@ function resolveBackendAnswer(job, conversationId, data) {
     is_generating: false,
     conversation_id: conversationId,
     node_fresh: true,
-    assistant_count: assistantAnswerCount,
-    turn_index: Math.max(0, assistantAnswerCount - 1),
+    assistant_count: lineageAnswerCount,
+    turn_index: Math.max(0, lineageAnswerCount - 1),
     node_id: String(answerNode.id ?? answerNode.message?.id ?? ""),
     has_copy_button: false,
     copy_button_count: 0
@@ -378,21 +378,29 @@ function answerTextOf(message) {
   return parts.filter((part) => typeof part === "string").join("").trim();
 }
 
-function walkToAnswerNode(mapping, currentNodeId) {
+// Walk current_node -> root once, collecting the COMPLETED assistant answer nodes that lie on the
+// ACTIVE lineage. Returns { answerNode: latest-on-lineage (closest to current_node), count }.
+// Off-branch answers (not on this path) are intentionally not seen here.
+function collectLineageAnswerNodes(mapping, currentNodeId) {
   let id = currentNodeId;
   let guard = 0;
+  let answerNode = null;
+  let count = 0;
   while (id && guard < 2000) {
     guard += 1;
     const node = mapping[id];
     if (!node) {
-      return null;
+      break;
     }
     if (isAssistantAnswerNode(node.message)) {
-      return node;
+      if (!answerNode) {
+        answerNode = node;
+      }
+      count += 1;
     }
     id = node.parent;
   }
-  return null;
+  return { answerNode, count };
 }
 
 function nonNegativeInt(value) {

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -220,18 +220,12 @@ async function fetchConversationAnswer(job, requestedConversationId) {
     || expectedConversationIdForJob(job)
     || conversationIdFromUrl(location.href);
   if (!conversationId) {
-    throw commandError("backend_api_unavailable", "no conversation id available for backend-api read", {
-      phase: "wait_response",
-      side_effect_started: true
-    });
+    throw backendApiError("backend_api_unavailable", "no conversation id available for backend-api read");
   }
   // accessToken is fetched PER CALL — it expires and must never be cached.
   const token = await fetchChatgptAccessToken();
   if (!token) {
-    throw commandError("backend_api_unauthorized", "no ChatGPT access token (session expired or signed out)", {
-      phase: "wait_response",
-      side_effect_started: true
-    });
+    throw backendApiError("backend_api_unauthorized", "no ChatGPT access token (session expired or signed out)");
   }
   let res;
   try {
@@ -241,34 +235,28 @@ async function fetchConversationAnswer(job, requestedConversationId) {
       headers: { Authorization: `Bearer ${token}`, Accept: "application/json" }
     });
   } catch (error) {
-    throw commandError("backend_api_unavailable", `backend-api conversation fetch failed: ${String(error?.message ?? error)}`, {
-      phase: "wait_response",
-      side_effect_started: true
-    });
+    throw backendApiError("backend_api_unavailable", `backend-api conversation fetch failed: ${String(error?.message ?? error)}`);
   }
   // 401/403 -> auth lane (SW falls back to reload-to-render / DOM); other non-2xx -> unavailable.
   if (res.status === 401 || res.status === 403) {
-    throw commandError("backend_api_unauthorized", `backend-api conversation returned ${res.status}`, {
-      phase: "wait_response",
-      side_effect_started: true
-    });
+    throw backendApiError("backend_api_unauthorized", `backend-api conversation returned ${res.status}`);
   }
   if (!res.ok) {
-    throw commandError("backend_api_unavailable", `backend-api conversation returned ${res.status}`, {
-      phase: "wait_response",
-      side_effect_started: true
-    });
+    throw backendApiError("backend_api_unavailable", `backend-api conversation returned ${res.status}`);
   }
   let data;
   try {
     data = await res.json();
   } catch (error) {
-    throw commandError("backend_api_unavailable", `backend-api conversation returned non-JSON: ${String(error?.message ?? error)}`, {
-      phase: "wait_response",
-      side_effect_started: true
-    });
+    throw backendApiError("backend_api_unavailable", `backend-api conversation returned non-JSON: ${String(error?.message ?? error)}`);
   }
   return resolveBackendAnswer(job, conversationId, data);
+}
+
+// Backend-api read failures are all wait_response-phase, side-effect-started (the prompt was already
+// sent). The SW maps backend_api_* codes to its T2 reload / T3 DOM fallback.
+function backendApiError(code, message) {
+  return commandError(code, message, { phase: "wait_response", side_effect_started: true });
 }
 
 async function fetchChatgptAccessToken() {

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -22,6 +22,8 @@ async function handleMessage(message) {
       return sendPrompt(message.job, message.prompt);
     case "yoetz_extract_response":
       return extractJobResponse(message.job);
+    case "yoetz_fetch_conversation":
+      return fetchConversationAnswer(message.job, message.conversation_id);
     case "yoetz_cancel_send":
       return cancelSend(message.job);
     case "yoetz_inspect_page":
@@ -199,6 +201,203 @@ async function extractJobResponse(job) {
     url: location.href,
     conversation_id: conversationId
   };
+}
+
+// T1 freeze-proof answer source: read the FINAL assistant answer from ChatGPT's backend
+// conversation API instead of the rendered DOM. The owned tab live-streams the answer while
+// BACKGROUNDED, where Chromium suspends rAF rendering, so the DOM freezes at the first token
+// ("I"); but a same-origin JSON GET runs on a task source Chrome does NOT throttle in background
+// tabs, so it returns the complete server-side answer (live-proven: full answer in a hidden tab
+// while the DOM was clipped). Same-origin fetch from this ISOLATED content script authenticates
+// with the page's httpOnly session cookie; host_permissions already covers chatgpt.com, so this
+// is zero new permission. The service worker owns WHEN to call this (gated on DOM idle) and the
+// T1->T2(reload)->T3(DOM) fallback; this function only reads + resolves the answer node.
+async function fetchConversationAnswer(job, requestedConversationId) {
+  const { parseOwnedWindowName } = await domHelpers();
+  // Ownership marker (window.name run/job) must still match — never read for the wrong job/tab.
+  assertJobOwnership(job, parseOwnedWindowName);
+  const conversationId = String(requestedConversationId ?? "").trim()
+    || expectedConversationIdForJob(job)
+    || conversationIdFromUrl(location.href);
+  if (!conversationId) {
+    throw commandError("backend_api_unavailable", "no conversation id available for backend-api read", {
+      phase: "wait_response",
+      side_effect_started: true
+    });
+  }
+  // accessToken is fetched PER CALL — it expires and must never be cached.
+  const token = await fetchChatgptAccessToken();
+  if (!token) {
+    throw commandError("backend_api_unauthorized", "no ChatGPT access token (session expired or signed out)", {
+      phase: "wait_response",
+      side_effect_started: true
+    });
+  }
+  let res;
+  try {
+    res = await fetch(`/backend-api/conversation/${encodeURIComponent(conversationId)}`, {
+      method: "GET",
+      credentials: "include",
+      headers: { Authorization: `Bearer ${token}`, Accept: "application/json" }
+    });
+  } catch (error) {
+    throw commandError("backend_api_unavailable", `backend-api conversation fetch failed: ${String(error?.message ?? error)}`, {
+      phase: "wait_response",
+      side_effect_started: true
+    });
+  }
+  // 401/403 -> auth lane (SW falls back to reload-to-render / DOM); other non-2xx -> unavailable.
+  if (res.status === 401 || res.status === 403) {
+    throw commandError("backend_api_unauthorized", `backend-api conversation returned ${res.status}`, {
+      phase: "wait_response",
+      side_effect_started: true
+    });
+  }
+  if (!res.ok) {
+    throw commandError("backend_api_unavailable", `backend-api conversation returned ${res.status}`, {
+      phase: "wait_response",
+      side_effect_started: true
+    });
+  }
+  let data;
+  try {
+    data = await res.json();
+  } catch (error) {
+    throw commandError("backend_api_unavailable", `backend-api conversation returned non-JSON: ${String(error?.message ?? error)}`, {
+      phase: "wait_response",
+      side_effect_started: true
+    });
+  }
+  return resolveBackendAnswer(job, conversationId, data);
+}
+
+async function fetchChatgptAccessToken() {
+  try {
+    const res = await fetch("/api/auth/session", {
+      method: "GET",
+      credentials: "include",
+      headers: { Accept: "application/json" }
+    });
+    if (!res.ok) {
+      return null;
+    }
+    const session = await res.json();
+    const token = session?.accessToken;
+    return typeof token === "string" && token.length > 0 ? token : null;
+  } catch {
+    return null;
+  }
+}
+
+// Resolve the FINAL assistant answer node from the conversation mapping. Returns an
+// extraction-shaped payload: node_fresh:true + is_generating:false when a NEW completed answer
+// exists; otherwise node_fresh:false + is_generating:true so the SW keeps waiting (never completes
+// on a stale/earlier turn). Never throws — a malformed/partial mapping is "not ready", not an
+// error.
+function resolveBackendAnswer(job, conversationId, data) {
+  const baseline = nonNegativeInt(job?.submitted_assistant_count ?? job?.response_baseline?.assistant_count ?? 0);
+  const notReady = (detail) => ({
+    method: "backend_api",
+    text: "",
+    is_generating: true,
+    conversation_id: conversationId,
+    node_fresh: false,
+    assistant_count: 0,
+    turn_index: -1,
+    has_copy_button: false,
+    copy_button_count: 0,
+    backend_api_detail: detail
+  });
+  const mapping = data && typeof data === "object" && data.mapping && typeof data.mapping === "object"
+    ? data.mapping
+    : null;
+  if (!mapping) {
+    return notReady("backend-api response had no conversation mapping");
+  }
+  // Count COMPLETED assistant answer turns addressed to the user (recipient 'all'). This excludes
+  // thoughts/reasoning_recap (content_type != text) and tool turns (recipient like container.exec /
+  // file_search.msearch). Freshness = the count exceeds the pre-send baseline, i.e. a NEW answer
+  // landed for THIS prompt (not a leftover from a resumed conversation).
+  const assistantAnswerCount = Object.values(mapping).filter((node) => isAssistantAnswerNode(node?.message)).length;
+  // Walk current_node UP its parent chain to the latest completed assistant answer node. current_node
+  // may be a tool/reasoning_recap node, so we cannot just read it directly.
+  const answerNode = walkToAnswerNode(mapping, data.current_node);
+  if (!answerNode) {
+    return notReady("no completed assistant answer node yet (still generating / tool-only)");
+  }
+  if (assistantAnswerCount <= baseline) {
+    return notReady(`assistant answer not fresh past baseline (${assistantAnswerCount} <= ${baseline})`);
+  }
+  const text = answerTextOf(answerNode.message);
+  if (!text) {
+    return notReady("latest assistant answer node had no text parts");
+  }
+  return {
+    method: "backend_api",
+    text,
+    is_generating: false,
+    conversation_id: conversationId,
+    node_fresh: true,
+    assistant_count: assistantAnswerCount,
+    turn_index: Math.max(0, assistantAnswerCount - 1),
+    node_id: String(answerNode.id ?? answerNode.message?.id ?? ""),
+    has_copy_button: false,
+    copy_button_count: 0
+  };
+}
+
+// A node is a deliverable assistant answer ONLY if: assistant role, content_type 'text', addressed
+// to the user (recipient 'all'), end_turn true, and non-empty text. content_type+end_turn alone is
+// NOT sufficient — reasoning_recap nodes also carry end_turn:true (verified live), and tool turns
+// use non-'all' recipients.
+function isAssistantAnswerNode(message) {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  if (message.author?.role !== "assistant") {
+    return false;
+  }
+  const content = message.content;
+  if (!content || content.content_type !== "text") {
+    return false;
+  }
+  if ((message.recipient ?? "all") !== "all") {
+    return false;
+  }
+  if (message.end_turn !== true) {
+    return false;
+  }
+  return answerTextOf(message).length > 0;
+}
+
+function answerTextOf(message) {
+  const parts = message?.content?.parts;
+  if (!Array.isArray(parts)) {
+    return "";
+  }
+  return parts.filter((part) => typeof part === "string").join("").trim();
+}
+
+function walkToAnswerNode(mapping, currentNodeId) {
+  let id = currentNodeId;
+  let guard = 0;
+  while (id && guard < 2000) {
+    guard += 1;
+    const node = mapping[id];
+    if (!node) {
+      return null;
+    }
+    if (isAssistantAnswerNode(node.message)) {
+      return node;
+    }
+    id = node.parent;
+  }
+  return null;
+}
+
+function nonNegativeInt(value) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 0;
 }
 
 async function inspectPage(runId, options = {}) {

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -1497,11 +1497,7 @@ async function waitForResponse(job) {
       // for the short confirm window, the response is settled — emit instead of
       // burning the full idle floor.
       if (stableForMs >= affordanceConfirmMs) {
-        return completedExtraction(
-          finalAffordanceCandidate,
-          completionReasonForFinalCandidate(finalAffordanceCandidate),
-          stableForMs
-        );
+        return completedExtraction(finalAffordanceCandidate, "copy_button", stableForMs);
       }
       unscopedCopyCandidate = null;
       bestUnscopedCopyCandidate = null;
@@ -2093,10 +2089,6 @@ function completedExtraction(extraction, completionReason, stableForMs) {
     assistant_turn_count: Number(extraction.assistant_count ?? 0),
     copy_button_count: Number(extraction.copy_button_count ?? 0)
   };
-}
-
-function completionReasonForFinalCandidate(extraction) {
-  return isFreshBackendApiExtraction(extraction) ? "backend_api" : "copy_button";
 }
 
 function enforceMessageCapability(message) {

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -28,6 +28,20 @@ const MIN_UNSCOPED_COPY_STABLE_TEXT_CHARS = Math.max(
   1,
   Number(globalThis.__YOETZ_MIN_UNSCOPED_COPY_STABLE_TEXT_CHARS ?? 4096) || 4096
 );
+const RENDER_FREEZE_SHORT_RESPONSE_MAX_CHARS = Math.max(
+  1,
+  Number(globalThis.__YOETZ_RENDER_FREEZE_SHORT_RESPONSE_MAX_CHARS ?? 32) || 32
+);
+const MIN_RENDER_FREEZE_IDLE_MS = Math.max(
+  0,
+  Number(globalThis.__YOETZ_MIN_RENDER_FREEZE_IDLE_MS ?? MIN_STABLE_IDLE_MS) || MIN_STABLE_IDLE_MS
+);
+const MAX_RENDER_REFRESH_ATTEMPTS = Math.max(
+  0,
+  Number.isFinite(Number(globalThis.__YOETZ_MAX_RENDER_REFRESH_ATTEMPTS))
+    ? Number(globalThis.__YOETZ_MAX_RENDER_REFRESH_ATTEMPTS)
+    : 1
+);
 // Once ChatGPT has exposed a final assistant affordance (copy control) AND scoped
 // text is extractable AND generation has stopped, the response is structurally
 // complete. Confirm it over a SHORT stable window at a FAST cadence instead of
@@ -1383,6 +1397,8 @@ async function waitForResponse(job) {
   let unscopedCopyCandidate = null;
   let bestUnscopedCopyCandidate = null;
   let unscopedCopyCandidateSinceMs = 0;
+  let renderRefreshCandidate = null;
+  let renderRefreshCandidateSinceMs = 0;
   let extractionFailureSinceMs = 0;
   let lastWaitingProgressAt = startedAt;
   const timeoutMs = responseWaitTimeoutMs(job);
@@ -1435,8 +1451,15 @@ async function waitForResponse(job) {
       && !finalAffordance
       && hasStableIdleUnscopedCopyAffordance(job, extraction)
     );
+    const renderRefreshCandidateEligible = isRenderFreezeRefreshCandidate(
+      job,
+      extraction,
+      scopedExtractionCandidate,
+      finalAffordance
+    );
     let stableForMs = 0;
     let unscopedCopyStableForMs = 0;
+    let renderRefreshStableForMs = 0;
     if (finalAffordance) {
       // Once ChatGPT exposes final assistant controls, scope and turn checks
       // have already ruled out pre-send content. From here we track the best
@@ -1480,6 +1503,8 @@ async function waitForResponse(job) {
       unscopedCopyCandidate = null;
       bestUnscopedCopyCandidate = null;
       unscopedCopyCandidateSinceMs = 0;
+      renderRefreshCandidate = null;
+      renderRefreshCandidateSinceMs = 0;
     }
     if (stableIdleUnscopedCopy) {
       const bestSelection = selectFinalAffordanceCandidate(bestUnscopedCopyCandidate, extraction);
@@ -1506,6 +1531,28 @@ async function waitForResponse(job) {
       if (!postSendAssistantActivity) {
         bestUnscopedCopyCandidate = null;
       }
+    }
+    if (renderRefreshCandidateEligible) {
+      if (!sameRenderRefreshCandidate(renderRefreshCandidate, extraction)) {
+        renderRefreshCandidate = extraction;
+        renderRefreshCandidateSinceMs = Date.now();
+      } else if (!renderRefreshCandidateSinceMs) {
+        renderRefreshCandidateSinceMs = Date.now();
+      }
+      renderRefreshStableForMs = Date.now() - renderRefreshCandidateSinceMs;
+      if (renderRefreshStableForMs >= MIN_RENDER_FREEZE_IDLE_MS && canRefreshFrozenRender(job)) {
+        await refreshFrozenRender(job, extraction, renderRefreshStableForMs);
+        renderRefreshCandidate = null;
+        renderRefreshCandidateSinceMs = 0;
+        finalAffordanceCandidate = null;
+        finalAffordanceCandidateSinceMs = 0;
+        unscopedCopyCandidate = null;
+        unscopedCopyCandidateSinceMs = 0;
+        continue;
+      }
+    } else {
+      renderRefreshCandidate = null;
+      renderRefreshCandidateSinceMs = 0;
     }
     const awaitingFinalAffordance = Boolean(scopedExtractionCandidate && !finalAffordance);
     if (finalAffordanceWithoutScopedText) {
@@ -1545,10 +1592,11 @@ async function waitForResponse(job) {
         elapsed_ms: elapsedMs,
         timeout_ms: timeoutMs,
         next_poll_ms: nextDelay,
-        stable_for_ms: Math.max(stableForMs, unscopedCopyStableForMs),
+        stable_for_ms: Math.max(stableForMs, unscopedCopyStableForMs, renderRefreshStableForMs),
         final_affordance: finalAffordance,
         stable_idle_unscoped_copy_candidate: stableIdleUnscopedCopy,
-        extraction_failure_candidate: finalAffordanceWithoutScopedText
+        extraction_failure_candidate: finalAffordanceWithoutScopedText,
+        render_refresh_candidate: renderRefreshCandidateEligible
       };
       if (awaitingFinalAffordance) {
         waitingDetail.awaiting_final_affordance = true;
@@ -1812,6 +1860,74 @@ function hasStableIdleUnscopedCopyAffordance(job, extraction) {
 function hasNoVisibleStopControls(extraction) {
   const stopControlCount = nonNegativeFiniteNumber(extraction?.diagnostics?.counts?.stop_controls);
   return stopControlCount === null || stopControlCount === 0;
+}
+
+function isRenderFreezeRefreshCandidate(job, extraction, scopedExtractionCandidate, finalAffordance) {
+  if (!scopedExtractionCandidate || finalAffordance) {
+    return false;
+  }
+  if (!canRefreshFrozenRender(job)) {
+    return false;
+  }
+  if (!hasExplicitlyNoVisibleStopControls(extraction)) {
+    return false;
+  }
+  const text = normalizedResponseText(extraction?.text);
+  if (!text || text.length > RENDER_FREEZE_SHORT_RESPONSE_MAX_CHARS) {
+    return false;
+  }
+  const conversationId = conversationIdForJob(job, extraction);
+  return Boolean(conversationId);
+}
+
+function hasExplicitlyNoVisibleStopControls(extraction) {
+  const stopControlCount = nonNegativeFiniteNumber(extraction?.diagnostics?.counts?.stop_controls);
+  return stopControlCount === 0;
+}
+
+function canRefreshFrozenRender(job) {
+  return Number(job?.render_refresh_attempts ?? 0) < MAX_RENDER_REFRESH_ATTEMPTS;
+}
+
+function sameRenderRefreshCandidate(candidate, extraction) {
+  if (!candidate || !extraction) {
+    return false;
+  }
+  return normalizedResponseText(candidate.text) === normalizedResponseText(extraction.text)
+    && Number(candidate.assistant_count ?? 0) === Number(extraction.assistant_count ?? 0)
+    && Number(candidate.turn_index ?? -1) === Number(extraction.turn_index ?? -1);
+}
+
+async function refreshFrozenRender(job, extraction, stableForMs) {
+  const conversationId = conversationIdForJob(job, extraction);
+  const url = chatgptConversationJobUrl(conversationId, job.run_id);
+  job.render_refresh_attempts = Number(job.render_refresh_attempts ?? 0) + 1;
+  job.updated_at = Date.now();
+  await persistJob(job);
+  postNative(progress(job, "render_refreshing", {
+    tab_id: job.tab_id,
+    conversation_id: conversationId,
+    conversation_url: url,
+    attempt: job.render_refresh_attempts,
+    max_attempts: MAX_RENDER_REFRESH_ATTEMPTS,
+    stable_for_ms: stableForMs,
+    response_length: extraction?.text?.length ?? 0,
+    extraction_method: extraction?.method ?? "none",
+    message: `refreshing owned ChatGPT conversation render after idle short response stayed frozen for ${formatDurationForMessage(stableForMs)}`
+  }));
+  await chrome.tabs.update(job.tab_id, { url, active: false });
+  await waitForChatgptTab(job.tab_id);
+  await waitForContentScript(job.tab_id);
+  const rebound = await sendToTab(job.tab_id, { type: "yoetz_bind_job", job });
+  postNative(progress(job, "render_refreshed", {
+    tab_id: job.tab_id,
+    conversation_id: conversationId,
+    conversation_url: url,
+    attempt: job.render_refresh_attempts,
+    url: rebound?.url ?? null,
+    title: rebound?.title ?? null,
+    message: "owned ChatGPT conversation render refreshed; continuing final-response polling"
+  }));
 }
 
 function responseStableIdleThresholdMs(intervalMs) {

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -67,6 +67,12 @@ const MAX_NATIVE_OUTBOUND_BYTES = Math.max(
   Number(globalThis.__YOETZ_MAX_NATIVE_OUTBOUND_BYTES ?? 64 * 1024 * 1024) || 64 * 1024 * 1024
 );
 const WAITING_RESPONSE_PROGRESS_INTERVAL_MS = Math.max(50, Number(globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS ?? 60000) || 60000);
+const BACKEND_API_FETCH_COOLDOWN_MS = Math.max(
+  0,
+  Number.isFinite(Number(globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS))
+    ? Number(globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS)
+    : 60000
+);
 const JOBS_KEY_PREFIX = "jobs.";
 const LEGACY_JOBS_KEY = "jobs";
 // Cap for the tail of last_response_progress_text persisted to chrome.storage.session.
@@ -1437,7 +1443,9 @@ async function waitForResponse(job) {
       && extractionIdle
       && extraction?.method !== "page_text_fallback"
     );
+    const backendApiFinal = Boolean(scopedExtractionCandidate && isFreshBackendApiExtraction(extraction));
     const finalAffordance = Boolean(scopedExtractionCandidate && hasFinalAssistantAffordance(extraction));
+    const finalStructuralResponse = finalAffordance || backendApiFinal;
     // Broad page text is diagnostic only; final controls without scoped text
     // means extraction failed, not that page chrome is safe to return.
     const finalAffordanceWithoutScopedText = Boolean(
@@ -1448,19 +1456,22 @@ async function waitForResponse(job) {
     );
     const stableIdleUnscopedCopy = Boolean(
       scopedExtractionCandidate
-      && !finalAffordance
+      && !finalStructuralResponse
       && hasStableIdleUnscopedCopyAffordance(job, extraction)
     );
     const renderRefreshCandidateEligible = isRenderFreezeRefreshCandidate(
       job,
       extraction,
       scopedExtractionCandidate,
-      finalAffordance
+      finalStructuralResponse
     );
     let stableForMs = 0;
     let unscopedCopyStableForMs = 0;
     let renderRefreshStableForMs = 0;
-    if (finalAffordance) {
+    if (backendApiFinal) {
+      return completedExtraction(extraction, "backend_api", 0);
+    }
+    if (finalStructuralResponse) {
       // Once ChatGPT exposes final assistant controls, scope and turn checks
       // have already ruled out pre-send content. From here we track the best
       // scoped candidate by text growth so late page chrome cannot replace a
@@ -1486,7 +1497,11 @@ async function waitForResponse(job) {
       // for the short confirm window, the response is settled — emit instead of
       // burning the full idle floor.
       if (stableForMs >= affordanceConfirmMs) {
-        return completedExtraction(finalAffordanceCandidate, "copy_button", stableForMs);
+        return completedExtraction(
+          finalAffordanceCandidate,
+          completionReasonForFinalCandidate(finalAffordanceCandidate),
+          stableForMs
+        );
       }
       unscopedCopyCandidate = null;
       bestUnscopedCopyCandidate = null;
@@ -1525,7 +1540,7 @@ async function waitForResponse(job) {
       if (unscopedCopyStableForMs >= finalAffordanceIdleMs) {
         return completedExtraction(unscopedCopyCandidate, "stable_idle_unscoped_copy_button", unscopedCopyStableForMs);
       }
-    } else if (!finalAffordance) {
+    } else if (!finalStructuralResponse) {
       unscopedCopyCandidate = null;
       unscopedCopyCandidateSinceMs = 0;
       if (!postSendAssistantActivity) {
@@ -1554,7 +1569,7 @@ async function waitForResponse(job) {
       renderRefreshCandidate = null;
       renderRefreshCandidateSinceMs = 0;
     }
-    const awaitingFinalAffordance = Boolean(scopedExtractionCandidate && !finalAffordance);
+    const awaitingFinalAffordance = Boolean(scopedExtractionCandidate && !finalStructuralResponse);
     if (finalAffordanceWithoutScopedText) {
       if (!extractionFailureSinceMs) {
         extractionFailureSinceMs = Date.now();
@@ -1594,6 +1609,7 @@ async function waitForResponse(job) {
         next_poll_ms: nextDelay,
         stable_for_ms: Math.max(stableForMs, unscopedCopyStableForMs, renderRefreshStableForMs),
         final_affordance: finalAffordance,
+        backend_api_final: backendApiFinal,
         stable_idle_unscoped_copy_candidate: stableIdleUnscopedCopy,
         extraction_failure_candidate: finalAffordanceWithoutScopedText,
         render_refresh_candidate: renderRefreshCandidateEligible
@@ -1756,6 +1772,12 @@ function diagnosticPayload(diagnostics) {
 }
 
 async function extractResponseForJob(job) {
+  const domExtraction = await extractDomResponseForJob(job);
+  const backendExtraction = await maybeBackendApiExtractionForJob(job, domExtraction);
+  return backendExtraction ?? domExtraction;
+}
+
+async function extractDomResponseForJob(job) {
   try {
     return await sendToTab(job.tab_id, { type: "yoetz_extract_response", job });
   } catch (error) {
@@ -1765,6 +1787,77 @@ async function extractResponseForJob(job) {
     await recoverContentScriptJob(job, error);
     return sendToTab(job.tab_id, { type: "yoetz_extract_response", job });
   }
+}
+
+async function maybeBackendApiExtractionForJob(job, domExtraction) {
+  if (!shouldFetchBackendApi(job, domExtraction)) {
+    return null;
+  }
+  const conversationId = conversationIdForJob(job, domExtraction);
+  job.backend_api_last_fetch_at = Date.now();
+  job.updated_at = Date.now();
+  await persistJob(job);
+  try {
+    const backendExtraction = await sendToTab(job.tab_id, {
+      type: "yoetz_fetch_conversation",
+      job,
+      conversation_id: conversationId
+    });
+    const normalized = normalizeBackendApiExtraction(backendExtraction, domExtraction, conversationId);
+    return isFreshBackendApiExtraction(normalized) ? normalized : null;
+  } catch (error) {
+    if (!isBackendApiFallbackError(error)) {
+      throw error;
+    }
+    job.backend_api_disabled = true;
+    job.backend_api_disabled_reason = error?.code ?? String(error?.message ?? error);
+    job.updated_at = Date.now();
+    await persistJob(job);
+    return null;
+  }
+}
+
+function shouldFetchBackendApi(job, domExtraction) {
+  if (job?.backend_api_disabled) {
+    return false;
+  }
+  if (!domExtraction || domExtraction.manual_handoff || domExtraction.is_generating) {
+    return false;
+  }
+  if (!conversationIdForJob(job, domExtraction)) {
+    return false;
+  }
+  const lastFetchAt = Number(job.backend_api_last_fetch_at ?? 0);
+  return Date.now() - lastFetchAt >= BACKEND_API_FETCH_COOLDOWN_MS;
+}
+
+function normalizeBackendApiExtraction(backendExtraction, domExtraction, conversationId) {
+  const nodeFresh = Boolean(backendExtraction?.node_fresh);
+  const text = nodeFresh ? String(backendExtraction?.text ?? "") : "";
+  return {
+    ...backendExtraction,
+    method: "backend_api",
+    text,
+    is_generating: !nodeFresh || Boolean(backendExtraction?.is_generating),
+    node_fresh: nodeFresh,
+    conversation_id: conversationId,
+    assistant_count: backendExtraction?.assistant_count ?? domExtraction?.assistant_count ?? 0,
+    user_count: backendExtraction?.user_count ?? domExtraction?.user_count ?? 0,
+    preceding_user_count: backendExtraction?.preceding_user_count ?? domExtraction?.preceding_user_count,
+    turn_index: backendExtraction?.turn_index ?? domExtraction?.turn_index ?? -1,
+    copy_button_count: backendExtraction?.copy_button_count ?? domExtraction?.copy_button_count ?? 0,
+    has_copy_button: Boolean(backendExtraction?.has_copy_button),
+    diagnostics: backendExtraction?.diagnostics ?? domExtraction?.diagnostics
+  };
+}
+
+function isBackendApiFallbackError(error) {
+  const code = String(error?.code ?? "");
+  if (code.startsWith("backend_api_")) {
+    return true;
+  }
+  const message = String(error?.message ?? error);
+  return /unknown content-script command yoetz_fetch_conversation|unexpected tab message yoetz_fetch_conversation|401|unauthorized|conversation api|backend api/i.test(message);
 }
 
 async function recoverContentScriptJob(job, error) {
@@ -1791,12 +1884,18 @@ function isPostSendExtraction(job, extraction) {
   if (!extraction || extraction.method === "page_text_fallback") {
     return false;
   }
+  if (isFreshBackendApiExtraction(extraction)) {
+    return true;
+  }
   return isPostSendAssistantActivity(job, extraction);
 }
 
 function isPostSendAssistantActivity(job, extraction, allowUnknownTurnIndex = false) {
   if (!extraction) {
     return false;
+  }
+  if (isFreshBackendApiExtraction(extraction)) {
+    return true;
   }
   const submittedUserCount = nonNegativeFiniteNumber(job.submitted_user_count);
   const precedingUserCount = nonNegativeFiniteNumber(extraction.preceding_user_count);
@@ -1815,6 +1914,13 @@ function isPostSendAssistantActivity(job, extraction, allowUnknownTurnIndex = fa
     return true;
   }
   return baselineCount === 0 && currentCount > 0;
+}
+
+function isFreshBackendApiExtraction(extraction) {
+  return extraction?.method === "backend_api"
+    && extraction.node_fresh === true
+    && !extraction.is_generating
+    && Boolean(normalizedResponseText(extraction.text));
 }
 
 function nonNegativeFiniteNumber(value) {
@@ -1987,6 +2093,10 @@ function completedExtraction(extraction, completionReason, stableForMs) {
     assistant_turn_count: Number(extraction.assistant_count ?? 0),
     copy_button_count: Number(extraction.copy_button_count ?? 0)
   };
+}
+
+function completionReasonForFinalCandidate(extraction) {
+  return isFreshBackendApiExtraction(extraction) ? "backend_api" : "copy_button";
 }
 
 function enforceMessageCapability(message) {

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -423,3 +423,159 @@ function resumeJob() {
     send_timeout_ms: 1000
   };
 }
+
+// ---- T1 backend-api read (yoetz_fetch_conversation) ----
+
+function fetchJob(submittedAssistantCount = 0) {
+  return {
+    job_id: "job_fetch",
+    run_id: "run_fetch",
+    conversation_id: "conv-123",
+    expected_conversation_id: "conv-123",
+    submitted_assistant_count: submittedAssistantCount,
+    upload_timeout_ms: 1000,
+    send_timeout_ms: 1000
+  };
+}
+
+function asstTextNode(id, parent, text, opts = {}) {
+  return {
+    id,
+    parent,
+    children: [],
+    message: {
+      id,
+      author: { role: "assistant" },
+      content: { content_type: "text", parts: [text] },
+      end_turn: opts.end_turn ?? true,
+      recipient: opts.recipient ?? "all",
+      status: "finished_successfully"
+    }
+  };
+}
+
+// Install a mocked same-origin fetch for /api/auth/session and /backend-api/conversation/<id>.
+// conv = { current_node, mapping } or null to 404; status overrides the conversation GET status.
+function installBackendFetch({ token = "tok-123", conv = null, conversationStatus = 200, sessionStatus = 200 } = {}) {
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.startsWith("/api/auth/session")) {
+      return { ok: sessionStatus >= 200 && sessionStatus < 300, status: sessionStatus, json: async () => ({ accessToken: token }) };
+    }
+    if (u.startsWith("/backend-api/conversation/")) {
+      return {
+        ok: conversationStatus >= 200 && conversationStatus < 300,
+        status: conversationStatus,
+        json: async () => conv ?? {}
+      };
+    }
+    throw new Error(`unexpected fetch ${u}`);
+  };
+  return () => { globalThis.fetch = original; };
+}
+
+async function prepareFetchJob(send, hooks, job) {
+  const prepared = await send({ type: "yoetz_prepare_job", job });
+  assert.equal(prepared.ok, true, `prepare failed: ${JSON.stringify(prepared)}`);
+}
+
+test("backend-api read returns the fresh final answer from the conversation mapping", async () => {
+  const { send, hooks, restore } = await loadContentScript("backend_happy", "https://chatgpt.com/c/conv-123?_yoetz=run_fetch");
+  const FINAL = "No P0 found. I found two P1 proof-integrity issues and several P2 residual risks across the bundle.";
+  const restoreFetch = installBackendFetch({ conv: {
+    current_node: "a_final",
+    mapping: {
+      root: { id: "root", parent: null, children: ["u1"], message: { author: { role: "system" }, content: { content_type: "text", parts: [""] } } },
+      u1: { id: "u1", parent: "root", children: ["a_interim"], message: { author: { role: "user" }, content: { content_type: "text", parts: ["review this"] }, end_turn: null } },
+      a_interim: asstTextNode("a_interim", "u1", "I'll review the bundled diff as the source of truth"),
+      a_final: asstTextNode("a_final", "a_interim", FINAL)
+    }
+  }});
+  try {
+    const job = fetchJob(0);
+    await prepareFetchJob(send, hooks, job);
+    const res = await send({ type: "yoetz_fetch_conversation", job, conversation_id: "conv-123" });
+    assert.equal(res.ok, true, JSON.stringify(res));
+    assert.equal(res.payload.method, "backend_api");
+    assert.equal(res.payload.node_fresh, true);
+    assert.equal(res.payload.is_generating, false);
+    assert.equal(res.payload.text, FINAL);
+    assert.equal(res.payload.conversation_id, "conv-123");
+    assert.equal(res.payload.assistant_count, 2);
+    assert.equal(res.payload.node_id, "a_final");
+  } finally {
+    restoreFetch();
+    restore();
+  }
+});
+
+test("backend-api read walks past reasoning_recap and tool nodes to the real assistant answer", async () => {
+  const { send, hooks, restore } = await loadContentScript("backend_walk", "https://chatgpt.com/c/conv-123?_yoetz=run_fetch");
+  const FINAL = "I reviewed the bundle end to end; the consumer guard is correct and the producer invariants hold.";
+  const restoreFetch = installBackendFetch({ conv: {
+    // current_node is a reasoning_recap with end_turn:true (the live trap) whose parent chain leads to the text answer
+    current_node: "recap",
+    mapping: {
+      u1: { id: "u1", parent: null, children: ["a_final"], message: { author: { role: "user" }, content: { content_type: "text", parts: ["review"] }, end_turn: null } },
+      a_final: asstTextNode("a_final", "u1", FINAL),
+      // a tool turn (recipient not 'all') must NOT count or be selected
+      tool1: { id: "tool1", parent: "a_final", children: ["recap"], message: { author: { role: "assistant" }, content: { content_type: "text", parts: ["{search}"] }, end_turn: true, recipient: "file_search.msearch" } },
+      // reasoning_recap with end_turn:true must NOT be selected
+      recap: { id: "recap", parent: "tool1", children: [], message: { author: { role: "assistant" }, content: { content_type: "reasoning_recap", parts: ["recapped"] }, end_turn: true, recipient: "all" } }
+    }
+  }});
+  try {
+    const job = fetchJob(0);
+    await prepareFetchJob(send, hooks, job);
+    const res = await send({ type: "yoetz_fetch_conversation", job, conversation_id: "conv-123" });
+    assert.equal(res.ok, true, JSON.stringify(res));
+    assert.equal(res.payload.node_fresh, true);
+    assert.equal(res.payload.text, FINAL);
+    assert.equal(res.payload.node_id, "a_final");
+    assert.equal(res.payload.assistant_count, 1, "recap + tool nodes must not count as answer turns");
+  } finally {
+    restoreFetch();
+    restore();
+  }
+});
+
+test("backend-api read returns not-ready (keep waiting) when no answer is fresh past baseline", async () => {
+  const { send, hooks, restore } = await loadContentScript("backend_stale", "https://chatgpt.com/c/conv-123?_yoetz=run_fetch");
+  const restoreFetch = installBackendFetch({ conv: {
+    current_node: "a_old",
+    mapping: {
+      u1: { id: "u1", parent: null, children: ["a_old"], message: { author: { role: "user" }, content: { content_type: "text", parts: ["prior"] }, end_turn: null } },
+      a_old: asstTextNode("a_old", "u1", "earlier answer from a prior turn")
+    }
+  }});
+  try {
+    // baseline already counts the single existing answer turn -> no NEW answer -> not fresh
+    const job = fetchJob(1);
+    await prepareFetchJob(send, hooks, job);
+    const res = await send({ type: "yoetz_fetch_conversation", job, conversation_id: "conv-123" });
+    assert.equal(res.ok, true, JSON.stringify(res));
+    assert.equal(res.payload.method, "backend_api");
+    assert.equal(res.payload.node_fresh, false);
+    assert.equal(res.payload.is_generating, true, "stale read must keep the SW waiting, not complete");
+    assert.equal(res.payload.text, "");
+  } finally {
+    restoreFetch();
+    restore();
+  }
+});
+
+test("backend-api read surfaces a 401 as backend_api_unauthorized so the SW can fall back", async () => {
+  const { send, hooks, restore } = await loadContentScript("backend_401", "https://chatgpt.com/c/conv-123?_yoetz=run_fetch");
+  const restoreFetch = installBackendFetch({ conversationStatus: 401 });
+  try {
+    const job = fetchJob(0);
+    await prepareFetchJob(send, hooks, job);
+    const res = await send({ type: "yoetz_fetch_conversation", job, conversation_id: "conv-123" });
+    assert.equal(res.ok, false);
+    assert.equal(res.code, "backend_api_unauthorized");
+  } finally {
+    restoreFetch();
+    restore();
+  }
+});

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -565,6 +565,37 @@ test("backend-api read returns not-ready (keep waiting) when no answer is fresh 
   }
 });
 
+test("backend-api read scopes freshness to the active lineage (off-branch answer must not inflate)", async () => {
+  // codex's blocking finding: a global answer count could be inflated past baseline by an
+  // OFF-branch completed answer (regen/abandoned/alternate branch) while the active current_node
+  // lineage still points at a STALE earlier answer -> must NOT return the stale answer as fresh.
+  const { send, hooks, restore } = await loadContentScript("backend_offbranch", "https://chatgpt.com/c/conv-123?_yoetz=run_fetch");
+  const restoreFetch = installBackendFetch({ conv: {
+    // active lineage: root -> u1 -> a_old (the visible, stale answer). current_node = a_old.
+    // a_alt_new is a sibling regeneration off the a_old lineage (child of u1, not reachable from a_old upward).
+    current_node: "a_old",
+    mapping: {
+      root: { id: "root", parent: null, children: ["u1"], message: { author: { role: "system" }, content: { content_type: "text", parts: [""] } } },
+      u1: { id: "u1", parent: "root", children: ["a_old", "a_alt_new"], message: { author: { role: "user" }, content: { content_type: "text", parts: ["q"] }, end_turn: null } },
+      a_old: asstTextNode("a_old", "u1", "earlier visible answer on the active branch"),
+      a_alt_new: asstTextNode("a_alt_new", "u1", "a regenerated answer on an off-branch not reachable from current_node")
+    }
+  }});
+  try {
+    // baseline already counts the single active-lineage answer (a_old) -> no NEW active answer.
+    const job = fetchJob(1);
+    await prepareFetchJob(send, hooks, job);
+    const res = await send({ type: "yoetz_fetch_conversation", job, conversation_id: "conv-123" });
+    assert.equal(res.ok, true, JSON.stringify(res));
+    assert.equal(res.payload.node_fresh, false, "off-branch answer must not make the stale lineage answer look fresh");
+    assert.equal(res.payload.is_generating, true);
+    assert.equal(res.payload.text, "");
+  } finally {
+    restoreFetch();
+    restore();
+  }
+});
+
 test("backend-api read surfaces a 401 as backend_api_unauthorized so the SW can fall back", async () => {
   const { send, hooks, restore } = await loadContentScript("backend_401", "https://chatgpt.com/c/conv-123?_yoetz=run_fetch");
   const restoreFetch = installBackendFetch({ conversationStatus: 401 });

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -3072,6 +3072,374 @@ test("service worker does not complete when ChatGPT idles before final assistant
   }
 });
 
+test("service worker completes with backend-api text when the DOM answer turn never paints", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  let tabId = 0;
+  let sent = false;
+  let backendFetch = null;
+  const FINAL = "Backend API captured the full Pro review even though the DOM stayed frozen.";
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/c/conv-api?_yoetz=run_job_backend_api_frozen_dom" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true, conversation_id: "conv-api", submitted_assistant_count: 1 } };
+          case "yoetz_fetch_conversation":
+            backendFetch = message;
+            return {
+              ok: true,
+              payload: {
+                method: "backend_api",
+                text: FINAL,
+                is_generating: false,
+                node_fresh: true,
+                conversation_id: "conv-api",
+                assistant_count: 1,
+                turn_index: 0,
+                copy_button_count: 0,
+                has_copy_button: false
+              }
+            };
+          case "yoetz_extract_response":
+            return {
+              ok: true,
+              payload: sent
+                ? {
+                    method: "assistant_dom_fallback",
+                    text: "I",
+                    is_generating: false,
+                    assistant_count: 1,
+                    user_count: 1,
+                    preceding_user_count: 1,
+                    copy_button_count: 1,
+                    has_copy_button: false,
+                    turn_index: 0,
+                    conversation_id: "conv-api",
+                    diagnostics: { counts: { stop_controls: 0, copy_buttons: 1 } }
+                  }
+                : {
+                    method: "copy_scope_dom_fallback",
+                    text: "previous answer",
+                    is_generating: false,
+                    assistant_count: 1,
+                    user_count: 0,
+                    copy_button_count: 1,
+                    has_copy_button: true,
+                    turn_index: 0,
+                    conversation_id: "conv-api"
+                  }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?backend_api_frozen_dom=${Date.now()}`);
+    port.emit(envelope("job_start", "job_backend_api_frozen_dom", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 3000
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_backend_api_frozen_dom", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_backend_api_frozen_dom.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_complete"), 5000);
+    const complete = port.messages.find((message) => message.type === "job_complete");
+    assert.equal(backendFetch?.conversation_id, "conv-api");
+    assert.equal(complete.payload.response, FINAL);
+    assert.equal(complete.payload.extraction_method, "backend_api");
+    assert.equal(complete.payload.completion_reason, "backend_api");
+    assert.equal(complete.payload.conversation_id, "conv-api");
+    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker treats a stale backend-api node as still generating until a fresh node appears", async () => {
+  const originalChrome = globalThis.chrome;
+  const previousCooldown = globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS;
+  globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS = 100;
+  const port = makePort();
+  let tabId = 0;
+  let sent = false;
+  let fetchCount = 0;
+  const FINAL = "Fresh backend API answer after the stale current_node advanced.";
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/c/conv-stale?_yoetz=run_job_backend_api_stale_then_fresh" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true, conversation_id: "conv-stale", submitted_assistant_count: 1 } };
+          case "yoetz_fetch_conversation":
+            fetchCount += 1;
+            return {
+              ok: true,
+              payload: fetchCount === 1
+                ? {
+                    method: "backend_api",
+                    text: "",
+                    is_generating: true,
+                    node_fresh: false,
+                    conversation_id: "conv-stale",
+                    assistant_count: 1,
+                    turn_index: 0
+                  }
+                : {
+                    method: "backend_api",
+                    text: FINAL,
+                    is_generating: false,
+                    node_fresh: true,
+                    conversation_id: "conv-stale",
+                    assistant_count: 1,
+                    turn_index: 0,
+                    copy_button_count: 0,
+                    has_copy_button: false
+                  }
+            };
+          case "yoetz_extract_response":
+            return {
+              ok: true,
+              payload: sent
+                ? {
+                    method: "assistant_dom_fallback",
+                    text: "I",
+                    is_generating: false,
+                    assistant_count: 1,
+                    user_count: 1,
+                    preceding_user_count: 1,
+                    copy_button_count: 0,
+                    has_copy_button: false,
+                    turn_index: 0,
+                    conversation_id: "conv-stale",
+                    diagnostics: { counts: { stop_controls: 0, copy_buttons: 0 } }
+                  }
+                : {
+                    method: "copy_scope_dom_fallback",
+                    text: "previous answer",
+                    is_generating: false,
+                    assistant_count: 1,
+                    user_count: 0,
+                    copy_button_count: 1,
+                    has_copy_button: true,
+                    turn_index: 0,
+                    conversation_id: "conv-stale"
+                  }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?backend_api_stale_then_fresh=${Date.now()}`);
+    port.emit(envelope("job_start", "job_backend_api_stale_then_fresh", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 4000
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_backend_api_stale_then_fresh", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_backend_api_stale_then_fresh.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_complete"), 6000);
+    const complete = port.messages.find((message) => message.type === "job_complete");
+    assert.ok(fetchCount >= 2, "backend API should be retried after a stale current_node result");
+    assert.equal(complete.payload.response, FINAL);
+    assert.equal(complete.payload.extraction_method, "backend_api");
+    assert.equal(complete.payload.completion_reason, "backend_api");
+    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+    if (previousCooldown === undefined) {
+      delete globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS;
+    } else {
+      globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS = previousCooldown;
+    }
+  }
+});
+
+test("service worker still refreshes a frozen render while backend-api reads are stale", async () => {
+  const originalChrome = globalThis.chrome;
+  const previousCooldown = globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS;
+  globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS = 30;
+  const port = makePort();
+  let tabId = 0;
+  let sent = false;
+  let reloaded = false;
+  let bindCount = 0;
+  let fetchCount = 0;
+  const updates = [];
+  const conversationUrl = "https://chatgpt.com/c/conv-stale-refresh?_yoetz=run_job_backend_stale_render_refresh";
+  let currentUrl = "https://chatgpt.com/";
+  const FINAL = "Reload recovered the rendered answer after backend API stayed not-ready.";
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => {
+        currentUrl = opts.url;
+        return { id: ++tabId, status: "complete", ...opts };
+      },
+      get: async (id) => ({ id, status: "complete", url: currentUrl }),
+      update: async (id, opts) => {
+        updates.push({ id, opts });
+        if (opts.url) {
+          currentUrl = opts.url;
+        }
+        reloaded = true;
+        return { id, status: "complete", url: currentUrl };
+      },
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            currentUrl = conversationUrl;
+            return { ok: true, payload: { sent: true, url: currentUrl, conversation_id: "conv-stale-refresh", submitted_assistant_count: 1 } };
+          case "yoetz_fetch_conversation":
+            fetchCount += 1;
+            return {
+              ok: true,
+              payload: {
+                method: "backend_api",
+                text: "",
+                is_generating: true,
+                node_fresh: false,
+                conversation_id: "conv-stale-refresh",
+                assistant_count: 1,
+                turn_index: 0
+              }
+            };
+          case "yoetz_bind_job":
+            bindCount += 1;
+            return { ok: true, payload: { rebound: true, url: currentUrl, title: "ChatGPT" } };
+          case "yoetz_extract_response":
+            if (!sent) {
+              return { ok: true, payload: { method: "none", text: "", is_generating: false, assistant_count: 0, user_count: 0, copy_button_count: 0, has_copy_button: false, turn_index: -1 } };
+            }
+            return {
+              ok: true,
+              payload: reloaded
+                ? {
+                    method: "copy_scope_dom_fallback",
+                    text: FINAL,
+                    is_generating: false,
+                    assistant_count: 1,
+                    user_count: 1,
+                    preceding_user_count: 1,
+                    copy_button_count: 1,
+                    has_copy_button: true,
+                    turn_index: 0,
+                    conversation_id: "conv-stale-refresh",
+                    diagnostics: { counts: { stop_controls: 0, copy_buttons: 1 } }
+                  }
+                : {
+                    method: "assistant_dom_fallback",
+                    text: "I",
+                    is_generating: false,
+                    assistant_count: 1,
+                    user_count: 1,
+                    preceding_user_count: 1,
+                    copy_button_count: 0,
+                    has_copy_button: false,
+                    turn_index: 0,
+                    conversation_id: "conv-stale-refresh",
+                    diagnostics: { counts: { stop_controls: 0, copy_buttons: 0 } }
+                  }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?backend_stale_render_refresh=${Date.now()}`);
+    port.emit(envelope("job_start", "job_backend_stale_render_refresh", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 5000
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_backend_stale_render_refresh", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_backend_stale_render_refresh.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_complete"), 7000);
+    const complete = port.messages.find((message) => message.type === "job_complete");
+    assert.ok(fetchCount >= 1, "backend API should be attempted before falling through to reload");
+    assert.equal(updates.length, 1);
+    assert.deepEqual(updates[0], { id: 1, opts: { url: conversationUrl, active: false } });
+    assert.equal(bindCount, 1);
+    assert.equal(complete.payload.response, FINAL);
+    assert.equal(complete.payload.completion_reason, "copy_button");
+    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+    if (previousCooldown === undefined) {
+      delete globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS;
+    } else {
+      globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS = previousCooldown;
+    }
+  }
+});
+
 test("service worker reloads an idle frozen short response and completes from the refreshed conversation", async () => {
   const originalChrome = globalThis.chrome;
   const previousWaitingProgressInterval = globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS;

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -3072,6 +3072,221 @@ test("service worker does not complete when ChatGPT idles before final assistant
   }
 });
 
+test("service worker reloads an idle frozen short response and completes from the refreshed conversation", async () => {
+  const originalChrome = globalThis.chrome;
+  const previousWaitingProgressInterval = globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS;
+  globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS = 100;
+  const port = makePort();
+  let tabId = 0;
+  let sent = false;
+  let reloaded = false;
+  let bindCount = 0;
+  const updates = [];
+  const conversationUrl = "https://chatgpt.com/c/conv-freeze?_yoetz=run_job_background_render_freeze";
+  let currentUrl = "https://chatgpt.com/";
+  const FINAL = "I reviewed the bundle. The consumer guard is correct, but Yoetz must refresh the frozen render.";
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => {
+        currentUrl = opts.url;
+        return { id: ++tabId, status: "complete", ...opts };
+      },
+      get: async (id) => ({ id, status: "complete", url: currentUrl }),
+      update: async (id, opts) => {
+        updates.push({ id, opts });
+        if (opts.url) {
+          currentUrl = opts.url;
+        }
+        reloaded = true;
+        return { id, status: "complete", url: currentUrl };
+      },
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            currentUrl = conversationUrl;
+            return { ok: true, payload: { sent: true, url: currentUrl, conversation_id: "conv-freeze" } };
+          case "yoetz_bind_job":
+            bindCount += 1;
+            return { ok: true, payload: { rebound: true, url: currentUrl, title: "ChatGPT" } };
+          case "yoetz_extract_response":
+            if (!sent) {
+              return { ok: true, payload: { method: "none", text: "", is_generating: false, assistant_count: 0, user_count: 0, copy_button_count: 0, has_copy_button: false, turn_index: -1 } };
+            }
+            return {
+              ok: true,
+              payload: reloaded
+                ? {
+                    method: "copy_scope_dom_fallback",
+                    text: FINAL,
+                    is_generating: false,
+                    assistant_count: 1,
+                    user_count: 1,
+                    preceding_user_count: 1,
+                    copy_button_count: 1,
+                    has_copy_button: true,
+                    turn_index: 0,
+                    conversation_id: "conv-freeze",
+                    diagnostics: { counts: { stop_controls: 0, copy_buttons: 1 } }
+                  }
+                : {
+                    method: "assistant_dom_fallback",
+                    text: "I",
+                    is_generating: false,
+                    assistant_count: 1,
+                    user_count: 1,
+                    preceding_user_count: 1,
+                    copy_button_count: 1,
+                    has_copy_button: false,
+                    turn_index: 0,
+                    conversation_id: "conv-freeze",
+                    diagnostics: { counts: { stop_controls: 0, copy_buttons: 1 } }
+                  }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?background_render_freeze=${Date.now()}`);
+    port.emit(envelope("job_start", "job_background_render_freeze", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 5000
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_background_render_freeze", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_background_render_freeze.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_complete"), 7000);
+    const complete = port.messages.find((message) => message.type === "job_complete");
+    assert.equal(updates.length, 1);
+    assert.deepEqual(updates[0], { id: 1, opts: { url: conversationUrl, active: false } });
+    assert.equal(bindCount, 1);
+    assert.equal(complete.payload.response, FINAL);
+    assert.equal(complete.payload.completion_reason, "copy_button");
+    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
+    assert.ok(port.messages.some((message) => message.type === "job_progress" && message.payload.phase === "render_refreshing"));
+    assert.ok(port.messages.some((message) => message.type === "job_progress" && message.payload.phase === "render_refreshed"));
+  } finally {
+    globalThis.chrome = originalChrome;
+    if (previousWaitingProgressInterval === undefined) {
+      delete globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS;
+    } else {
+      globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS = previousWaitingProgressInterval;
+    }
+  }
+});
+
+test("service worker refreshes a frozen short render at most once", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  let tabId = 0;
+  let sent = false;
+  const updates = [];
+  const conversationUrl = "https://chatgpt.com/c/conv-still-frozen?_yoetz=run_job_render_refresh_bounded";
+  let currentUrl = "https://chatgpt.com/";
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => {
+        currentUrl = opts.url;
+        return { id: ++tabId, status: "complete", ...opts };
+      },
+      get: async (id) => ({ id, status: "complete", url: currentUrl }),
+      update: async (id, opts) => {
+        updates.push({ id, opts });
+        if (opts.url) {
+          currentUrl = opts.url;
+        }
+        return { id, status: "complete", url: currentUrl };
+      },
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            currentUrl = conversationUrl;
+            return { ok: true, payload: { sent: true, url: currentUrl, conversation_id: "conv-still-frozen" } };
+          case "yoetz_bind_job":
+            return { ok: true, payload: { rebound: true, url: currentUrl, title: "ChatGPT" } };
+          case "yoetz_extract_response":
+            return {
+              ok: true,
+              payload: sent
+                ? {
+                    method: "assistant_dom_fallback",
+                    text: "I",
+                    is_generating: false,
+                    assistant_count: 1,
+                    user_count: 1,
+                    preceding_user_count: 1,
+                    copy_button_count: 1,
+                    has_copy_button: false,
+                    turn_index: 0,
+                    conversation_id: "conv-still-frozen",
+                    diagnostics: { counts: { stop_controls: 0, copy_buttons: 1 } }
+                  }
+                : { method: "none", text: "", is_generating: false, assistant_count: 0, user_count: 0, copy_button_count: 0, has_copy_button: false, turn_index: -1 }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?render_refresh_bounded=${Date.now()}`);
+    port.emit(envelope("job_start", "job_render_refresh_bounded", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 1800
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_render_refresh_bounded", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_render_refresh_bounded.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_error" && message.payload.code === "response_timeout"), 5000);
+    assert.equal(updates.length, 1);
+    assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
+    assert.equal(port.messages.filter((message) => message.type === "job_progress" && message.payload.phase === "render_refreshing").length, 1);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker rejects stale copy-button extraction from a pre-send assistant turn", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();


### PR DESCRIPTION
## Summary
- add a backend-api answer read path for ChatGPT native captures, scoped to the active current_node lineage so stale/off-branch answers cannot complete a job
- prefer fresh backend-api finals in the service worker while preserving DOM-driven reload-to-render and DOM fallback paths for stale/unavailable backend reads
- add bounded reload-to-render recovery for frozen short DOM prefixes and document both recovery layers in the changelog

## Verification
- npm test --prefix extensions/chatgpt-native (219 pass)
- ./scripts/build-chatgpt-native-extension.sh --check
- cargo test -p yoetz browser_extension_native (38 pass)
- live branch-extension proof from BmwB72: DOM stayed frozen at "I" for ~10 minutes, no T2 reload fired, recipe returned a full 12,444-char Extended Pro response via backend_api

## Release note
This PR is intended for v0.5.27 after merge.