### PR TITLE
fix(chatgpt-native): accept deduped upload attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- ChatGPT native-extension uploads now recognize ChatGPT's deduplicated
+  attachment filenames (for example `bundle(13).md` for `bundle.md`) and accept
+  a single new composer-scoped attachment tile when Enterprise hides the
+  filename, preventing false upload timeouts for repeated bundle submissions.
 
 ## [0.5.28] - 2026-06-15
 ### Fixed

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -1736,12 +1736,12 @@ function findAttachmentTiles(root, options = {}) {
 }
 
 function hasAttachmentNamed(root, filename, baselineAttachments = new Set()) {
-  const needle = normalizeText(filename).toLowerCase();
+  const needle = normalizedAttachmentText(filename);
   if (!needle) {
     return false;
   }
   const candidates = findAttachmentCandidates(root);
-  return candidates.some((node) => {
+  const nameMatched = candidates.some((node) => {
     if (baselineAttachments.has(attachmentNodeKey(node))) {
       return false;
     }
@@ -1750,8 +1750,47 @@ function hasAttachmentNamed(root, filename, baselineAttachments = new Set()) {
       node.getAttribute?.("aria-label"),
       node.getAttribute?.("title")
     ].filter(Boolean).join(" ");
-    return normalizeText(text).toLowerCase().includes(needle);
+    return attachmentTextMatchesFilename(text, needle);
   });
+  if (nameMatched) {
+    return true;
+  }
+
+  const newTiles = findAttachmentTiles(root, { composerOnly: true })
+    .filter((node) => !baselineAttachments.has(attachmentNodeKey(node)));
+  return newTiles.length === 1;
+}
+
+function attachmentTextMatchesFilename(text, filename) {
+  const haystack = normalizedAttachmentText(text);
+  if (!haystack || !filename) {
+    return false;
+  }
+  if (haystack.includes(filename)) {
+    return true;
+  }
+
+  const lastDot = filename.lastIndexOf(".");
+  const stem = lastDot > 0 ? filename.slice(0, lastDot) : filename;
+  const extension = lastDot > 0 ? filename.slice(lastDot) : "";
+  if (!stem) {
+    return false;
+  }
+
+  const boundary = "[^\\p{L}\\p{N}._-]";
+  const pattern = new RegExp(
+    `(^|${boundary})${escapeRegExp(stem)}\\s*\\(\\d+\\)${escapeRegExp(extension)}($|${boundary})`,
+    "iu"
+  );
+  return pattern.test(haystack);
+}
+
+function normalizedAttachmentText(value) {
+  return normalizeText(value).replace(/\s+/g, " ").toLowerCase();
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 // Broad candidate selector shared by upload baseline capture and the

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -1631,6 +1631,62 @@ test("uploadFile waits for a new composer-scoped attachment tile", async () => {
   }
 });
 
+test("uploadFile accepts ChatGPT deduped attachment filenames", async () => {
+  const previousDataTransfer = globalThis.DataTransfer;
+  globalThis.DataTransfer = FakeDataTransfer;
+  try {
+    const composer = new FakeElement("textarea", { placeholder: "Message ChatGPT" });
+    const send = new FakeElement("button", { "aria-label": "Send message" }, "Send");
+    const upload = new FakeElement("input", {
+      type: "file",
+      accept: "text/markdown",
+      style: "display:none",
+      onChange: () => composer.parentElement.append(
+        new FakeElement("div", { "aria-label": "bundle(13).md", class: "file-tile" }, "bundle(13).md")
+      )
+    });
+    const body = new FakeElement("body", {}, "Message ChatGPT").append(composer, upload, send);
+    const doc = new FakeDocument(body);
+
+    await uploadFile(doc, new File(["bundle"], "bundle.md", { type: "text/markdown" }), {
+      timeoutMs: 250,
+      intervalMs: 10
+    });
+
+    assert.equal(upload.files[0].name, "bundle.md");
+  } finally {
+    globalThis.DataTransfer = previousDataTransfer;
+  }
+});
+
+test("uploadFile accepts one new attachment tile when ChatGPT hides the filename", async () => {
+  const previousDataTransfer = globalThis.DataTransfer;
+  globalThis.DataTransfer = FakeDataTransfer;
+  try {
+    const composer = new FakeElement("textarea", { placeholder: "Message ChatGPT" });
+    const send = new FakeElement("button", { "aria-label": "Send message" }, "Send");
+    const upload = new FakeElement("input", {
+      type: "file",
+      accept: "text/markdown",
+      style: "display:none",
+      onChange: () => composer.parentElement.append(
+        new FakeElement("div", { "aria-label": "Attached file", class: "file-tile" }, "File")
+      )
+    });
+    const body = new FakeElement("body", {}, "Message ChatGPT").append(composer, upload, send);
+    const doc = new FakeDocument(body);
+
+    await uploadFile(doc, new File(["bundle"], "bundle.md", { type: "text/markdown" }), {
+      timeoutMs: 250,
+      intervalMs: 10
+    });
+
+    assert.equal(upload.files[0].name, "bundle.md");
+  } finally {
+    globalThis.DataTransfer = previousDataTransfer;
+  }
+});
+
 test("uploadFile rejects a pre-existing composer-scoped node bearing only the filename", async () => {
   // Locks the regression behind H6: a composer-scoped node whose text
   // contains the bundle filename but which lacks any attachment-tile


### PR DESCRIPTION
## Summary

- Accept ChatGPT-deduplicated attachment names like `bundle(13).md` / `bundle (13).md` when the requested upload filename is `bundle.md`.
- Add a guarded fallback for exactly one new composer-scoped attachment tile when Enterprise hides the uploaded filename.
- Add regression coverage for deduped names and hidden-filename tiles while preserving the existing stale/pre-existing-node guard.

## Verification

- `node --test extensions/chatgpt-native/tests/*.test.js` — 222 pass / 0 fail
- Claude AMQ review PASS on `bug/yoetz-chatgpt-upload-detect` / `session4`

## Notes

Live Enterprise repro was downgraded from a hard gate: existing captured diagnostics showed the real Enterprise tile as `ariaLabel: bundle(13).md`, and this patch directly matches that exact shape against `bundle.md`.
