### PR TITLE
fix(chatgpt-native): prefer extension for browser checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Changed
+
+- `yoetz browser check` now auto-selects the ChatGPT native extension dry-run
+  when the extension is installed and connected, reports whether the native path
+  was `auto_selected`, and avoids the CDP/dev-browser stack unless callers pass
+  an explicit transport, browser target, or managed profile.
+
+### Fixed
+
+- ChatGPT Pro browser recipes and checks now preserve explicit `--cdp`,
+  `--browser-id`, and managed `--profile` requests instead of hijacking them
+  into the native extension path.
+- Native extension `bridge_check` is now a side-effect-free readiness probe and
+  no longer resumes queued jobs while checking connectivity.
+- Native extension failures after browser-side effects now include inspectable
+  recovery context such as the ChatGPT tab id, terminal phase, and
+  `inspect_command`.
 
 ## [0.5.29] - 2026-06-21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Native extension failures after browser-side effects now include inspectable
   recovery context such as the ChatGPT tab id, terminal phase, and
   `inspect_command`.
+- Updated the locked `anyhow` version to address `RUSTSEC-2026-0190`.
 
 ## [0.5.29] - 2026-06-21
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,8 +126,12 @@ recipe selects it as the only default transport.
   `setup --chatgpt --open-chrome`, `doctor --chatgpt`, `status --chatgpt`,
   `reconnect --chatgpt`, `update --chatgpt`,
   `inspect --chatgpt --run-id <id>`, and `grant-identity --chatgpt`. Use
-  `yoetz browser check --transport chrome-extension-native` for extension
-  readiness; plain `yoetz browser check` verifies the default CDP/browser stack.
+  `yoetz browser check --transport chrome-extension-native` for explicit
+  extension readiness. Plain `yoetz browser check` auto-selects the native
+  extension check when the extension reports connected; pass `--transport
+  chrome-devtools-mcp`, `--transport dev-browser`, `--transport agent-browser`,
+  `--cdp`, `--browser-id`, or a managed `--profile` when you specifically need
+  to verify the CDP/browser stack.
 - ChatGPT conversation resume uses `--var conversation=<id|url>` with the
   `conversation_id` / `conversation_url` fields returned by earlier runs. It is
   native-extension only and does not manage context automatically; callers own

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "assert_cmd"

--- a/README.md
+++ b/README.md
@@ -268,9 +268,10 @@ yoetz browser recipe --recipe chatgpt --bundle ~/.yoetz/sessions/<id>/bundle.md 
 ```
 
 The default browser stack is extension-free unless the ChatGPT native extension
-is installed and connected. When connected, the ChatGPT recipe selects
-`chrome-extension-native` as the only default transport. Use an explicit
-`--transport <name>` when you want a different browser transport.
+is installed and connected. When connected, plain `yoetz browser check` uses a
+native dry-run and the ChatGPT recipe selects `chrome-extension-native` as the
+only default transport. Use an explicit `--transport <name>` when you want a
+different browser transport.
 
 Native extension happy path:
 

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -2081,11 +2081,16 @@ fn job_error_message(payload: &Value) -> String {
         .unwrap_or("chrome-extension-native job failed")
         .to_string();
     let code = payload.get("code").and_then(Value::as_str).unwrap_or("");
+    let mut detail = Vec::new();
     if !code.starts_with("conversation_") {
+        append_job_error_detail(payload, &message, &mut detail);
+        if !detail.is_empty() {
+            message.push_str(". ");
+            message.push_str(&detail.join("; "));
+        }
         return message;
     }
 
-    let mut detail = Vec::new();
     if let Some(requested) = payload
         .get("requested_conversation_id")
         .and_then(Value::as_str)
@@ -2114,6 +2119,36 @@ fn job_error_message(payload: &Value) -> String {
             detail.push(phase_text);
         }
     }
+    append_job_error_detail(payload, &message, &mut detail);
+
+    if !detail.is_empty() {
+        message.push_str(". ");
+        message.push_str(&detail.join("; "));
+    }
+    message
+}
+
+fn append_job_error_detail(payload: &Value, message: &str, detail: &mut Vec<String>) {
+    if let Some(tab_id) = payload
+        .get("tab_id")
+        .and_then(Value::as_i64)
+        .filter(|value| *value >= 0)
+    {
+        let tab_text = format!("tab {tab_id}");
+        if !message.contains(&tab_text) {
+            detail.push(tab_text);
+        }
+    }
+    if let Some(phase) = payload
+        .get("phase")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        let phase_text = format!("phase {phase}");
+        if !message.contains(&phase_text) && !detail.iter().any(|item| item == &phase_text) {
+            detail.push(phase_text);
+        }
+    }
     if let Some(inspect_command) = payload
         .get("inspect_command")
         .and_then(Value::as_str)
@@ -2123,12 +2158,6 @@ fn job_error_message(payload: &Value) -> String {
             detail.push(format!("inspect with: {inspect_command}"));
         }
     }
-
-    if !detail.is_empty() {
-        message.push_str(". ");
-        message.push_str(&detail.join("; "));
-    }
-    message
 }
 
 fn emit_progress(format: OutputFormat, envelope: &ProtocolEnvelope) -> Result<()> {
@@ -4153,11 +4182,38 @@ mod tests {
                 "inspect_command": "yoetz browser extension inspect --chatgpt --run-id run_conv",
             }),
         ));
-        let text = err.to_string();
+        let text = format!("{err:#}");
 
         assert!(text.contains("requested conversation conv-404"));
         assert!(text.contains("current URL https://chatgpt.com/c/conv-404?_yoetz=run_conv"));
         assert!(text.contains("phase upload"));
         assert!(text.contains("yoetz browser extension inspect --chatgpt --run-id run_conv"));
+    }
+
+    #[test]
+    fn job_error_non_conversation_failures_surface_inspect_context() {
+        let err = job_error(ProtocolEnvelope::new(
+            "job_error",
+            Some("job_ready".to_string()),
+            Some("run_ready".to_string()),
+            json!({
+                "code": "extension_error",
+                "message": "Yoetz content script did not become ready in ChatGPT tab 920272522",
+                "phase": "upload",
+                "side_effect_started": true,
+                "tab_id": 920272522,
+                "inspect_command": "yoetz browser extension inspect --chatgpt --run-id run_ready",
+            }),
+        ));
+        let text = format!("{err:#}");
+
+        assert!(text.contains("Yoetz content script did not become ready"));
+        assert!(text.contains("tab 920272522"));
+        assert!(text.contains("phase upload"));
+        assert!(text.contains("yoetz browser extension inspect --chatgpt --run-id run_ready"));
+        assert_eq!(
+            crate::chatgpt_recipe::terminal_fallback_phase(&err),
+            Some(ChatgptTransportPhase::Upload)
+        );
     }
 }

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -1167,6 +1167,22 @@ fn recipe_should_auto_discover_cdp_target(
         && (!extension_native_will_route || (requested_extension_native && allow_cdp_fallback))
 }
 
+fn recipe_should_auto_select_extension_native(
+    requested_transport: Option<browser::RecipeTransport>,
+    is_chatgpt: bool,
+    recipe_transports_pinned: bool,
+    managed_profile_only: bool,
+    explicit_browser_target: bool,
+    extension_connected: bool,
+) -> bool {
+    requested_transport.is_none()
+        && is_chatgpt
+        && !recipe_transports_pinned
+        && !managed_profile_only
+        && !explicit_browser_target
+        && extension_connected
+}
+
 fn manual_browser_recipe_fallback(recipe_path: &Path, bundle: Option<&Path>) -> String {
     let bundle_hint = bundle
         .map(|path| format!(" Upload or paste `{}` manually.", path.display()))
@@ -1487,6 +1503,30 @@ fn maybe_print_auto_selected_extension_native_transport(
     }
 }
 
+fn auto_selected_browser_check_extension_native_notice(
+    auto_selected: bool,
+) -> Option<&'static str> {
+    if auto_selected {
+        Some(
+            "info: auto-selected chrome-extension-native for browser check because the Yoetz Chrome extension is installed and connected (pass --transport chrome-devtools-mcp, --transport dev-browser, --transport agent-browser, --cdp, --browser-id, or --profile to check the CDP/browser stack)",
+        )
+    } else {
+        None
+    }
+}
+
+fn maybe_print_auto_selected_browser_check_extension_native(
+    auto_selected: bool,
+    format: OutputFormat,
+) {
+    if !matches!(format, OutputFormat::Text | OutputFormat::Markdown) {
+        return;
+    }
+    if let Some(notice) = auto_selected_browser_check_extension_native_notice(auto_selected) {
+        eprintln!("{notice}");
+    }
+}
+
 fn running_profile_recipe_transport_priority(transport: browser::RecipeTransport) -> u8 {
     match transport {
         browser::RecipeTransport::ChromeDevtoolsMcp => 0,
@@ -1603,7 +1643,11 @@ fn browser_check_transport_override(
         }
         browser::RecipeTransport::DevBrowser => Ok(Some(BrowserCheckTransport::DevBrowser)),
         browser::RecipeTransport::AgentBrowser => Ok(Some(BrowserCheckTransport::AgentBrowser)),
-        browser::RecipeTransport::ChromeExtensionNative => Ok(None),
+        browser::RecipeTransport::ChromeExtensionNative => {
+            bail!(
+                "chrome-extension-native check is handled before browser-stack fallback selection"
+            )
+        }
         browser::RecipeTransport::Manual => {
             bail!("manual transport is not valid for `yoetz browser check`")
         }
@@ -1690,6 +1734,7 @@ fn check_args_have_extension_selector(args: &BrowserCheckArgs) -> bool {
 fn handle_browser_extension_native_check(
     args: &BrowserCheckArgs,
     format: OutputFormat,
+    auto_selected: bool,
 ) -> Result<()> {
     if args.profile.is_some() || args.cdp.is_some() || args.browser_id.is_some() {
         bail!(
@@ -1706,6 +1751,7 @@ fn handle_browser_extension_native_check(
         "status": "ok",
         "method": "extension_native_dry_run",
         "transport": browser_extension_native::TRANSPORT_NAME,
+        "auto_selected": auto_selected,
         "live": false,
         "extension": bridge,
     });
@@ -1713,6 +1759,7 @@ fn handle_browser_extension_native_check(
         OutputFormat::Json => write_json(&payload),
         OutputFormat::Jsonl => write_jsonl("browser.check", &payload),
         OutputFormat::Text | OutputFormat::Markdown => {
+            maybe_print_auto_selected_browser_check_extension_native(auto_selected, format);
             for line in browser_extension_native_check_text_lines() {
                 println!("{line}");
             }
@@ -1726,6 +1773,18 @@ fn browser_extension_native_check_text_lines() -> [&'static str; 2] {
         "Browser extension bridge ready via chrome-extension-native (dry-run bridge check; no CDP approval).",
         "No live canary is required before normal ChatGPT Pro recipe runs.",
     ]
+}
+
+fn browser_check_should_auto_select_extension_native(
+    requested_transport: Option<browser::RecipeTransport>,
+    managed_profile_only: bool,
+    explicit_browser_target: bool,
+    extension_connected: bool,
+) -> bool {
+    requested_transport.is_none()
+        && !managed_profile_only
+        && !explicit_browser_target
+        && extension_connected
 }
 
 fn maybe_print_auto_selected_cdp_target(
@@ -2940,8 +2999,27 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
         }
         BrowserCommand::Check(check_args) => {
             let requested_transport = check_args.transport;
-            if requested_transport == Some(browser::RecipeTransport::ChromeExtensionNative) {
-                return handle_browser_extension_native_check(&check_args, format);
+            let managed_profile_only = profile_forces_managed_browser(
+                check_args.profile.as_deref(),
+                check_args.cdp.as_deref(),
+                check_args.browser_id.as_deref(),
+            );
+            let explicit_browser_target =
+                check_args.cdp.is_some() || check_args.browser_id.is_some();
+            let auto_select_extension_native = browser_check_should_auto_select_extension_native(
+                requested_transport,
+                managed_profile_only,
+                explicit_browser_target,
+                extension_status_connected_for_auto_selection(),
+            );
+            if requested_transport == Some(browser::RecipeTransport::ChromeExtensionNative)
+                || auto_select_extension_native
+            {
+                return handle_browser_extension_native_check(
+                    &check_args,
+                    format,
+                    auto_select_extension_native,
+                );
             }
             if check_args_have_extension_selector(&check_args) {
                 bail!(
@@ -2952,13 +3030,6 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 .map(browser_check_transport_override)
                 .transpose()?
                 .flatten();
-            let managed_profile_only = profile_forces_managed_browser(
-                check_args.profile.as_deref(),
-                check_args.cdp.as_deref(),
-                check_args.browser_id.as_deref(),
-            );
-            let explicit_browser_target =
-                check_args.cdp.is_some() || check_args.browser_id.is_some();
             let mut resolved_cdp_target = browser::resolve_cdp_target_with_selector(
                 check_args.cdp.as_deref(),
                 check_args.browser_id.as_deref(),
@@ -3362,10 +3433,16 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 Some(browser::RecipeTransport::ChromeExtensionNative)
             );
             let recipe_transports_pinned = recipe.transports.is_some();
-            let extension_auto_selection_eligible = recipe_args.transport.is_none()
-                && is_chatgpt
-                && !recipe_transports_pinned
-                && extension_status_connected_for_auto_selection();
+            let explicit_browser_target =
+                recipe_args.cdp.is_some() || recipe_args.browser_id.is_some();
+            let extension_auto_selection_eligible = recipe_should_auto_select_extension_native(
+                recipe_args.transport,
+                is_chatgpt,
+                recipe_transports_pinned,
+                managed_profile_only,
+                explicit_browser_target,
+                extension_status_connected_for_auto_selection(),
+            );
             let extension_native_will_route =
                 requested_extension_native || extension_auto_selection_eligible;
             let effective_allow_cdp_fallback = recipe_effective_allow_cdp_fallback(
@@ -4756,6 +4833,30 @@ mod tests {
     }
 
     #[test]
+    fn recipe_native_auto_selection_respects_explicit_targets() {
+        assert!(recipe_should_auto_select_extension_native(
+            None, true, false, false, false, true
+        ));
+        assert!(!recipe_should_auto_select_extension_native(
+            None, true, false, false, true, true
+        ));
+        assert!(!recipe_should_auto_select_extension_native(
+            None, true, false, true, false, true
+        ));
+        assert!(!recipe_should_auto_select_extension_native(
+            Some(browser::RecipeTransport::ChromeDevtoolsMcp),
+            true,
+            false,
+            false,
+            false,
+            true,
+        ));
+        assert!(!recipe_should_auto_select_extension_native(
+            None, false, false, false, false, true
+        ));
+    }
+
+    #[test]
     fn cdp_auto_discovery_is_disabled_for_native_only_routes() {
         assert!(recipe_should_auto_discover_cdp_target(
             false, false, false, false
@@ -5187,6 +5288,28 @@ mod tests {
     }
 
     #[test]
+    fn browser_check_native_auto_selection_respects_explicit_targets() {
+        assert!(browser_check_should_auto_select_extension_native(
+            None, false, false, true
+        ));
+        assert!(!browser_check_should_auto_select_extension_native(
+            Some(browser::RecipeTransport::ChromeDevtoolsMcp),
+            false,
+            false,
+            true
+        ));
+        assert!(!browser_check_should_auto_select_extension_native(
+            None, true, false, true
+        ));
+        assert!(!browser_check_should_auto_select_extension_native(
+            None, false, true, true
+        ));
+        assert!(!browser_check_should_auto_select_extension_native(
+            None, false, false, false
+        ));
+    }
+
+    #[test]
     fn browser_check_transport_override_maps_recipe_transports() {
         assert_eq!(
             browser_check_transport_override(browser::RecipeTransport::ChromeDevtoolsMcp).unwrap(),
@@ -5200,10 +5323,9 @@ mod tests {
             browser_check_transport_override(browser::RecipeTransport::AgentBrowser).unwrap(),
             Some(BrowserCheckTransport::AgentBrowser)
         );
-        assert_eq!(
+        assert!(
             browser_check_transport_override(browser::RecipeTransport::ChromeExtensionNative)
-                .unwrap(),
-            None
+                .is_err()
         );
         assert!(browser_check_transport_override(browser::RecipeTransport::Manual).is_err());
     }
@@ -5215,6 +5337,15 @@ mod tests {
         assert!(text.contains("No live canary is required"));
         assert!(!text.contains("dry-run canary"));
         assert!(!text.contains("For a live ChatGPT auth probe"));
+    }
+
+    #[test]
+    fn browser_extension_native_check_notice_explains_auto_selection() {
+        assert!(auto_selected_browser_check_extension_native_notice(false).is_none());
+        let notice = auto_selected_browser_check_extension_native_notice(true).unwrap();
+        assert!(notice.contains("auto-selected chrome-extension-native"));
+        assert!(notice.contains("--transport chrome-devtools-mcp"));
+        assert!(notice.contains("--cdp"));
     }
 
     #[test]

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -675,6 +675,18 @@ async function handleReconnect(message) {
     await handleDoctorAuthProbe(message);
     return;
   }
+  if (message.payload?.intent === "bridge_check") {
+    postNative(makeEnvelope("job_complete", {
+      request_id: message.request_id,
+      job_id: message.job_id,
+      run_id: message.run_id,
+      workspace_id: message.workspace_id,
+      payload: {
+        status: "ok"
+      }
+    }));
+    return;
+  }
   await recoverJobs(message);
 }
 
@@ -1098,6 +1110,9 @@ function errorContextForJob(job, error = null) {
       ? error.side_effect_started
       : Boolean(job.tab_id)
   };
+  if (job.tab_id != null) {
+    detail.tab_id = job.tab_id;
+  }
   if (job.run_id) {
     detail.inspect_command = inspectCommandForJob(job);
   }

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -205,6 +205,59 @@ test("service worker doctor auth probe prefers active non-owned ChatGPT tab and 
   }
 });
 
+test("service worker bridge_check is a no-op and does not recover jobs", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const storage = makeStorage();
+  const now = Date.now();
+  await storage.set({
+    "jobs.job_bridge_restore": {
+      job_id: "job_bridge_restore",
+      run_id: "run_job_bridge_restore",
+      workspace_id: "workspace_test",
+      status: "waiting_for_file",
+      prompt: "prompt",
+      tab_id: 42,
+      started_at: now,
+      updated_at: now
+    }
+  });
+
+  globalThis.chrome = chromeStub({
+    port,
+    storage,
+    tabs: {}
+  });
+
+  try {
+    await import(`../src/service-worker.js?bridge_check=${Date.now()}`);
+    await eventually(() => port.messages.some((message) => message.type === "hello"));
+    await eventually(() => port.messages.some((message) =>
+      message.type === "job_progress"
+      && message.job_id === "job_bridge_restore"
+      && message.payload.phase === "ready_for_file"
+    ));
+    port.messages.length = 0;
+
+    port.emit(envelope("reconnect", "job_bridge_check", { intent: "bridge_check" }));
+
+    await eventually(() => port.messages.some((message) =>
+      message.type === "job_complete" && message.job_id === "job_bridge_check"
+    ));
+    const complete = port.messages.find((message) =>
+      message.type === "job_complete" && message.job_id === "job_bridge_check"
+    );
+    assert.equal(complete.payload.status, "ok");
+    assert.equal(Object.hasOwn(complete.payload, "restored_jobs"), false);
+    assert.equal(port.messages.some((message) => message.type === "reconnect"), false);
+    assert.equal(port.messages.some((message) =>
+      message.type === "job_progress" && message.job_id === "job_bridge_restore"
+    ), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker opens fresh and resume jobs in new owned tabs", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
@@ -625,6 +678,44 @@ test("service worker marks manual handoff as terminal after tab side effects", a
     assert.equal(error.payload.side_effect_started, true);
   } finally {
     globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker content-script readiness failure includes inspect context", async () => {
+  const originalChrome = globalThis.chrome;
+  const originalSetTimeout = globalThis.setTimeout;
+  const port = makePort();
+  const tabId = 920272522;
+
+  globalThis.setTimeout = (fn, _ms, ...args) => originalSetTimeout(fn, 0, ...args);
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/?_yoetz=run_job_content_script_missing" }),
+      sendMessage: async (_id, message) => {
+        if (message.type === "yoetz_probe") {
+          throw new Error("receiving end does not exist");
+        }
+        throw new Error(`unexpected tab message ${message.type}`);
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?content_script_missing=${Date.now()}`);
+    port.emit(envelope("job_start", "job_content_script_missing", { prompt: "prompt" }));
+    await eventually(() => port.messages.some((message) => message.type === "job_error"));
+    const error = port.messages.find((message) => message.type === "job_error");
+    assert.equal(error.payload.code, "extension_error");
+    assert.equal(error.payload.phase, "upload");
+    assert.equal(error.payload.side_effect_started, true);
+    assert.equal(error.payload.tab_id, tabId);
+    assert.equal(error.payload.inspect_command, "yoetz browser extension inspect --chatgpt --run-id run_job_content_script_missing");
+    assert.match(error.payload.message, /Yoetz content script did not become ready in ChatGPT tab 920272522/);
+  } finally {
+    globalThis.chrome = originalChrome;
+    globalThis.setTimeout = originalSetTimeout;
   }
 });
 

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -116,7 +116,7 @@ yoetz models list -s claude --format json
 | Bundle files | `yoetz bundle -p "context" -f "src/**/*.rs" --format json` |
 | Generate image | `yoetz generate image -p "description" --provider openai --model MODEL_ID --format json` |
 | Estimate cost | `yoetz pricing estimate --model MODEL_ID --input-tokens 1000 --output-tokens 500` |
-| Browser check (CDP/default) | `yoetz browser check --format json` |
+| Browser check (native if connected; CDP/default otherwise) | `yoetz browser check --format json` |
 | Extension check | `yoetz browser check --transport chrome-extension-native --format json` |
 | Browser attach | `yoetz browser attach --format json` |
 | Browser login | `yoetz browser login` |
@@ -339,10 +339,14 @@ yoetz browser extension grant-identity --chatgpt
 The extension transport is ChatGPT-only, native-host backed, and currently
 macOS/Linux-only. Do not use it as a general browser interpreter, and do not
 silently fall back to CDP after browser-side side effects have started.
-For extension-native workflows, do not run plain `yoetz browser check`; that
-checks the default CDP/browser stack and may trigger Chrome's remote-debugging
-approval. Use `yoetz browser check --transport chrome-extension-native --format json`
-or `yoetz browser extension doctor --chatgpt` instead.
+For extension-native workflows, plain `yoetz browser check --format json`
+auto-selects `chrome-extension-native` when the extension reports connected,
+returns `auto_selected: true`, and avoids Chrome's remote-debugging approval
+dialog. Use `yoetz browser check --transport chrome-extension-native --format json`
+for an explicit extension check, or `yoetz browser extension doctor --chatgpt`
+for deeper diagnostics. If you specifically need the CDP/browser stack, pass
+`--transport chrome-devtools-mcp`, `--transport dev-browser`,
+`--transport agent-browser`, `--cdp`, `--browser-id`, or a managed `--profile`.
 Do not run a live canary as a routine readiness step before ChatGPT Pro recipe
 runs; reserve it for explicit diagnostics.
 If `doctor` or `inspect` points to a live ChatGPT-side problem and the user
@@ -409,7 +413,7 @@ If auto-connect isn't available, cookie sync is still supported:
 ```bash
 # Log into ChatGPT in real Chrome, close Chrome, then:
 yoetz browser sync-cookies
-yoetz browser check --format json
+yoetz browser check --transport agent-browser --format json
 ```
 Requires Node >= 24.4. If macOS shows a Keychain prompt for `Chrome Safe Storage`, click `Always Allow`.
 


### PR DESCRIPTION
## Summary
- auto-select chrome-extension-native for plain browser checks when the ChatGPT extension is connected
- preserve explicit browser targets/transports and expose auto_selected in browser-check JSON
- make bridge_check side-effect-free and surface inspect context for post-side-effect native failures
- update release notes and docs for the new default

## Verification
- cargo fmt --check && git diff --check
- npm test -- --test-name-pattern 'bridge_check|content-script readiness failure' (224 pass)
- cargo test -p yoetz (530 unit pass, 37 CLI pass, 3 daemon-policy pass)
- live native browser check: plain check auto_selected true; explicit native check auto_selected false

Peer review: Claude PASS via AMQ 2026-06-30T08-10-52.265Z_pid56077_af715967