### PR TITLE
feat: polish council output artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Council runs now write per-model result/error artifacts, include aggregate
+  success, failure, cost, and elapsed-time summaries, and support
+  `--partial fail` for strict partial-failure exit semantics.
+
 ## [0.5.31] - 2026-07-11
 ### Changed
 

--- a/crates/yoetz-cli/src/commands/council.rs
+++ b/crates/yoetz-cli/src/commands/council.rs
@@ -4,12 +4,15 @@ use crate::{
     add_usage, call_litellm, maybe_write_output, normalize_model_name_with_aliases,
     render_bundle_md, resolve_max_output_tokens, resolve_prompt, resolve_provider_from_registry,
     resolve_registry_model_id, resolve_response_format, AppContext, CouncilArgs,
-    CouncilModelResult, CouncilPricing, ModelEstimate,
+    CouncilModelArtifact, CouncilModelResult, CouncilPricing, CouncilSummary, ModelEstimate,
+    PartialPolicy,
 };
 use crate::{budget, registry};
 use crate::{CouncilModelError, CouncilResult};
-use std::collections::BTreeSet;
-use std::path::PathBuf;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
 use yoetz_core::bundle::{build_bundle, estimate_tokens, BundleOptions};
 use yoetz_core::output::{write_json, write_jsonl, OutputFormat};
 use yoetz_core::session::{create_session_dir, write_json as write_json_file, write_text};
@@ -20,6 +23,7 @@ pub(crate) async fn handle_council(
     args: CouncilArgs,
     format: OutputFormat,
 ) -> Result<()> {
+    let started_at = Instant::now();
     let prompt = resolve_prompt(args.prompt.clone(), args.prompt_file.clone())?;
     let config = &ctx.config;
 
@@ -113,6 +117,7 @@ pub(crate) async fn handle_council(
         .collect();
 
     let mut per_model = Vec::new();
+    let mut per_model_pricing = Vec::new();
     let mut estimate_sum = 0.0;
     let mut estimate_complete = true;
     for (idx, (model, _provider)) in resolved_models.iter().enumerate() {
@@ -124,6 +129,7 @@ pub(crate) async fn handle_council(
             input_tokens,
             output_tokens,
         )?;
+        per_model_pricing.push(estimate.clone());
         if let Some(cost) = estimate.estimate_usd {
             estimate_sum += cost;
         } else {
@@ -165,6 +171,7 @@ pub(crate) async fn handle_council(
     let mut results = Vec::new();
     let mut total_usage = Usage::default();
     let mut errors = Vec::new();
+    let mut model_artifacts = Vec::new();
     let model_prompt = std::sync::Arc::new(if let Some(bundle_ref) = &bundle {
         render_bundle_md(bundle_ref)
     } else {
@@ -176,7 +183,7 @@ pub(crate) async fn handle_council(
             let registry_id =
                 resolve_registry_model_id(Some(provider), Some(model), registry_cache.as_ref());
             let output_tokens = per_model_max_output_tokens[idx].unwrap_or(4096);
-            results.push(CouncilModelResult {
+            let result = CouncilModelResult {
                 model: model.clone(),
                 content: "(dry-run) no provider call executed".to_string(),
                 usage: Usage::default(),
@@ -187,7 +194,12 @@ pub(crate) async fn handle_council(
                     output_tokens,
                 )?,
                 response_id: None,
-            });
+            };
+            model_artifacts.push((
+                idx,
+                successful_model_artifact(model.clone(), provider.clone(), &result),
+            ));
+            results.push(result);
         }
     } else {
         let max_parallel = args.max_parallel.max(1);
@@ -204,6 +216,7 @@ pub(crate) async fn handle_council(
             join_set.spawn(async move {
                 let _permit = semaphore.acquire_owned().await.map_err(|err| {
                     (
+                        idx,
                         model.clone(),
                         provider.clone(),
                         anyhow!("failed to acquire council permit: {err}"),
@@ -223,7 +236,7 @@ pub(crate) async fn handle_council(
                 .await;
                 match call {
                     Ok(call) => Ok((idx, model, provider, call)),
-                    Err(err) => Err((model, provider, err)),
+                    Err(err) => Err((idx, model, provider, err)),
                 }
             });
         }
@@ -262,40 +275,67 @@ pub(crate) async fn handle_council(
                         output_tokens,
                     )?;
 
-                    ordered[idx] = Some(CouncilModelResult {
-                        model,
+                    let result = CouncilModelResult {
+                        model: model.clone(),
                         content: call.content,
                         usage,
                         pricing,
                         response_id: call.response_id,
-                    });
+                    };
+                    model_artifacts
+                        .push((idx, successful_model_artifact(model, provider, &result)));
+                    ordered[idx] = Some(result);
                 }
-                Ok(Err((model, provider, err))) => {
+                Ok(Err((idx, model, provider, err))) => {
+                    let error = err.to_string();
+                    model_artifacts.push((
+                        idx,
+                        failed_model_artifact(
+                            model.clone(),
+                            provider.clone(),
+                            per_model_pricing[idx].clone(),
+                            error.clone(),
+                        ),
+                    ));
                     errors.push(CouncilModelError {
                         model,
                         provider,
-                        error: err.to_string(),
+                        error,
                     });
                 }
                 Err(err) => {
+                    let error = err.to_string();
+                    model_artifacts.push((
+                        usize::MAX,
+                        failed_model_artifact(
+                            "<task>".to_string(),
+                            "internal".to_string(),
+                            Default::default(),
+                            error.clone(),
+                        ),
+                    ));
                     errors.push(CouncilModelError {
                         model: "<task>".to_string(),
                         provider: "internal".to_string(),
-                        error: err.to_string(),
+                        error,
                     });
                 }
             }
         }
 
         results = ordered.into_iter().flatten().collect();
-        if results.is_empty() && !errors.is_empty() {
-            let joined = errors
-                .iter()
-                .map(|error| format!("- {} ({}): {}", error.model, error.provider, error.error))
-                .collect::<Vec<_>>()
-                .join("\n");
-            return Err(anyhow!("all council models failed:\n{joined}"));
-        }
+    }
+
+    model_artifacts.sort_by_key(|(index, _)| *index);
+
+    if results.is_empty() && !errors.is_empty() {
+        write_model_artifacts(&session.path, &model_artifacts);
+        let joined = errors
+            .iter()
+            .map(|error| format!("- {} ({}): {}", error.model, error.provider, error.error))
+            .collect::<Vec<_>>()
+            .join("\n");
+        return Err(anyhow!("all council models failed:\n{joined}"));
     }
 
     if budget_enabled && !args.dry_run {
@@ -318,12 +358,25 @@ pub(crate) async fn handle_council(
         }
     }
 
+    let summary = CouncilSummary {
+        succeeded: results.len(),
+        failed: errors.len(),
+        total: results.len() + errors.len(),
+        cost_usd: results
+            .iter()
+            .filter_map(|result| result.usage.cost_usd)
+            .sum(),
+        elapsed_ms: u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX),
+    };
+    let strict_partial_failure = matches!(args.partial, PartialPolicy::Fail) && !errors.is_empty();
+
     let mut council = CouncilResult {
         id: session.id,
         provider: council_provider,
         bundle,
         results,
         errors,
+        summary,
         pricing: CouncilPricing {
             estimate_usd_total: total_estimate,
             per_model,
@@ -337,6 +390,7 @@ pub(crate) async fn handle_council(
     write_json_file(&response_json, &council)?;
 
     maybe_write_output(ctx, &council)?;
+    write_model_artifacts(&session.path, &model_artifacts);
 
     // Omit bundle from stdout to keep JSON output compact (full result is in session file)
     council.bundle = None;
@@ -370,6 +424,99 @@ pub(crate) async fn handle_council(
             }
             Ok(())
         }
+    }?;
+
+    if strict_partial_failure {
+        return Err(anyhow!(
+            "council completed with {} failed model(s) under --partial fail",
+            council.summary.failed
+        ));
+    }
+    Ok(())
+}
+
+fn write_model_artifacts(session_dir: &Path, artifacts: &[(usize, CouncilModelArtifact)]) {
+    let models_dir = session_dir.join("models");
+    if let Err(error) = fs::create_dir_all(&models_dir) {
+        eprintln!(
+            "warning: could not create council model artifact directory {}: {error}",
+            models_dir.display()
+        );
+        return;
+    }
+    let mut slug_counts = BTreeMap::new();
+    for (_, artifact) in artifacts {
+        let slug = model_artifact_slug(&artifact.model);
+        let count = slug_counts.entry(slug.clone()).or_insert(0_usize);
+        *count += 1;
+        let filename = if *count == 1 {
+            format!("{slug}.json")
+        } else {
+            format!("{slug}-{}.json", *count)
+        };
+        let path = models_dir.join(filename);
+        if let Err(error) = write_json_file(&path, artifact) {
+            eprintln!(
+                "warning: could not write council model artifact {}: {error}",
+                path.display()
+            );
+        }
+    }
+}
+
+fn successful_model_artifact(
+    model: String,
+    provider: String,
+    result: &CouncilModelResult,
+) -> CouncilModelArtifact {
+    CouncilModelArtifact {
+        status: "succeeded",
+        model,
+        provider,
+        content: Some(result.content.clone()),
+        usage: result.usage.clone(),
+        pricing: result.pricing.clone(),
+        response_id: result.response_id.clone(),
+        error: None,
+    }
+}
+
+fn failed_model_artifact(
+    model: String,
+    provider: String,
+    pricing: yoetz_core::types::PricingEstimate,
+    error: String,
+) -> CouncilModelArtifact {
+    CouncilModelArtifact {
+        status: "failed",
+        model,
+        provider,
+        content: None,
+        usage: Usage::default(),
+        pricing,
+        response_id: None,
+        error: Some(error),
+    }
+}
+
+fn model_artifact_slug(model: &str) -> String {
+    let mut slug = String::new();
+    let mut pending_separator = false;
+    for ch in model.chars() {
+        if ch.is_ascii_alphanumeric() {
+            if pending_separator && !slug.is_empty() {
+                slug.push('-');
+            }
+            slug.push(ch.to_ascii_lowercase());
+            pending_separator = false;
+        } else {
+            pending_separator = true;
+        }
+    }
+    if slug.is_empty() {
+        "model".to_string()
+    } else {
+        slug
     }
 }
 
@@ -401,4 +548,42 @@ fn prefixed_council_provider(model: &str) -> Option<String> {
         return None;
     }
     Some(prefix.to_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{model_artifact_slug, write_model_artifacts, CouncilModelArtifact};
+    use std::fs;
+    use yoetz_core::types::{PricingEstimate, Usage};
+
+    #[test]
+    fn model_artifact_slug_is_safe_for_provider_qualified_ids() {
+        assert_eq!(
+            model_artifact_slug("openai/gpt-5.4-pro"),
+            "openai-gpt-5-4-pro"
+        );
+        assert_eq!(model_artifact_slug("///"), "model");
+    }
+
+    #[test]
+    fn model_artifact_write_failure_is_best_effort() {
+        let session = tempfile::tempdir().unwrap();
+        fs::write(session.path().join("models"), "not a directory").unwrap();
+        let artifacts = vec![(
+            0,
+            CouncilModelArtifact {
+                status: "succeeded",
+                model: "test/model".to_string(),
+                provider: "test".to_string(),
+                content: Some("paid result".to_string()),
+                usage: Usage::default(),
+                pricing: PricingEstimate::default(),
+                response_id: None,
+                error: None,
+            },
+        )];
+
+        write_model_artifacts(session.path(), &artifacts);
+        assert!(session.path().join("models").is_file());
+    }
 }

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, bail, Context, Result};
 use base64::{engine::general_purpose, Engine as _};
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use jsonschema::Validator;
 use litellm_rust::{
     ChatContentPart, ChatContentPartFile, ChatContentPartImageUrl, ChatContentPartText, ChatFile,
@@ -520,6 +520,10 @@ struct CouncilArgs {
     #[arg(long, default_value = "4")]
     max_parallel: usize,
 
+    /// Whether a council with some failed models exits successfully.
+    #[arg(long, value_enum, default_value = "ok")]
+    partial: PartialPolicy,
+
     #[arg(long)]
     dry_run: bool,
 
@@ -537,6 +541,12 @@ struct CouncilArgs {
 
     #[arg(long)]
     response_schema_name: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum PartialPolicy {
+    Ok,
+    Fail,
 }
 
 #[derive(Args)]
@@ -853,18 +863,40 @@ struct CouncilResult {
     results: Vec<CouncilModelResult>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     errors: Vec<CouncilModelError>,
+    summary: CouncilSummary,
     pricing: CouncilPricing,
     usage: Usage,
     artifacts: ArtifactPaths,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 struct CouncilModelResult {
     model: String,
     content: String,
     usage: Usage,
     pricing: PricingEstimate,
     response_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct CouncilSummary {
+    succeeded: usize,
+    failed: usize,
+    total: usize,
+    cost_usd: f64,
+    elapsed_ms: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct CouncilModelArtifact {
+    status: &'static str,
+    model: String,
+    provider: String,
+    content: Option<String>,
+    usage: Usage,
+    pricing: PricingEstimate,
+    response_id: Option<String>,
+    error: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/yoetz-cli/tests/cli.rs
+++ b/crates/yoetz-cli/tests/cli.rs
@@ -231,7 +231,8 @@ fn council_help() {
         .args(["council", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("--models"));
+        .stdout(predicate::str::contains("--models"))
+        .stdout(predicate::str::contains("--partial"));
 }
 
 #[test]

--- a/crates/yoetz-cli/tests/council.rs
+++ b/crates/yoetz-cli/tests/council.rs
@@ -1,0 +1,253 @@
+use assert_cmd::Command;
+use serde_json::Value;
+use std::fs;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::thread;
+use tempfile::TempDir;
+
+fn yoetz() -> Command {
+    #[allow(deprecated)]
+    Command::cargo_bin("yoetz").unwrap()
+}
+
+struct CouncilFixture {
+    _dir: TempDir,
+    config_path: PathBuf,
+    state_dir: PathBuf,
+}
+
+impl CouncilFixture {
+    fn new() -> Self {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let address = listener.local_addr().unwrap();
+        thread::spawn(move || {
+            for stream in listener.incoming() {
+                let mut stream = stream.unwrap();
+                let request = read_http_request(&mut stream);
+                let (status, body) = if request.contains("fail-model") {
+                    (
+                        "400 Bad Request",
+                        serde_json::json!({
+                            "error": {
+                                "message": "forced model failure",
+                                "type": "invalid_request_error"
+                            }
+                        }),
+                    )
+                } else {
+                    (
+                        "200 OK",
+                        serde_json::json!({
+                        "id": "successful-response",
+                        "object": "chat.completion",
+                        "created": 0,
+                        "model": "success-model",
+                        "choices": [{
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "successful answer"},
+                            "finish_reason": "stop"
+                        }],
+                        "usage": {
+                            "prompt_tokens": 7,
+                            "completion_tokens": 3,
+                            "total_tokens": 10
+                        }
+                        }),
+                    )
+                };
+                let body = body.to_string();
+                write!(
+                    stream,
+                    "HTTP/1.1 {status}\r\ncontent-type: application/json\r\nx-litellm-response-cost: 0.25\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                )
+                .unwrap();
+            }
+        });
+
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        let state_dir = dir.path().join("state");
+        fs::write(
+            &config_path,
+            format!(
+                r#"
+[providers.mock]
+base_url = "http://{address}/v1"
+api_key_env = "MOCK_API_KEY"
+kind = "openai_compatible"
+
+[registry]
+auto_sync_secs = 0
+"#
+            ),
+        )
+        .unwrap();
+
+        Self {
+            _dir: dir,
+            config_path,
+            state_dir,
+        }
+    }
+
+    fn command(&self) -> Command {
+        self.command_with_models("success-model,fail-model")
+    }
+
+    fn command_with_models(&self, models: &str) -> Command {
+        let mut command = yoetz();
+        command
+            .env("YOETZ_CONFIG_PATH", &self.config_path)
+            .env("YOETZ_DIR", &self.state_dir)
+            .env("MOCK_API_KEY", "test-key")
+            .env_remove("OPENAI_API_KEY")
+            .env_remove("ANTHROPIC_API_KEY")
+            .env_remove("GEMINI_API_KEY")
+            .env_remove("OPENROUTER_API_KEY")
+            .env_remove("XAI_API_KEY")
+            .args([
+                "--format",
+                "json",
+                "--allow-unknown",
+                "council",
+                "--prompt",
+                "compare",
+                "--provider",
+                "mock",
+                "--models",
+                models,
+            ]);
+        command
+    }
+}
+
+fn read_http_request(stream: &mut TcpStream) -> String {
+    let mut bytes = Vec::new();
+    let mut chunk = [0_u8; 4096];
+    loop {
+        let read = stream.read(&mut chunk).unwrap();
+        if read == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&chunk[..read]);
+        let Some(header_end) = bytes.windows(4).position(|window| window == b"\r\n\r\n") else {
+            continue;
+        };
+        let header_end = header_end + 4;
+        let headers = String::from_utf8_lossy(&bytes[..header_end]);
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().unwrap())
+            })
+            .unwrap_or(0);
+        if bytes.len() >= header_end + content_length {
+            break;
+        }
+    }
+    String::from_utf8(bytes).unwrap()
+}
+
+fn parse_stdout(output: &std::process::Output) -> Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "stdout was not JSON: {error}\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+fn assert_model_artifacts(payload: &Value) {
+    let session_dir = Path::new(payload["artifacts"]["session_dir"].as_str().unwrap());
+    let success: Value =
+        serde_json::from_slice(&fs::read(session_dir.join("models/success-model.json")).unwrap())
+            .unwrap();
+    assert_eq!(success["status"], "succeeded");
+    assert_eq!(success["model"], "success-model");
+    assert_eq!(success["content"], "successful answer");
+    assert_eq!(success["usage"]["total_tokens"], 10);
+    assert_eq!(success["usage"]["cost_usd"], 0.25);
+    assert!(success.get("pricing").is_some());
+    assert!(success["error"].is_null());
+
+    let failed: Value =
+        serde_json::from_slice(&fs::read(session_dir.join("models/fail-model.json")).unwrap())
+            .unwrap();
+    assert_eq!(failed["status"], "failed");
+    assert_eq!(failed["model"], "fail-model");
+    assert!(!failed["error"].as_str().unwrap().is_empty());
+    assert!(failed.get("usage").is_some());
+    assert!(failed.get("pricing").is_some());
+}
+
+#[test]
+fn partial_ok_is_default_and_writes_summary_and_model_artifacts() {
+    let fixture = CouncilFixture::new();
+    let output = fixture.command().output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout.clone()).unwrap();
+    assert!(stdout.find("\"results\"").unwrap() < stdout.find("\"errors\"").unwrap());
+    let payload = parse_stdout(&output);
+    assert_eq!(payload["summary"]["succeeded"], 1);
+    assert_eq!(payload["summary"]["failed"], 1);
+    assert_eq!(payload["summary"]["total"], 2);
+    assert_eq!(payload["summary"]["cost_usd"], 0.25);
+    assert!(payload["summary"]["elapsed_ms"].as_u64().is_some());
+    assert_eq!(payload["results"].as_array().unwrap().len(), 1);
+    assert_eq!(payload["errors"].as_array().unwrap().len(), 1);
+    assert_model_artifacts(&payload);
+}
+
+#[test]
+fn partial_fail_exits_nonzero_after_emitting_complete_council() {
+    let fixture = CouncilFixture::new();
+    let output = fixture
+        .command()
+        .args(["--partial", "fail"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+
+    let payload = parse_stdout(&output);
+    assert_eq!(payload["summary"]["succeeded"], 1);
+    assert_eq!(payload["summary"]["failed"], 1);
+    assert_eq!(payload["summary"]["total"], 2);
+    assert_eq!(payload["results"].as_array().unwrap().len(), 1);
+    assert_eq!(payload["errors"].as_array().unwrap().len(), 1);
+    assert!(String::from_utf8_lossy(&output.stderr).contains("--partial fail"));
+    assert_model_artifacts(&payload);
+}
+
+#[test]
+fn all_models_failed_remains_a_hard_error_under_partial_ok() {
+    let fixture = CouncilFixture::new();
+    let output = fixture.command_with_models("fail-model").output().unwrap();
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("all council models failed"));
+
+    let sessions = fixture.state_dir.join("sessions");
+    let session_dir = fs::read_dir(sessions)
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    let failed: Value =
+        serde_json::from_slice(&fs::read(session_dir.join("models/fail-model.json")).unwrap())
+            .unwrap();
+    assert_eq!(failed["status"], "failed");
+    assert!(!failed["error"].as_str().unwrap().is_empty());
+}

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -150,6 +150,12 @@ Use the returned model IDs verbatim. Do not add provider prefixes, nested
 OpenRouter wrappers, or old example names around IDs returned by `frontier` or
 `resolve`.
 
+Council JSON keeps successful `results` before `errors`, includes aggregate
+`summary` counts/cost/elapsed time, and writes one full result or error artifact
+per model under `<session_dir>/models/`. Partial success exits zero by default;
+pass `--partial fail` when any failed model must make the command nonzero while
+still emitting the complete council result.
+
 ## Ask (Single Model)
 
 Quick question with file context:


### PR DESCRIPTION
## What changed

- Write a structured success/error artifact for each council model under `<session_dir>/models/`.
- Add an additive JSON `summary` with success/failure counts, total cost, and elapsed time.
- Add `--partial ok|fail`; the default preserves partial-success exit 0, while strict mode emits the complete result before exiting nonzero.
- Document the stable `results`-before-`errors` order and agent-facing artifact contract.
- Keep auxiliary model artifacts best-effort so an artifact-path failure cannot suppress the primary council envelope.

## Why

Council consumers need machine-readable per-model records and a concise aggregate without reconstructing state from mixed success/error arrays. Strict partial failure also lets automation choose whether any failed member should fail the command without losing successful answers.

## Compatibility

The default exit behavior is unchanged. The summary and artifact files are additive, and all-model failure remains a hard error.

## Verification

- `cargo test -p yoetz` — 522 passed, 2 ignored
- CLI integration — 37 passed
- Council integration — 3 passed
- Daemon policy — 3 passed
- `cargo fmt --all -- --check`
- `cargo clippy -p yoetz --all-targets -- -D warnings`
- Peer review completed; required best-effort artifact-write fix applied and regression-tested
