### PR TITLE
feat: target GPT-5.6 Sol Pro in ChatGPT recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- The built-in ChatGPT recipe now targets GPT-5.6 Sol with Pro intelligence
+  across the native extension and CDP/dev-browser fallback transports. Model
+  selection results now carry separate verified family and effort proofs.
+
+### Fixed
+
+- Updated ChatGPT model selection for the new composer pill and Radix
+  Intelligence/family menus. Yoetz verifies GPT-5.6 Sol and Pro together before
+  upload, refuses the stale GPT-5.5 Pro Extended trap, and reports legacy picker
+  DOMs instead of silently downgrading.
+- ChatGPT response extraction now recognizes the new whole-line model chrome
+  labels such as `Sol`, `Extra High`, and `GPT-5.6 Sol` without stripping those
+  words from normal answer prose.
+
 ## [0.5.30] - 2026-06-30
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Agent skill installation options are listed in [Agent Skills](#agent-skills).
 ## Browser Recipes And ChatGPT Pro
 
 Browser recipes let Yoetz use web-only model surfaces from the terminal. The
-built-in ChatGPT recipe targets ChatGPT Pro with Extended enabled and is
+built-in ChatGPT recipe targets GPT-5.6 Sol with Pro intelligence and is
 fail-closed: if Yoetz cannot prove the requested surface is available, it stops
 instead of silently downgrading.
 

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -1586,7 +1586,7 @@ fn run_chatgpt_select_model(
     use_stealth: bool,
     headed: bool,
 ) -> Result<String> {
-    let requested_model = crate::chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL;
+    let requested_model = crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL;
     let function = chatgpt_web::build_model_selection_function(requested_model);
     let expression = chatgpt_web::wrap_function_source_for_json_eval(&function)?;
     let stdout = run_agent_browser_with_connection_timeout(
@@ -1607,7 +1607,10 @@ fn run_chatgpt_select_model(
     let model_selection_status =
         chatgpt_web::chatgpt_model_selection_status(&selection, requested_model);
     match status {
-        "selected" | "already-selected" => {
+        "selected"
+            if model_selection_status
+                == chatgpt_recipe::ChatgptModelSelectionStatus::Selected =>
+        {
             Ok(json!({
                 "status": "ok",
                 "model_used": model_used,
@@ -1615,6 +1618,9 @@ fn run_chatgpt_select_model(
             })
             .to_string())
         }
+        "selected" => Err(anyhow!(
+            "ChatGPT reported selected without verified GPT-5.6 Sol + Pro proof"
+        )),
         "missing-selector" => Err(anyhow!(
             "ChatGPT model selector button not found. url={:?}, title={:?}",
             selection.get("url").and_then(Value::as_str).unwrap_or(""),
@@ -1640,24 +1646,22 @@ fn run_chatgpt_select_model(
                 .unwrap_or_else(|| "<unknown>".to_string())
         )),
         "selection-mismatch" => Err(anyhow!(
-            "requested ChatGPT model `{}` was not actually selected. selected_label={:?}; target_testid={:?}; available_after={}",
+            "requested ChatGPT model `{}` was not actually selected. family_status={:?}; effort_status={:?}; family_label={:?}; warning={:?}",
             selection
                 .get("requested")
                 .and_then(Value::as_str)
                 .unwrap_or(requested_model),
-            selection.get("selectedLabel").and_then(Value::as_str),
-            selection.get("targetTestId").and_then(Value::as_str),
+            selection.get("familyStatus").and_then(Value::as_str),
+            selection.get("effortStatus").and_then(Value::as_str),
+            selection.get("familyLabel").and_then(Value::as_str),
+            selection.get("warning").and_then(Value::as_str)
+        )),
+        "legacy-picker" => Err(anyhow!(
+            "{}",
             selection
-                .get("availableItemsAfter")
-                .and_then(Value::as_array)
-                .map(|items| {
-                    items
-                        .iter()
-                        .filter_map(Value::as_str)
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                })
-                .unwrap_or_default()
+                .get("warning")
+                .and_then(Value::as_str)
+                .unwrap_or("legacy ChatGPT picker detected; this yoetz version requires the GPT-5.6 UI")
         )),
         other => Err(anyhow!("unexpected ChatGPT model selection status `{other}`")),
     }
@@ -4967,7 +4971,10 @@ mod tests {
             use_stealth: true,
             headed: false,
             target_url: CHATGPT_URL.to_string(),
-            vars: BTreeMap::from([("model".to_string(), "gpt-5-4-pro".to_string())]),
+            vars: BTreeMap::from([(
+                "model".to_string(),
+                crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL.to_string(),
+            )]),
         }
     }
 
@@ -5114,7 +5121,7 @@ case "$*" in
     count=$((count + 1))
     printf '%s' "$count" > "$EVAL_COUNT_PATH"
     if [ "$count" = "1" ]; then
-      printf '{"status":"already-selected","currentLabel":"Pro Extended"}'
+      printf '{"status":"selected","requested":"gpt-5-6-sol-pro","modelUsed":"GPT-5.6 Sol Pro","familyStatus":"verified","effortStatus":"verified"}'
     elif [ "$count" = "2" ]; then
       printf '{"status":"marked"}'
     else
@@ -5145,7 +5152,7 @@ if %errorlevel%==0 (
   set /a count=count+1
   > "%EVAL_COUNT_PATH%" echo !count!
   if "!count!"=="1" (
-    echo {"status":"already-selected","currentLabel":"Pro Extended"}
+    echo {"status":"selected","requested":"gpt-5-6-sol-pro","modelUsed":"GPT-5.6 Sol Pro","familyStatus":"verified","effortStatus":"verified"}
   ) else if "!count!"=="2" (
     echo {"status":"marked"}
   ) else (
@@ -6028,7 +6035,7 @@ browser_cdp = "http://evil.example.com:9222"
     fn interpolate_replaces_bundle_and_recipe_vars() {
         let ctx = recipe_context();
         let value = interpolate("open {{bundle_path}} {{model}}", &ctx, Some("ignored")).unwrap();
-        assert_eq!(value, "open /tmp/bundle.md gpt-5-4-pro");
+        assert_eq!(value, "open /tmp/bundle.md gpt-5-6-sol-pro");
     }
 
     #[test]
@@ -6299,7 +6306,7 @@ steps:
             r#"{"ref": "prompt-textarea", "text": ""}"#
         ));
         assert!(looks_authenticated(
-            r#"{"ref": "model-switcher-dropdown-button", "text": "ChatGPT"}"#
+            r#"{"class": "__composer-pill", "text": "Pro"}"#
         ));
         assert!(looks_authenticated(
             r#"{"ref": "composer-plus-btn", "text": ""}"#
@@ -6939,7 +6946,7 @@ steps:
                 "action": CHATGPT_SELECT_MODEL_ACTION,
                 "stdout": {
                     "status": "ok",
-                    "model_used": crate::chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL,
+                    "model_used": "GPT-5.6 Sol Pro",
                     "model_selection_status": "selected"
                 }
             }),
@@ -6958,10 +6965,7 @@ steps:
         assert_eq!(payload["transport"], "agent-browser");
         assert_eq!(payload["backend"], "agent-browser");
         assert_eq!(payload["response"], "final answer");
-        assert_eq!(
-            payload["model_used"],
-            crate::chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL
-        );
+        assert_eq!(payload["model_used"], "GPT-5.6 Sol Pro");
         assert_eq!(payload["model_selection_status"], "selected");
         assert_eq!(payload["fallback_used"], true);
         assert_eq!(payload["warnings"], json!(["used paste fallback"]));

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -968,7 +968,7 @@ pub fn canary(live: bool, selector: ExtensionInstanceSelector<'_>) -> Result<Val
     fs::write(&bundle_path, "Reply with exactly OK.\n")?;
     let spec = ChatgptRecipeSpec {
         bundle_path: Some(bundle_path),
-        model: crate::chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL.to_string(),
+        model: crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL.to_string(),
         prompt: "Reply with exactly OK.".to_string(),
         browser_context_id: None,
         profile_email: selector.profile_email.map(str::to_string),
@@ -3236,7 +3236,7 @@ mod tests {
         };
         let spec = ChatgptRecipeSpec {
             bundle_path: Some(bundle.path.clone()),
-            model: "extended-pro".to_string(),
+            model: crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL.to_string(),
             prompt: "continue".to_string(),
             browser_context_id: None,
             profile_email: None,
@@ -3263,7 +3263,7 @@ mod tests {
             Some("run_1".to_string()),
             json!({
                 "response": "done",
-                "model_used": "Pro Extended",
+                "model_used": "GPT-5.6 Sol Pro",
                 "model_selection_status": "selected",
                 "warnings": ["kept current"],
                 "conversation_id": "conv-123",
@@ -3274,7 +3274,7 @@ mod tests {
         let result = parse_recipe_result(envelope).unwrap();
 
         assert_eq!(result.response, "done");
-        assert_eq!(result.model_used.as_deref(), Some("Pro Extended"));
+        assert_eq!(result.model_used.as_deref(), Some("GPT-5.6 Sol Pro"));
         assert_eq!(
             result.model_selection_status,
             ChatgptModelSelectionStatus::Selected

--- a/crates/yoetz-cli/src/chatgpt_recipe.rs
+++ b/crates/yoetz-cli/src/chatgpt_recipe.rs
@@ -6,7 +6,7 @@ use serde_json::{json, Value};
 use std::fmt;
 use std::path::PathBuf;
 
-pub const CHATGPT_PRO_EXTENDED_MODEL: &str = "extended-pro";
+pub const CHATGPT_SOL_PRO_MODEL: &str = "gpt-5-6-sol-pro";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ChatgptTransportPhase {
@@ -229,7 +229,7 @@ mod tests {
             transport: "dev-browser".to_string(),
             backend: "dev-browser".to_string(),
             response: "ok".to_string(),
-            model_used: Some(CHATGPT_PRO_EXTENDED_MODEL.to_string()),
+            model_used: Some("GPT-5.6 Sol Pro".to_string()),
             model_selection_status: ChatgptModelSelectionStatus::Selected,
             warnings: vec!["fallback".to_string()],
             fallback_used: true,
@@ -244,7 +244,7 @@ mod tests {
         assert_eq!(payload["transport"], "dev-browser");
         assert_eq!(payload["backend"], "dev-browser");
         assert_eq!(payload["response"], "ok");
-        assert_eq!(payload["model_used"], CHATGPT_PRO_EXTENDED_MODEL);
+        assert_eq!(payload["model_used"], "GPT-5.6 Sol Pro");
         assert_eq!(payload["model_selection_status"], "selected");
         assert_eq!(payload["warnings"], json!(["fallback"]));
         assert_eq!(payload["fallback_used"], true);

--- a/crates/yoetz-cli/src/chatgpt_web.rs
+++ b/crates/yoetz-cli/src/chatgpt_web.rs
@@ -13,8 +13,7 @@ const CHATGPT_LEGACY_HOST: &str = "chat.openai.com";
 const CHATGPT_HOST: &str = "chatgpt.com";
 pub const COMPOSER_SELECTOR: &str =
     "#prompt-textarea, div[contenteditable='true'][role='textbox'], [role='textbox']";
-pub const MODEL_SELECTOR_BUTTON_SELECTOR: &str = "[data-testid='model-switcher-dropdown-button'], button[aria-label='Model selector'], button[aria-label='Model selector menu'], button:has([data-testid='selected-model']), button:has([data-testid='model-switcher-selected-model'])";
-pub const MODEL_ITEM_SELECTOR: &str = "[role='menuitem'], [role='menuitemradio'], [data-testid^='model-switcher-']:not([data-testid='model-switcher-selected-model'])";
+pub const MODEL_SELECTOR_BUTTON_SELECTOR: &str = "button[aria-haspopup='menu']";
 pub const ATTACHMENT_TILE_SELECTOR: &str = "[class*='file-tile'], [data-testid*='attachment']";
 pub const ATTACHMENT_TRIGGER_SELECTOR: &str = "button[data-testid='composer-plus-btn'], button[aria-label*='Attach'], button[aria-label*='attach'], button[data-testid*='attach']";
 pub const SEND_BUTTON_SELECTOR: &str =
@@ -73,8 +72,6 @@ const AUTH_MARKERS: &[&str] = &[
     "send-button",
     "prompt-textarea",
     "composer",
-    "model-switcher-dropdown-button",
-    "model-switcher-selected-model",
     "create-new-chat-button",
     "composer-plus-btn",
 ];
@@ -256,28 +253,17 @@ pub fn build_set_window_name_js(run_id: &str) -> String {
     )
 }
 
-pub fn model_testid_alias_map() -> BTreeMap<&'static str, &'static str> {
+pub fn model_alias_map() -> BTreeMap<&'static str, &'static str> {
     BTreeMap::from([
-        ("extended-pro", "extended-pro"),
-        ("pro", "gpt-5-4-pro"),
-        ("gpt-5-pro", "gpt-5-4-pro"),
-        ("thinking", "gpt-5-4-thinking"),
-        ("gpt-5-thinking", "gpt-5-4-thinking"),
-        ("instant", "gpt-5-3"),
+        ("gpt-5-6-sol-pro", "gpt-5-6-sol-pro"),
+        ("sol-pro", "gpt-5-6-sol-pro"),
     ])
 }
 
-pub fn model_testid_candidate_map() -> BTreeMap<&'static str, Vec<&'static str>> {
+pub fn model_candidate_map() -> BTreeMap<&'static str, Vec<&'static str>> {
     BTreeMap::from([
-        ("extended-pro", vec!["extended-pro"]),
-        ("pro", vec!["gpt-5-4-pro"]),
-        ("gpt-5-pro", vec!["gpt-5-4-pro"]),
-        ("gpt-5-4-pro", vec!["gpt-5-4-pro"]),
-        ("thinking", vec!["gpt-5-4-thinking"]),
-        ("gpt-5-thinking", vec!["gpt-5-4-thinking"]),
-        ("gpt-5-4-thinking", vec!["gpt-5-4-thinking"]),
-        ("instant", vec!["gpt-5-3"]),
-        ("gpt-5-3", vec!["gpt-5-3"]),
+        ("gpt-5-6-sol-pro", vec!["gpt-5-6-sol-pro"]),
+        ("sol-pro", vec!["gpt-5-6-sol-pro"]),
     ])
 }
 
@@ -311,18 +297,19 @@ fn is_low_signal_chatgpt_model_key(key: &str) -> bool {
             | "model-selector"
             | "selected-model"
             | "dropdown-button"
+            | "pro"
+            | "extended-pro"
+            | "thinking"
+            | "instant"
     )
 }
 
 pub fn canonical_chatgpt_model_slug(value: &str) -> Option<String> {
     let normalized = normalize_chatgpt_model_key(value)?;
-    if let Some(stripped) = normalized.strip_prefix("model-switcher-") {
-        return canonical_chatgpt_model_slug(stripped);
-    }
-    if let Some(candidates) = model_testid_candidate_map().get(normalized.as_str()) {
+    if let Some(candidates) = model_candidate_map().get(normalized.as_str()) {
         return candidates.first().map(|value| (*value).to_string());
     }
-    if let Some(alias) = model_testid_alias_map().get(normalized.as_str()) {
+    if let Some(alias) = model_alias_map().get(normalized.as_str()) {
         return Some((*alias).to_string());
     }
     if is_low_signal_chatgpt_model_key(&normalized) {
@@ -335,29 +322,13 @@ pub fn select_reported_chatgpt_model(
     selection: &serde_json::Value,
     requested_model: &str,
 ) -> Option<String> {
-    for field in ["targetTestId", "modelUsed", "selectedLabel", "currentLabel"] {
-        if let Some(model) = selection
-            .get(field)
-            .and_then(serde_json::Value::as_str)
-            .and_then(canonical_chatgpt_model_slug)
-        {
-            return Some(model);
-        }
+    if !is_verified_sol_pro_selection(selection, requested_model) {
+        return None;
     }
-
-    let requested_model = requested_model.trim();
-    if should_keep_current_chatgpt_model(requested_model) {
-        None
-    } else {
-        canonical_chatgpt_model_slug(requested_model)
-    }
-}
-
-pub fn should_keep_current_chatgpt_model(requested_model: &str) -> bool {
-    let requested_model = requested_model.trim();
-    requested_model.is_empty()
-        || requested_model.eq_ignore_ascii_case("current")
-        || requested_model.eq_ignore_ascii_case("keep-current")
+    selection
+        .get("modelUsed")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
 }
 
 pub(crate) fn chatgpt_model_selection_status(
@@ -368,15 +339,40 @@ pub(crate) fn chatgpt_model_selection_status(
         .get("status")
         .and_then(serde_json::Value::as_str)
         .unwrap_or("unknown");
-    let keep_current_model = should_keep_current_chatgpt_model(requested_model);
     match status {
-        "selected" => ChatgptModelSelectionStatus::Selected,
-        "already-selected" if keep_current_model => ChatgptModelSelectionStatus::KeptCurrent,
-        "already-selected" => ChatgptModelSelectionStatus::Selected,
+        "selected" if is_verified_sol_pro_selection(selection, requested_model) => {
+            ChatgptModelSelectionStatus::Selected
+        }
+        "selected" | "selection-mismatch" => ChatgptModelSelectionStatus::Mismatch,
         "missing-selector" | "not-found" => ChatgptModelSelectionStatus::Unavailable,
-        "selection-mismatch" => ChatgptModelSelectionStatus::Mismatch,
         _ => ChatgptModelSelectionStatus::Unavailable,
     }
+}
+
+fn is_verified_sol_pro_selection(selection: &serde_json::Value, requested_model: &str) -> bool {
+    if selection.get("status").and_then(serde_json::Value::as_str) != Some("selected")
+        || requested_model.trim() != crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL
+        || selection
+            .get("requested")
+            .and_then(serde_json::Value::as_str)
+            != Some(crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL)
+        || selection
+            .get("familyStatus")
+            .and_then(serde_json::Value::as_str)
+            != Some("verified")
+        || selection
+            .get("effortStatus")
+            .and_then(serde_json::Value::as_str)
+            != Some("verified")
+    {
+        return false;
+    }
+    let model_used = selection
+        .get("modelUsed")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default();
+    canonical_chatgpt_model_slug(model_used).as_deref()
+        == Some(crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL)
 }
 
 pub fn model_selector_button_selector_json() -> String {
@@ -386,10 +382,6 @@ pub fn model_selector_button_selector_json() -> String {
 
 pub fn composer_selector_json() -> String {
     serde_json::to_string(COMPOSER_SELECTOR).expect("serialize composer selector")
-}
-
-pub fn model_item_selector_json() -> String {
-    serde_json::to_string(MODEL_ITEM_SELECTOR).expect("serialize model item selector")
 }
 
 pub fn attachment_tile_selector_json() -> String {
@@ -413,744 +405,297 @@ pub fn upload_menu_text_pattern_json() -> String {
     serde_json::to_string(UPLOAD_MENU_TEXT_PATTERN).expect("serialize upload menu text pattern")
 }
 
-pub fn model_testid_aliases_json() -> String {
-    serde_json::to_string(&model_testid_alias_map()).expect("serialize model alias map")
-}
-
-pub fn model_testid_candidates_json() -> String {
-    serde_json::to_string(&model_testid_candidate_map()).expect("serialize model candidate map")
-}
-
 pub fn build_model_selection_function(requested_model: &str) -> String {
     let requested_model =
         serde_json::to_string(requested_model).expect("serialize requested model");
     let model_button_selector = model_selector_button_selector_json();
     let composer_selector = composer_selector_json();
-    let model_item_selector = model_item_selector_json();
-    let model_testid_aliases = model_testid_aliases_json();
-    let model_testid_candidates = model_testid_candidates_json();
     format!(
         r##"
 async () => {{
   const requested = {requested_model};
+  const supported = "gpt-5-6-sol-pro";
   const MODEL_BUTTON_SELECTOR = {model_button_selector};
   const COMPOSER_SELECTOR = {composer_selector};
-  const MODEL_ITEM_SELECTOR = {model_item_selector};
-  const MODEL_TESTID_ALIASES = {model_testid_aliases};
-  const MODEL_TESTID_CANDIDATES = {model_testid_candidates};
   const normalize = (value) => String(value || "").replace(/\s+/g, " ").trim();
+  const fold = (value) => normalize(value).toLowerCase();
   const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-  const isCheckedState = (ariaChecked, dataState) => ariaChecked === "true" || dataState === "checked";
-  const hasSelectedCurrentMarker = (ariaSelected, ariaCurrent, dataSelected, dataCurrent) =>
-    ariaSelected === "true" ||
-    dataSelected === "true" ||
-    (!!ariaCurrent && ariaCurrent !== "false") ||
-    (!!dataCurrent && dataCurrent !== "false");
-    const itemIsSelected = (item) => !!item && (
-      isCheckedState(item.ariaChecked || "", item.dataState || "") ||
-      hasSelectedCurrentMarker(item.ariaSelected || "", item.ariaCurrent || "", item.dataSelected || "", item.dataCurrent || "")
-    );
+  const textOf = (node) => normalize(node?.innerText || node?.textContent || "");
 {visibility_helpers}
-  const composerScopes = () => {{
+
+  function classTokens(node) {{
+    return normalize(node?.getAttribute?.("class") || "").split(" ").filter(Boolean);
+  }}
+
+  function legacyPickerMarkers() {{
+    return Array.from(document.querySelectorAll(
+      "[data-testid='model-switcher-dropdown-button'], [data-testid='model-switcher-selected-model'], [data-testid^='model-switcher-']"
+    )).filter(isVisible).map((node) => node.getAttribute("data-testid") || "").filter(Boolean);
+  }}
+
+  function composerScopes() {{
     const composer = document.querySelector(COMPOSER_SELECTOR);
     const scopes = [];
-    const add = (scope) => {{
-      if (scope && !scopes.includes(scope)) scopes.push(scope);
-    }};
+    const add = (scope) => {{ if (scope && !scopes.includes(scope)) scopes.push(scope); }};
     add(composer?.closest("form"));
-    add(composer?.closest("[data-testid*='composer'], [class*='composer'], main, [role='main']"));
+    add(composer?.closest("[data-testid*='composer'], [class*='composer']"));
     add(composer?.parentElement);
+    const local = scopes.slice();
+    for (const scope of local) {{
+      const parent = scope?.parentElement;
+      if (!parent) continue;
+      for (const sibling of Array.from(parent.children || [])) {{
+        const marker = fold([
+          sibling.getAttribute?.("data-testid"),
+          sibling.getAttribute?.("class"),
+          sibling.getAttribute?.("aria-label")
+        ].filter(Boolean).join(" "));
+        if (sibling !== scope && /\b(composer|model|toolbar|controls|pill)\b/.test(marker)) add(sibling);
+      }}
+    }}
     return scopes;
-  }};
-  const modelCandidateText = (node, target = node) => normalize([
-    node?.getAttribute?.("aria-label"),
-    node?.getAttribute?.("title"),
-    node?.getAttribute?.("data-testid"),
-    node?.getAttribute?.("class"),
-    node?.innerText,
-    node?.textContent,
-    target?.getAttribute?.("aria-label"),
-    target?.getAttribute?.("title"),
-    target?.getAttribute?.("data-testid"),
-    target?.getAttribute?.("class"),
-    target?.innerText,
-    target?.textContent,
-  ].filter(Boolean).join(" ")).toLowerCase();
-  const isModelActionableElement = (node) => {{
-    const tag = String(node?.tagName || "").toLowerCase();
-    const role = normalize(node?.getAttribute?.("role") || "").toLowerCase();
-    return tag === "button" ||
-      role === "button" ||
-      node?.getAttribute?.("aria-haspopup") !== null ||
-      node?.getAttribute?.("tabindex") !== null;
-  }};
-  const isModelChipLike = (node) => {{
-    const marker = normalize([
-      node?.getAttribute?.("data-testid"),
-      node?.getAttribute?.("class"),
-      node?.getAttribute?.("aria-label"),
-      node?.getAttribute?.("title"),
-    ].filter(Boolean).join(" ")).toLowerCase();
-    return /\b(model|model-switcher)\b/.test(marker) && /\b(chip|pill|token|button|menu|dropdown|switcher)\b/.test(marker);
-  }};
-  const modelClickTarget = (node, stopAt) => {{
-    for (let current = node; current; current = current.parentElement) {{
-      if (isModelActionableElement(current) || isModelChipLike(current)) return current;
-      if (current === stopAt) return null;
-    }}
-    return null;
-  }};
-  const looksLikeModelControl = (text) =>
-    /\bextended\s+pro\b/.test(text) ||
-    /\bgpt[\s.-]*\d/.test(text) ||
-    /\b(pro|instant|thinking|model)\b/.test(text);
-  const findComposerModelControl = () => {{
+  }}
+
+  function summaryMatches(value) {{
+    const valueFolded = fold(value);
+    return /^(instant|medium|high|extra high|pro)$/.test(valueFolded)
+      || /^\d+(?:\.\d+)+ (instant|medium|high|extra high|pro)$/.test(valueFolded)
+      || /\bgpt[\s.-]*\d/.test(valueFolded);
+  }}
+
+  function findPill() {{
     for (const scope of composerScopes()) {{
-      const candidates = Array.from(scope.querySelectorAll("button, [role='button'], [aria-haspopup], [tabindex], [aria-label], [title], [data-testid], span, div"));
-      for (const node of candidates) {{
-        const target = modelClickTarget(node, scope);
-        if (!target || !isVisible(target)) continue;
-        const haystack = modelCandidateText(node, target);
-        if (!looksLikeModelControl(haystack)) continue;
-        if (/\b(send|stop|copy|share|new chat|attach|upload|search|history|dictation|voice|microphone|account|profile|settings|upgrade)\b/.test(haystack)) continue;
-        return target;
-      }}
+      const buttons = Array.from(scope.querySelectorAll(MODEL_BUTTON_SELECTOR)).filter(isVisible);
+      const exact = buttons.find((button) => button.classList.contains("__composer-pill"));
+      if (exact) return exact;
+      const fallback = buttons.find((button) => summaryMatches(textOf(button)));
+      if (fallback) return fallback;
     }}
     return null;
-  }};
-    const slugify = (value) => normalize(value).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
-  const isLowSignalSelectorLabel = (value) => {{
-    const key = slugify(value);
-    return !key || key === "chatgpt" || key === "chat-gpt" || key === "openai" || key === "model-selector" || key === "selected-model";
-  }};
-  const selectorLabelMatchesTarget = (label, item, tierSlug, targetTestId, candidateTestIds) => {{
-    const labelText = normalize(label).toLowerCase();
-    const labelSlug = slugify(labelText);
-    if (isLowSignalSelectorLabel(labelText)) return false;
-    const candidates = [];
-    const add = (value) => {{
-      const raw = normalize(value || "");
-      const key = slugify(raw);
-      if (!key || isLowSignalSelectorLabel(raw)) return;
-      candidates.push({{ raw: raw.toLowerCase(), key }});
-    }};
-    add(tierSlug);
-    add(item?.text || "");
-    add((item?.testId || "").replace(/^model-switcher-/, ""));
-    add((targetTestId || "").replace(/^model-switcher-/, ""));
-    (candidateTestIds || []).forEach((value) => add(value));
-    return candidates.some((candidate) => {{
-      if (candidate.key === labelSlug) return true;
-      if (tierSlug && candidate.key === slugify(tierSlug)) {{
-        const escaped = candidate.raw.replace(/[.*+?^$()|[\]\\]/g, "\\$&");
-        return new RegExp(`(^|[^a-z0-9])${{escaped}}([^a-z0-9]|$)`).test(labelText);
-      }}
-      return candidate.key.length >= 4 && labelSlug.includes(candidate.key);
-    }});
-  }};
-  const realClick = (el) => {{
-    el.dispatchEvent(new PointerEvent("pointerdown", {{ bubbles: true, cancelable: true, pointerId: 1 }}));
-    el.dispatchEvent(new MouseEvent("mousedown", {{ bubbles: true, cancelable: true }}));
-    el.dispatchEvent(new PointerEvent("pointerup", {{ bubbles: true, cancelable: true, pointerId: 1 }}));
-    el.dispatchEvent(new MouseEvent("mouseup", {{ bubbles: true, cancelable: true }}));
-    el.dispatchEvent(new MouseEvent("click", {{ bubbles: true, cancelable: true }}));
-  }};
-  const keyPress = (el, key, code) => {{
-    el.dispatchEvent(new KeyboardEvent("keydown", {{ key, code, bubbles: true, cancelable: true }}));
-    el.dispatchEvent(new KeyboardEvent("keyup", {{ key, code, bubbles: true, cancelable: true }}));
-  }};
-  const isVersionedModelTestId = (value) => /^model-switcher-gpt-\d/.test(normalize(value).toLowerCase());
-  const findPreferredTestIdItem = (entries, orderedTestIds) => {{
-    for (const testId of orderedTestIds) {{
-      const match = entries.find((item) => item.testId.toLowerCase() === testId);
-      if (match) return match;
-    }}
-    return null;
-  }};
-  const findGenericNeedleItem = (entries, needles) =>
-    entries.find((item) =>
-      !isVersionedModelTestId(item.testId) &&
-      needles.some((needle) => item.haystack.includes(needle))
-    ) || null;
-  const hasExactTierLabel = (item, slug) => {{
-    const text = normalize(item?.text || "").toLowerCase();
-    if (slug === "extended-pro") return /\bextended\b/.test(text) && /\bpro\b/.test(text);
-    return text === slug || text.startsWith(`${{slug}} `);
-  }};
-  const deriveRequestedTier = (value) => {{
-    if (!value) return null;
-    if (/\bextended\b/.test(value) && /\bpro\b/.test(value)) return "extended-pro";
-    if (/\bthinking\b/.test(value)) return "thinking";
-    if (/\binstant\b/.test(value)) return "instant";
-    if (/\bpro\b/.test(value) && !/\b5[- .]?3\b/.test(value)) return "pro";
-    return null;
-  }};
-  const hasTrustedUserFacingTierLabel = (item, slug) => {{
-    const haystack = item?.haystack || "";
-    if (slug === "extended-pro") return /\bextended\b/.test(haystack) && /\bpro\b/.test(haystack);
-    if (slug === "pro") return /research-grade intelligence/.test(haystack);
-    if (slug === "thinking") return /for complex questions/.test(haystack);
-    if (slug === "instant") return /for everyday chats/.test(haystack);
-    return false;
-  }};
-  const classifyTier = (item) => {{
-    const haystack = item?.haystack || "";
-    if (hasTrustedUserFacingTierLabel(item, "extended-pro") || hasExactTierLabel(item, "extended-pro")) return "extended-pro";
-    if (hasTrustedUserFacingTierLabel(item, "pro") || /\bpro\b/.test(haystack)) return "pro";
-    if (hasTrustedUserFacingTierLabel(item, "thinking") || /thinking/.test(haystack)) return "thinking";
-    if (hasTrustedUserFacingTierLabel(item, "instant") || /instant/.test(haystack)) return "instant";
-    return null;
-  }};
-  const parseVersionParts = (item) => {{
-    const haystack = item?.haystack || "";
-    const match = haystack.match(/gpt[- ]?(\d+)(?:[- .]?(\d+))?/i);
-    return match ? [Number.parseInt(match[1], 10) || 0, Number.parseInt(match[2] || "0", 10) || 0] : [0, 0];
-  }};
-  const compareVersionParts = (left, right) => (left[0] - right[0]) || (left[1] - right[1]);
-  const maxVersionPartsForTier = (entries, tier) =>
-    entries
-      .filter((item) => classifyTier(item) === tier)
-      .map((item) => parseVersionParts(item))
-      .reduce((best, current) => compareVersionParts(current, best) > 0 ? current : best, [0, 0]);
-  const effectiveVersionParts = (item, tier, tierMaxVersions) => {{
-    const parsed = parseVersionParts(item);
-    if (!tier) return parsed;
-    if (hasTrustedUserFacingTierLabel(item, tier) && compareVersionParts(parsed, tierMaxVersions[tier] || [0, 0]) < 0) {{
-      return tierMaxVersions[tier] || parsed;
-    }}
-    return parsed;
-  }};
-  const hasConflictingTierHint = (item, slug) => {{
-    const haystack = item?.haystack || "";
-    if (hasTrustedUserFacingTierLabel(item, slug) || hasExactTierLabel(item, slug)) return false;
-    if (slug === "extended-pro") {{
-      return !(/\bextended\b/.test(haystack) && /\bpro\b/.test(haystack));
-    }}
-    if (slug === "pro") {{
-      return /\b5[- .]?3\b|gpt-5[- .]?3-pro/.test(haystack);
-    }}
-    if (slug === "thinking") {{
-      return /\b5[- .]?3\b|instant/.test(haystack);
-    }}
-    if (slug === "instant") {{
-      return /\bthinking\b|\bpro\b|gpt-5[- .]?4/.test(haystack);
-    }}
-    return false;
-  }};
-  const findSingleGenericTierItem = (entries, slug) => {{
-    if (!(slug === "extended-pro" || slug === "pro" || slug === "thinking" || slug === "instant")) return null;
-    const matches = entries.filter((item) =>
-      item.haystack.includes(slug) && !hasConflictingTierHint(item, slug)
-    );
-    return matches.length === 1 ? matches[0] : null;
-  }};
-  const findExactTierLabelItem = (entries, slug) => {{
-    if (!(slug === "extended-pro" || slug === "pro" || slug === "thinking" || slug === "instant")) return null;
-    return entries.find((item) => hasExactTierLabel(item, slug) && !hasConflictingTierHint(item, slug)) || null;
-  }};
-  const modelSlug = (value) => {{
-    let key = slugify(value);
-    if (key.startsWith("model-switcher-")) key = key.slice("model-switcher-".length);
-    if (!key || isLowSignalSelectorLabel(key)) return "";
-    if (key === "extended-pro") return "extended-pro";
-    return (MODEL_TESTID_CANDIDATES[key] || [MODEL_TESTID_ALIASES[key] || key])[0] || "";
-  }};
-  const currentLabelSatisfiesRequest = (label) => {{
-    const labelText = normalize(label).toLowerCase();
-    const labelSlug = modelSlug(labelText);
-    if (!labelSlug) return false;
-    const isProLabel = /\bextended\s+pro\b/.test(labelText) ||
-      /\bgpt[\s.-]*\d+(?:[\s.-]*\d+)*[\s.-]*pro\b/.test(labelText) ||
-      /\bpro\b/.test(labelText);
-    if (autoMode) return isProLabel;
-    if (requestedGenericTier === "extended-pro") return /\bextended\b/.test(labelText) && /\bpro\b/.test(labelText);
-    if (requestedGenericTier === "pro") return isProLabel;
-    if (requestedGenericTier === "thinking") return /\bthinking\b/.test(labelText);
-    if (requestedGenericTier === "instant") return /\binstant\b/.test(labelText);
-    const requestedKeys = Array.from(new Set(
-      (MODEL_TESTID_CANDIDATES[requestedLower] || [MODEL_TESTID_ALIASES[requestedLower] || requestedLower])
-        .map((value) => modelSlug(value))
-        .filter(Boolean)
-    ));
-    return requestedKeys.includes(labelSlug);
-  }};
-  const selectorLabelConfirmsTextTarget = (label, item, tierSlug, needles) => {{
-    if (!item || item.testId) return false;
-    return selectorLabelMatchesTarget(label, item, tierSlug, null, needles || []);
-  }};
-  const buildTierRankings = (entries) => {{
-    const tierMaxVersions = {{
-      "extended-pro": maxVersionPartsForTier(entries, "extended-pro"),
-      pro: maxVersionPartsForTier(entries, "pro"),
-      thinking: maxVersionPartsForTier(entries, "thinking"),
-      instant: maxVersionPartsForTier(entries, "instant"),
-    }};
-    const tierScore = (tier) => tier === "extended-pro" ? 400 : tier === "pro" ? 300 : tier === "thinking" ? 200 : tier === "instant" ? 100 : 0;
-    const candidateScore = (item) => {{
-      const tier = classifyTier(item);
-      const version = effectiveVersionParts(item, tier, tierMaxVersions);
-      const trusted = tier && hasTrustedUserFacingTierLabel(item, tier);
-      return {{
-        tier,
-        version,
-        trusted,
-        score: tierScore(tier) * 1_000_000 + version[0] * 1_000 + version[1] + (trusted ? 1 : 0),
-      }};
-    }};
-    return {{ tierMaxVersions, candidateScore }};
-  }};
-  const selectBestTierItem = (entries, slug, rankings) =>
-    entries
-      .map((item) => ({{ item, meta: rankings.candidateScore(item) }}))
-      .filter(({{ item, meta }}) => meta.tier === slug && !hasConflictingTierHint(item, slug))
-      .sort((left, right) =>
-        right.meta.score - left.meta.score ||
-        right.item.text.length - left.item.text.length
-      )
-      .map(({{ item }}) => item)[0] || null;
-  const findSelectorButton = () => document.querySelector(MODEL_BUTTON_SELECTOR) || findComposerModelControl();
-  const requestedTrimmed = normalize(requested);
-  const requestedLower = requestedTrimmed.toLowerCase();
-  const keepCurrentMode = !requestedTrimmed || requestedLower === "current" || requestedLower === "keep-current";
-  const autoMode = requestedLower === "auto";
-  const requestedGenericTier = deriveRequestedTier(requestedLower);
-  const waitForSelectorButton = async () => {{
-    let button = findSelectorButton();
-    if (button || keepCurrentMode) return button;
-    for (let attempt = 0; attempt < 5 && !button; attempt += 1) {{
-      await wait(1000);
-      button = findSelectorButton();
-    }}
-    return button;
-  }};
-  const selectorButton = await waitForSelectorButton();
-  const currentLabel = normalize(
-    selectorButton?.querySelector?.("[data-testid='selected-model'], [data-testid='model-switcher-selected-model']")?.textContent ||
-    selectorButton?.innerText ||
-    selectorButton?.textContent ||
-    selectorButton?.getAttribute?.("aria-label") ||
-    selectorButton?.getAttribute?.("title") ||
-    ""
-  );
-  const responseBase = {{
-    requested,
-    currentLabel,
-    url: window.location.href || "",
-    title: document.title || "",
-    bodyText: normalize(document.body?.innerText || "").slice(0, 240),
-  }};
-
-  if (keepCurrentMode) {{
-    return {{
-      ...responseBase,
-      status: "already-selected",
-      modelUsed: currentLabel || null,
-      keepCurrent: true,
-    }};
   }}
 
-  if (currentLabelSatisfiesRequest(currentLabel) && requestedGenericTier !== "extended-pro" && !autoMode) {{
-    return {{
-      ...responseBase,
-      status: "already-selected",
-      modelUsed: currentLabel,
-    }};
+  function visibleMenus() {{
+    return Array.from(document.querySelectorAll("[role='menu']")).filter(isVisible);
   }}
 
-  if (!selectorButton) {{
-    return {{
-      ...responseBase,
-      status: "missing-selector",
-      modelUsed: currentLabel || null,
-    }};
+  function radios(menu) {{
+    return Array.from(menu?.querySelectorAll?.("[role='menuitemradio']") || []).filter(isVisible);
   }}
 
-  const popupRoots = () => {{
-    const selectorButton = findSelectorButton();
-    const roots = [];
-    const add = (el) => {{
-      if (el && !roots.includes(el) && isVisible(el)) roots.push(el);
-    }};
-    const controlledId = selectorButton.getAttribute("aria-controls") || selectorButton.getAttribute("aria-owns");
-    if (controlledId) {{
-      add(document.getElementById(controlledId));
-    }}
-    Array.from(document.querySelectorAll("[role='menu'], [role='listbox'], [data-radix-popper-content-wrapper], [data-state='open']"))
-      .filter((el) => isVisible(el))
-      .forEach((el) => {{
-        if (el.querySelector(MODEL_ITEM_SELECTOR)) add(el);
-      }});
-    return roots;
-  }};
+  function isChecked(item) {{
+    return item?.getAttribute?.("aria-checked") === "true" || item?.getAttribute?.("data-state") === "checked";
+  }}
 
-  const readItems = () => {{
-    const selectorButton = findSelectorButton();
-    const roots = popupRoots();
-    let nodes = roots.flatMap((root) => Array.from(root.querySelectorAll(MODEL_ITEM_SELECTOR)));
-    if (nodes.length === 0) {{
-      nodes = Array.from(document.querySelectorAll(MODEL_ITEM_SELECTOR))
-        .filter((el) => !(selectorButton && selectorButton.contains(el)) && isVisible(el));
-    }}
-    const seen = new Set();
-    return nodes
-      .filter((el) => isVisible(el))
-      .map((el) => {{
-        const text = normalize(el.innerText || el.textContent || el.getAttribute?.("aria-label") || el.getAttribute?.("title") || "");
-        const testId = normalize(el.getAttribute?.("data-testid") || "");
-        const haystack = `${{testId}} ${{text}}`.toLowerCase();
-        const key = `${{testId}}|${{text}}`;
-        if (seen.has(key)) return null;
-        seen.add(key);
-        return {{
-          text,
-          testId,
-          haystack,
-          ariaChecked: normalize(el.getAttribute?.("aria-checked") || "").toLowerCase(),
-          dataState: normalize(el.getAttribute?.("data-state") || "").toLowerCase(),
-          ariaSelected: normalize(el.getAttribute?.("aria-selected") || "").toLowerCase(),
-          ariaCurrent: normalize(el.getAttribute?.("aria-current") || "").toLowerCase(),
-          dataSelected: normalize(el.getAttribute?.("data-selected") || "").toLowerCase(),
-          dataCurrent: normalize(el.getAttribute?.("data-current") || "").toLowerCase(),
-        }};
-      }})
-      .filter((item) => item && (item.text || item.testId));
-  }};
+  function mainMenu() {{
+    return visibleMenus().find((menu) => {{
+      const labels = radios(menu).map((item) => fold(textOf(item)));
+      return labels.includes("medium") && labels.includes("high")
+        && (labels.includes("pro") || labels.includes("pro extended"));
+    }}) || null;
+  }}
 
-  const openSelectorMenu = async () => {{
-    const button = findSelectorButton();
-    if (!button) return readItems();
-    const attempts = [
-      () => realClick(button),
-      () => button.click?.(),
-      () => {{
-        button.focus?.();
-        keyPress(button, "Enter", "Enter");
-      }},
-      () => {{
-        button.focus?.();
-        keyPress(button, " ", "Space");
-      }},
+  function familyMenu(main) {{
+    return visibleMenus().find((menu) => menu !== main
+      && radios(menu).some((item) => fold(textOf(item)) === "gpt-5.6 sol")) || null;
+  }}
+
+  function readState(menu) {{
+    const effortItems = radios(menu);
+    const familyTrigger = Array.from(menu?.querySelectorAll?.("[role='menuitem']") || [])
+      .find((item) => item.getAttribute("aria-haspopup") === "menu" && /^gpt\b/i.test(textOf(item))) || null;
+    return {{ menu, effortItems, familyTrigger, familyLabel: textOf(familyTrigger) }};
+  }}
+
+  function dispatch(element, type, kind, init = {{}}) {{
+    const Constructor = window[kind] || Event;
+    element.dispatchEvent(new Constructor(type, {{ bubbles: true, cancelable: true, composed: true, ...init }}));
+  }}
+
+  async function pointerOpen(element, mode, main) {{
+    element?.focus?.();
+    const phases = [
+      ["pointerdown", "PointerEvent", {{ button: 0, buttons: 1, pointerId: 1, pointerType: "mouse", isPrimary: true }}],
+      ["mousedown", "MouseEvent", {{ button: 0, buttons: 1 }}],
+      ["pointerup", "PointerEvent", {{ button: 0, buttons: 0, pointerId: 1, pointerType: "mouse", isPrimary: true }}],
+      ["mouseup", "MouseEvent", {{ button: 0, buttons: 0 }}],
+      ["click", "MouseEvent", {{ button: 0, buttons: 0, detail: 1 }}]
     ];
-    let openedItems = readItems();
-    for (const attempt of attempts) {{
-      if (openedItems.length > 0) break;
-      attempt();
-      await wait(250);
-      openedItems = readItems();
+    for (const phase of phases) {{
+      dispatch(element, phase[0], phase[1], phase[2]);
+      await wait(125);
+      if (mode === "main" ? mainMenu() : familyMenu(main)) return true;
     }}
-    return openedItems;
-  }};
-  const readSelectorLabel = () => {{
-    const liveSelectorButton = findSelectorButton();
-    return normalize(
-      liveSelectorButton?.querySelector?.("[data-testid='selected-model'], [data-testid='model-switcher-selected-model']")?.textContent ||
-      liveSelectorButton?.innerText ||
-      liveSelectorButton?.textContent ||
-      liveSelectorButton?.getAttribute?.("aria-label") ||
-      liveSelectorButton?.getAttribute?.("title") ||
-      ""
-    ).toLowerCase();
-  }};
-  const targetCandidateForTier = (entries, slug) => {{
-    const rankings = buildTierRankings(entries);
-    return findExactTierLabelItem(entries, slug) ||
-      selectBestTierItem(entries, slug, rankings) ||
-      findSingleGenericTierItem(entries, slug) ||
-      null;
-  }};
-  const autoPreferredTargetCandidate = (entries) =>
-    targetCandidateForTier(entries, "extended-pro") ||
-    targetCandidateForTier(entries, "pro") ||
-    null;
-  const autoTargetCandidate = (entries) =>
-    autoPreferredTargetCandidate(entries) ||
-    targetCandidateForTier(entries, "thinking") ||
-    targetCandidateForTier(entries, "instant") ||
-    null;
-  const itemSetSignature = (entries) => entries
-    .map((item) => `${{item.testId}}|${{item.text}}|${{item.ariaChecked}}|${{item.dataState}}`)
-    .join("\n");
-  const waitForTargetOrStableItems = async (initialItems) => {{
-    let currentItems = initialItems;
-    let signature = itemSetSignature(currentItems);
-    let stableSince = signature ? Date.now() : null;
-    const deadline = Date.now() + 7000;
-    while (Date.now() < deadline) {{
-      if (requestedGenericTier && targetCandidateForTier(currentItems, requestedGenericTier)) {{
-        return currentItems;
-      }}
-      if (autoMode && autoPreferredTargetCandidate(currentItems)) {{
-        return currentItems;
-      }}
-      const nextSignature = itemSetSignature(currentItems);
-      if (nextSignature && nextSignature === signature) {{
-        if (stableSince !== null && Date.now() - stableSince >= 600) {{
-          return currentItems;
-        }}
-      }} else {{
-        signature = nextSignature;
-        stableSince = nextSignature ? Date.now() : null;
-      }}
+    return false;
+  }}
+
+  function realClick(element) {{
+    element?.focus?.();
+    dispatch(element, "pointerdown", "PointerEvent", {{ button: 0, buttons: 1, pointerId: 1, pointerType: "mouse", isPrimary: true }});
+    dispatch(element, "mousedown", "MouseEvent", {{ button: 0, buttons: 1 }});
+    dispatch(element, "pointerup", "PointerEvent", {{ button: 0, buttons: 0, pointerId: 1, pointerType: "mouse", isPrimary: true }});
+    dispatch(element, "mouseup", "MouseEvent", {{ button: 0, buttons: 0 }});
+    dispatch(element, "click", "MouseEvent", {{ button: 0, buttons: 0, detail: 1 }});
+  }}
+
+  function keyPress(element, key, code) {{
+    dispatch(element, "keydown", "KeyboardEvent", {{ key, code }});
+    dispatch(element, "keyup", "KeyboardEvent", {{ key, code }});
+  }}
+
+  async function waitForMain() {{
+    for (let attempt = 0; attempt < 30; attempt += 1) {{
+      const menu = mainMenu();
+      if (menu) return menu;
       await wait(100);
-      currentItems = readItems();
-      if (currentItems.length === 0) {{
-        currentItems = await openSelectorMenu();
-      }}
     }}
-    return currentItems;
-  }};
+    return null;
+  }}
 
-  let items = readItems();
-  if (items.length === 0) {{
-    items = await openSelectorMenu();
-    for (let attempt = 0; attempt < 20 && items.length === 0; attempt += 1) {{
-      await wait(250);
-      items = readItems();
+  async function openMain(pill) {{
+    const existing = mainMenu();
+    if (existing) return existing;
+    await pointerOpen(pill, "main", null);
+    let menu = await waitForMain();
+    if (menu) return menu;
+    keyPress(pill, "Enter", "Enter");
+    return waitForMain();
+  }}
+
+  async function openFamilyMenu(state) {{
+    if (!state?.familyTrigger) return null;
+    const hover = [
+      ["pointerenter", "PointerEvent", {{ pointerId: 1, pointerType: "mouse", isPrimary: true }}],
+      ["mouseenter", "MouseEvent", {{}}],
+      ["pointermove", "PointerEvent", {{ pointerId: 1, pointerType: "mouse", isPrimary: true }}],
+      ["mousemove", "MouseEvent", {{}}]
+    ];
+    for (const phase of hover) {{
+      dispatch(state.familyTrigger, phase[0], phase[1], phase[2]);
+      await wait(125);
+      const opened = familyMenu(state.menu);
+      if (opened) return opened;
+    }}
+    await pointerOpen(state.familyTrigger, "family", state.menu);
+    for (let attempt = 0; attempt < 20; attempt += 1) {{
+      const opened = familyMenu(state.menu);
+      if (opened) return opened;
+      await wait(100);
+    }}
+    return null;
+  }}
+
+  async function closeMenus(pill) {{
+    for (let attempt = 0; attempt < 3 && visibleMenus().length > 0; attempt += 1) {{
+      keyPress(pill, "Escape", "Escape");
+      await wait(100);
     }}
   }}
-  items = await waitForTargetOrStableItems(items);
 
-  if (items.length === 0) {{
+  function familyVerified(state) {{
+    return fold(state?.familyLabel) === "gpt-5.6 sol";
+  }}
+
+  function effortVerified(state) {{
+    return state?.effortItems?.some((item) => fold(textOf(item)) === "pro" && isChecked(item)) || false;
+  }}
+
+  function result(status, pill, state, families, warning = null) {{
+    const familyIsVerified = familyVerified(state);
+    const effortIsVerified = effortVerified(state);
     return {{
-      ...responseBase,
-      status: "not-found",
-      availableItems: [],
-      selectorExpanded: normalize(findSelectorButton()?.getAttribute?.("aria-expanded") || "").toLowerCase(),
-      itemCount: 0,
-      modelUsed: currentLabel || null,
+      requested,
+      status,
+      modelUsed: familyIsVerified && effortIsVerified ? "GPT-5.6 Sol Pro" : null,
+      familyStatus: familyIsVerified ? "verified" : "unverified",
+      effortStatus: effortIsVerified ? "verified" : "unverified",
+      pillText: textOf(pill),
+      familyLabel: state?.familyLabel || null,
+      availableItems: (state?.effortItems || []).map(textOf).filter(Boolean),
+      availableFamilies: families || [],
+      warning,
+      url: window.location.href || "",
+      title: document.title || ""
     }};
   }}
 
-  const rankings = buildTierRankings(items);
-
-  let target = null;
-  let selectionNeedles = [];
-  let requestedTestIds = [];
-  if (autoMode) {{
-    target =
-      findExactTierLabelItem(items, "extended-pro") ||
-      selectBestTierItem(items, "extended-pro", rankings) ||
-      findSingleGenericTierItem(items, "extended-pro") ||
-      findExactTierLabelItem(items, "pro") ||
-      selectBestTierItem(items, "pro", rankings) ||
-      findSingleGenericTierItem(items, "pro") ||
-      findExactTierLabelItem(items, "thinking") ||
-      selectBestTierItem(items, "thinking", rankings) ||
-      findSingleGenericTierItem(items, "thinking") ||
-      findExactTierLabelItem(items, "instant") ||
-      selectBestTierItem(items, "instant", rankings) ||
-      findSingleGenericTierItem(items, "instant") ||
-      items
-        .map((item) => ({{ item, meta: rankings.candidateScore(item) }}))
-        .filter(({{ item, meta }}) => !meta.tier || !hasConflictingTierHint(item, meta.tier))
-        .sort((left, right) => right.meta.score - left.meta.score || right.item.text.length - left.item.text.length)
-        .map(({{ item }}) => item)[0] || null;
-    if (!target || rankings.candidateScore(target).score <= 0) {{
-      return {{
-        ...responseBase,
-        status: "not-found",
-        availableItems: items.map((item) => item.text || item.testId).filter(Boolean).slice(0, 12),
-        itemCount: items.length,
-        modelUsed: currentLabel || null,
-      }};
-    }}
-    selectionNeedles.push(target.testId.toLowerCase(), target.text.toLowerCase());
-  }} else {{
-    requestedTestIds = Array.from(new Set(
-      (MODEL_TESTID_CANDIDATES[requestedLower] || [MODEL_TESTID_ALIASES[requestedLower] || requestedLower])
-        .map((value) => normalize(value).toLowerCase())
-        .filter(Boolean)
-    ));
-    const exactTestIds = requestedTestIds.map((value) => `model-switcher-${{value}}`.toLowerCase());
-    const fallbackNeedles = Array.from(new Set([
-      requestedLower,
-      requestedLower.replace(/-/g, " "),
-      ...(requestedGenericTier ? [requestedGenericTier] : []),
-      ...requestedTestIds,
-      ...requestedTestIds.map((value) => value.replace(/-/g, " ")),
-      ...exactTestIds,
-    ])).filter(Boolean);
-    target = requestedGenericTier
-      ? findExactTierLabelItem(items, requestedGenericTier) ||
-        selectBestTierItem(items, requestedGenericTier, rankings) ||
-        findSingleGenericTierItem(items, requestedGenericTier) ||
-        null
-      : findPreferredTestIdItem(items, exactTestIds) ||
-        findGenericNeedleItem(items, fallbackNeedles) ||
-        null;
-    if (!target) {{
-      return {{
-        ...responseBase,
-        status: "not-found",
-        availableItems: items.map((item) => item.text || item.testId).filter(Boolean).slice(0, 12),
-        selectorExpanded: normalize(findSelectorButton()?.getAttribute?.("aria-expanded") || "").toLowerCase(),
-        itemCount: items.length,
-        modelUsed: currentLabel || null,
-      }};
-    }}
-    selectionNeedles.push(...fallbackNeedles, ...exactTestIds);
+  if (requested !== supported) {{
+    return result("not-found", null, null, [], "this recipe supports only GPT-5.6 Sol + Pro intelligence");
+  }}
+  const legacy = legacyPickerMarkers();
+  if (legacy.length > 0) {{
+    const failure = result("legacy-picker", null, null, [], "legacy ChatGPT picker detected; this yoetz version requires the GPT-5.6 UI");
+    failure.legacyPicker = legacy.slice(0, 10);
+    return failure;
   }}
 
-  const targetTestId = target.testId || null;
-  if (itemIsSelected(target) && classifyTier(target) !== "extended-pro") {{
-    return {{
-      ...responseBase,
-      status: "already-selected",
-      modelUsed: target.text || currentLabel || requestedTrimmed || null,
-      targetTestId,
-    }};
-  }}
-
-  let selectionConfirmed = false;
-  let selectedLabel = "";
-  let targetChecked = false;
-  let menuReopenAttempts = 0;
-  const targetTierSlug = autoMode ? classifyTier(target) : (requestedGenericTier || classifyTier(target));
-  for (let attempt = 0; attempt < 20; attempt += 1) {{
-    realClick(findSelectorButton());
+  let pill = findPill();
+  for (let attempt = 0; attempt < 20 && !pill; attempt += 1) {{
     await wait(250);
-    const currentItems = readItems();
-    let currentTarget = targetTierSlug
-      ? findExactTierLabelItem(currentItems, targetTierSlug) ||
-        selectBestTierItem(currentItems, targetTierSlug, buildTierRankings(currentItems)) ||
-        findSingleGenericTierItem(currentItems, targetTierSlug) ||
-        null
-      : targetTestId
-        ? findPreferredTestIdItem(currentItems, [targetTestId.toLowerCase()]) || null
-        : findGenericNeedleItem(currentItems, selectionNeedles) || null;
-    if (!currentTarget && currentItems.length === 0 && menuReopenAttempts < 3) {{
-      await openSelectorMenu();
-      menuReopenAttempts += 1;
-      continue;
+    pill = findPill();
+  }}
+  if (!pill) {{
+    const lateLegacy = legacyPickerMarkers();
+    if (lateLegacy.length > 0) {{
+      const failure = result("legacy-picker", null, null, [], "legacy ChatGPT picker detected; this yoetz version requires the GPT-5.6 UI");
+      failure.legacyPicker = lateLegacy.slice(0, 10);
+      return failure;
     }}
-    const selectorButton = findSelectorButton();
-    if (currentTarget) {{
-      realClick(document.querySelector(`[data-testid="${{currentTarget.testId}}"]`) || Array.from(document.querySelectorAll(MODEL_ITEM_SELECTOR)).find((el) => {{
-        const text = normalize(el.innerText || el.textContent || "");
-        const testId = normalize(el.getAttribute?.("data-testid") || "");
-        return testId === currentTarget.testId || text === currentTarget.text;
-      }}) || selectorButton);
-    }}
-    // Verify polling: after clicking the menu item, the menu usually closes,
-    // Radix propagates aria-checked, and ChatGPT's selector button label
-    // updates on its own schedule (sometimes >1s after the click). Poll up to
-    // ~3s on this attempt before re-opening/re-clicking on the next outer
-    // iteration.
-    let verifyConfirmed = false;
-    let updatedItems = [];
-    let updatedTarget = null;
-    for (let verify = 0; verify < 12 && !verifyConfirmed; verify += 1) {{
-      await wait(250);
-      updatedItems = readItems();
-      const updatedRankings = buildTierRankings(updatedItems);
-      updatedTarget = targetTierSlug
-        ? findExactTierLabelItem(updatedItems, targetTierSlug) ||
-          selectBestTierItem(updatedItems, targetTierSlug, updatedRankings) ||
-          findSingleGenericTierItem(updatedItems, targetTierSlug) ||
-          null
-        : targetTestId
-          ? findPreferredTestIdItem(updatedItems, [targetTestId.toLowerCase()]) || null
-          : findGenericNeedleItem(updatedItems, selectionNeedles) || null;
-      const targetNode = targetTestId
-        ? Array.from(document.querySelectorAll(`[data-testid="${{targetTestId}}"]`)).find((el) => isVisible(el)) || null
-        : null;
-      targetChecked = isCheckedState(
-        normalize(targetNode?.getAttribute?.("aria-checked") || "").toLowerCase(),
-        normalize(targetNode?.getAttribute?.("data-state") || "").toLowerCase(),
-      ) ||
-        hasSelectedCurrentMarker(
-          normalize(targetNode?.getAttribute?.("aria-selected") || "").toLowerCase(),
-          normalize(targetNode?.getAttribute?.("aria-current") || "").toLowerCase(),
-          normalize(targetNode?.getAttribute?.("data-selected") || "").toLowerCase(),
-          normalize(targetNode?.getAttribute?.("data-current") || "").toLowerCase(),
-        ) ||
-        itemIsSelected(updatedTarget);
-      selectedLabel = readSelectorLabel();
-      const textTargetLabelConfirmed = selectorLabelConfirmsTextTarget(
-        selectedLabel,
-        updatedTarget || currentTarget || target,
-        targetTierSlug,
-        selectionNeedles
-      );
-      if (targetChecked) {{
-        verifyConfirmed = true;
-      }} else if (textTargetLabelConfirmed) {{
-        verifyConfirmed = true;
-      }}
-    }}
-    if (verifyConfirmed) {{
-      selectionConfirmed = true;
-      return {{
-        ...responseBase,
-        status: "selected",
-        modelUsed: updatedTarget?.text || target.text || requestedTrimmed || currentLabel || null,
-        selectedLabel: selectedLabel || null,
-        targetTestId,
-        targetChecked,
-        menuReopenAttempts,
-        selectorExpanded: normalize(findSelectorButton()?.getAttribute?.("aria-expanded") || "").toLowerCase(),
-        availableItemsAfter: updatedItems.map((item) => item.text || item.testId).filter(Boolean).slice(0, 12),
-      }};
-    }}
-    const reopenedItems = await openSelectorMenu();
-    if (reopenedItems.length > 0) {{
-      menuReopenAttempts += 1;
-    }}
-    const reopenedRankings = buildTierRankings(reopenedItems);
-    const reopenedTarget = targetTierSlug
-      ? findExactTierLabelItem(reopenedItems, targetTierSlug) ||
-        selectBestTierItem(reopenedItems, targetTierSlug, reopenedRankings) ||
-        findSingleGenericTierItem(reopenedItems, targetTierSlug) ||
-        null
-      : targetTestId
-        ? findPreferredTestIdItem(reopenedItems, [targetTestId.toLowerCase()]) ||
-          findGenericNeedleItem(reopenedItems, selectionNeedles) ||
-          null
-        : findGenericNeedleItem(reopenedItems, selectionNeedles) || null;
-    const reopenedChecked = isCheckedState(
-      reopenedTarget?.ariaChecked || "",
-      reopenedTarget?.dataState || "",
-    ) || itemIsSelected(reopenedTarget);
-    const reopenedLabel = readSelectorLabel();
-    if (reopenedChecked) {{
-      selectionConfirmed = true;
-      updatedItems = reopenedItems;
-      updatedTarget = reopenedTarget;
-      targetChecked = reopenedChecked;
-      selectedLabel = reopenedLabel;
-      return {{
-        ...responseBase,
-        status: "selected",
-        modelUsed: reopenedTarget?.text || target.text || requestedTrimmed || currentLabel || null,
-        selectedLabel: reopenedLabel || null,
-        targetTestId,
-        targetChecked: reopenedChecked,
-        menuReopenAttempts,
-        selectorExpanded: normalize(findSelectorButton()?.getAttribute?.("aria-expanded") || "").toLowerCase(),
-        availableItemsAfter: reopenedItems.map((item) => item.text || item.testId).filter(Boolean).slice(0, 12),
-      }};
-    }}
+    return result("missing-selector", null, null, [], "ChatGPT GPT-5.6 composer model pill not found");
   }}
 
-  return {{
-    ...responseBase,
-    status: selectionConfirmed ? "selected" : "selection-mismatch",
-    modelUsed: selectedLabel || target.text || null,
-    selectedLabel: selectedLabel || null,
-    targetTestId,
-    targetChecked,
-    menuReopenAttempts,
-    selectorExpanded: normalize(findSelectorButton()?.getAttribute?.("aria-expanded") || "").toLowerCase(),
-    itemCount: items.length,
-    availableItems: items.map((item) => item.text || item.testId).filter(Boolean).slice(0, 12),
-  }};
+  let menu = await openMain(pill);
+  let state = menu ? readState(menu) : null;
+  let families = [];
+  if (!state) return result("not-found", pill, null, families, "ChatGPT GPT-5.6 model picker did not open");
+
+  if (!familyVerified(state)) {{
+    const submenu = await openFamilyMenu(state);
+    const familyItems = radios(submenu);
+    families = familyItems.map(textOf).filter(Boolean);
+    const sol = familyItems.find((item) => fold(textOf(item)) === "gpt-5.6 sol") || null;
+    if (!sol) {{
+      await closeMenus(pill);
+      return result("not-found", pill, state, families, "GPT-5.6 Sol was not visible in the family submenu");
+    }}
+    realClick(sol);
+    await wait(250);
+    menu = await openMain(pill);
+    state = menu ? readState(menu) : null;
+    if (!state) return result("selection-mismatch", pill, null, families, "picker did not reopen after selecting GPT-5.6 Sol");
+  }}
+
+  if (!effortVerified(state)) {{
+    const pro = state.effortItems.find((item) => fold(textOf(item)) === "pro") || null;
+    if (!pro) {{
+      await closeMenus(pill);
+      return result("not-found", pill, state, families, "Pro intelligence was not visible for GPT-5.6 Sol");
+    }}
+    realClick(pro);
+    await wait(250);
+    menu = await openMain(pill);
+    state = menu ? readState(menu) : null;
+    if (!state) return result("selection-mismatch", pill, null, families, "picker did not reopen after selecting Pro intelligence");
+  }}
+
+  const familyIsVerified = familyVerified(state);
+  const effortIsVerified = effortVerified(state);
+  if (families.length === 0 && state.familyTrigger) {{
+    const submenu = await openFamilyMenu(state);
+    families = radios(submenu).map(textOf).filter(Boolean);
+  }}
+  await closeMenus(pill);
+  return result(
+    familyIsVerified && effortIsVerified ? "selected" : "selection-mismatch",
+    pill,
+    state,
+    families,
+    familyIsVerified && effortIsVerified ? null : "GPT-5.6 Sol + Pro could not be verified in one picker pass"
+  );
 }}
 "##,
+        requested_model = requested_model,
         model_button_selector = model_button_selector,
         composer_selector = composer_selector,
-        model_item_selector = model_item_selector,
-        model_testid_aliases = model_testid_aliases,
-        model_testid_candidates = model_testid_candidates,
         visibility_helpers = JS_VISIBILITY_HELPERS,
     )
 }
@@ -1642,85 +1187,85 @@ mod tests {
 
     #[test]
     fn model_aliases_cover_shortcuts() {
-        let aliases = model_testid_alias_map();
-        assert_eq!(aliases.get("extended-pro"), Some(&"extended-pro"));
-        assert_eq!(aliases.get("pro"), Some(&"gpt-5-4-pro"));
-        assert_eq!(aliases.get("gpt-5-thinking"), Some(&"gpt-5-4-thinking"));
-        assert_eq!(aliases.get("instant"), Some(&"gpt-5-3"));
-        let candidates = model_testid_candidate_map();
-        assert_eq!(candidates.get("extended-pro"), Some(&vec!["extended-pro"]));
-        assert_eq!(candidates.get("pro"), Some(&vec!["gpt-5-4-pro"]));
-        assert_eq!(candidates.get("gpt-5-3-pro"), None);
+        let aliases = model_alias_map();
+        assert_eq!(aliases.get("gpt-5-6-sol-pro"), Some(&"gpt-5-6-sol-pro"));
+        assert_eq!(aliases.get("sol-pro"), Some(&"gpt-5-6-sol-pro"));
+        assert_eq!(aliases.get("gpt-5-4-pro"), None);
+        let candidates = model_candidate_map();
+        assert_eq!(
+            candidates.get("gpt-5-6-sol-pro"),
+            Some(&vec!["gpt-5-6-sol-pro"])
+        );
+        assert_eq!(candidates.get("gpt-5-4-pro"), None);
     }
 
     #[test]
     fn canonical_chatgpt_model_slug_rejects_generic_labels() {
         assert_eq!(canonical_chatgpt_model_slug("ChatGPT"), None);
         assert_eq!(canonical_chatgpt_model_slug("Configure..."), None);
+        assert_eq!(canonical_chatgpt_model_slug("Pro"), None);
+        assert_eq!(canonical_chatgpt_model_slug("Extended Pro"), None);
         assert_eq!(
-            canonical_chatgpt_model_slug("Pro"),
-            Some("gpt-5-4-pro".to_string())
-        );
-        assert_eq!(
-            canonical_chatgpt_model_slug("Extended Pro"),
-            Some("extended-pro".to_string())
-        );
-        assert_eq!(
-            canonical_chatgpt_model_slug("model-switcher-gpt-5-4-thinking"),
-            Some("gpt-5-4-thinking".to_string())
+            canonical_chatgpt_model_slug("GPT-5.6 Sol Pro"),
+            Some("gpt-5-6-sol-pro".to_string())
         );
     }
 
     #[test]
-    fn reported_chatgpt_model_prefers_target_test_id_over_generic_button_label() {
+    fn reported_chatgpt_model_requires_verified_sol_and_pro_proofs() {
         let selection = serde_json::json!({
             "status": "selected",
-            "modelUsed": "chatgpt",
-            "selectedLabel": "chatgpt",
-            "currentLabel": "chatgpt",
-            "targetTestId": "model-switcher-gpt-5-4-pro"
+            "requested": "gpt-5-6-sol-pro",
+            "modelUsed": "GPT-5.6 Sol Pro",
+            "familyStatus": "verified",
+            "effortStatus": "verified"
         });
         assert_eq!(
-            select_reported_chatgpt_model(&selection, "pro"),
-            Some("gpt-5-4-pro".to_string())
+            select_reported_chatgpt_model(&selection, "gpt-5-6-sol-pro"),
+            Some("GPT-5.6 Sol Pro".to_string())
         );
     }
 
     #[test]
-    fn reported_chatgpt_model_falls_back_to_requested_alias_when_ui_label_is_generic() {
+    fn reported_chatgpt_model_never_echoes_an_unverified_request() {
         let selection = serde_json::json!({
             "status": "selected",
-            "modelUsed": "chatgpt",
-            "selectedLabel": "chatgpt",
-            "currentLabel": "chatgpt"
+            "requested": "gpt-5-6-sol-pro",
+            "modelUsed": "Pro Extended",
+            "extendedStatus": "required"
         });
         assert_eq!(
-            select_reported_chatgpt_model(&selection, "pro"),
-            Some("gpt-5-4-pro".to_string())
+            select_reported_chatgpt_model(&selection, "gpt-5-6-sol-pro"),
+            None
         );
-    }
-
-    #[test]
-    fn keep_current_chatgpt_model_detects_current_and_empty_requests() {
-        assert!(should_keep_current_chatgpt_model(""));
-        assert!(should_keep_current_chatgpt_model("current"));
-        assert!(should_keep_current_chatgpt_model(" KEEP-CURRENT "));
-        assert!(!should_keep_current_chatgpt_model("auto"));
-        assert!(!should_keep_current_chatgpt_model("pro"));
     }
 
     #[test]
     fn chatgpt_model_selection_status_reports_contract_values() {
         assert_eq!(
-            chatgpt_model_selection_status(&serde_json::json!({"status": "selected"}), "pro"),
+            chatgpt_model_selection_status(
+                &serde_json::json!({
+                    "status": "selected",
+                    "requested": "gpt-5-6-sol-pro",
+                    "modelUsed": "GPT-5.6 Sol Pro",
+                    "familyStatus": "verified",
+                    "effortStatus": "verified"
+                }),
+                "gpt-5-6-sol-pro"
+            ),
             ChatgptModelSelectionStatus::Selected
         );
         assert_eq!(
             chatgpt_model_selection_status(
-                &serde_json::json!({"status": "already-selected"}),
-                "current"
+                &serde_json::json!({
+                    "status": "selected",
+                    "requested": "extended-pro",
+                    "modelUsed": "Pro Extended",
+                    "extendedStatus": "required"
+                }),
+                "gpt-5-6-sol-pro"
             ),
-            ChatgptModelSelectionStatus::KeptCurrent
+            ChatgptModelSelectionStatus::Mismatch
         );
         assert_eq!(
             chatgpt_model_selection_status(
@@ -1732,7 +1277,7 @@ mod tests {
         assert_eq!(
             chatgpt_model_selection_status(
                 &serde_json::json!({"status": "selection-mismatch"}),
-                "pro"
+                "gpt-5-6-sol-pro"
             ),
             ChatgptModelSelectionStatus::Mismatch
         );
@@ -1762,179 +1307,29 @@ mod tests {
     }
 
     #[test]
-    fn model_selection_auto_mode_filters_conflicting_tier_items() {
-        // Regression guard: auto mode must honor hasConflictingTierHint so
-        // items like `model-switcher-gpt-5-3-pro` are never auto-selected over
-        // the real current Pro. The explicit-model path already did this;
-        // the auto branch was missing the filter and would pick 5-3-pro when
-        // 5-4-pro wasn't visibly tagged.
-        let script = build_model_selection_function("auto");
-        assert!(
-            script
-                .contains(".filter(({ item, meta }) => !meta.tier || !hasConflictingTierHint(item, meta.tier))"),
-            "auto-mode ranking missing hasConflictingTierHint filter"
-        );
+    fn model_selection_function_requires_verified_sol_family_and_pro_effort() {
+        let script = build_model_selection_function("gpt-5-6-sol-pro");
+        assert!(script.contains(r#"const requested = "gpt-5-6-sol-pro";"#));
+        assert!(script.contains("classList.contains(\"__composer-pill\")"));
+        assert!(script.contains(
+            "legacy ChatGPT picker detected; this yoetz version requires the GPT-5.6 UI"
+        ));
+        assert!(script.contains(r#"familyStatus: familyIsVerified ? "verified" : "unverified""#));
+        assert!(script.contains(r#"effortStatus: effortIsVerified ? "verified" : "unverified""#));
+        assert!(script.contains(r#"fold(textOf(item)) === "gpt-5.6 sol""#));
+        assert!(script.contains(r#"fold(textOf(item)) === "pro""#));
+        assert!(script.contains("await openFamilyMenu"));
+        assert!(script.contains("await closeMenus"));
+        assert!(!script.contains("model-switcher-gpt-5-4"));
     }
 
     #[test]
     fn scope_composer_file_input_function_targets_composer_form_only() {
-        // The upload scoping helper must bind to the composer's own form and
-        // write the shared marker — otherwise yoetz can tag a page-wide hidden
-        // file input and inject the bundle there (review finding #10).
         let script = build_scope_composer_file_input_function();
-        assert!(
-            script.contains("composer.closest(\"form\")"),
-            "scope helper must walk to the composer's form ancestor"
-        );
-        assert!(
-            script.contains("form.querySelector(\"input[type='file']\")"),
-            "scope helper must restrict search to the composer form"
-        );
-        assert!(
-            script.contains(&format!("\"{}\"", COMPOSER_FILE_INPUT_MARKER)),
-            "scope helper must write the shared marker value"
-        );
-        assert!(
-            script.contains("status: \"marked\""),
-            "scope helper must report a `marked` status on success"
-        );
-    }
-
-    #[test]
-    fn model_selection_function_polls_verification_beyond_initial_click() {
-        // The verify loop must poll up to ~3s per outer attempt to let Radix
-        // propagate aria-checked and ChatGPT update the selector button label.
-        // A single 250ms wait is not enough on the live Pro UI.
-        let script = build_model_selection_function("auto");
-        assert!(
-            script.contains("verify < 12 && !verifyConfirmed"),
-            "verify loop missing or sized wrong; saw: {script}"
-        );
-        assert!(
-            script.contains("let verifyConfirmed = false;"),
-            "verify confirmation flag missing"
-        );
-    }
-
-    #[test]
-    fn model_selection_function_waits_for_selector_button_before_failing() {
-        // Fresh ChatGPT tabs can render the shell before the model selector
-        // exists in the React tree. Explicit model selection should wait
-        // briefly for that button instead of failing on the first probe.
-        let script = build_model_selection_function("pro");
-        assert!(script.contains("const waitForSelectorButton = async () =>"));
-        assert!(script.contains("attempt < 5 && !button"));
-        assert!(script.contains("await wait(1000);"));
-        assert!(script.contains("if (button || keepCurrentMode) return button;"));
-        assert!(script.contains("const selectorButton = await waitForSelectorButton();"));
-    }
-
-    #[test]
-    fn model_selection_function_supports_personal_composer_model_control() {
-        // Personal ChatGPT can expose the selected model as a composer pop-up
-        // labeled `Extended Pro` instead of the enterprise
-        // model-switcher-dropdown-button. The shared script must support that
-        // surface without removing the battle-tested enterprise selector.
-        let script = build_model_selection_function("auto");
-        assert!(script.contains("const findComposerModelControl = () =>"));
-        assert!(script.contains(
-            "document.querySelector(MODEL_BUTTON_SELECTOR) || findComposerModelControl()"
-        ));
-        assert!(script.contains("const currentLabelSatisfiesRequest = (label) =>"));
-        assert!(script.contains(r#"if (key === "extended-pro") return "extended-pro";"#));
-        assert!(script.contains("return isProLabel;"));
-    }
-
-    #[test]
-    fn model_selection_function_prefers_exact_tier_labels_before_fuzzy_matching() {
-        // Live ChatGPT currently exposes generic tier labels like
-        // `Pro Research-grade intelligence` while the selector button itself
-        // often stays labeled `ChatGPT`. The explicit-model branch must first
-        // match the visible tier label before falling back to broader haystack
-        // heuristics, otherwise `model=pro` can falsely report not-found.
-        let script = build_model_selection_function("gpt-5-4-pro");
-        assert!(script.contains("const findExactTierLabelItem = (entries, slug) =>"));
-        assert!(script.contains("text === slug || text.startsWith(`${slug} `)"));
-        assert!(script.contains("findExactTierLabelItem(items, requestedGenericTier) ||"));
-    }
-
-    #[test]
-    fn model_selection_function_exact_labels_override_stale_testid_conflicts() {
-        // Live ChatGPT currently exposes `Pro` / `Thinking` on menu items whose
-        // testids still look like `gpt-5-3-pro` / `gpt-5-3-thinking`. The
-        // visible tier label must win over the stale suffix or auto/pro
-        // selection falls back to Instant.
-        let script = build_model_selection_function("pro");
-        assert!(script.contains("const hasExactTierLabel = (item, slug) =>"));
-        assert!(script.contains(
-            "hasTrustedUserFacingTierLabel(item, slug) || hasExactTierLabel(item, slug)"
-        ));
-    }
-
-    #[test]
-    fn model_selection_function_reopens_menu_when_button_label_stays_generic() {
-        // Live ChatGPT can keep the selector button text at `ChatGPT` even
-        // after the right radio item is checked. Reopen the menu once more and
-        // inspect the visible checked state before returning mismatch.
-        let script = build_model_selection_function("auto");
-        assert!(script.contains("const reopenedItems = await openSelectorMenu();"));
-        assert!(script.contains("const reopenedChecked = isCheckedState("));
-        assert!(script.contains("const reopenedLabel = readSelectorLabel();"));
-    }
-
-    #[test]
-    fn model_selection_function_does_not_confirm_visible_unchecked_pro_with_generic_label() {
-        let visible_unchecked_pro_fixture = r#"
-<button data-testid="model-switcher-dropdown-button">
-  <span data-testid="model-switcher-selected-model">ChatGPT</span>
-</button>
-<div role="menuitemradio" data-testid="model-switcher-gpt-5-4-pro" aria-checked="false">
-  Pro Research-grade intelligence
-</div>
-"#;
-        assert!(visible_unchecked_pro_fixture.contains("aria-checked=\"false\""));
-        assert!(visible_unchecked_pro_fixture.contains(">ChatGPT<"));
-
-        let script = build_model_selection_function("pro");
-        assert!(
-            script.contains("if (targetChecked)"),
-            "model selection must require checked/current menu state, not only selector label text"
-        );
-        assert!(
-            !script.contains("targetChecked || selectorLabelConfirmed"),
-            "selector label text must not confirm model selection without checked/current state"
-        );
-        assert!(
-            !script.contains("reopenedChecked ||"),
-            "reopened selector label text must not confirm model selection without checked/current state"
-        );
-        assert!(
-            !script.contains("trustedTierSelected"),
-            "visible trusted tier menu text must not confirm selection by itself"
-        );
-        assert!(
-            !script.contains("reopenedTrustedTierSelected"),
-            "visible trusted tier menu text must not confirm selection after reopen"
-        );
-    }
-
-    #[test]
-    fn model_selection_function_supports_auto_and_explicit_modes() {
-        let auto_script = build_model_selection_function("auto");
-        assert!(auto_script.contains(r#"const requested = "auto";"#));
-        assert!(!auto_script.contains(r#""kept-current-no-selector""#));
-        assert!(auto_script.contains("const deriveRequestedTier = (value) =>"));
-        assert!(auto_script.contains("const classifyTier = (item) =>"));
-        assert!(auto_script.contains("const buildTierRankings = (entries) =>"));
-        assert!(auto_script.contains("const waitForTargetOrStableItems = async (initialItems) =>"));
-        assert!(auto_script.contains("targetCandidateForTier(entries, \"extended-pro\")"));
-
-        let explicit_script =
-            build_model_selection_function(crate::chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL);
-        assert!(explicit_script.contains(r#"const requested = "extended-pro";"#));
-        assert!(explicit_script.contains("\"extended-pro\":\"extended-pro\""));
-        assert!(explicit_script.contains("\"gpt-5-pro\":\"gpt-5-4-pro\""));
-        assert!(!explicit_script.contains("\"gpt-5-3-pro\""));
+        assert!(script.contains("composer.closest(\"form\")"));
+        assert!(script.contains("form.querySelector(\"input[type='file']\")"));
+        assert!(script.contains(&format!("\"{}\"", COMPOSER_FILE_INPUT_MARKER)));
+        assert!(script.contains("status: \"marked\""));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/chatgpt_web.rs
+++ b/crates/yoetz-cli/src/chatgpt_web.rs
@@ -474,6 +474,15 @@ async () => {{
     return null;
   }}
 
+  async function waitForPill() {{
+    let pill = findPill();
+    for (let attempt = 0; attempt < 20 && !pill; attempt += 1) {{
+      await wait(250);
+      pill = findPill();
+    }}
+    return pill;
+  }}
+
   function visibleMenus() {{
     return Array.from(document.querySelectorAll("[role='menu']")).filter(isVisible);
   }}
@@ -629,11 +638,7 @@ async () => {{
     return failure;
   }}
 
-  let pill = findPill();
-  for (let attempt = 0; attempt < 20 && !pill; attempt += 1) {{
-    await wait(250);
-    pill = findPill();
-  }}
+  let pill = await waitForPill();
   if (!pill) {{
     const lateLegacy = legacyPickerMarkers();
     if (lateLegacy.length > 0) {{
@@ -660,6 +665,8 @@ async () => {{
     }}
     realClick(sol);
     await wait(250);
+    pill = await waitForPill();
+    if (!pill) return result("selection-mismatch", null, null, families, "ChatGPT composer model pill did not remount after selecting GPT-5.6 Sol");
     menu = await openMain(pill);
     state = menu ? readState(menu) : null;
     if (!state) return result("selection-mismatch", pill, null, families, "picker did not reopen after selecting GPT-5.6 Sol");
@@ -673,6 +680,8 @@ async () => {{
     }}
     realClick(pro);
     await wait(250);
+    pill = await waitForPill();
+    if (!pill) return result("selection-mismatch", null, null, families, "ChatGPT composer model pill did not remount after selecting Pro intelligence");
     menu = await openMain(pill);
     state = menu ? readState(menu) : null;
     if (!state) return result("selection-mismatch", pill, null, families, "picker did not reopen after selecting Pro intelligence");
@@ -1317,6 +1326,13 @@ mod tests {
         assert!(script.contains(r#"fold(textOf(item)) === "pro""#));
         assert!(script.contains(r#"/^(?:gpt|o\d)\b/i.test(textOf(item))"#));
         assert!(script.contains("await openFamilyMenu"));
+        assert!(script.contains("async function waitForPill()"));
+        assert!(script.contains("pill = await waitForPill();"));
+        assert!(script
+            .contains("ChatGPT composer model pill did not remount after selecting GPT-5.6 Sol"));
+        assert!(script.contains(
+            "ChatGPT composer model pill did not remount after selecting Pro intelligence"
+        ));
         assert!(script.contains("return visibleMenus().length === 0;"));
         assert!(script.contains("if (!await closeMenus(pill))"));
         assert!(!script.contains("if (families.length === 0 && state.familyTrigger)"));

--- a/crates/yoetz-cli/src/chatgpt_web.rs
+++ b/crates/yoetz-cli/src/chatgpt_web.rs
@@ -502,7 +502,7 @@ async () => {{
   function readState(menu) {{
     const effortItems = radios(menu);
     const familyTrigger = Array.from(menu?.querySelectorAll?.("[role='menuitem']") || [])
-      .find((item) => item.getAttribute("aria-haspopup") === "menu" && /^gpt\b/i.test(textOf(item))) || null;
+      .find((item) => item.getAttribute("aria-haspopup") === "menu" && /^(?:gpt|o\d)\b/i.test(textOf(item))) || null;
     return {{ menu, effortItems, familyTrigger, familyLabel: textOf(familyTrigger) }};
   }}
 
@@ -589,6 +589,7 @@ async () => {{
       keyPress(pill, "Escape", "Escape");
       await wait(100);
     }}
+    return visibleMenus().length === 0;
   }}
 
   function familyVerified(state) {{
@@ -679,18 +680,14 @@ async () => {{
 
   const familyIsVerified = familyVerified(state);
   const effortIsVerified = effortVerified(state);
-  if (families.length === 0 && state.familyTrigger) {{
-    const submenu = await openFamilyMenu(state);
-    families = radios(submenu).map(textOf).filter(Boolean);
+  if (!familyIsVerified || !effortIsVerified) {{
+    await closeMenus(pill);
+    return result("selection-mismatch", pill, state, families, "GPT-5.6 Sol + Pro could not be verified in one picker pass");
   }}
-  await closeMenus(pill);
-  return result(
-    familyIsVerified && effortIsVerified ? "selected" : "selection-mismatch",
-    pill,
-    state,
-    families,
-    familyIsVerified && effortIsVerified ? null : "GPT-5.6 Sol + Pro could not be verified in one picker pass"
-  );
+  if (!await closeMenus(pill)) {{
+    return result("selection-mismatch", pill, state, families, "ChatGPT model picker remained open after verification");
+  }}
+  return result("selected", pill, state, families);
 }}
 "##,
         requested_model = requested_model,
@@ -1318,7 +1315,11 @@ mod tests {
         assert!(script.contains(r#"effortStatus: effortIsVerified ? "verified" : "unverified""#));
         assert!(script.contains(r#"fold(textOf(item)) === "gpt-5.6 sol""#));
         assert!(script.contains(r#"fold(textOf(item)) === "pro""#));
+        assert!(script.contains(r#"/^(?:gpt|o\d)\b/i.test(textOf(item))"#));
         assert!(script.contains("await openFamilyMenu"));
+        assert!(script.contains("return visibleMenus().length === 0;"));
+        assert!(script.contains("if (!await closeMenus(pill))"));
+        assert!(!script.contains("if (families.length === 0 && state.familyTrigger)"));
         assert!(script.contains("await closeMenus"));
         assert!(!script.contains("model-switcher-gpt-5-4"));
     }

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
@@ -32,7 +32,7 @@
 //! disappearing, moving into kebab menus, absent in Custom GPT / Canvas
 //! flows). Instead, we poll `.result-streaming` absence on the last
 //! assistant message plus stability of `(messageCount, textLength)` across
-//! N consecutive polls. This matches the heuristic yoetz's old Pro Extended
+//! N consecutive polls. This matches the heuristic yoetz's old Pro
 //! auto-poll already uses.
 
 use anyhow::{anyhow, Context, Result};
@@ -334,7 +334,7 @@ async fn run_attached_recipe_inner(
         .await
         .context("mark yoetz-owned ChatGPT tab with window.name")?;
 
-    // Step 2: wait for the composer to mount, then select ChatGPT Pro Extended
+    // Step 2: wait for the composer to mount, then verify GPT-5.6 Sol + Pro
     // before any upload/send side effects.
     wait_for_composer_ready(client, /* focus_composer */ true).await?;
     let model_selection = maybe_select_model(client, &ctx.model).await?;
@@ -409,7 +409,7 @@ async fn run_attached_recipe_inner(
 
     // Step 6: stable-idle polling for response completion.
     //
-    // Heuristic (ported from yoetz v0.2.33 Pro Extended auto-poll):
+    // Heuristic (ported from yoetz v0.2.33 Pro auto-poll):
     // - Absence of `.result-streaming` class on the last assistant message
     // - (messageCount, textLength) unchanged across N consecutive polls
     //
@@ -733,7 +733,6 @@ async fn maybe_select_model(
     client: &ChromeCdpClient,
     requested_model: &str,
 ) -> Result<ModelSelectionOutcome> {
-    let keep_current_model = chatgpt_web::should_keep_current_chatgpt_model(requested_model);
     let script = build_model_selection_script(requested_model);
     let selection = client
         .evaluate_script(&script, vec![])
@@ -750,14 +749,19 @@ async fn maybe_select_model(
     let model_selection_status =
         chatgpt_web::chatgpt_model_selection_status(&selection, requested_model);
     match status {
-        "selected" | "already-selected" => Ok(ModelSelectionOutcome {
-            model_used,
-            model_selection_status,
-        }),
-        "missing-selector" | "not-found" if keep_current_model => Ok(ModelSelectionOutcome {
-            model_used,
-            model_selection_status,
-        }),
+        "selected"
+            if model_selection_status == chatgpt_recipe::ChatgptModelSelectionStatus::Selected =>
+        {
+            Ok(ModelSelectionOutcome {
+                model_used,
+                model_selection_status,
+            })
+        }
+        "selected" => Err(anyhow!(
+            "ChatGPT reported selected without verified GPT-5.6 Sol + Pro proof.{} {}",
+            format_model_selection_diagnostics(&selection),
+            format_page_probe_summary(&selection)
+        )),
         "missing-selector" => Err(anyhow!(
             "ChatGPT model selector button not found. {}",
             format_page_probe_summary(&selection)
@@ -794,6 +798,15 @@ async fn maybe_select_model(
                 format_page_probe_summary(&selection)
             ))
         }
+        "legacy-picker" => Err(anyhow!(
+            "{}",
+            selection
+                .get("warning")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or(
+                    "legacy ChatGPT picker detected; this yoetz version requires the GPT-5.6 UI"
+                )
+        )),
         other => Err(anyhow!(
             "unexpected ChatGPT model selection status `{other}`"
         )),
@@ -801,65 +814,21 @@ async fn maybe_select_model(
 }
 
 fn format_model_selection_diagnostics(selection: &serde_json::Value) -> String {
-    let selected_label = selection
-        .get("selectedLabel")
-        .and_then(serde_json::Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(|value| format!(" selected_label={value:?};"))
-        .unwrap_or_default();
-    let target_test_id = selection
-        .get("targetTestId")
-        .and_then(serde_json::Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(|value| format!(" target_testid={value:?};"))
-        .unwrap_or_default();
-    let target_checked = selection
-        .get("targetChecked")
-        .and_then(serde_json::Value::as_bool)
-        .map(|value| format!(" target_checked={value};"))
-        .unwrap_or_default();
-    let menu_reopen_attempts = selection
-        .get("menuReopenAttempts")
-        .and_then(serde_json::Value::as_u64)
-        .map(|value| format!(" menu_reopen_attempts={value};"))
-        .unwrap_or_default();
-    let selector_expanded = selection
-        .get("selectorExpanded")
-        .and_then(serde_json::Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(|value| format!(" selector_expanded={value:?};"))
-        .unwrap_or_default();
-    let item_count = selection
-        .get("itemCount")
-        .and_then(serde_json::Value::as_u64)
-        .map(|value| format!(" item_count={value};"))
-        .unwrap_or_default();
-    let available_items = selection
-        .get("availableItemsAfter")
-        .and_then(serde_json::Value::as_array)
-        .map(|items| {
-            items
-                .iter()
-                .filter_map(serde_json::Value::as_str)
-                .filter(|value| !value.trim().is_empty())
-                .collect::<Vec<_>>()
-        })
-        .filter(|items| !items.is_empty())
-        .map(|items| format!(" available_after=[{}];", items.join(", ")))
-        .unwrap_or_default();
-
+    let text = |key: &str| {
+        selection
+            .get(key)
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    };
     format!(
-        "{}{}{}{}{}{}{}",
-        selected_label,
-        target_test_id,
-        target_checked,
-        menu_reopen_attempts,
-        selector_expanded,
-        item_count,
-        available_items
+        " family_status={:?}; effort_status={:?}; family_label={:?}; pill_text={:?}; warning={:?};",
+        text("familyStatus"),
+        text("effortStatus"),
+        text("familyLabel"),
+        text("pillText"),
+        text("warning")
     )
 }
 
@@ -2161,21 +2130,14 @@ mod tests {
     }
 
     #[test]
-    fn model_selection_script_supports_auto_and_explicit_modes() {
-        let auto_script = build_model_selection_script("auto");
-        assert!(auto_script.contains(r#"const requested = "auto";"#));
-        assert!(!auto_script.contains(r#""kept-current-no-selector""#));
-        assert!(auto_script.contains("const deriveRequestedTier = (value) =>"));
-        assert!(auto_script.contains("const classifyTier = (item) =>"));
-        assert!(auto_script.contains("const buildTierRankings = (entries) =>"));
-
+    fn model_selection_script_requires_verified_sol_pro_contract() {
         let explicit_script =
-            build_model_selection_script(crate::chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL);
-        assert!(explicit_script.contains(r#"const requested = "extended-pro";"#));
-        assert!(explicit_script.contains("targetCandidateForTier(entries, \"extended-pro\")"));
-        assert!(explicit_script.contains("\"gpt-5-pro\":\"gpt-5-4-pro\""));
-        assert!(!explicit_script.contains("\"gpt-5-3-pro\""));
-        assert!(explicit_script.contains("const selectBestTierItem = (entries, slug, rankings) =>"));
+            build_model_selection_script(crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL);
+        assert!(explicit_script.contains(r#"const requested = "gpt-5-6-sol-pro";"#));
+        assert!(explicit_script.contains("classList.contains(\"__composer-pill\")"));
+        assert!(explicit_script.contains("familyStatus"));
+        assert!(explicit_script.contains("effortStatus"));
+        assert!(explicit_script.contains("legacy-picker"));
         assert!(explicit_script.contains("availableItems"));
     }
 

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/mod.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/mod.rs
@@ -122,7 +122,7 @@ impl Default for DevtoolsMcpRecipeContext {
             browser_context_id: None,
             profile_email: None,
             run_id: String::new(),
-            response_timeout_ms: 5_400_000, // 90 min default for ChatGPT Pro Extended
+            response_timeout_ms: 5_400_000, // 90 min default for ChatGPT Pro
             response_poll_interval_ms: 30_000,
             upload_timeout_ms: 120_000,
             show_approval_guidance: true,

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -907,8 +907,6 @@ struct ChatgptPrepareResult {
     logged_in: bool,
     #[serde(rename = "composerReady")]
     composer_ready: bool,
-    #[serde(rename = "modelUsed")]
-    model_used: Option<String>,
     #[serde(rename = "modelSelection")]
     model_selection: Option<Value>,
     url: String,
@@ -955,9 +953,6 @@ fn build_chatgpt_prepare_script(page_name: &str, model: &str, run_id: &str) -> S
         r##"
 const PAGE_NAME = {page_name_json};
 const MODEL = {model_json};
-const MODEL_TRIMMED = String(MODEL || "").trim();
-const MODEL_LOWER = MODEL_TRIMMED.toLowerCase();
-const KEEP_CURRENT_MODEL = !MODEL_TRIMMED || MODEL_LOWER === "current" || MODEL_LOWER === "keep-current";
 const MARKED_URL = {marked_url_json};
 const WINDOW_NAME = {window_name_json};
 const MODEL_SELECTION_FUNCTION_SOURCE = {model_selection_function_json};
@@ -1028,15 +1023,16 @@ if (loggedIn && composerReady) {{
   }}, MODEL_SELECTION_FUNCTION_SOURCE);
   const selectionStatus = selection?.status || "unknown";
   modelSelection = selection || null;
-  const keepCurrentModel = KEEP_CURRENT_MODEL && ["missing-selector", "not-found"].includes(selectionStatus);
-  if (!["selected", "already-selected"].includes(selectionStatus) && !keepCurrentModel) {{
+  if (selectionStatus !== "selected") {{
     const diagnostics = JSON.stringify({{
       status: selectionStatus,
       requested: selection?.requested || MODEL || "",
-      selectedLabel: selection?.selectedLabel || "",
-      targetTestId: selection?.targetTestId || "",
+      familyStatus: selection?.familyStatus || "unverified",
+      effortStatus: selection?.effortStatus || "unverified",
+      familyLabel: selection?.familyLabel || "",
+      warning: selection?.warning || "",
       availableItems: selection?.availableItems || [],
-      availableItemsAfter: selection?.availableItemsAfter || [],
+      availableFamilies: selection?.availableFamilies || [],
     }});
     if (selectionStatus === "missing-selector") {{
       throw new Error("model selector button not found (" + diagnostics + ")");
@@ -1049,12 +1045,7 @@ if (loggedIn && composerReady) {{
     }}
     throw new Error("unexpected model selection status '" + selectionStatus + "' (" + diagnostics + ")");
   }}
-  selectedModel =
-    selection?.targetTestId ||
-    selection?.modelUsed ||
-    selection?.selectedLabel ||
-    selection?.currentLabel ||
-    null;
+  selectedModel = selection?.modelUsed || null;
   await page.waitForTimeout(500);
 }}
 console.log(JSON.stringify({{
@@ -1579,15 +1570,9 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<ChatgptRecipe
             .clone()
             .unwrap_or_else(|| serde_json::json!({"status": "unknown"}));
         let model_used = prepare
-            .model_used
-            .as_deref()
-            .and_then(chatgpt_web::canonical_chatgpt_model_slug)
-            .or_else(|| {
-                prepare
-                    .model_selection
-                    .as_ref()
-                    .and_then(|selection| chatgpt_web::select_reported_chatgpt_model(selection, &ctx.model))
-            });
+            .model_selection
+            .as_ref()
+            .and_then(|selection| chatgpt_web::select_reported_chatgpt_model(selection, &ctx.model));
         let model_selection_status =
             chatgpt_web::chatgpt_model_selection_status(&model_selection, &ctx.model);
         let classified_issue =
@@ -1618,6 +1603,12 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<ChatgptRecipe
                     prepare.url
                 ));
             }
+        }
+        if model_selection_status != chatgpt_recipe::ChatgptModelSelectionStatus::Selected {
+            return Err(anyhow!(
+                "ChatGPT did not provide verified GPT-5.6 Sol + Pro selection proof: {}",
+                model_selection
+            ));
         }
 
         let send_script = build_chatgpt_send_script(
@@ -1982,15 +1973,12 @@ mod tests {
     fn build_chatgpt_prepare_script_uses_named_page_and_login_check() {
         let script = build_chatgpt_prepare_script(
             "yoetz-chatgpt-test",
-            crate::chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL,
+            crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL,
             "run-123",
         );
 
         assert!(script.contains("const PAGE_NAME = \"yoetz-chatgpt-test\";"));
-        assert!(script.contains("const MODEL = \"extended-pro\";"));
-        assert!(script.contains(
-            "const KEEP_CURRENT_MODEL = !MODEL_TRIMMED || MODEL_LOWER === \"current\" || MODEL_LOWER === \"keep-current\";"
-        ));
+        assert!(script.contains("const MODEL = \"gpt-5-6-sol-pro\";"));
         assert!(script.contains("const MARKED_URL = \"https://chatgpt.com/?_yoetz=run-123\";"));
         assert!(script.contains("const WINDOW_NAME = \"yoetz:run-123\";"));
         assert!(
@@ -2006,22 +1994,18 @@ mod tests {
         assert!(script.contains("state.assistantCount === 0"));
         assert!(script.contains("pathname.startsWith(\"/c/\")"));
         assert!(script.contains("const selection = await page.evaluate((functionSource) => {"));
-        assert!(script.contains("targetCandidateForTier(entries, \\\"extended-pro\\\")"));
-        assert!(script.contains("\\\"gpt-5-pro\\\":\\\"gpt-5-4-pro\\\""));
-        assert!(!script.contains("\\\"gpt-5-3-pro\\\""));
+        assert!(script.contains("classList.contains(\\\"__composer-pill\\\")"));
+        assert!(script.contains("familyStatus"));
+        assert!(script.contains("effortStatus"));
         assert!(script.contains(
             "requested model '\" + (selection?.requested || MODEL || \"\") + \"' was not selected"
         ));
         assert!(script.contains("let selectedModel = null;"));
         assert!(script.contains("let modelSelection = null;"));
-        assert!(script.contains(
-            "const keepCurrentModel = KEEP_CURRENT_MODEL && [\"missing-selector\", \"not-found\"].includes(selectionStatus);"
-        ));
         assert!(script.contains("modelSelection = selection || null;"));
         assert!(!script.contains("modelSelectionStatus ="));
-        assert!(!script.contains("? (KEEP_CURRENT_MODEL ? \"kept_current\" : \"selected\")"));
         assert!(script.contains("selectedModel ="));
-        assert!(script.contains("selection?.currentLabel ||"));
+        assert!(script.contains("selectedModel = selection?.modelUsed || null;"));
         assert!(script.contains("modelUsed: selectedModel,"));
         assert!(script.contains("modelSelection,"));
         assert!(script.contains("bodyText"));
@@ -2103,7 +2087,7 @@ mod tests {
     fn parse_script_json_reads_prepare_result() {
         let result: ChatgptPrepareResult = parse_script_json(
             "prepare",
-            r#"{"status":"ready","loggedIn":true,"composerReady":true,"modelUsed":"model-switcher-gpt-5-4-pro","modelSelection":{"status":"selected"},"url":"https://chatgpt.com/","title":"ChatGPT","bodyText":"Send a message"}"#,
+            r#"{"status":"ready","loggedIn":true,"composerReady":true,"modelUsed":"GPT-5.6 Sol Pro","modelSelection":{"status":"selected","requested":"gpt-5-6-sol-pro","modelUsed":"GPT-5.6 Sol Pro","familyStatus":"verified","effortStatus":"verified"},"url":"https://chatgpt.com/","title":"ChatGPT","bodyText":"Send a message"}"#,
         )
         .unwrap();
 
@@ -2111,16 +2095,20 @@ mod tests {
         assert!(result.logged_in);
         assert!(result.composer_ready);
         assert_eq!(
-            result.model_used.as_deref(),
-            Some("model-switcher-gpt-5-4-pro")
-        );
-        assert_eq!(
             result
                 .model_selection
                 .as_ref()
                 .and_then(|selection| selection.get("status"))
                 .and_then(Value::as_str),
             Some("selected")
+        );
+        assert_eq!(
+            result
+                .model_selection
+                .as_ref()
+                .and_then(|selection| selection.get("modelUsed"))
+                .and_then(Value::as_str),
+            Some("GPT-5.6 Sol Pro")
         );
         assert_eq!(result.title, "ChatGPT");
     }

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -2054,7 +2054,7 @@ fn build_chatgpt_recipe_spec(
     recipe_args: &BrowserRecipeArgs,
     recipe_vars: &BTreeMap<String, String>,
 ) -> Result<chatgpt_recipe::ChatgptRecipeSpec> {
-    ensure_chatgpt_pro_extended_only_vars(recipe_vars)?;
+    ensure_chatgpt_sol_pro_only_vars(recipe_vars)?;
     let poll_settings = dev_browser::resolve_chatgpt_poll_settings(recipe_vars)?;
     let upload_timeout_ms =
         dev_browser::resolve_chatgpt_upload_timeout_ms(recipe_vars, recipe_args.bundle.as_deref())?;
@@ -2066,7 +2066,7 @@ fn build_chatgpt_recipe_spec(
         .transpose()?;
     Ok(chatgpt_recipe::ChatgptRecipeSpec {
         bundle_path: recipe_args.bundle.clone(),
-        model: chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL.to_string(),
+        model: chatgpt_recipe::CHATGPT_SOL_PRO_MODEL.to_string(),
         prompt: recipe_vars
             .get("prompt")
             .cloned()
@@ -2100,7 +2100,7 @@ fn build_chatgpt_recipe_spec(
     })
 }
 
-fn ensure_chatgpt_pro_extended_only_vars(recipe_vars: &BTreeMap<String, String>) -> Result<()> {
+fn ensure_chatgpt_sol_pro_only_vars(recipe_vars: &BTreeMap<String, String>) -> Result<()> {
     let unsupported = ["model", "extended"]
         .into_iter()
         .filter(|key| recipe_vars.contains_key(*key))
@@ -2109,7 +2109,7 @@ fn ensure_chatgpt_pro_extended_only_vars(recipe_vars: &BTreeMap<String, String>)
         return Ok(());
     }
     bail!(
-        "ChatGPT recipe supports only ChatGPT Pro Extended; remove unsupported var(s): {}",
+        "ChatGPT recipe supports only GPT-5.6 Sol + Pro intelligence; remove unsupported var(s): {}",
         unsupported.join(", ")
     )
 }
@@ -5752,7 +5752,7 @@ mod tests {
 
         let spec = build_chatgpt_recipe_spec(&recipe_args, &recipe_vars).unwrap();
         assert_eq!(spec.bundle_path, Some(PathBuf::from("/tmp/bundle.md")));
-        assert_eq!(spec.model, chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL);
+        assert_eq!(spec.model, chatgpt_recipe::CHATGPT_SOL_PRO_MODEL);
         assert_eq!(spec.prompt, "Review this repo");
         assert_eq!(spec.browser_context_id.as_deref(), Some("ctx-123"));
         assert_eq!(spec.profile_email.as_deref(), Some("user@example.com"));
@@ -5785,13 +5785,13 @@ mod tests {
 
         let err = build_chatgpt_recipe_spec(&recipe_args, &recipe_vars).unwrap_err();
         let message = format!("{err:#}");
-        assert!(message.contains("only ChatGPT Pro Extended"));
+        assert!(message.contains("only GPT-5.6 Sol + Pro intelligence"));
         assert!(message.contains("model"));
         assert!(message.contains("extended"));
     }
 
     #[test]
-    fn builtin_chatgpt_recipe_defaults_flow_into_shared_spec_with_extended_enabled() {
+    fn builtin_chatgpt_recipe_defaults_flow_into_shared_sol_pro_spec() {
         let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../recipes/chatgpt.yaml");
         let content = fs::read_to_string(&path).expect("read recipes/chatgpt.yaml");
         let recipe: browser::Recipe =
@@ -5811,7 +5811,7 @@ mod tests {
             .expect("build recipe vars");
         let spec = build_chatgpt_recipe_spec(&recipe_args, &recipe_vars).unwrap();
 
-        assert_eq!(spec.model, chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL);
+        assert_eq!(spec.model, chatgpt_recipe::CHATGPT_SOL_PRO_MODEL);
         assert!(!recipe_vars.contains_key("model"));
         assert!(!recipe_vars.contains_key("extended"));
     }
@@ -5991,7 +5991,7 @@ mod tests {
             transport: "dev-browser".to_string(),
             backend: "dev-browser".to_string(),
             response: "ok".to_string(),
-            model_used: Some(chatgpt_recipe::CHATGPT_PRO_EXTENDED_MODEL.to_string()),
+            model_used: Some("GPT-5.6 Sol Pro".to_string()),
             model_selection_status: crate::chatgpt_recipe::ChatgptModelSelectionStatus::Selected,
             warnings: vec!["clipboard fallback".to_string()],
             fallback_used: true,

--- a/crates/yoetz-cli/src/registry.rs
+++ b/crates/yoetz-cli/src/registry.rs
@@ -535,7 +535,7 @@ fn parse_openrouter_capability(item: &Value) -> Option<ModelCapability> {
     let web_search = item
         .get("pricing")
         .and_then(|v| v.get("web_search"))
-        .and_then(|v| if v.is_null() { None } else { Some(v) })
+        .filter(|v| !v.is_null())
         .is_some();
     if web_search {
         cap.web_search = Some(true);

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -468,13 +468,12 @@ async function selectSolProModel(root, options = {}) {
 
   const familyVerified = familyIsSol(state.family_label);
   const effortVerified = effortIsPro(state);
-  if (availableFamilies.length === 0 && state.family_trigger) {
-    const familyMenu = await openFamilyPicker(root, state.menu, state.family_trigger, options);
-    availableFamilies = familyMenuRadios(familyMenu).map((item) => textOf(item)).filter(Boolean);
-  }
-  await closeModelPicker(root, modelButton);
   if (!familyVerified || !effortVerified) {
+    await closeModelPicker(root, modelButton);
     return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol + Pro could not be verified in one picker pass");
+  }
+  if (!await closeModelPicker(root, modelButton)) {
+    return selectionFailure(base, modelButton, state, availableFamilies, "ChatGPT model picker remained open after verification");
   }
 
   return {
@@ -649,6 +648,7 @@ async function closeModelPicker(root, modelButton) {
     pressActivationKey(modelButton, "Escape");
     await sleep(50);
   }
+  return visibleMenus(root).length === 0;
 }
 
 async function waitForPickerState(root, options = {}) {
@@ -694,7 +694,11 @@ function visibleMenus(root) {
 function readPickerState(menu) {
   const effortItems = menuRadioItems(menu);
   const familyTrigger = Array.from(menu.querySelectorAll('[role="menuitem"]'))
-    .find((item) => item.getAttribute?.("aria-haspopup") === "menu" && /^gpt\b/i.test(normalizeText(textOf(item))));
+    .find((item) => {
+      const label = normalizeText(textOf(item));
+      return item.getAttribute?.("aria-haspopup") === "menu"
+        && /^(?:gpt|o\d)\b/i.test(label);
+    });
   return {
     menu,
     family_trigger: familyTrigger ?? null,

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -3,6 +3,9 @@ export const OWNERSHIP_ATTR = "data-yoetz-chatgpt-native-job";
 const DEFAULT_WAIT_TIMEOUT_MS = 15000;
 const DEFAULT_WAIT_INTERVAL_MS = 250;
 const DEFAULT_SEND_MIN_TIMEOUT_MS = 120000;
+const CHATGPT_SOL_PRO_MODEL = "gpt-5-6-sol-pro";
+const CHATGPT_SOL_FAMILY_LABEL = "GPT-5.6 Sol";
+const CHATGPT_PRO_EFFORT_LABEL = "Pro";
 
 export function ownedWindowName(job) {
   return `${YOETZ_WINDOW_PREFIX}${job.run_id}:${job.job_id}`;
@@ -89,23 +92,21 @@ export function findSendButton(root = document) {
   return findSendButtonControl(root, { requireEnabled: true });
 }
 
-export function findModelButton(root = document, options = {}) {
-  // ChatGPT serves at least two picker families: Enterprise exposes a global
-  // model-switcher button, while personal ChatGPT can render a composer-scoped
-  // model chip. Keep both paths because either account type may back Pro.
-  const enterpriseButton = firstVisibleModelControlInScopes(modelHeaderScopes(root, options), [
-    'button[data-testid="model-switcher-dropdown-button"]',
-    'button:has([data-testid="selected-model"])',
-    'button:has([data-testid="model-switcher-selected-model"])',
-    'button[aria-label*="model" i]',
-    'button[aria-controls*="model" i]',
-    'button[id*="model" i]'
-  ], options);
-  const composerButton = findComposerModelControl(root, options);
-  if (options.allowStandaloneFallback === false) {
-    return enterpriseButton ?? composerButton;
+export function findModelButton(root = document) {
+  const scopes = modelControlScopes(root);
+  for (const scope of scopes) {
+    const buttons = Array.from(scope.querySelectorAll('button[aria-haspopup="menu"]'))
+      .filter((node) => isVisible(node, { allowDisabled: true }) && !isTranscriptModelControl(node));
+    const composerPill = buttons.find((node) => classTokens(node).includes("__composer-pill"));
+    if (composerPill) {
+      return composerPill;
+    }
+    const summaryFallback = buttons.find((node) => modelPillSummaryMatches(modelControlLabel(node)));
+    if (summaryFallback) {
+      return summaryFallback;
+    }
   }
-  return enterpriseButton ?? composerButton ?? findStandaloneProExtendedModelControl(root);
+  return null;
 }
 
 export function getPageText(root = document) {
@@ -302,15 +303,19 @@ function conversationUnavailableError(conversationId, currentConversationId, win
 }
 
 export async function configureModelState(root, job = {}) {
-  const requested = proExtendedModelRequest();
-  const selection = await selectRequestedModel(root, requested, modelSelectionOptionsForJob(job));
+  const selection = await selectSolProModel(root, modelSelectionOptionsForJob(job));
   const warnings = selection.warning ? [selection.warning] : [];
   return {
     status: selection.status,
     model_used: selection.model_used,
-    requested_model: requested.raw,
+    requested_model: CHATGPT_SOL_PRO_MODEL,
     available_options: selection.available_options ?? [],
-    extended_status: "required",
+    available_families: selection.available_families ?? [],
+    family_status: selection.family_status ?? "unverified",
+    effort_status: selection.effort_status ?? "unverified",
+    pill_text: selection.pill_text ?? null,
+    family_label: selection.family_label ?? null,
+    effort_options: selection.effort_options ?? [],
     warning: warnings[0] ?? null,
     warnings
   };
@@ -318,9 +323,6 @@ export async function configureModelState(root, job = {}) {
 
 function modelSelectionOptionsForJob(job = {}) {
   const options = {};
-  if (String(job?.conversation_id ?? "").trim()) {
-    options.allowStandaloneFallback = false;
-  }
   const timeoutMs = Number(job?.model_selection_timeout_ms);
   if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
     options.timeoutMs = timeoutMs;
@@ -332,88 +334,7 @@ function modelSelectionOptionsForJob(job = {}) {
   return options;
 }
 
-function isActionableElement(node) {
-  const tag = String(node?.tagName ?? "").toLowerCase();
-  const role = String(node?.getAttribute?.("role") ?? "").toLowerCase();
-  return tag === "button"
-    || ["button", "switch", "checkbox"].includes(role)
-    || node?.getAttribute?.("tabindex") !== null;
-}
-
-function findComposerModelControl(root, options = {}) {
-  for (const scope of modelControlScopes(root, options)) {
-    const candidates = uniqueElements(Array.from(scope.querySelectorAll([
-      "button",
-      '[role="button"]',
-      "[aria-haspopup]",
-      "[tabindex]",
-      "[aria-label]",
-      "[title]",
-      "[data-testid]",
-      "span",
-      "div"
-    ].join(","))));
-    for (const node of candidates) {
-      const target = modelClickTarget(node, scope);
-      if (!target || !isVisible(target, { allowDisabled: true })) {
-        continue;
-      }
-      if (isTranscriptModelControl(target, options)) {
-        continue;
-      }
-      const haystack = modelCandidateText(node, target);
-      if (!looksLikeModelControl(haystack)) {
-        continue;
-      }
-      if (/\b(send|stop|copy|share|new chat|attach|upload|search|history|dictation|voice|microphone|account|profile|settings|upgrade)\b/.test(haystack)) {
-        continue;
-      }
-      return target;
-    }
-  }
-  return null;
-}
-
-function firstVisibleModelControlInScopes(scopes, selectors, options = {}) {
-  for (const scope of scopes) {
-    const control = firstVisibleModelControl(scope, selectors, options);
-    if (control) {
-      return control;
-    }
-  }
-  return null;
-}
-
-function findStandaloneProExtendedModelControl(root) {
-  const requested = proExtendedModelRequest();
-  const candidates = uniqueElements(Array.from(root.querySelectorAll([
-    "button",
-    '[role="button"]',
-    "[aria-haspopup]"
-  ].join(","))));
-  return candidates.find((node) => {
-    if (!isVisible(node, { allowDisabled: true })) {
-      return false;
-    }
-    const haystack = modelCandidateText(node);
-    if (!modelTextMatchesRequest(haystack, requested)) {
-      return false;
-    }
-    return !/\b(send|stop|copy|share|new chat|attach|upload|search|history|dictation|voice|microphone|account|profile|settings|upgrade)\b/.test(haystack);
-  }) ?? null;
-}
-
-function modelHeaderScopes(root, options = {}) {
-  if (options.allowStandaloneFallback !== false) {
-    return [root];
-  }
-  return uniqueElements(Array.from(root.querySelectorAll([
-    "header",
-    '[role="banner"]'
-  ].join(","))));
-}
-
-function modelControlScopes(root, options = {}) {
+function modelControlScopes(root) {
   const composer = findComposer(root);
   const scopes = [];
   const add = (scope) => {
@@ -424,14 +345,11 @@ function modelControlScopes(root, options = {}) {
   add(composer?.closest("form"));
   add(composer?.closest('[data-testid*="composer"], [class*="composer"]'));
   const parent = composer?.parentElement;
-  if (options.allowStandaloneFallback !== false || isLocalComposerScope(parent)) {
+  if (isLocalComposerScope(parent)) {
     add(parent);
   }
   for (const scope of [...scopes]) {
     addAdjacentComposerControlScopes(scope, add);
-  }
-  if (options.allowStandaloneFallback !== false) {
-    add(composer?.closest("main, [role=\"main\"]"));
   }
   return scopes;
 }
@@ -468,37 +386,6 @@ function looksLikeComposerControlScope(node) {
     && !/\b(conversation|transcript|message|turn|assistant|user)\b/.test(marker);
 }
 
-function modelClickTarget(node, stopAt) {
-  let current = node;
-  while (current) {
-    if (isModelActionableElement(current) || isModelChipLike(current)) {
-      return current;
-    }
-    if (current === stopAt) {
-      return null;
-    }
-    current = current.parentElement;
-  }
-  return null;
-}
-
-function modelCandidateText(node, target = node) {
-  return normalizeText([
-    node?.getAttribute?.("aria-label"),
-    node?.getAttribute?.("title"),
-    node?.getAttribute?.("data-testid"),
-    node?.getAttribute?.("class"),
-    node?.innerText,
-    node?.textContent,
-    target?.getAttribute?.("aria-label"),
-    target?.getAttribute?.("title"),
-    target?.getAttribute?.("data-testid"),
-    target?.getAttribute?.("class"),
-    target?.innerText,
-    target?.textContent
-  ].filter(Boolean).join(" ")).toLowerCase();
-}
-
 function modelControlLabel(node) {
   return normalizeText([
     textOf(node),
@@ -507,147 +394,134 @@ function modelControlLabel(node) {
   ].filter(Boolean).join(" "));
 }
 
-function looksLikeModelControl(text) {
-  return /\bextended\s+pro\b/.test(text)
-    || /\bgpt[\s.-]*\d/.test(text)
-    || /\b(pro|instant|thinking|model)\b/.test(text);
-}
-
-function isModelActionableElement(node) {
-  const tag = String(node?.tagName ?? "").toLowerCase();
-  const role = String(node?.getAttribute?.("role") ?? "").toLowerCase();
-  return tag === "button"
-    || role === "button"
-    || node?.getAttribute?.("aria-haspopup") !== null
-    || node?.getAttribute?.("tabindex") !== null;
-}
-
-function isModelChipLike(node) {
-  const marker = normalizeText([
-    node?.getAttribute?.("data-testid"),
-    node?.getAttribute?.("class"),
-    node?.getAttribute?.("aria-label"),
-    node?.getAttribute?.("title")
-  ].filter(Boolean).join(" ")).toLowerCase();
-  return /\b(model|model-switcher)\b/.test(marker) && /\b(chip|pill|token|button|menu|dropdown|switcher)\b/.test(marker);
-}
-
-export async function selectRequestedModel(root, requested, options = {}) {
-  const readiness = await waitForModelSelectionTarget(root, requested, options);
-  if (readiness.selection.selected) {
+async function selectSolProModel(root, options = {}) {
+  const base = {
+    status: "unavailable",
+    model_used: null,
+    family_status: "unverified",
+    effort_status: "unverified",
+    available_options: [],
+    available_families: [],
+    effort_options: []
+  };
+  const legacyMarkers = visibleLegacyPickerMarkers(root);
+  if (legacyMarkers.length > 0) {
     return {
-      status: "selected",
-      model_used: readiness.selection.model_used,
-      available_options: []
+      ...base,
+      warning: "legacy ChatGPT picker detected; this yoetz version requires the GPT-5.6 UI",
+      legacy_picker: legacyMarkers.slice(0, 10)
     };
   }
 
-  const modelButton = readiness.modelButton;
+  const modelButton = await waitForModelButton(root, options);
   if (!modelButton) {
-    return {
-      status: "unavailable",
-      model_used: readiness.selection.model_used,
-      warning: "ChatGPT model selector button not found"
-    };
-  }
-
-  const currentSelection = currentRequestedModelSelection(root, requested, options);
-  if (currentSelection.selected) {
-    return {
-      status: "selected",
-      model_used: currentSelection.model_used,
-      available_options: []
-    };
-  }
-
-  let selectedOption = null;
-  let availableOptions = [];
-  const openAttempts = 3;
-  for (let attempt = 0; attempt < openAttempts; attempt += 1) {
-    await openModelPicker(root, modelButton);
-    const result = await waitForRequestedModelOption(root, requested, {
-      timeoutMs: attempt === openAttempts - 1 ? 7000 : 2500,
-      stableForMs: attempt === openAttempts - 1 ? 0 : 600
-    });
-    selectedOption = result.option;
-    availableOptions = result.availableOptions;
-    if (selectedOption) {
-      break;
-    }
-  }
-  if (!selectedOption) {
-    const verification = await waitForRequestedModelSelected(root, requested, null, options);
-    if (verification.selected) {
+    const lateLegacyMarkers = visibleLegacyPickerMarkers(root);
+    if (lateLegacyMarkers.length > 0) {
       return {
-        status: "selected",
-        model_used: verification.model_used,
-        available_options: availableOptions
+        ...base,
+        warning: "legacy ChatGPT picker detected; this yoetz version requires the GPT-5.6 UI",
+        legacy_picker: lateLegacyMarkers.slice(0, 10)
       };
     }
-    return {
-      status: "unavailable",
-      model_used: currentModelLabel(root, options),
-      available_options: availableOptions,
-      warning: "ChatGPT Pro Extended was not visible in the model picker"
-    };
+    return { ...base, warning: "ChatGPT GPT-5.6 composer model pill not found" };
   }
-  realClick(selectedOption);
 
-  const verification = await waitForRequestedModelSelected(root, requested, selectedOption, options);
-  if (verification.selected) {
+  let availableFamilies = [];
+  let state = await openAndReadModelPicker(root, modelButton, options);
+  if (!state) {
     return {
-      status: "selected",
-      model_used: verification.model_used || textOf(selectedOption),
-      available_options: availableOptions
+      ...base,
+      pill_text: modelControlLabel(modelButton),
+      warning: "ChatGPT GPT-5.6 model picker did not open"
     };
   }
+
+  if (!familyIsSol(state.family_label)) {
+    const familyMenu = await openFamilyPicker(root, state.menu, state.family_trigger, options);
+    availableFamilies = familyMenu ? familyMenuRadios(familyMenu).map((item) => textOf(item)).filter(Boolean) : [];
+    const solOption = familyMenuRadios(familyMenu).find((item) => foldedModelText(textOf(item)) === foldedModelText(CHATGPT_SOL_FAMILY_LABEL));
+    if (!solOption) {
+      await closeModelPicker(root, modelButton);
+      return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol was not visible in the family submenu");
+    }
+    realClick(solOption);
+    await sleep(Number(options.actionSettleMs ?? 250));
+    state = await openAndReadModelPicker(root, modelButton, options);
+    if (!state) {
+      return selectionFailure(base, modelButton, null, availableFamilies, "ChatGPT picker did not reopen after selecting GPT-5.6 Sol");
+    }
+  }
+
+  if (!effortIsPro(state)) {
+    const proOption = state.effort_items.find((item) => foldedModelText(textOf(item)) === foldedModelText(CHATGPT_PRO_EFFORT_LABEL));
+    if (!proOption) {
+      await closeModelPicker(root, modelButton);
+      return selectionFailure(base, modelButton, state, availableFamilies, "Pro intelligence was not visible for GPT-5.6 Sol");
+    }
+    realClick(proOption);
+    await sleep(Number(options.actionSettleMs ?? 250));
+    state = await openAndReadModelPicker(root, modelButton, options);
+    if (!state) {
+      return selectionFailure(base, modelButton, null, availableFamilies, "ChatGPT picker did not reopen after selecting Pro intelligence");
+    }
+  }
+
+  const familyVerified = familyIsSol(state.family_label);
+  const effortVerified = effortIsPro(state);
+  if (availableFamilies.length === 0 && state.family_trigger) {
+    const familyMenu = await openFamilyPicker(root, state.menu, state.family_trigger, options);
+    availableFamilies = familyMenuRadios(familyMenu).map((item) => textOf(item)).filter(Boolean);
+  }
+  await closeModelPicker(root, modelButton);
+  if (!familyVerified || !effortVerified) {
+    return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol + Pro could not be verified in one picker pass");
+  }
+
   return {
-    status: "mismatch",
-    model_used: verification.model_used || "unknown",
-    available_options: availableOptions,
-    warning: `ChatGPT Pro Extended was clicked but selected label is ${verification.model_used || "unknown"}`
+    status: "selected",
+    model_used: `${CHATGPT_SOL_FAMILY_LABEL} ${CHATGPT_PRO_EFFORT_LABEL}`,
+    family_status: "verified",
+    effort_status: "verified",
+    pill_text: modelControlLabel(modelButton),
+    family_label: state.family_label,
+    available_options: state.effort_items.map((item) => textOf(item)).filter(Boolean),
+    available_families: availableFamilies,
+    effort_options: effortDiagnostics(state.effort_items)
   };
 }
 
-async function waitForModelSelectionTarget(root, requested, options = {}) {
+async function waitForModelButton(root, options = {}) {
   const timeoutMs = Number(options.timeoutMs ?? 30000);
   const intervalMs = Number(options.intervalMs ?? 250);
   const startedAt = Date.now();
-  let selection = currentRequestedModelSelection(root, requested, options);
-  let modelButton = findModelButton(root, options);
-
+  let modelButton = findModelButton(root);
   while (Date.now() - startedAt < timeoutMs) {
-    selection = currentRequestedModelSelection(root, requested, options);
-    if (selection.selected) {
-      return { selection, modelButton: findModelButton(root, options) };
-    }
-    modelButton = findModelButton(root, options);
+    modelButton = findModelButton(root);
     if (modelButton) {
-      return { selection, modelButton };
+      return modelButton;
     }
     await sleep(intervalMs);
   }
-
-  return { selection, modelButton };
+  return modelButton;
 }
 
-function currentRequestedModelSelection(root, requested, options = {}) {
-  const modelUsed = currentModelLabel(root, options);
-  return {
-    selected: modelTextMatchesRequest(modelUsed, requested),
-    model_used: modelUsed
-  };
+async function openAndReadModelPicker(root, modelButton, options = {}) {
+  if (!await openModelPicker(root, modelButton, options)) {
+    return null;
+  }
+  return waitForPickerState(root, options);
 }
 
 async function openModelPicker(root, modelButton, options = {}) {
   const settleMs = Number(options.settleMs ?? 150);
-  if (visibleModelOptions(root).length > 0) {
+  const opened = () => Boolean(findMainModelMenu(root));
+  if (opened()) {
     return true;
   }
   const activators = [openWithPointerEvents, pressEnter, pressSpace];
   for (const activate of activators) {
     try {
-      if (await activate(root, modelButton, { settleMs })) {
+      if (await activate(modelButton, opened, { settleMs })) {
         return true;
       }
     } catch {
@@ -657,7 +531,36 @@ async function openModelPicker(root, modelButton, options = {}) {
   return false;
 }
 
-async function openWithPointerEvents(root, element, options = {}) {
+async function openFamilyPicker(root, mainMenu, trigger, options = {}) {
+  if (!trigger) {
+    return null;
+  }
+  const opened = () => findFamilySubmenu(root, mainMenu);
+  const settleMs = Number(options.settleMs ?? 150);
+  for (const activate of [openWithHoverEvents, openWithPointerEvents, pressEnter, pressSpace]) {
+    try {
+      if (await activate(trigger, opened, { settleMs })) {
+        return waitForFamilyMenu(root, mainMenu, options);
+      }
+    } catch {
+      // Try the next Radix activation path.
+    }
+  }
+  return null;
+}
+
+async function openWithHoverEvents(element, isOpen, options = {}) {
+  const settleMs = Number(options.settleMs ?? 150);
+  const phases = [
+    ["pointerenter", "PointerEvent", { pointerId: 1, pointerType: "mouse", isPrimary: true }],
+    ["mouseenter", "MouseEvent", {}],
+    ["pointermove", "PointerEvent", { pointerId: 1, pointerType: "mouse", isPrimary: true }],
+    ["mousemove", "MouseEvent", {}]
+  ];
+  return dispatchActivationPhases(element, isOpen, phases, settleMs);
+}
+
+async function openWithPointerEvents(element, isOpen, options = {}) {
   element?.focus?.();
   const settleMs = Number(options.settleMs ?? 150);
   const phases = [
@@ -679,26 +582,28 @@ async function openWithPointerEvents(root, element, options = {}) {
     ["mouseup", "MouseEvent", { button: 0, buttons: 0 }],
     ["click", "MouseEvent", { button: 0, buttons: 0, detail: 1 }]
   ];
+  return dispatchActivationPhases(element, isOpen, phases, settleMs);
+}
+
+async function dispatchActivationPhases(element, isOpen, phases, settleMs) {
   for (const [type, constructorName, init] of phases) {
     dispatchSyntheticEvent(element, type, constructorName, init);
     await sleep(settleMs);
-    if (visibleModelOptions(root).length > 0) {
-      return true;
-    }
+    if (isOpen()) return true;
   }
   return false;
 }
 
-async function pressEnter(root, element, options = {}) {
+async function pressEnter(element, isOpen, options = {}) {
   pressActivationKey(element, "Enter");
   await sleep(Number(options.settleMs ?? 150));
-  return visibleModelOptions(root).length > 0;
+  return Boolean(isOpen());
 }
 
-async function pressSpace(root, element, options = {}) {
+async function pressSpace(element, isOpen, options = {}) {
   pressActivationKey(element, " ");
   await sleep(Number(options.settleMs ?? 150));
-  return visibleModelOptions(root).length > 0;
+  return Boolean(isOpen());
 }
 
 function realClick(element) {
@@ -737,6 +642,129 @@ function pressActivationKey(element, key) {
   element?.focus?.();
   dispatchSyntheticEvent(element, "keydown", "KeyboardEvent", { key, code });
   dispatchSyntheticEvent(element, "keyup", "KeyboardEvent", { key, code });
+}
+
+async function closeModelPicker(root, modelButton) {
+  for (let attempt = 0; attempt < 3 && visibleMenus(root).length > 0; attempt += 1) {
+    pressActivationKey(modelButton, "Escape");
+    await sleep(50);
+  }
+}
+
+async function waitForPickerState(root, options = {}) {
+  const timeoutMs = Number(options.pickerTimeoutMs ?? 3000);
+  const intervalMs = Number(options.intervalMs ?? 100);
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const menu = findMainModelMenu(root);
+    if (menu) return readPickerState(menu);
+    await sleep(intervalMs);
+  }
+  return null;
+}
+
+async function waitForFamilyMenu(root, mainMenu, options = {}) {
+  const timeoutMs = Number(options.pickerTimeoutMs ?? 3000);
+  const intervalMs = Number(options.intervalMs ?? 100);
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const menu = findFamilySubmenu(root, mainMenu);
+    if (menu) return menu;
+    await sleep(intervalMs);
+  }
+  return null;
+}
+
+function findMainModelMenu(root) {
+  return visibleMenus(root).find((menu) => {
+    const labels = menuRadioItems(menu).map((item) => foldedModelText(textOf(item)));
+    return labels.includes("medium") && labels.includes("high")
+      && (labels.includes("pro") || labels.includes("pro extended"));
+  }) ?? null;
+}
+
+function findFamilySubmenu(root, mainMenu) {
+  return visibleMenus(root).find((menu) => menu !== mainMenu && familyMenuRadios(menu).some((item) => familyIsSol(textOf(item)))) ?? null;
+}
+
+function visibleMenus(root) {
+  return Array.from(root.querySelectorAll('[role="menu"]')).filter((menu) => isVisible(menu));
+}
+
+function readPickerState(menu) {
+  const effortItems = menuRadioItems(menu);
+  const familyTrigger = Array.from(menu.querySelectorAll('[role="menuitem"]'))
+    .find((item) => item.getAttribute?.("aria-haspopup") === "menu" && /^gpt\b/i.test(normalizeText(textOf(item))));
+  return {
+    menu,
+    family_trigger: familyTrigger ?? null,
+    family_label: textOf(familyTrigger),
+    effort_items: effortItems
+  };
+}
+
+function menuRadioItems(menu) {
+  return Array.from(menu?.querySelectorAll?.('[role="menuitemradio"]') ?? []).filter((item) => isVisible(item));
+}
+
+function familyMenuRadios(menu) {
+  return menuRadioItems(menu).filter((item) => /^gpt\b|^o3$/i.test(normalizeText(textOf(item))));
+}
+
+function effortIsPro(state) {
+  return state?.effort_items?.some((item) => foldedModelText(textOf(item)) === "pro" && itemIsChecked(item)) ?? false;
+}
+
+function familyIsSol(value) {
+  return foldedModelText(value) === foldedModelText(CHATGPT_SOL_FAMILY_LABEL);
+}
+
+function itemIsChecked(item) {
+  return item?.getAttribute?.("aria-checked") === "true" || item?.getAttribute?.("data-state") === "checked";
+}
+
+function effortDiagnostics(items) {
+  return items.map((item) => ({ label: textOf(item), checked: itemIsChecked(item) }));
+}
+
+function selectionFailure(base, modelButton, state, availableFamilies, warning) {
+  return {
+    ...base,
+    family_status: familyIsSol(state?.family_label) ? "verified" : "unverified",
+    effort_status: effortIsPro(state) ? "verified" : "unverified",
+    pill_text: modelControlLabel(modelButton),
+    family_label: state?.family_label ?? null,
+    available_options: state?.effort_items?.map((item) => textOf(item)).filter(Boolean) ?? [],
+    available_families: availableFamilies,
+    effort_options: effortDiagnostics(state?.effort_items ?? []),
+    warning
+  };
+}
+
+function visibleLegacyPickerMarkers(root) {
+  return Array.from(root.querySelectorAll([
+    '[data-testid="model-switcher-dropdown-button"]',
+    '[data-testid="model-switcher-selected-model"]',
+    '[data-testid^="model-switcher-"]'
+  ].join(",")))
+    .filter((node) => isVisible(node, { allowDisabled: true }))
+    .map((node) => String(node.getAttribute?.("data-testid") ?? ""))
+    .filter(Boolean);
+}
+
+function classTokens(node) {
+  return String(node?.getAttribute?.("class") ?? "").split(/\s+/).filter(Boolean);
+}
+
+function modelPillSummaryMatches(value) {
+  const folded = foldedModelText(value);
+  return /^(instant|medium|high|extra high|pro)$/.test(folded)
+    || /^\d+(?:\.\d+)+ (instant|medium|high|extra high|pro)$/.test(folded)
+    || /\bgpt[\s.-]*\d/.test(folded);
+}
+
+function foldedModelText(value) {
+  return normalizeText(value).toLowerCase();
 }
 
 function dispatchSyntheticEvent(element, type, constructorName, init = {}) {
@@ -877,6 +905,7 @@ export function extractResponse(root = document) {
       copy_button_count: copyButtonCount,
       has_copy_button: latestTurnHasCopyButton,
       turn_index: turnIndex,
+      model_slug: messageModelSlug(latestAssistant ?? latestTextEntry?.node),
       diagnostics
     };
   }
@@ -894,6 +923,7 @@ export function extractResponse(root = document) {
       copy_button_count: Math.max(copyButtonCount, standalone.hasCopyButton ? 1 : 0),
       has_copy_button: standalone.hasCopyButton,
       turn_index: assistantCount - 1,
+      model_slug: messageModelSlug(standalone.node),
       diagnostics
     };
   }
@@ -908,6 +938,7 @@ export function extractResponse(root = document) {
     copy_button_count: copyButtonCount,
     has_copy_button: copyButtonCount > 0,
     turn_index: -1,
+    model_slug: messageModelSlug(latestAssistant),
     diagnostics
   };
 }
@@ -1237,8 +1268,10 @@ function isAssistantControlLine(line, options = {}) {
 
 function isModelStatusText(text) {
   const value = normalizeText(text);
-  return /^(pro thinking|extended thinking|thinking|pro|extended pro)$/i.test(value)
-    || /^gpt[\s.-]*\d+(?:[\s.-]*\d+)*(?:\s+(?:pro|thinking))?$/i.test(value);
+  const effort = "instant|medium|high|extra high|pro";
+  return /^(sol|instant|medium|high|extra high|pro|pro thinking|thinking)$/i.test(value)
+    || new RegExp(`^\\d+(?:\\.\\d+)+\\s+(?:${effort})$`, "i").test(value)
+    || new RegExp(`^gpt[\\s.-]*\\d+(?:[\\s.-]*\\d+)*(?:\\s+sol)?(?:\\s+(?:${effort}|thinking))?$`, "i").test(value);
 }
 
 function isMarkdownNode(node) {
@@ -1343,23 +1376,7 @@ function firstVisible(root, selectors) {
   return firstMatching(root, selectors, { allowHidden: false });
 }
 
-function firstVisibleModelControl(root, selectors, options = {}) {
-  for (const selector of selectors) {
-    const nodes = Array.from(root.querySelectorAll(selector));
-    const visible = nodes.find((node) =>
-      isVisible(node, options) && !isTranscriptModelControl(node, options)
-    );
-    if (visible) {
-      return visible;
-    }
-  }
-  return null;
-}
-
-function isTranscriptModelControl(node, options = {}) {
-  if (options.allowStandaloneFallback !== false) {
-    return false;
-  }
+function isTranscriptModelControl(node) {
   return Boolean(node?.closest?.([
     "[data-message-author-role]",
     "article",
@@ -1490,132 +1507,6 @@ async function waitForCondition(predicate, description, options = {}) {
     await sleep(intervalMs);
   }
   throw new Error(description);
-}
-
-function findModelOption(root, labels) {
-  const options = visibleModelOptions(root);
-  for (const slug of labels.slugs) {
-    const exact = options.find((node) => optionSlugs(node).includes(slug));
-    if (exact) {
-      return exact;
-    }
-  }
-  for (const label of labels.labels) {
-    const textMatch = options.find((node) => modelOptionMatchesLabel(node, label));
-    if (textMatch) {
-      return textMatch;
-    }
-  }
-  return null;
-}
-
-function visibleModelOptions(root) {
-  return Array.from(root.querySelectorAll('[role="menuitem"], [role="menuitemradio"], [role="option"], [data-testid^="model-switcher-"]:not([data-testid="model-switcher-selected-model"])'))
-    .filter((node) => isVisible(node) && !/model-switcher-(dropdown-button|selected-model)$/i.test(String(node.getAttribute?.("data-testid") ?? "")));
-}
-
-function visibleModelOptionLabels(root) {
-  return visibleModelOptions(root)
-    .map((node) => optionText(node))
-    .filter(Boolean);
-}
-
-async function waitForRequestedModelOption(root, requested, options = {}) {
-  const timeoutMs = Number(options.timeoutMs ?? 7000);
-  const intervalMs = Number(options.intervalMs ?? 100);
-  const stableForMs = Number(options.stableForMs ?? 600);
-  const startedAt = Date.now();
-  let lastSignature = "";
-  let stableSince = 0;
-  let availableOptions = [];
-
-  while (Date.now() - startedAt < timeoutMs) {
-    const option = findModelOption(root, requested);
-    availableOptions = visibleModelOptionLabels(root);
-    if (option) {
-      return { option, availableOptions };
-    }
-
-    const signature = availableOptions.join("\n");
-    const now = Date.now();
-    if (signature !== lastSignature) {
-      lastSignature = signature;
-      stableSince = signature ? now : 0;
-    }
-
-    if (stableForMs > 0 && signature && stableSince > 0 && now - stableSince >= stableForMs) {
-      return { option: null, availableOptions };
-    }
-    await sleep(intervalMs);
-  }
-
-  return { option: null, availableOptions };
-}
-
-async function waitForRequestedModelSelected(root, requested, _option, options = {}) {
-  const timeoutMs = Number(options.timeoutMs ?? 4000);
-  const intervalMs = Number(options.intervalMs ?? 100);
-  const startedAt = Date.now();
-  let modelUsed = currentModelLabel(root, options);
-
-  while (Date.now() - startedAt < timeoutMs) {
-    modelUsed = currentModelLabel(root, options);
-    if (modelTextMatchesRequest(modelUsed, requested)) {
-      return { selected: true, model_used: modelUsed };
-    }
-    await sleep(intervalMs);
-  }
-
-  return { selected: false, model_used: modelUsed };
-}
-
-function optionSlugs(node) {
-  return [
-    node.getAttribute?.("data-testid")?.replace(/^model-switcher-/, ""),
-    node.getAttribute?.("aria-label"),
-    node.getAttribute?.("title"),
-    textOf(node)
-  ]
-    .filter(Boolean)
-    .map(canonicalModelSlug)
-    .filter(Boolean);
-}
-
-function optionText(node) {
-  return [
-    textOf(node),
-    node.getAttribute?.("aria-label"),
-    node.getAttribute?.("title"),
-    node.getAttribute?.("data-testid")
-  ].filter(Boolean).join(" ");
-}
-
-function modelTextMatchesRequest(text, requested) {
-  if (!text) {
-    return false;
-  }
-  const slug = canonicalModelSlug(text);
-  return requested.slugs.includes(slug) || requested.labels.some((label) => modelLabelMatchesText(label, text));
-}
-
-function modelOptionMatchesLabel(node, label) {
-  const labelSlug = canonicalModelSlug(label);
-  return optionSlugs(node).includes(labelSlug) || modelLabelMatchesText(label, optionText(node));
-}
-
-function modelLabelMatchesText(label, text) {
-  const labelSlug = canonicalModelSlug(label);
-  const folded = normalizeText(text).toLowerCase();
-  if (!labelSlug || !folded) {
-    return false;
-  }
-  if (labelSlug === "pro" || labelSlug === "thinking") {
-    return new RegExp(`\\b${labelSlug}\\b`).test(folded);
-  }
-  if (labelSlug === "gpt-5") {
-    return /\bgpt[\s.-]*5\b(?![\s.-]*\d)/i.test(folded);
-  }
-  return canonicalModelSlug(text) === labelSlug;
 }
 
 async function waitForUploadComplete(root, file, options = {}) {
@@ -2209,6 +2100,7 @@ function elementSummary(node) {
     testid: String(node?.getAttribute?.("data-testid") ?? "").slice(0, 120),
     class: String(node?.getAttribute?.("class") ?? "").slice(0, 160),
     aria: String(node?.getAttribute?.("aria-label") ?? "").slice(0, 160),
+    model_slug: messageModelSlug(node),
     text_chars: textOf(node).length,
     // text_content_chars exposes the layout-independent textContent length next to the
     // innerText-derived text_chars. On the truncation failure mode this node will show
@@ -2219,61 +2111,37 @@ function elementSummary(node) {
   };
 }
 
+function messageModelSlug(node) {
+  const direct = String(node?.getAttribute?.("data-message-model-slug") ?? "").trim();
+  if (direct) return direct;
+  const owner = node?.closest?.("[data-message-model-slug]")
+    ?? node?.querySelectorAll?.("[data-message-model-slug]")?.[0];
+  return String(owner?.getAttribute?.("data-message-model-slug") ?? "").trim() || null;
+}
+
 function uniqueElements(nodes) {
   return nodes.filter((node, index) => node && nodes.indexOf(node) === index);
 }
 
-function currentModelLabel(root, options = {}) {
-  const modelButton = findModelButton(root, options);
-  const selected = options.allowStandaloneFallback === false
-    ? (modelButton ? firstVisible(modelButton, ['[data-testid="model-switcher-selected-model"]']) : null)
-    : firstVisible(root, ['[data-testid="model-switcher-selected-model"]']);
-  const selectedText = normalizeText(selected?.innerText ?? selected?.textContent ?? "");
-  if (selectedText) {
-    return selectedText;
-  }
-  if (visibleModelOptions(root).length > 0) {
-    return "";
-  }
-  return modelControlLabel(modelButton);
-}
-
 export function modelSelectionDiagnostics(root = document) {
-  const requested = proExtendedModelRequest();
   const modelButton = findModelButton(root);
-  const modelUsed = currentModelLabel(root);
+  const mainMenu = findMainModelMenu(root);
+  const state = mainMenu ? readPickerState(mainMenu) : null;
+  const familyMenu = findFamilySubmenu(root, mainMenu);
   return {
-    requested_model: requested.raw,
-    current_model_label: modelUsed,
-    current_matches_requested: modelTextMatchesRequest(modelUsed, requested),
+    requested_model: CHATGPT_SOL_PRO_MODEL,
+    current_model_label: modelControlLabel(modelButton),
+    current_matches_requested: Boolean(familyIsSol(state?.family_label) && effortIsPro(state)),
+    family_status: familyIsSol(state?.family_label) ? "verified" : "unverified",
+    effort_status: effortIsPro(state) ? "verified" : "unverified",
+    family_label: state?.family_label ?? null,
     model_button: modelButton ? elementSummary(modelButton) : null,
-    visible_options: visibleModelOptionLabels(root).slice(0, 20),
+    visible_options: state?.effort_items?.map((item) => textOf(item)).filter(Boolean).slice(0, 20) ?? [],
+    visible_families: familyMenuRadios(familyMenu).map((item) => textOf(item)).filter(Boolean).slice(0, 20),
+    legacy_picker: visibleLegacyPickerMarkers(root).slice(0, 10),
     composer: elementSummary(findComposer(root)),
     model_control_scopes: modelControlScopes(root).slice(0, 5).map(elementSummary)
   };
-}
-
-function proExtendedModelRequest() {
-  return {
-    raw: "extended-pro",
-    labels: ["Extended Pro"],
-    slugs: ["extended-pro"]
-  };
-}
-
-function canonicalModelSlug(value) {
-  const folded = normalizeText(value).toLowerCase();
-  if (folded === "pro") return "pro";
-  if (/\bextended\b/.test(folded) && /\bpro\b/.test(folded)) return "extended-pro";
-  if (folded.includes("thinking")) return "thinking";
-  const match = folded.match(/^gpt[\s-]*(\d+)(?:[.\s-]*(\d+))?(?:[.\s-]*(\d+))?(?:[\s.-]*(pro))?$/);
-  if (!match) return folded.replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
-  const version = [match[1], match[2], match[3]].filter(Boolean).join("-");
-  return `gpt-${version}${match[4] ? "-pro" : ""}`;
-}
-
-function includesFolded(value, needle) {
-  return normalizeText(value).toLowerCase().includes(normalizeText(needle).toLowerCase());
 }
 
 function textOf(node) {

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -413,7 +413,7 @@ async function selectSolProModel(root, options = {}) {
     };
   }
 
-  const modelButton = await waitForModelButton(root, options);
+  let modelButton = await waitForModelButton(root, options);
   if (!modelButton) {
     const lateLegacyMarkers = visibleLegacyPickerMarkers(root);
     if (lateLegacyMarkers.length > 0) {
@@ -446,6 +446,10 @@ async function selectSolProModel(root, options = {}) {
     }
     realClick(solOption);
     await sleep(Number(options.actionSettleMs ?? 250));
+    modelButton = await waitForModelButton(root, options);
+    if (!modelButton) {
+      return selectionFailure(base, null, null, availableFamilies, "ChatGPT composer model pill did not remount after selecting GPT-5.6 Sol");
+    }
     state = await openAndReadModelPicker(root, modelButton, options);
     if (!state) {
       return selectionFailure(base, modelButton, null, availableFamilies, "ChatGPT picker did not reopen after selecting GPT-5.6 Sol");
@@ -460,6 +464,10 @@ async function selectSolProModel(root, options = {}) {
     }
     realClick(proOption);
     await sleep(Number(options.actionSettleMs ?? 250));
+    modelButton = await waitForModelButton(root, options);
+    if (!modelButton) {
+      return selectionFailure(base, null, null, availableFamilies, "ChatGPT composer model pill did not remount after selecting Pro intelligence");
+    }
     state = await openAndReadModelPicker(root, modelButton, options);
     if (!state) {
       return selectionFailure(base, modelButton, null, availableFamilies, "ChatGPT picker did not reopen after selecting Pro intelligence");

--- a/extensions/chatgpt-native/src/protocol.js
+++ b/extensions/chatgpt-native/src/protocol.js
@@ -85,7 +85,7 @@ export function progress(job, phase, detail = {}) {
   // INVARIANT: every job_progress event is non-final. The authoritative answer is only ever
   // delivered in the terminal job_complete envelope (payload.is_final=true). A machine consumer
   // (inspect/JSONL stream) must be able to trust is_final to never mistake a streaming/interim
-  // turn's partial text for the final response — ChatGPT Pro Extended streams the answer as several
+  // turn's partial text for the final response — ChatGPT Pro streams the answer as several
   // interim end_turn turns before the real one, so any progress text may be an interim turn's head
   // (observed live as a single "I"). Strip any caller-supplied is_final and force false LAST so no
   // call site can ever emit a final-looking progress event, now or in the future.

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -796,7 +796,7 @@ async function handleInspectRun(message) {
         tab_id: tab.id,
         url: tab.url ?? inspection?.url ?? null,
         title: tab.title ?? inspection?.title ?? null,
-        // Non-final marker for inspect read mid-stream. ChatGPT Pro Extended streams several interim
+        // Non-final marker for inspect read mid-stream. ChatGPT Pro streams several interim
         // turns before the answer; while generating, inspection.extraction.text is a partial/interim
         // turn's body (observed live as a single "I"), NOT the verdict. Wait for generation to stop.
         response_in_progress: responseInProgress,
@@ -1051,7 +1051,7 @@ function normalizeJob(message) {
     capability_token: message.capability_token,
     request_id: message.request_id,
     prompt: payload.prompt ?? "",
-    model: "extended-pro",
+    model: "gpt-5-6-sol-pro",
     wait_timeout_ms: payload.wait_timeout_ms ?? DEFAULT_WAIT_TIMEOUT_MS,
     wait_interval_ms: payload.wait_interval_ms ?? 30000,
     upload_timeout_ms: payload.upload_timeout_ms ?? 120000,
@@ -1667,14 +1667,14 @@ async function waitForResponse(job) {
 
 // How many assistant turns have appeared since the prompt was sent. The post-send baseline is
 // captured before send; the first turn beyond it is the response's first turn, and any turn beyond
-// THAT (while still generating) means the earlier turns were interim Pro-Extended status posts.
+// THAT (while still generating) means the earlier turns were interim Pro status posts.
 function assistantTurnsSinceSend(job, extraction) {
   const baseline = Number(job.response_baseline?.assistant_count ?? 0);
   const current = Number(extraction?.assistant_count ?? 0);
   return Math.max(0, current - baseline);
 }
 
-// Single source of truth for "is this progress an interim Pro-Extended turn, not the answer?".
+// Single source of truth for "is this progress an interim Pro turn, not the answer?".
 // A second-or-later assistant turn appearing while generation is still active proves the earlier
 // turn(s) were interim status posts ("I'll review...", "I've narrowed..."), not the final answer.
 function interimTurnState(job, extraction) {
@@ -1941,14 +1941,15 @@ function nonNegativeFiniteNumber(value) {
 
 function isAcceptableModelSelection(selection) {
   return selection?.status === "selected"
-    && selection?.requested_model === "extended-pro"
-    && selection?.extended_status === "required"
-    && modelUsedLooksLikeProExtended(selection?.model_used);
+    && selection?.requested_model === "gpt-5-6-sol-pro"
+    && selection?.family_status === "verified"
+    && selection?.effort_status === "verified"
+    && modelUsedLooksLikeSolPro(selection?.model_used);
 }
 
-function modelUsedLooksLikeProExtended(value) {
+function modelUsedLooksLikeSolPro(value) {
   const folded = String(value ?? "").toLowerCase();
-  return /\bpro\b/.test(folded) && /\bextended\b/.test(folded);
+  return /\bsol\b/.test(folded) && /\bpro\b/.test(folded);
 }
 
 function hasFinalAssistantAffordance(extraction) {

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -74,7 +74,7 @@ export async function uploadFile(_document, file, options) {
 
 export function configureModelState(_document, job) {
   hooks.configureModelCalls.push(job);
-  return { status: "selected", model_used: "Pro • Extended", requested_model: "extended-pro", extended_status: "required" };
+  return { status: "selected", model_used: "GPT-5.6 Sol Pro", requested_model: "gpt-5-6-sol-pro", family_status: "verified", effort_status: "verified" };
 }
 
 export function sendAcceptanceBaseline() {

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -1939,6 +1939,20 @@ test("GPT-5.6 Sol picker switches GPT-5.5 Instant to Sol Pro", async () => {
   assert.equal(fixture.menusOpen(), 0);
 });
 
+test("GPT-5.6 Sol picker recovers from the o3 family", async () => {
+  const fixture = makeSolPickerFixture({ family: "o3", effort: "High" });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "selected");
+  assert.equal(result.model_used, "GPT-5.6 Sol Pro");
+  assert.equal(result.family_status, "verified");
+  assert.equal(result.effort_status, "verified");
+  assert.equal(fixture.familyClicks(), 1);
+  assert.equal(fixture.effortClicks(), 1);
+  assert.equal(fixture.menusOpen(), 0);
+});
+
 test("GPT-5.6 Sol picker verifies already-correct state with one menu open", async () => {
   const fixture = makeSolPickerFixture({ family: "GPT-5.6 Sol", effort: "Pro" });
 
@@ -1948,12 +1962,27 @@ test("GPT-5.6 Sol picker verifies already-correct state with one menu open", asy
   assert.equal(result.model_used, "GPT-5.6 Sol Pro");
   assert.equal(result.family_status, "verified");
   assert.equal(result.effort_status, "verified");
-  assert.ok(result.available_families.includes("GPT-5.6 Sol"));
-  assert.ok(result.available_families.includes("GPT-5.5"));
+  assert.deepEqual(result.available_families, []);
   assert.equal(fixture.mainOpens(), 1);
   assert.equal(fixture.familyClicks(), 0);
   assert.equal(fixture.effortClicks(), 0);
   assert.equal(fixture.menusOpen(), 0);
+});
+
+test("GPT-5.6 Sol picker fails closed when Escape cannot close the menu", async () => {
+  const fixture = makeSolPickerFixture({
+    family: "GPT-5.6 Sol",
+    effort: "Pro",
+    escapeCloses: false
+  });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "unavailable");
+  assert.equal(result.family_status, "verified");
+  assert.equal(result.effort_status, "verified");
+  assert.match(result.warning, /picker remained open/);
+  assert.equal(fixture.menusOpen(), 1);
 });
 
 test("GPT-5.6 Sol picker fails loudly on the legacy model-switcher DOM", async () => {
@@ -1978,7 +2007,7 @@ test("GPT-5.6 Sol picker fails loudly on the legacy model-switcher DOM", async (
   assert.equal(legacyButton.events.includes("pointerdown"), false);
 });
 
-function makeSolPickerFixture({ family, effort }) {
+function makeSolPickerFixture({ family, effort, escapeCloses = true }) {
   let currentFamily = family;
   let currentEffort = effort;
   let mainOpenCount = 0;
@@ -2077,7 +2106,7 @@ function makeSolPickerFixture({ family, effort }) {
     "aria-haspopup": "menu",
     onPointerDown: openMainMenu,
     onKeyDown: (event) => {
-      if (event.key === "Escape") closeMenus();
+      if (event.key === "Escape" && escapeCloses) closeMenus();
     }
   });
   form.append(pill);

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -33,10 +33,12 @@ class FakeElement {
     this.innerText = text;
     this.onClick = attrs.onClick;
     this.onPointerDown = attrs.onPointerDown;
+    this.onKeyDown = attrs.onKeyDown;
     this.hidden = Boolean(attrs.hidden);
     this.onChange = attrs.onChange;
     delete this.attrs.onClick;
     delete this.attrs.onPointerDown;
+    delete this.attrs.onKeyDown;
     delete this.attrs.onChange;
   }
 
@@ -78,6 +80,9 @@ class FakeElement {
     if (event.type === "click") {
       this.recordClick();
       this.onClick?.(event);
+    }
+    if (event.type === "keydown") {
+      this.onKeyDown?.(event);
     }
     if (event.type === "change") {
       this.onChange?.();
@@ -127,6 +132,13 @@ class FakeDocument {
     this.body = body;
     this.documentElement = new FakeElement("html").append(body);
     this.defaultView = {
+      KeyboardEvent: class extends Event {
+        constructor(type, init = {}) {
+          super(type, init);
+          this.key = init.key;
+          this.code = init.code;
+        }
+      },
       getComputedStyle: (element) => {
         const style = String(element.attrs.style ?? "");
         return {
@@ -529,6 +541,21 @@ test("extractResponse ignores ChatGPT model status text when assistant content i
   assert.equal(extraction.has_copy_button, true);
 });
 
+test("extractResponse recognizes new GPT-5.6 picker labels only as whole-line status chrome", () => {
+  for (const status of ["Sol", "Instant", "Medium", "High", "Extra High", "Pro", "GPT-5.6 Sol", "5.6 Pro", "5.5 Extra High"]) {
+    const assistant = new FakeElement("article", { "data-message-author-role": "assistant" }, status)
+      .append(new FakeElement("button", { "aria-label": "Copy" }, "Copy"));
+    const doc = new FakeDocument(new FakeElement("body", {}, status).append(assistant));
+    assert.equal(extractResponse(doc).method, "page_text_fallback", `${status} should be treated as model chrome`);
+  }
+
+  const prose = "High confidence is earned through verification.";
+  const assistant = new FakeElement("article", { "data-message-author-role": "assistant" }, prose)
+    .append(new FakeElement("button", { "aria-label": "Copy" }, "Copy"));
+  const doc = new FakeDocument(new FakeElement("body", {}, prose).append(assistant));
+  assert.equal(extractResponse(doc).text, prose);
+});
+
 test("extractResponse prefers assistant markdown over wrapper model status text", () => {
   const copy = new FakeElement("button", { "aria-label": "Copy" }, "Copy");
   const assistant = new FakeElement("article", { "data-message-author-role": "assistant" }, "Pro thinking")
@@ -648,6 +675,8 @@ test("extractResponse selects the answer turn when its class embeds a chrome key
   assert.equal(extraction.has_copy_button, true);
   assert.equal(extraction.is_generating, false);
   assert.notEqual(extraction.turn_index, -1);
+  assert.equal(extraction.model_slug, "gpt-5-5-pro");
+  assert.ok(extraction.diagnostics.assistant_turn_snippets.some((entry) => entry.model_slug === "gpt-5-5-pro"));
 });
 
 test("extractResponse diagnostics expose textContent length next to innerText length for the truncation fork", () => {
@@ -1866,637 +1895,204 @@ test("clickSend reports disabled send controls distinctly from missing controls"
   assert.equal(send.clicked, false);
 });
 
-test("fake ChatGPT model controls always select Pro Extended", async () => {
+test("GPT-5.6 Sol picker rejects checked GPT-5.5 Pro Extended as stale", async () => {
+  const fixture = makeSolPickerFixture({ family: "GPT-5.5", effort: "Pro Extended" });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "selected");
+  assert.equal(result.model_used, "GPT-5.6 Sol Pro");
+  assert.equal(result.requested_model, "gpt-5-6-sol-pro");
+  assert.equal(result.family_status, "verified");
+  assert.equal(result.effort_status, "verified");
+  assert.equal(fixture.familyClicks(), 1);
+  assert.equal(fixture.effortClicks(), 0, "family switch should preserve the Pro tier");
+});
+
+test("GPT-5.6 Sol picker upgrades High effort to Pro and verifies both proofs", async () => {
+  const fixture = makeSolPickerFixture({ family: "GPT-5.6 Sol", effort: "High" });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "selected");
+  assert.equal(result.model_used, "GPT-5.6 Sol Pro");
+  assert.equal(result.family_status, "verified");
+  assert.equal(result.effort_status, "verified");
+  assert.equal(fixture.familyClicks(), 0);
+  assert.equal(fixture.effortClicks(), 1);
+  assert.ok(fixture.mainOpens() >= 2, "selection must reopen the picker to verify");
+  assert.equal(fixture.menusOpen(), 0, "verification must leave the picker closed");
+});
+
+test("GPT-5.6 Sol picker switches GPT-5.5 Instant to Sol Pro", async () => {
+  const fixture = makeSolPickerFixture({ family: "GPT-5.5", effort: "Instant" });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "selected");
+  assert.equal(result.model_used, "GPT-5.6 Sol Pro");
+  assert.equal(result.family_status, "verified");
+  assert.equal(result.effort_status, "verified");
+  assert.equal(fixture.familyClicks(), 1);
+  assert.equal(fixture.effortClicks(), 1);
+  assert.ok(fixture.pill.events.includes("pointerdown"));
+  assert.equal(fixture.menusOpen(), 0);
+});
+
+test("GPT-5.6 Sol picker verifies already-correct state with one menu open", async () => {
+  const fixture = makeSolPickerFixture({ family: "GPT-5.6 Sol", effort: "Pro" });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "selected");
+  assert.equal(result.model_used, "GPT-5.6 Sol Pro");
+  assert.equal(result.family_status, "verified");
+  assert.equal(result.effort_status, "verified");
+  assert.ok(result.available_families.includes("GPT-5.6 Sol"));
+  assert.ok(result.available_families.includes("GPT-5.5"));
+  assert.equal(fixture.mainOpens(), 1);
+  assert.equal(fixture.familyClicks(), 0);
+  assert.equal(fixture.effortClicks(), 0);
+  assert.equal(fixture.menusOpen(), 0);
+});
+
+test("GPT-5.6 Sol picker fails loudly on the legacy model-switcher DOM", async () => {
   const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
-  const modelButton = new FakeElement("button", {
+  const legacyButton = new FakeElement("button", {
     "data-testid": "model-switcher-dropdown-button",
-    "aria-haspopup": "menu",
-    onClick: () => {
-      for (const option of [instantOption, thinkingOption, extendedProOption]) {
-        if (!body.children.includes(option)) {
-          body.append(option);
-        }
-      }
-    }
-  }, "Instant");
-  const extended = new FakeElement("button", { "aria-label": "click to remove Extended" }, "Extended");
-  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Instant");
-  const instantOption = new FakeElement("div", { role: "menuitemradio" }, "Instant");
-  const thinkingOption = new FakeElement("div", { role: "menuitemradio" }, "Thinking");
-  const extendedProOption = new FakeElement("div", {
-    role: "menuitemradio",
-    "data-testid": "model-switcher-gpt-5-5-pro",
-    onClick: () => {
-      selected.innerText = "Pro • Extended";
-      selected.textContent = "Pro • Extended";
-    }
-  }, "Pro • Extended");
-  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
-  const body = new FakeElement("body", {}, "Ask anything Instant")
-    .append(extended, form, selected);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {});
-
-  assert.equal(extended.clicked, false);
-  assert.equal(modelButton.clicked, true);
-  assert.equal(instantOption.clicked, false);
-  assert.equal(thinkingOption.clicked, false);
-  assert.equal(extendedProOption.clicked, true);
-  assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "Pro • Extended");
-  assert.equal(result.extended_status, "required");
-  assert.equal(result.warning, null);
-});
-
-test("fake ChatGPT waits for late Pro Extended option before selecting", async () => {
-  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
-  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Instant");
-  const instantOption = new FakeElement("div", {
-    role: "menuitemradio",
-    "data-testid": "model-switcher-gpt-5-5"
-  }, "Instant");
-  const thinkingOption = new FakeElement("div", {
-    role: "menuitemradio",
-    "data-testid": "model-switcher-gpt-5-5-thinking"
-  }, "Thinking");
-  const proOption = new FakeElement("div", {
-    role: "menuitemradio",
-    "data-testid": "model-switcher-gpt-5-5-pro",
-    onClick: () => {
-      selected.innerText = "Pro • Extended";
-      selected.textContent = "Pro • Extended";
-    }
-  }, "Pro • Extended");
-  const modelButton = new FakeElement("button", {
-    "data-testid": "model-switcher-dropdown-button",
-    "aria-haspopup": "menu",
-    onClick: () => {
-      body.append(instantOption, thinkingOption);
-      setTimeout(() => body.append(proOption), 250);
-    }
-  }, "Instant");
-  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
-  const body = new FakeElement("body", {}, "Ask anything Instant Thinking").append(form, selected);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {});
-
-  assert.equal(modelButton.clicked, true);
-  assert.equal(instantOption.clicked, false);
-  assert.equal(thinkingOption.clicked, false);
-  assert.equal(proOption.clicked, true);
-  assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "Pro • Extended");
-});
-
-test("fake ChatGPT keeps waiting when non-Pro options render before Pro Extended", async () => {
-  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
-  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Instant");
-  const instantOption = new FakeElement("div", {
-    role: "menuitemradio",
-    "data-testid": "model-switcher-gpt-5-5"
-  }, "Instant");
-  const thinkingOption = new FakeElement("div", {
-    role: "menuitemradio",
-    "data-testid": "model-switcher-gpt-5-5-thinking"
-  }, "Thinking");
-  const proOption = new FakeElement("div", {
-    role: "menuitemradio",
-    "data-testid": "model-switcher-gpt-5-5-pro",
-    onClick: () => {
-      selected.innerText = "Pro • Extended";
-      selected.textContent = "Pro • Extended";
-    }
-  }, "Pro • Extended");
-  const modelButton = new FakeElement("button", {
-    "data-testid": "model-switcher-dropdown-button",
-    "aria-haspopup": "menu",
-    onClick: () => {
-      if (!body.children.includes(instantOption)) {
-        body.append(instantOption, thinkingOption);
-        setTimeout(() => body.append(proOption), 900);
-      }
-    }
-  }, "Instant");
-  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
-  const body = new FakeElement("body", {}, "Ask anything Instant Thinking").append(form, selected);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {});
-
-  assert.equal(proOption.clicked, true);
-  assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "Pro • Extended");
-});
-
-test("fake ChatGPT opens model menu with pointer events when DOM click does not open it", async () => {
-  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
-  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Thinking");
-  const proOption = new FakeElement("div", {
-    role: "menuitemradio",
-    "data-testid": "model-switcher-gpt-5-5-pro",
-    onClick: () => {
-      selected.innerText = "Pro • Extended";
-      selected.textContent = "Pro • Extended";
-    }
-  }, "Pro • Extended");
-  const modelButton = new FakeElement("button", {
-    "data-testid": "model-switcher-dropdown-button",
-    "aria-haspopup": "menu",
-    onPointerDown: () => {
-      if (!body.children.includes(proOption)) {
-        body.append(proOption);
-      }
-    }
-  }, "Thinking");
-  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
-  const body = new FakeElement("body", {}, "Ask anything Thinking").append(form, selected);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {});
-
-  assert.ok(modelButton.events.includes("pointerdown"));
-  assert.equal(modelButton.clicked, false);
-  assert.equal(proOption.clicked, true);
-  assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "Pro • Extended");
-});
-
-test("fake ChatGPT stops opening sequence when pointerdown opens the menu", async () => {
-  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
-  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Thinking");
-  const proOption = new FakeElement("div", {
-    role: "menuitemradio",
-    "data-testid": "model-switcher-gpt-5-5-pro",
-    onClick: () => {
-      selected.innerText = "Pro • Extended";
-      selected.textContent = "Pro • Extended";
-    }
-  }, "Pro • Extended");
-  const modelButton = new FakeElement("button", {
-    "data-testid": "model-switcher-dropdown-button",
-    "aria-haspopup": "menu",
-    onPointerDown: () => {
-      if (!body.children.includes(proOption)) {
-        body.append(proOption);
-      }
-    },
-    onClick: () => {
-      body.children = body.children.filter((child) => child !== proOption);
-    }
-  }, "Thinking");
-  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
-  const body = new FakeElement("body", {}, "Ask anything Thinking").append(form, selected);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {});
-
-  assert.ok(modelButton.events.includes("pointerdown"));
-  assert.equal(modelButton.events.includes("click"), false);
-  assert.equal(proOption.clicked, true);
-  assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "Pro • Extended");
-});
-
-test("fake personal ChatGPT composer model chip selects Pro Extended", async () => {
-  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
-  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Thinking");
-  const proOption = new FakeElement("div", {
-    role: "menuitemradio",
-    "data-testid": "model-switcher-gpt-5-5-pro",
-    onClick: () => {
-      selected.innerText = "Pro • Extended";
-      selected.textContent = "Pro • Extended";
-    }
-  }, "Pro • Extended");
-  const modelChip = new FakeElement("button", {
-    class: "model-chip",
-    "aria-haspopup": "menu",
-    onPointerDown: () => {
-      if (!body.children.includes(proOption)) {
-        body.append(proOption);
-      }
-    }
-  }, "Thinking");
-  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelChip);
-  const body = new FakeElement("body", {}, "Ask anything Thinking").append(form, selected);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {});
-
-  assert.ok(modelChip.events.includes("pointerdown"));
-  assert.equal(modelChip.clicked, false);
-  assert.equal(proOption.clicked, true);
-  assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "Pro • Extended");
-  assert.equal(result.extended_status, "required");
-});
-
-test("fake personal ChatGPT composer model chip verifies the chip label after the menu closes", async () => {
-  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
-  const proOption = new FakeElement("div", {
-    role: "menuitemradio",
-    "data-testid": "model-switcher-gpt-5-5-pro",
-    onClick: () => {
-      modelChip.innerText = "Pro Extended";
-      modelChip.textContent = "Pro Extended";
-      body.children = body.children.filter((child) => child !== proOption);
-    }
-  }, "Pro Extended");
-  const modelChip = new FakeElement("button", {
-    class: "model-chip",
-    "aria-haspopup": "menu",
-    onPointerDown: () => {
-      if (!body.children.includes(proOption)) {
-        body.append(proOption);
-      }
-    }
-  }, "Thinking");
-  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelChip);
-  const body = new FakeElement("body", {}, "Ask anything Thinking").append(form);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {});
-
-  assert.ok(modelChip.events.includes("pointerdown"));
-  assert.equal(proOption.clicked, true);
-  assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "Pro Extended");
-  assert.equal(result.extended_status, "required");
-});
-
-test("fake personal ChatGPT composer model chip accepts already selected Extended Pro", async () => {
-  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
-  const modelChip = new FakeElement("button", {
-    class: "model-chip",
-    "aria-haspopup": "menu",
-    onPointerDown: () => {
-      throw new Error("already selected Pro Extended should not open the picker");
-    }
-  }, "Extended Pro");
-  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelChip);
-  const body = new FakeElement("body", {}, "Ask anything Extended Pro").append(form);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {});
-
-  assert.equal(modelChip.events.includes("pointerdown"), false);
-  assert.equal(modelChip.clicked, false);
-  assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "Extended Pro");
-  assert.equal(result.extended_status, "required");
-});
-
-test("fake ChatGPT finds visible Extended Pro control before composer scope exists", () => {
-  const modelChip = new FakeElement("button", {
-    class: "__composer-pill __composer-pill--neutral group/pill",
     "aria-haspopup": "menu"
-  }, "Extended Pro");
-  const body = new FakeElement("body", {}, "Extended Pro").append(modelChip);
-  const doc = new FakeDocument(body);
-
-  assert.equal(findModelButton(doc), modelChip);
-});
-
-test("fake ChatGPT accepts hydrated already selected Extended Pro before selector exists", async () => {
-  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
-  const body = new FakeElement("body", {}, "Ask anything").append(composer);
-  const doc = new FakeDocument(body);
-  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Extended Pro");
-  setTimeout(() => body.append(selected), 250);
-
-  const result = await configureModelState(doc, {});
-
-  assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "Extended Pro");
-  assert.equal(result.extended_status, "required");
-});
-
-test("fake personal ChatGPT composer pill can live outside the inner composer scope", async () => {
-  const composer = new FakeElement("div", { id: "prompt-textarea", role: "textbox" }, "");
-  const innerComposer = new FakeElement("div", { class: "deep-research-composer-shell" }, "").append(composer);
-  const modelPill = new FakeElement("button", {
-    class: "__composer-pill __composer-pill--neutral group/pill",
-    "aria-haspopup": "menu",
-    onPointerDown: () => {
-      throw new Error("already selected Pro Extended should not open the picker");
-    }
-  }, "Extended Pro");
-  const trailingControls = new FakeElement("div", { class: "composer-trailing-controls" }, "").append(modelPill);
-  const main = new FakeElement("main", {}, "Ask anything Extended Pro").append(innerComposer, trailingControls);
-  const body = new FakeElement("body", {}, "Ask anything Extended Pro").append(main);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {});
-
-  assert.equal(modelPill.events.includes("pointerdown"), false);
-  assert.equal(modelPill.clicked, false);
-  assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "Extended Pro");
-  assert.equal(result.extended_status, "required");
-});
-
-test("fake ChatGPT accepts Pro Extended label that appears after the picker stays empty", async () => {
-  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
-  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Thinking");
-  const modelButton = new FakeElement("button", {
-    "data-testid": "model-switcher-dropdown-button",
-    "aria-haspopup": "menu",
-    onPointerDown: () => {
-      setTimeout(() => {
-        selected.innerText = "Extended Pro";
-        selected.textContent = "Extended Pro";
-      }, 500);
-    }
-  }, "Thinking");
-  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
-  const body = new FakeElement("body", {}, "Ask anything Thinking").append(form, selected);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {});
-
-  assert.ok(modelButton.events.includes("pointerdown"));
-  assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "Extended Pro");
-  assert.equal(result.extended_status, "required");
-});
-
-test("fake ChatGPT resume selects Enterprise header model switcher", async () => {
-  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
-  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Thinking");
-  const proOption = new FakeElement("div", {
-    role: "menuitemradio",
-    "data-testid": "model-switcher-gpt-5-5-pro",
-    onClick: () => {
-      selected.innerText = "Pro Extended";
-      selected.textContent = "Pro Extended";
-    }
   }, "Pro Extended");
-  const modelButton = new FakeElement("button", {
-    "data-testid": "model-switcher-dropdown-button",
-    "aria-haspopup": "menu",
-    onPointerDown: () => {
-      if (!body.children.includes(proOption)) {
-        body.append(proOption);
-      }
-    }
-  }, "Thinking").append(selected);
-  const header = new FakeElement("header", {}, "Thinking").append(modelButton);
-  const main = new FakeElement("main", {}, "Ask anything").append(composer);
-  const body = new FakeElement("body", {}, "Thinking Ask anything").append(header, main);
+  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer);
+  const body = new FakeElement("body", {}, "Ask anything Pro Extended").append(form, legacyButton);
   const doc = new FakeDocument(body);
-  doc.defaultView.location.pathname = "/c/conv-123";
-
-  const result = await configureModelState(doc, { conversation_id: "conv-123" });
-
-  assert.ok(modelButton.events.includes("pointerdown"));
-  assert.equal(proOption.clicked, true);
-  assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "Pro Extended");
-  assert.equal(result.extended_status, "required");
-});
-
-test("fake ChatGPT resume selects personal composer model picker", async () => {
-  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
-  const proOption = new FakeElement("div", {
-    role: "menuitemradio",
-    "data-testid": "model-switcher-gpt-5-5-pro",
-    onClick: () => {
-      modelChip.innerText = "Pro Extended";
-      modelChip.textContent = "Pro Extended";
-      body.children = body.children.filter((child) => child !== proOption);
-    }
-  }, "Pro Extended");
-  const modelChip = new FakeElement("button", {
-    class: "model-chip",
-    "aria-haspopup": "menu",
-    onPointerDown: () => {
-      if (!body.children.includes(proOption)) {
-        body.append(proOption);
-      }
-    }
-  }, "Thinking");
-  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelChip);
-  const body = new FakeElement("body", {}, "Ask anything Thinking").append(form);
-  const doc = new FakeDocument(body);
-  doc.defaultView.location.pathname = "/c/conv-123";
-
-  const result = await configureModelState(doc, { conversation_id: "conv-123" });
-
-  assert.ok(modelChip.events.includes("pointerdown"));
-  assert.equal(proOption.clicked, true);
-  assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "Pro Extended");
-  assert.equal(result.extended_status, "required");
-});
-
-test("fake ChatGPT resume treats stale transcript model chip as unavailable", async () => {
-  const staleModelChip = new FakeElement("button", {
-    class: "model-chip",
-    "aria-haspopup": "menu",
-    onPointerDown: () => {
-      throw new Error("stale transcript model chip should not be opened");
-    }
-  }, "Extended Pro");
-  const staleTranscript = new FakeElement("section", { class: "old-transcript-row" }, "Earlier model Extended Pro")
-    .append(staleModelChip);
-  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
-  const main = new FakeElement("main", {}, "Earlier model Extended Pro Ask anything")
-    .append(staleTranscript, composer);
-  const body = new FakeElement("body", {}, "Earlier model Extended Pro Ask anything").append(main);
-  const doc = new FakeDocument(body);
-  doc.defaultView.location.pathname = "/c/conv-123";
 
   const result = await configureModelState(doc, {
-    conversation_id: "conv-123",
     model_selection_timeout_ms: 30,
     model_selection_interval_ms: 10
   });
 
-  assert.equal(staleModelChip.events.includes("pointerdown"), false);
-  assert.equal(staleModelChip.clicked, false);
   assert.equal(result.status, "unavailable");
-  assert.equal(result.extended_status, "required");
-  assert.match(result.warning, /model selector button not found/);
+  assert.equal(result.family_status, "unverified");
+  assert.equal(result.effort_status, "unverified");
+  assert.match(result.warning, /legacy ChatGPT picker detected; this yoetz version requires the GPT-5\.6 UI/);
+  assert.equal(legacyButton.events.includes("pointerdown"), false);
 });
 
-test("fake ChatGPT resume does not accept stale conversation Pro Extended labels as current model", async () => {
-  const staleConversationControl = new FakeElement("button", {}, "Pro Extended");
-  const staleSelectedLabel = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Pro Extended");
-  const priorAssistant = new FakeElement("article", { "data-message-author-role": "assistant" }, "")
-    .append(staleConversationControl, staleSelectedLabel);
+function makeSolPickerFixture({ family, effort }) {
+  let currentFamily = family;
+  let currentEffort = effort;
+  let mainOpenCount = 0;
+  let familyClickCount = 0;
+  let effortClickCount = 0;
+  let mainMenu = null;
+  let familyMenu = null;
+
   const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
   const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer);
-  const body = new FakeElement("body", {}, "Pro Extended Ask anything")
-    .append(priorAssistant, form);
-  const doc = new FakeDocument(body);
-  doc.defaultView.location.pathname = "/c/conv-123";
+  const body = new FakeElement("body", {}, "Ask anything").append(form);
 
-  const result = await configureModelState(doc, {
-    conversation_id: "conv-123",
-    model_selection_timeout_ms: 30,
-    model_selection_interval_ms: 10
-  });
-
-  assert.equal(staleConversationControl.clicked, false);
-  assert.equal(result.status, "unavailable");
-  assert.equal(result.extended_status, "required");
-  assert.match(result.warning, /model selector button not found/);
-});
-
-test("fake ChatGPT resume ignores stale transcript model switcher buttons", async () => {
-  const staleSelectedLabel = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Pro Extended");
-  const staleConversationControl = new FakeElement("button", {
-    "data-testid": "model-switcher-dropdown-button",
-    "aria-haspopup": "menu",
-    onPointerDown: () => {
-      throw new Error("stale transcript model button should not be opened");
-    }
-  }, "Pro Extended").append(staleSelectedLabel);
-  const priorAssistant = new FakeElement("article", { "data-message-author-role": "assistant" }, "")
-    .append(staleConversationControl);
-  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
-  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer);
-  const body = new FakeElement("body", {}, "Pro Extended Ask anything")
-    .append(priorAssistant, form);
-  const doc = new FakeDocument(body);
-  doc.defaultView.location.pathname = "/c/conv-123";
-
-  const result = await configureModelState(doc, {
-    conversation_id: "conv-123",
-    model_selection_timeout_ms: 30,
-    model_selection_interval_ms: 10
-  });
-
-  assert.equal(staleConversationControl.clicked, false);
-  assert.equal(staleConversationControl.events.includes("pointerdown"), false);
-  assert.equal(result.status, "unavailable");
-  assert.equal(result.extended_status, "required");
-  assert.match(result.warning, /model selector button not found/);
-});
-
-test("fake ChatGPT reports mismatch when option checks but selected label stays Thinking", async () => {
-  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
-  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Thinking");
-  const proOption = new FakeElement("div", {
-    role: "menuitemradio",
-    "data-testid": "model-switcher-gpt-5-5-pro",
-    onClick: () => {
-      proOption.attrs["aria-checked"] = "true";
-    }
-  }, "Pro • Extended");
-  const modelButton = new FakeElement("button", {
-    "data-testid": "model-switcher-dropdown-button",
-    "aria-haspopup": "menu",
-    onClick: () => {
-      if (!body.children.includes(proOption)) {
-        body.append(proOption);
-      }
-    }
-  }, "Thinking");
-  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
-  const body = new FakeElement("body", {}, "Ask anything Thinking").append(form, selected);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {});
-
-  assert.equal(proOption.clicked, true);
-  assert.equal(result.status, "mismatch");
-  assert.equal(result.model_used, "Thinking");
-  assert.match(result.warning, /selected label is Thinking/);
-});
-
-test("fake ChatGPT does not certify transient Pro text on an open dropdown", async () => {
-  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
-  const proOption = new FakeElement("div", {
-    role: "menuitemradio",
-    "data-testid": "model-switcher-gpt-5-5-pro",
-    onClick: () => {
-      modelButton.innerText = "Pro • Extended";
-      modelButton.textContent = "Pro • Extended";
-      modelButton.attrs["aria-selected"] = "true";
-    }
-  }, "Pro • Extended");
-  const modelButton = new FakeElement("button", {
-    "data-testid": "model-switcher-dropdown-button",
-    "aria-haspopup": "menu",
-    onClick: () => {
-      if (!body.children.includes(proOption)) {
-        body.append(proOption);
-      }
-    }
-  }, "Thinking");
-  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelButton);
-  const body = new FakeElement("body", {}, "Ask anything Thinking").append(form);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {});
-
-  assert.equal(proOption.clicked, true);
-  assert.equal(result.status, "mismatch");
-  assert.equal(result.model_used, "unknown");
-  assert.match(result.warning, /selected label is unknown/);
-});
-
-test("fake ChatGPT fails when Pro Extended is absent", async () => {
-  const modelButton = new FakeElement("button", {
-    "data-testid": "model-switcher-dropdown-button",
-    "aria-haspopup": "menu",
-    onClick: () => {
-      for (const option of [instantOption, thinkingOption]) {
-        if (!body.children.includes(option)) {
-          body.append(option);
+  const removeMenu = (menu) => {
+    if (!menu) return;
+    body.children = body.children.filter((child) => child !== menu);
+    menu.parentElement = null;
+  };
+  const closeMenus = () => {
+    removeMenu(mainMenu);
+    removeMenu(familyMenu);
+    mainMenu = null;
+    familyMenu = null;
+  };
+  const updatePill = () => {
+    const pillEffort = currentEffort === "Pro Extended" ? "Pro" : currentEffort;
+    const label = currentFamily === "GPT-5.6 Sol" ? pillEffort : `5.5\n${pillEffort}`;
+    pill.innerText = label;
+    pill.textContent = label;
+  };
+  const effortLabels = () => currentFamily === "GPT-5.6 Sol"
+    ? ["Instant\n5.5", "Medium", "High", "Extra High", "Pro"]
+    : ["Instant", "Medium", "High", "Extra High", "Pro Extended"];
+  const openFamilyMenu = () => {
+    removeMenu(familyMenu);
+    familyMenu = new FakeElement("div", { role: "menu", "data-radix-menu-content": "" });
+    for (const label of ["GPT-5.6 Sol", "GPT-5.5", "GPT-5.4\nLeaving on July 23", "GPT-5.3", "o3"]) {
+      const radio = new FakeElement("div", {
+        role: "menuitemradio",
+        "aria-checked": String(label === currentFamily),
+        "data-state": label === currentFamily ? "checked" : "unchecked",
+        onClick: () => {
+          if (label === "GPT-5.6 Sol" || label === "GPT-5.5") {
+            currentFamily = label;
+            if (currentFamily === "GPT-5.6 Sol") {
+              currentEffort = currentEffort === "Pro Extended" ? "Pro" : currentEffort === "Instant" ? "Medium" : currentEffort;
+            } else if (currentEffort === "Pro") {
+              currentEffort = "Pro Extended";
+            }
+            familyClickCount += 1;
+            updatePill();
+          }
+          closeMenus();
         }
-      }
+      }, label);
+      familyMenu.append(radio);
     }
-  }, "ChatGPT");
-  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Instant");
-  const instantOption = new FakeElement("div", { role: "menuitemradio" }, "Instant");
-  const thinkingOption = new FakeElement("div", { role: "menuitemradio" }, "Thinking");
-  const body = new FakeElement("body", {}, "ChatGPT Instant Thinking")
-    .append(modelButton, selected);
-  const doc = new FakeDocument(body);
-
-  const result = await configureModelState(doc, {});
-
-  assert.equal(modelButton.clicked, true);
-  assert.equal(instantOption.clicked, false);
-  assert.equal(thinkingOption.clicked, false);
-  assert.equal(result.status, "unavailable");
-  assert.equal(result.extended_status, "required");
-  assert.match(result.warning, /Pro Extended was not visible/);
-});
-
-test("fake personal ChatGPT composer model chip fails when Pro Extended is absent", async () => {
-  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
-  const selected = new FakeElement("span", { "data-testid": "model-switcher-selected-model" }, "Thinking");
-  const instantOption = new FakeElement("div", { role: "menuitemradio" }, "Instant");
-  const thinkingOption = new FakeElement("div", { role: "menuitemradio" }, "Thinking");
-  const modelChip = new FakeElement("button", {
-    class: "model-chip",
-    "aria-haspopup": "menu",
-    onPointerDown: () => {
-      for (const option of [instantOption, thinkingOption]) {
-        if (!body.children.includes(option)) {
-          body.append(option);
+    body.append(familyMenu);
+  };
+  const openMainMenu = () => {
+    closeMenus();
+    mainOpenCount += 1;
+    mainMenu = new FakeElement("div", { role: "menu", "data-radix-menu-content": "" });
+    mainMenu.append(new FakeElement("div", {}, "Intelligence"));
+    for (const label of effortLabels()) {
+      const checked = label === currentEffort;
+      const radio = new FakeElement("div", {
+        role: "menuitemradio",
+        "aria-checked": String(checked),
+        "data-state": checked ? "checked" : "unchecked",
+        class: "group __menu-item",
+        onClick: () => {
+          effortClickCount += 1;
+          if (label === "Instant\n5.5") {
+            currentFamily = "GPT-5.5";
+            currentEffort = "Instant";
+          } else {
+            currentEffort = label;
+          }
+          updatePill();
+          closeMenus();
         }
-      }
+      }, label);
+      mainMenu.append(radio);
     }
-  }, "Thinking");
-  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer, modelChip);
-  const body = new FakeElement("body", {}, "Ask anything Thinking").append(form, selected);
+    mainMenu.append(new FakeElement("div", {
+      role: "menuitem",
+      "aria-haspopup": "menu",
+      onPointerDown: openFamilyMenu
+    }, currentFamily));
+    mainMenu.append(new FakeElement("div", { role: "menuitem", "aria-haspopup": "menu" }, ""));
+    body.append(mainMenu);
+  };
+
+  const pill = new FakeElement("button", {
+    class: "__composer-pill __composer-pill--neutral text-body-regular! group/pill",
+    "aria-haspopup": "menu",
+    onPointerDown: openMainMenu,
+    onKeyDown: (event) => {
+      if (event.key === "Escape") closeMenus();
+    }
+  });
+  form.append(pill);
+  updatePill();
   const doc = new FakeDocument(body);
 
-  const result = await configureModelState(doc, {});
-
-  assert.ok(modelChip.events.includes("pointerdown"));
-  assert.equal(instantOption.clicked, false);
-  assert.equal(thinkingOption.clicked, false);
-  assert.equal(result.status, "unavailable");
-  assert.equal(result.extended_status, "required");
-  assert.match(result.warning, /Pro Extended was not visible/);
-});
+  return {
+    doc,
+    pill,
+    mainOpens: () => mainOpenCount,
+    familyClicks: () => familyClickCount,
+    effortClicks: () => effortClickCount,
+    menusOpen: () => [mainMenu, familyMenu].filter(Boolean).length
+  };
+}
 
 function flatten(root) {
   return [root, ...root.children.flatMap(flatten)];
@@ -2681,6 +2277,9 @@ function matchesSimpleSelector(element, selector) {
   if (selector.includes('[data-message-author-role="assistant"]')) {
     return attr("data-message-author-role") === "assistant";
   }
+  if (selector.includes('[data-message-model-slug]')) {
+    return Boolean(attr("data-message-model-slug"));
+  }
   if (selector.includes('[data-message-author-role="user"]')) {
     return attr("data-message-author-role") === "user";
   }
@@ -2689,6 +2288,9 @@ function matchesSimpleSelector(element, selector) {
   }
   if (selector.includes('[role="menuitemradio"]')) {
     return attr("role") === "menuitemradio";
+  }
+  if (selector.includes('[role="menu"]')) {
+    return attr("role") === "menu";
   }
   if (selector.includes('[role="option"]')) {
     return attr("role") === "option";

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -1925,7 +1925,11 @@ test("GPT-5.6 Sol picker upgrades High effort to Pro and verifies both proofs", 
 });
 
 test("GPT-5.6 Sol picker switches GPT-5.5 Instant to Sol Pro", async () => {
-  const fixture = makeSolPickerFixture({ family: "GPT-5.5", effort: "Instant" });
+  const fixture = makeSolPickerFixture({
+    family: "GPT-5.5",
+    effort: "Instant",
+    remountPillOnSelection: true
+  });
 
   const result = await configureModelState(fixture.doc, {});
 
@@ -2007,7 +2011,12 @@ test("GPT-5.6 Sol picker fails loudly on the legacy model-switcher DOM", async (
   assert.equal(legacyButton.events.includes("pointerdown"), false);
 });
 
-function makeSolPickerFixture({ family, effort, escapeCloses = true }) {
+function makeSolPickerFixture({
+  family,
+  effort,
+  escapeCloses = true,
+  remountPillOnSelection = false
+}) {
   let currentFamily = family;
   let currentEffort = effort;
   let mainOpenCount = 0;
@@ -2015,6 +2024,7 @@ function makeSolPickerFixture({ family, effort, escapeCloses = true }) {
   let effortClickCount = 0;
   let mainMenu = null;
   let familyMenu = null;
+  let pill = null;
 
   const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
   const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer);
@@ -2031,9 +2041,20 @@ function makeSolPickerFixture({ family, effort, escapeCloses = true }) {
     mainMenu = null;
     familyMenu = null;
   };
-  const updatePill = () => {
+  const updatePill = (remount = false) => {
     const pillEffort = currentEffort === "Pro Extended" ? "Pro" : currentEffort;
     const label = currentFamily === "GPT-5.6 Sol" ? pillEffort : `5.5\n${pillEffort}`;
+    if (remount && remountPillOnSelection) {
+      const previousPill = pill;
+      pill = createPill();
+      const index = form.children.indexOf(previousPill);
+      form.children[index] = pill;
+      pill.parentElement = form;
+      pill.ownerDocument = form.ownerDocument;
+      previousPill.parentElement = null;
+      previousPill.onPointerDown = undefined;
+      previousPill.onKeyDown = undefined;
+    }
     pill.innerText = label;
     pill.textContent = label;
   };
@@ -2057,7 +2078,7 @@ function makeSolPickerFixture({ family, effort, escapeCloses = true }) {
               currentEffort = "Pro Extended";
             }
             familyClickCount += 1;
-            updatePill();
+            updatePill(true);
           }
           closeMenus();
         }
@@ -2086,7 +2107,7 @@ function makeSolPickerFixture({ family, effort, escapeCloses = true }) {
           } else {
             currentEffort = label;
           }
-          updatePill();
+          updatePill(true);
           closeMenus();
         }
       }, label);
@@ -2101,7 +2122,7 @@ function makeSolPickerFixture({ family, effort, escapeCloses = true }) {
     body.append(mainMenu);
   };
 
-  const pill = new FakeElement("button", {
+  const createPill = () => new FakeElement("button", {
     class: "__composer-pill __composer-pill--neutral text-body-regular! group/pill",
     "aria-haspopup": "menu",
     onPointerDown: openMainMenu,
@@ -2109,6 +2130,7 @@ function makeSolPickerFixture({ family, effort, escapeCloses = true }) {
       if (event.key === "Escape" && escapeCloses) closeMenus();
     }
   });
+  pill = createPill();
   form.append(pill);
   updatePill();
   const doc = new FakeDocument(body);

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -51,7 +51,7 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro • Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -136,7 +136,7 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
     assert.equal(sentToTabs.filter((item) => item.message.type === "yoetz_upload_file").length, 2);
     assert.equal(
       sentToTabs.find((item) => item.message.type === "yoetz_configure_model" && item.message.job.job_id === "job_b")?.message.job.model,
-      "extended-pro"
+      "gpt-5-6-sol-pro"
     );
   } finally {
     globalThis.chrome = originalChrome;
@@ -286,7 +286,7 @@ test("service worker opens fresh and resume jobs in new owned tabs", async () =>
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro • Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           default:
             throw new Error(`unexpected tab message ${message.type}`);
         }
@@ -414,7 +414,7 @@ test("service worker trims a valid conversation id before opening the resume tab
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro • Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           default:
             throw new Error(`unexpected tab message ${message.type}`);
         }
@@ -459,7 +459,7 @@ test("service worker fails immediately when send reports the wrong resumed conve
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro • Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_extract_response":
@@ -530,7 +530,7 @@ test("service worker fails resumed jobs when post-send extraction omits the conv
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro • Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -736,7 +736,7 @@ test("service worker fails fast on metadata manual handoff detected while waitin
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -797,7 +797,7 @@ test("service worker fails fast on metadata manual handoff detected while waitin
   }
 });
 
-test("service worker fails closed when Pro Extended is unavailable", async () => {
+test("service worker fails closed when GPT-5.6 Sol Pro is unavailable", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
   const sentToTabs = [];
@@ -820,9 +820,9 @@ test("service worker fails closed when Pro Extended is unavailable", async () =>
               payload: {
                 status: "unavailable",
                 model_used: "Default",
-                requested_model: "extended-pro",
+                requested_model: "gpt-5-6-sol-pro",
                 available_options: ["Default"],
-                warning: "ChatGPT Pro Extended was not visible in the model picker"
+                warning: "GPT-5.6 Sol was not visible in the family submenu"
               }
             };
           default:
@@ -850,7 +850,7 @@ test("service worker fails closed when Pro Extended is unavailable", async () =>
   }
 });
 
-test("service worker fails resumed jobs before upload when Pro Extended is unavailable", async () => {
+test("service worker fails resumed jobs before upload when GPT-5.6 Sol Pro is unavailable", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
   const createdTabs = [];
@@ -877,8 +877,9 @@ test("service worker fails resumed jobs before upload when Pro Extended is unava
               payload: {
                 status: "unavailable",
                 model_used: "Default",
-                requested_model: "extended-pro",
-                extended_status: "required",
+                requested_model: "gpt-5-6-sol-pro",
+                family_status: "unverified",
+                effort_status: "unverified",
                 available_options: ["Default"],
                 warning: "ChatGPT model selector button not found"
               }
@@ -914,7 +915,7 @@ test("service worker fails resumed jobs before upload when Pro Extended is unava
   }
 });
 
-test("service worker fails closed when Pro Extended selection is only kept_current", async () => {
+test("service worker fails closed when GPT-5.6 Sol Pro selection is only kept_current", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
   const sentToTabs = [];
@@ -956,7 +957,7 @@ test("service worker fails closed when Pro Extended selection is only kept_curre
   }
 });
 
-test("service worker fails closed when Pro Extended selection fails", async () => {
+test("service worker fails closed when GPT-5.6 Sol Pro selection fails", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
   let tabId = 0;
@@ -995,14 +996,14 @@ test("service worker fails closed when Pro Extended selection fails", async () =
     await eventually(() => port.messages.some((message) => message.type === "job_error"));
     const error = port.messages.find((message) => message.type === "job_error");
     assert.equal(error.payload.code, "model_selection_failed");
-    assert.equal(error.payload.requested_model, "extended-pro");
+    assert.equal(error.payload.requested_model, "gpt-5-6-sol-pro");
     assert.equal(port.messages.some((message) => message.payload?.phase === "ready_for_file"), false);
   } finally {
     globalThis.chrome = originalChrome;
   }
 });
 
-test("service worker fails closed when selected model proof is incomplete", async () => {
+test("service worker rejects the legacy extended_status selection proof", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
   const sentToTabs = [];
@@ -1024,7 +1025,9 @@ test("service worker fails closed when selected model proof is incomplete", asyn
               ok: true,
               payload: {
                 status: "selected",
-                model_used: "Pro Extended"
+                model_used: "Pro Extended",
+                requested_model: "extended-pro",
+                extended_status: "required"
               }
             };
           default:
@@ -1052,6 +1055,52 @@ test("service worker fails closed when selected model proof is incomplete", asyn
   }
 });
 
+test("service worker accepts only verified GPT-5.6 Sol Pro selection", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  let tabId = 0;
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return {
+              ok: true,
+              payload: {
+                status: "selected",
+                model_used: "GPT-5.6 Sol Pro",
+                requested_model: "gpt-5-6-sol-pro",
+                family_status: "verified",
+                effort_status: "verified"
+              }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?sol_pro_verified=${Date.now()}`);
+    port.emit(envelope("job_start", "job_sol_pro_verified", { prompt: "prompt" }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    assert.equal(
+      port.messages.some((message) => message.type === "job_error" && message.payload.code === "model_selection_failed"),
+      false
+    );
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker rejects duplicate active job starts before opening another tab", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
@@ -1068,7 +1117,7 @@ test("service worker rejects duplicate active job starts before opening another 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           default:
             throw new Error(`unexpected tab message ${message.type}`);
         }
@@ -1106,7 +1155,7 @@ test("service worker rejects follow-on messages with the wrong capability token"
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           default:
             throw new Error(`unexpected tab message ${message.type}`);
         }
@@ -1273,7 +1322,7 @@ test("service worker allows matching extension instance id when profile identity
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           default:
             throw new Error(`unexpected tab message ${message.type}`);
         }
@@ -1349,7 +1398,7 @@ test("service worker allows matching profile email before opening a tab", async 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           default:
             throw new Error(`unexpected tab message ${message.type}`);
         }
@@ -1689,7 +1738,7 @@ test("service worker times out stale pre-send assistant text as job_error", asyn
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1748,7 +1797,7 @@ test("service worker classifies final affordance without scoped assistant text",
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1760,7 +1809,7 @@ test("service worker classifies final affordance without scoped assistant text",
               payload: sent
                 ? {
                     method: "page_text_fallback",
-                    text: "Skip to content\nbundle.md\nFile\nReview the attached file and provide your analysis.\n\nI\n\nExtended Pro",
+                    text: "Skip to content\nbundle.md\nFile\nReview the attached file and provide your analysis.\n\nI\n\nGPT-5.6 Sol Pro",
                     is_generating: false,
                     assistant_count: 1,
                     user_count: 1,
@@ -1832,7 +1881,7 @@ test("service worker fails extraction when final affordance page text alternates
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1917,7 +1966,7 @@ test("service worker completes post-send response when preceding user count is u
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -1989,7 +2038,7 @@ test("service worker does not complete on brief stable assistant text without a 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2061,7 +2110,7 @@ test("service worker completes long stable assistant text with an unscoped copy 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2141,7 +2190,7 @@ test("service worker does not complete long idle assistant text with only baseli
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2224,7 +2273,7 @@ test("service worker emits low-noise waiting progress while ChatGPT is quiet", a
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2310,7 +2359,7 @@ test("service worker completion is structural and does not classify response tex
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2380,7 +2429,7 @@ test("service worker accepts a scoped single-letter assistant markdown response"
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2456,7 +2505,7 @@ test("service worker reports oversized completed responses before native deliver
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2541,7 +2590,7 @@ test("service worker latches a completed scoped response when later ChatGPT DOM 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2621,7 +2670,7 @@ test("service worker preserves the best final response across a transient genera
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2714,8 +2763,8 @@ test("service worker preserves the best final response across a transient genera
   }
 });
 
-test("service worker labels interim Pro-Extended turns as non-final and completes on the later real answer", async () => {
-  // RC4 regression: ChatGPT Pro Extended streams the answer as MULTIPLE interim end_turn turns
+test("service worker labels interim Pro turns as non-final and completes on the later real answer", async () => {
+  // RC4 regression: ChatGPT Pro streams the answer as MULTIPLE interim end_turn turns
   // ("I'll review...", "I've narrowed...") before the real answer arrives minutes later. The first
   // interim turn's streaming head is a single "I" (observed live in conv 6a23a3a6). The waiter must
   // NOT surface that interim "I" as if it were the final response, and must complete on the later
@@ -2739,7 +2788,7 @@ test("service worker labels interim Pro-Extended turns as non-final and complete
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2838,7 +2887,7 @@ test("service worker settles same-length post-final text churn instead of timing
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -2916,7 +2965,7 @@ test("service worker waits for scoped response text bytes to stabilize after fin
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -3001,7 +3050,7 @@ test("service worker waits for streaming one-letter prefix to reach final assist
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -3092,7 +3141,7 @@ test("service worker does not complete when ChatGPT idles before final assistant
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -3182,7 +3231,7 @@ test("service worker completes with backend-api text when the DOM answer turn ne
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -3291,7 +3340,7 @@ test("service worker treats a stale backend-api node as still generating until a
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -3430,7 +3479,7 @@ test("service worker still refreshes a frozen render while backend-api reads are
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -3567,7 +3616,7 @@ test("service worker reloads an idle frozen short response and completes from th
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -3685,7 +3734,7 @@ test("service worker refreshes a frozen short render at most once", async () => 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -3763,7 +3812,7 @@ test("service worker rejects stale copy-button extraction from a pre-send assist
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -3839,7 +3888,7 @@ test("service worker does not complete on copy button while response is still ge
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -3908,7 +3957,7 @@ test("service worker does not complete long unscoped-copy text while response is
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -3983,7 +4032,7 @@ test("service worker completes when a generating response becomes idle without t
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -4056,7 +4105,7 @@ test("service worker does not complete only because post-send copy controls incr
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -4129,7 +4178,7 @@ test("service worker rebinds owned tab after content script reload during respon
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -4199,7 +4248,7 @@ test("service worker preserves content-script committed-send error metadata", as
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_extract_response":
@@ -4358,7 +4407,7 @@ test("service worker stops before upload when final chunk ack cannot reach nativ
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           default:
             throw new Error(`unexpected tab message ${message.type}`);
         }
@@ -4409,7 +4458,7 @@ test("service worker shards storage by job id so concurrent jobs do not clobber 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -4493,7 +4542,7 @@ test("service worker caps last_response_progress_text on disk while keeping the 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -4615,7 +4664,7 @@ test("service worker does not persist on every in-flight chunk", async () => {
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 16 } };
           case "yoetz_send_prompt":
@@ -4796,7 +4845,7 @@ test("service worker cancelJob clicks stop, removes tab, and evicts the in-memor
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -4900,7 +4949,7 @@ test("service worker cancelJob still removes the tab when the content script is 
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -4990,7 +5039,7 @@ test("service worker cancelJob waits for cancelSend to resolve before removing t
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -5086,7 +5135,7 @@ test("service worker cancelJob removes the tab but warns may_still_be_running wh
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -5166,7 +5215,7 @@ test("service worker cancelJob on an already-idle response removes the tab and r
           case "yoetz_prepare_job":
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
-            return { ok: true, payload: { status: "selected", model_used: "Pro Extended", requested_model: "extended-pro", extended_status: "required" } };
+            return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
@@ -5459,6 +5508,16 @@ test("service worker still fails receiving_file jobs after service-worker restar
     globalThis.chrome = originalChrome;
   }
 });
+
+function verifiedSolProSelection() {
+  return {
+    status: "selected",
+    model_used: "GPT-5.6 Sol Pro",
+    requested_model: "gpt-5-6-sol-pro",
+    family_status: "verified",
+    effort_status: "verified"
+  };
+}
 
 function envelope(type, jobId, payload = {}, fields = {}) {
   return {

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -49,11 +49,11 @@ name: chatgpt
 # transports connect directly to Chrome via CDP.
 #
 # Variables:
-#   This recipe supports exactly one ChatGPT target: Pro with Extended enabled.
+#   This recipe supports exactly one ChatGPT target: GPT-5.6 Sol with Pro intelligence.
 #   `model` and `extended` overrides are intentionally unsupported.
-#   The Pro Extended selector must work against both ChatGPT Enterprise and
-#              personal ChatGPT accounts. Their picker DOM differs, but both
-#              are fail-closed if Pro Extended cannot be proven selected.
+#   Selection is fail-closed unless the picker proves both the GPT-5.6 Sol
+#              family and Pro effort in one verification pass. The legacy
+#              model-switcher DOM is rejected with a diagnostic breadcrumb.
 #   prompt   — prompt text to send with the attachment. For Yoetz bundle
 #              sessions, typed ChatGPT transports default this to bundle.json's
 #              stored user prompt unless --var prompt=... explicitly overrides.
@@ -165,7 +165,7 @@ steps:
   # Click send once the typed prompt has enabled the button.
   - action: chatgpt_send
 
-  # Poll for response completion. Default 90min timeout for Extended Pro;
+  # Poll for response completion. Default 90min timeout for GPT-5.6 Sol Pro;
   # override with --var wait_timeout_ms=N or --var wait_interval_ms=N.
   - action: chatgpt_wait_response
     args: ["--interval-ms", "{{wait_interval_ms}}", "--timeout-ms", "{{wait_timeout_ms}}"]

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -217,9 +217,9 @@ Chrome remote-debugging approval friction, recommend the opt-in
 `chrome-extension-native` transport as the robust path. Use the native setup
 flow, load/update the extension in Chrome, run `doctor`, then target the stable
 `extension_instance_id` when multiple profiles are open.
-The recipe supports both ChatGPT Enterprise and personal ChatGPT account UIs;
-their model pickers differ, but Yoetz still targets only Pro with Extended
-enabled and fails closed if that selection cannot be proven.
+The recipe requires ChatGPT's GPT-5.6 composer-pill picker. Yoetz targets only
+GPT-5.6 Sol with Pro intelligence and fails closed if that selection cannot be
+proven; Enterprise accounts still on the legacy picker are rejected explicitly.
 
 Do not silently switch transports after upload/send/wait side effects. If the
 extension reports a terminal ChatGPT phase, preserve the manual-recovery tab and
@@ -419,11 +419,10 @@ Requires Node >= 24.4. If macOS shows a Keychain prompt for `Chrome Safe Storage
 
 ### Use ChatGPT Pro via recipe
 
-The built-in ChatGPT recipe always targets Pro with Extended enabled. Do not pass
-`model` or `extended` overrides; the CLI rejects them. This applies to both
-ChatGPT Enterprise and personal ChatGPT accounts. Different picker layouts are
-handled by the transport, but an unproven Pro Extended selection is a hard
-failure before upload/send.
+The built-in ChatGPT recipe always targets GPT-5.6 Sol with Pro intelligence.
+Do not pass `model` or `extended` overrides; the CLI rejects them. An unproven
+GPT-5.6 Sol + Pro selection is a hard failure before upload/send, including
+Enterprise accounts that still expose the legacy picker.
 
 ```bash
 # Create bundle and get bundle.md path


### PR DESCRIPTION
## Summary

- pin the built-in ChatGPT recipe to **GPT-5.6 Sol + Pro intelligence**
- replace the removed header model-switcher path with the composer-pill/Radix family-and-effort selector
- require separate verified family and effort proofs in the native extension and Rust fallback transports
- update extraction diagnostics, tests, recipe documentation, skill guidance, and release notes

## Root cause

ChatGPT removed the old `model-switcher-*` UI and split selection into a family submenu plus an intelligence menu. The previous `extended-pro` matcher could fail on Sol accounts or silently accept stale GPT-5.5 `Pro Extended`.

The forced-wrong canary exposed a second live-runtime detail: React remounts the composer pill after family and effort changes. Reusing the detached pill let the UI reach Pro while verification failed to reopen the picker. Both the native selector and Rust fallback now reacquire the current pill after every mutating click.

## Deliberate compatibility call

This PR intentionally **drops the legacy old-testid selection path**. If legacy `model-switcher-*` testids are detected, Yoetz fails before upload with:

> legacy ChatGPT picker detected; this yoetz version requires the GPT-5.6 UI

We do not maintain an unverified Enterprise-only parallel selector.

## Review follow-up

Claude's early review identified an `o3` edge case. Family triggers are now identified structurally for `GPT*` and `o<number>` labels, so `o3` recovers to Sol+Pro. The already-correct fast path no longer opens the family submenu for diagnostics, and picker closure is verified before prompt insertion.

Claude also approved the remounted-pill follow-up and its regression fixture before commit. The unrelated Rust 1.97 `manual_filter` lint cleanup is isolated in its own commit.

## Validation

- `npm test`: 212 passed
- `cargo test --workspace`: 605 passed, 2 intentional Chrome-fixture ignores
- `cargo clippy --workspace --all-targets -- -D warnings`: passed
- `cargo fmt --all -- --check`: passed
- `./scripts/build-chatgpt-native-extension.sh --check`: passed
- correct-state native canaries: exact `OK`, `model_selection_status=selected`, `model_used=GPT-5.6 Sol Pro`
- forced-wrong native canary `canary_18c0fcf6b0614720_5be5a4bde2c59081`: exact `OK`
- observed answer `data-message-model-slug`: `gpt-5-6-pro`

## Live acceptance gate

Forced-wrong run: `canary_18c0fcf6b0614720_5be5a4bde2c59081` / `job_18c0fcf6b06513c8_130b8b04e46e6fac`

- [x] start from family GPT-5.5 + effort Instant
- [x] sync/reload the worktree-built managed extension
- [x] verify `service_worker_build=0.5.30` and `content_script_build=0.5.30`
- [x] native canary returns exact `OK`
- [x] `model_selection=selected`
- [x] `family_status=verified` and `effort_status=verified`
- [x] `model_used=GPT-5.6 Sol Pro`
- [x] answer `data-message-model-slug=gpt-5-6-pro`
- [x] restore account to Sol+Pro (confirmed live by Claude; home pill reads bare `Pro`)
