### PR TITLE
docs: fix stale ARCHITECTURE claims, compress CLAUDE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -89,9 +89,9 @@ Daily spend is tracked in a local JSON file. The `--max-cost-usd` flag estimates
 
 ### Browser Mode
 
-For models without API access (e.g., ChatGPT Pro), yoetz bundles files into markdown, then connects to the user's running Chrome via CDP (Chrome DevTools Protocol) and submits the bundle through the web UI.
+For models without API access (e.g., ChatGPT Pro), yoetz bundles files into markdown and submits the bundle through the web UI in the user's running Chrome — via the ChatGPT native extension when it is connected, otherwise via CDP (Chrome DevTools Protocol) transports.
 
-Browser integrations are extension-free by default. Yoetz prefers to act as a wrapper over the underlying transport rather than reimplementing transport logic itself:
+Outside the connected-ChatGPT-extension exception described below, the browser transport stack is extension-free. Yoetz prefers to act as a wrapper over the underlying transport rather than reimplementing transport logic itself:
 
 - `chrome-devtools-mcp` is the primary live-Chrome transport for ChatGPT recipes.
 - `dev-browser` is the secondary live-Chrome transport.
@@ -106,24 +106,26 @@ for the ownership model behind the live Chrome attach path.
 
 Chrome 146+ may show a one-time "Allow remote debugging?" approval dialog for a new CDP session. The acceptance criterion is one approval per browser session, not per yoetz invocation, so yoetz avoids silently tearing down live-attach daemons in normal attach/check/recipe flows. Recovery is explicit via `yoetz browser reset`.
 
-The experimental `chrome-extension-native` transport is the only browser
-extension exception. It is ChatGPT-only, opt-in via
-`yoetz browser recipe --recipe chatgpt --transport chrome-extension-native`, and
-is not part of the default transport order. Its lifecycle is explicit:
-`yoetz browser extension install-host --chatgpt`,
-`doctor --chatgpt`, `status --chatgpt`, `reconnect --chatgpt`, and
-`update --chatgpt`; `inspect --chatgpt --run-id <id>` is the read-only
-diagnostic path for failed runs, `canary --chatgpt --live` is reserved for
-explicit diagnostic probes, and `grant-identity --chatgpt` opts into Chrome's
-`identity.email` permission when `profile_email` routing is required.
-Release builds package it as a separate versioned extension zip so the CLI
-archives do not make the extension path implicit. Manual Chrome-side
-install/update is intentionally explicit: unzip the release artifact, load the
-extracted extension via `chrome://extensions` Developer mode, reload the
-extension after replacing files, then use `reconnect` and `doctor` to confirm the
-native bridge and extension protocol version agree. The native-host install and
-runtime are currently macOS/Linux-only; Windows requires registry-based native
-messaging host registration before this transport can run there.
+The `chrome-extension-native` transport is the only browser extension
+exception, and it is ChatGPT-only. When the extension is installed and
+`yoetz browser extension status --chatgpt` reports `connected`, the ChatGPT
+recipe auto-selects it as the only default transport and fails closed instead
+of falling through to CDP transports; `--transport <other>` opts out, and CDP
+fallback after a native failure requires the explicit
+`--transport chrome-extension-native --allow-cdp-fallback`. Unhealthy or
+missing extensions leave the default CDP transport order untouched.
+
+Its lifecycle is managed by `yoetz browser extension <subcommand> --chatgpt`
+(see `--help` for the full set). `setup` materializes the packaged extension
+source into the stable `$YOETZ_DIR/chatgpt-native-extension` directory; users
+load that unpacked directory in Chrome once, and `update --chatgpt` afterwards
+re-syncs the managed copy atomically, reloads the extension over the native
+bridge, and verifies the loaded version. Recipe dispatch auto-heals version
+skew the same way. Release builds still package the extension as a separate
+versioned zip so the CLI archives do not make the extension path implicit.
+The native-host install and runtime are currently macOS/Linux-only; Windows
+requires registry-based native messaging host registration before this
+transport can run there.
 
 The native host manifest follows Chrome's Native Messaging lookup rules: the
 default Google Chrome profile is automatic, while custom `--user-data-dir`,
@@ -170,9 +172,12 @@ runner relies on. A run never returns success unless every gate below holds.
 - Completion gate: `extractResponse` rejects "thought/status chrome only"
   bodies (`Thought for ...`, `Reasoned for ...`, `Analyzing...`, etc.) and
   the SW refuses completion when extracted text is chrome-only, even if a
-  copy button is visible. Stable-idle completion still requires the
-  90-second `MIN_STABLE_IDLE_MS` floor; copy-button completion now also
-  requires that floor so an early-arriving Copy cannot bypass safety.
+  copy button is visible. Turns with a response-scoped copy affordance
+  confirm over the `MIN_AFFORDANCE_CONFIRM_MS` window; the only
+  long-floor path is stable-idle-with-unscoped-copy, which requires scoped
+  idle text, a new unscoped copy affordance above the baseline count, no
+  visible stop controls, a minimum text length, and the `MIN_STABLE_IDLE_MS`
+  floor. There is no pure text-stability completion path.
 - Send acceptance: when `clickSend` commits but `waitForSendAccepted`
   cannot confirm a post-click signal within budget, the run fails with
   `send_acceptance_unknown` carrying `side_effect_started: true`. The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,47 +25,25 @@ Tests use `assert_cmd`, `predicates`, and `serial_test` — no API keys needed f
 
 ## Release
 
-### Release Contract
-
-- Release from `main` only through `./scripts/release.sh X.Y.Z` and the resulting release PR; do not create manual tags or GitHub releases.
-- A push to `main` updates the AvivSinai marketplace immediately for the `yoetz` skill.
-- Keep one version across `CHANGELOG.md`, workspace metadata, skill/plugin metadata, and the release commit; after merge, CI validates the merged commit, creates the tag, publishes the GitHub release from the committed changelog entry, and updates Homebrew/Scoop.
-
-Use the fast release path:
-
-```bash
-./scripts/release.sh 0.2.24
-```
-
-This script updates `CHANGELOG.md`, bumps `[workspace.package].version`,
-aligns skill/plugin metadata, runs `cargo check --workspace`, creates
-`release/vX.Y.Z`, commits
-`chore(release): vX.Y.Z`, pushes the branch, and opens a PR with `gh`.
-
-After the release PR merges:
-- `.github/workflows/release.yml` detects the merged `chore(release): vX.Y.Z`
-  commit on `main`, creates/pushes the matching tag, publishes artifacts,
-  uses `CHANGELOG.md` for the GitHub release notes, and updates Homebrew/Scoop
-- Release verification also runs
-  `./scripts/build-chatgpt-native-extension.sh --check`; the release publishes
-  the experimental ChatGPT native extension as a separate
-  `yoetz-chatgpt-native-extension-X.Y.Z.zip` artifact when the extension source
-  is present.
-- `.github/workflows/release.yml` also supports `workflow_dispatch` as a retry
-  path for an existing tag if a release job needs to be rerun manually
-
-Repository setup for the fast path:
-- `gh auth login`: needed locally if you want `./scripts/release.sh` to open the
-  PR automatically after pushing the release branch
-
-`CHANGELOG.md` is part of release prep again. The release commit is the source
-of truth, and CI republishes that same changelog entry in the GitHub release.
-
-We intentionally keep the custom GitHub Actions release flow instead of adopting
-`release-plz`/`release-please` wholesale: this repo ships GitHub release
-artifacts plus Homebrew/Scoop updates, but does not use crates.io publishing as
-its primary release path. The fastest fit here is letting the merged release
-commit drive the entire pipeline, not replacing the release pipeline.
+- Release from `main` only through `./scripts/release.sh [options] X.Y.Z`
+  (the parser consumes options before the positional version) and the
+  resulting release PR. Never create
+  manual tags or GitHub releases; never push directly to `main`.
+- Populate `## [Unreleased]` in `CHANGELOG.md` BEFORE running the script: the
+  release commit's changelog section becomes the GitHub release notes.
+- The script moves the Unreleased section, bumps and aligns ALL version
+  metadata (workspace, plugin.json files, SKILL.md frontmatter, extension
+  manifest — CI validates consistency), runs `cargo check --workspace`, pushes
+  `release/vX.Y.Z`, and opens the PR with `gh`.
+- After the release PR merges, `release.yml` detects `chore(release): vX.Y.Z`
+  on `main`, creates the tag, publishes artifacts (including the ChatGPT
+  native extension zip when the extension source is present), and updates
+  Homebrew/Scoop. `workflow_dispatch` is the retry path for an existing tag.
+- A push to `main` also updates the AvivSinai marketplace immediately for the
+  `yoetz` skill.
+- We deliberately keep this custom release flow over release-plz/release-please:
+  the repo ships GitHub artifacts plus Homebrew/Scoop, not crates.io, and the
+  merged release commit driving the whole pipeline is the fastest fit.
 
 ## Code Style
 
@@ -102,54 +80,37 @@ recipe flows, treat `dev-browser` as a QuickJS/WASM runner, not Node.js:
 
 ## Browser Architecture
 
-Yoetz browser integrations are extension-free by default unless the Yoetz
-Chrome extension is installed and connected, in which case the `chatgpt`
-recipe selects it as the only default transport.
-
 - Treat yoetz as a thin wrapper over the underlying browser transport unless
   yoetz must own behavior for correctness or UX.
-- Preferred transport order for live Chrome work is `chrome-devtools-mcp`
-  first, `dev-browser` second, `agent-browser` third. Keep the non-extension
-  stack extension-free.
-- For the `chatgpt` recipe specifically, when `yoetz browser extension
-  status --chatgpt` reports `connected`, `chrome-extension-native` is
-  auto-selected as the only default transport and fails closed instead of
-  falling through to CDP/dev-browser transports; pass `--transport <other>` or
-  pin `transports:` in the recipe yaml to opt out. CDP fallback after a native
-  extension failure requires the explicit
-  `--transport chrome-extension-native --allow-cdp-fallback` opt-in.
-  Non-ChatGPT recipes and unhealthy/missing extensions are not affected.
-- The `chrome-extension-native` path stays the explicit choice when callers
-  want it regardless of detection, via
-  `yoetz browser recipe --recipe chatgpt --transport chrome-extension-native`,
-  and is managed with `yoetz browser extension install-host --chatgpt`,
-  `setup --chatgpt --open-chrome`, `doctor --chatgpt`, `status --chatgpt`,
-  `reconnect --chatgpt`, `update --chatgpt`,
-  `inspect --chatgpt --run-id <id>`, and `grant-identity --chatgpt`. Use
-  `yoetz browser check --transport chrome-extension-native` for explicit
-  extension readiness. Plain `yoetz browser check` auto-selects the native
-  extension check when the extension reports connected; pass `--transport
-  chrome-devtools-mcp`, `--transport dev-browser`, `--transport agent-browser`,
-  `--cdp`, `--browser-id`, or a managed `--profile` when you specifically need
-  to verify the CDP/browser stack.
-- ChatGPT conversation resume uses `--var conversation=<id|url>` with the
-  `conversation_id` / `conversation_url` fields returned by earlier runs. It is
-  native-extension only and does not manage context automatically; callers own
-  the decision to resume a saved conversation or start fresh.
-- For multiple loaded Chrome extension profiles, route extension-native jobs by
-  `profile_email` when Chrome exposes it, or by the stable
-  `extension_instance_id` shown in `status --chatgpt` when it does not.
-- Extension setup materializes packaged source into the stable
-  `$YOETZ_DIR/chatgpt-native-extension` directory. Users load that unpacked
-  directory once; future updates use
-  `yoetz browser extension update --chatgpt`, which re-syncs the managed copy,
-  reloads the extension, and verifies the loaded version.
+- Extension-free by default. Preferred live-Chrome transport order:
+  `chrome-devtools-mcp`, then `dev-browser`, then `agent-browser`.
+- ChatGPT recipe exception: when `yoetz browser extension status --chatgpt`
+  reports `connected`, `chrome-extension-native` is auto-selected as the only
+  default transport and fails closed instead of falling through to CDP
+  transports. Opt out with `--transport <other>` or a pinned `transports:` in
+  the recipe yaml; CDP fallback after a native failure requires the explicit
+  `--transport chrome-extension-native --allow-cdp-fallback`. Non-ChatGPT
+  recipes and unhealthy/missing extensions are unaffected. Plain
+  `yoetz browser check` follows the same auto-selection; pass an explicit
+  `--transport`, `--cdp`, `--browser-id`, or `--profile` to verify the CDP
+  stack instead.
+- Extension lifecycle: `setup --chatgpt` materializes packaged source into the
+  stable `$YOETZ_DIR/chatgpt-native-extension` directory, loaded unpacked in
+  Chrome exactly once; `update --chatgpt` re-syncs the managed copy, reloads
+  the extension, and verifies the loaded version. Never hand-patch the managed
+  directory. Other subcommands (`doctor`, `status`, `inspect`, ...) are listed
+  in `yoetz browser extension --help`.
+- ChatGPT conversation resume uses `--var conversation=<id|url>`
+  (native-extension only, no automatic context management); callers own the
+  resume-vs-fresh decision.
+- Multiple loaded extension profiles route by `profile_email` when Chrome
+  exposes it, else by the stable `extension_instance_id` from
+  `status --chatgpt`.
 - Default mode is connect-first: attach to the user's already running Chrome
-  session (`--connect`, auto-connect, or explicit `--cdp`) before considering
-  cookie sync or managed-profile fallbacks.
-- The daemon is trusted by default. Do not silently recycle live-attach daemons
-  during normal attach/check/recipe flows. If recovery is needed, require an
-  explicit `yoetz browser reset`.
+  before considering cookie sync or managed-profile fallbacks.
+- The daemon is trusted by default. Do not silently recycle live-attach
+  daemons during normal attach/check/recipe flows; recovery is an explicit
+  `yoetz browser reset`.
 
 ## Provider Configuration
 


### PR DESCRIPTION
## Summary
- ARCHITECTURE.md: fix three claims that contradicted shipped behavior — extension described as opt-in/not-in-default-order (stale since v0.5.9 auto-promotion), the manual unzip+reload update flow (stale since v0.5.16 managed dir), and the completion-gate bullet claiming copy-button completion requires the 90s stable-idle floor (stale since v0.5.20 fast-confirm; now describes the real affordance paths, including that no pure text-stability path exists)
- CLAUDE.md: same policy in half the words — Release section deduplicated into one contract list including the operational landmines (options before the version arg; populate Unreleased first); Browser Architecture keeps every behavioral rule, drops subcommand catalogs that duplicate --help/README/SKILL
- README.md reviewed, deliberately untouched (current and tight)

Peer-reviewed by codex over AMQ (two rounds; completion-gate wording corrected to match the shipped service worker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBwqzHG4ffkEGRgXCiwiG9