### PR TITLE
fix: ignore rust-toolchain in actions dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # dtolnay/rust-toolchain is branch-oriented (stable/MSRV), not a normal
+      # semver release action, and Dependabot currently reports it as an
+      # unknown_error while refreshing the grouped GitHub Actions PR.
+      - dependency-name: "dtolnay/rust-toolchain"
     groups:
       actions:
         patterns: ["*"]


### PR DESCRIPTION
## Summary
- ignore dtolnay/rust-toolchain in the GitHub Actions Dependabot updater
- keep the grouped actions Dependabot PR behavior for normal release-tagged actions

## Root Cause
Dependabot Updates run 28718794023 failed with `dtolnay/rust-toolchain | unknown_error | null` while refreshing the grouped actions job. That action is branch-oriented rather than a normal semver release action.

## Verification
- peer reviewed by Codex worker
- ruby YAML.load_file(".github/dependabot.yml")
- actionlint
- git diff --check
- gh run view 28718794023 --log-failed