### PR TITLE
feat: add ChatGPT followup ergonomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Council runs now write per-model result/error artifacts, include aggregate
   success, failure, cost, and elapsed-time summaries, and support
   `--partial fail` for strict partial-failure exit semantics.
+- ChatGPT recipe follow-ups now support native-only resumes via
+  `--followup <session-id|conversation-id|url>` plus
+  `--allow-duplicate-prompt` for explicit replays. Session-id lookups resolve
+  stored conversation metadata and fail clearly when a session has no
+  follow-up record.
 
 ## [0.5.31] - 2026-07-11
 ### Changed

--- a/crates/yoetz-cli/src/followup.rs
+++ b/crates/yoetz-cli/src/followup.rs
@@ -1,0 +1,267 @@
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::chatgpt_web::{self, ChatgptConversation};
+use yoetz_core::session::{list_sessions_in, write_json};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct FollowupMetadata {
+    pub session_id: String,
+    pub conversation_id: String,
+    pub conversation_url: String,
+    pub prompt_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedFollowup {
+    pub conversation: ChatgptConversation,
+    pub source_session_id: Option<String>,
+    pub prior_prompt_hash: Option<String>,
+}
+
+pub(crate) fn resolve_followup_target(raw: &str, sessions_base: &Path) -> Result<ResolvedFollowup> {
+    let sessions = list_sessions_in(sessions_base)?;
+    if let Some(session) = sessions.iter().find(|session| session.id == raw) {
+        let metadata = read_followup_metadata(&session.path)?.ok_or_else(|| {
+            anyhow!(
+                "session `{}` does not contain followup metadata; followup only works for ChatGPT browser recipe runs that wrote session metadata",
+                session.id
+            )
+        })?;
+        let conversation = chatgpt_web::normalize_conversation(&metadata.conversation_id)?;
+        return Ok(ResolvedFollowup {
+            conversation,
+            source_session_id: Some(metadata.session_id),
+            prior_prompt_hash: Some(metadata.prompt_hash),
+        });
+    }
+
+    let conversation = chatgpt_web::normalize_conversation(raw)?;
+    let previous = find_latest_followup_metadata_for_conversation(&conversation.id, &sessions)?;
+    Ok(ResolvedFollowup {
+        conversation,
+        source_session_id: previous
+            .as_ref()
+            .map(|metadata| metadata.session_id.clone()),
+        prior_prompt_hash: previous.map(|metadata| metadata.prompt_hash),
+    })
+}
+
+pub(crate) fn compute_prompt_hash(prompt: &str, bundle_path: Option<&Path>) -> Result<String> {
+    let bundle_hash = if let Some(bundle_path) = bundle_path {
+        let bundle_bytes = fs::read(bundle_path)
+            .with_context(|| format!("read bundle for followup hash {}", bundle_path.display()))?;
+        let mut hasher = Sha256::new();
+        hasher.update(bundle_bytes);
+        hex::encode(hasher.finalize())
+    } else {
+        String::new()
+    };
+
+    let mut hasher = Sha256::new();
+    hasher.update(prompt.as_bytes());
+    hasher.update([0]);
+    hasher.update(bundle_hash.as_bytes());
+    Ok(hex::encode(hasher.finalize()))
+}
+
+pub(crate) fn guard_duplicate_prompt(
+    current_hash: &str,
+    prior_hash: Option<&str>,
+    allow_duplicate_prompt: bool,
+    conversation_id: &str,
+    prior_session_id: Option<&str>,
+) -> Result<()> {
+    if allow_duplicate_prompt {
+        return Ok(());
+    }
+    let Some(prior_hash) = prior_hash else {
+        return Ok(());
+    };
+    if current_hash != prior_hash {
+        return Ok(());
+    }
+
+    let prior_context = prior_session_id
+        .map(|session_id| format!(" from prior session `{session_id}`"))
+        .unwrap_or_default();
+    bail!(
+        "duplicate followup prompt for conversation `{conversation_id}` matches the immediately previous turn{prior_context}. Pass --allow-duplicate-prompt to override."
+    )
+}
+
+pub(crate) fn validate_followup_args(
+    followup: Option<&str>,
+    conversation_var: Option<&str>,
+) -> Result<()> {
+    if followup.is_some() && conversation_var.is_some() {
+        bail!("--followup is mutually exclusive with --var conversation=");
+    }
+    Ok(())
+}
+
+pub(crate) fn write_followup_metadata(
+    session_dir: &Path,
+    session_id: &str,
+    conversation: &ChatgptConversation,
+    prompt_hash: &str,
+) -> Result<()> {
+    let path = followup_metadata_path(session_dir);
+    let metadata = FollowupMetadata {
+        session_id: session_id.to_string(),
+        conversation_id: conversation.id.clone(),
+        conversation_url: conversation.url.clone(),
+        prompt_hash: prompt_hash.to_string(),
+    };
+    write_json(&path, &metadata)?;
+    Ok(())
+}
+
+pub(crate) fn read_followup_metadata(session_dir: &Path) -> Result<Option<FollowupMetadata>> {
+    let path = followup_metadata_path(session_dir);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(&path)
+        .with_context(|| format!("read followup metadata {}", path.display()))?;
+    let metadata = serde_json::from_str(&raw)
+        .with_context(|| format!("parse followup metadata {}", path.display()))?;
+    Ok(Some(metadata))
+}
+
+fn followup_metadata_path(session_dir: &Path) -> PathBuf {
+    session_dir.join("followup.json")
+}
+
+fn find_latest_followup_metadata_for_conversation(
+    conversation_id: &str,
+    sessions: &[yoetz_core::types::SessionInfo],
+) -> Result<Option<FollowupMetadata>> {
+    for session in sessions {
+        if let Some(metadata) = read_followup_metadata(&session.path)? {
+            if metadata.conversation_id == conversation_id {
+                return Ok(Some(metadata));
+            }
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn prompt_hash_changes_with_prompt_or_bundle() {
+        let dir = tempdir().unwrap();
+        let bundle = dir.path().join("bundle.md");
+        fs::write(&bundle, "bundle one").unwrap();
+
+        let a = compute_prompt_hash("prompt one", Some(&bundle)).unwrap();
+        let b = compute_prompt_hash("prompt two", Some(&bundle)).unwrap();
+        let c = compute_prompt_hash("prompt one", None).unwrap();
+
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn duplicate_guard_hits_and_can_be_overridden() {
+        let err = guard_duplicate_prompt("abc", Some("abc"), false, "conv-1", Some("sess-1"))
+            .unwrap_err();
+        assert!(err.to_string().contains("duplicate followup prompt"));
+        assert!(guard_duplicate_prompt("abc", Some("abc"), true, "conv-1", Some("sess-1")).is_ok());
+        assert!(
+            guard_duplicate_prompt("abc", Some("def"), false, "conv-1", Some("sess-1")).is_ok()
+        );
+        assert!(guard_duplicate_prompt("abc", None, false, "conv-1", None).is_ok());
+    }
+
+    #[test]
+    fn followup_args_are_mutually_exclusive_with_conversation_var() {
+        assert!(validate_followup_args(Some("session-1"), None).is_ok());
+        assert!(validate_followup_args(None, Some("https://chatgpt.com/c/conv-1")).is_ok());
+        let err = validate_followup_args(Some("session-1"), Some("https://chatgpt.com/c/conv-1"))
+            .unwrap_err();
+        assert!(err.to_string().contains("mutually exclusive"));
+    }
+
+    #[test]
+    fn session_id_resolution_requires_metadata() {
+        let root = tempdir().unwrap();
+        let sessions_dir = root.path().join("sessions");
+        fs::create_dir_all(sessions_dir.join("20260711_000000_aaaaaa")).unwrap();
+        let err = resolve_followup_target("20260711_000000_aaaaaa", &sessions_dir).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("does not contain followup metadata"));
+    }
+
+    #[test]
+    fn direct_conversation_resolution_uses_latest_session_metadata() {
+        let root = tempdir().unwrap();
+        let sessions_dir = root.path().join("sessions");
+        let old = sessions_dir.join("20260711_000000_aaaaaa");
+        let new = sessions_dir.join("20260711_010000_bbbbbb");
+        fs::create_dir_all(&old).unwrap();
+        fs::create_dir_all(&new).unwrap();
+        write_followup_metadata(
+            &old,
+            "20260711_000000_aaaaaa",
+            &ChatgptConversation {
+                id: "conv-1".to_string(),
+                url: "https://chatgpt.com/c/conv-1".to_string(),
+            },
+            "old-hash",
+        )
+        .unwrap();
+        write_followup_metadata(
+            &new,
+            "20260711_010000_bbbbbb",
+            &ChatgptConversation {
+                id: "conv-1".to_string(),
+                url: "https://chatgpt.com/c/conv-1".to_string(),
+            },
+            "new-hash",
+        )
+        .unwrap();
+
+        let resolved = resolve_followup_target("conv-1", &sessions_dir).unwrap();
+        assert_eq!(resolved.conversation.id, "conv-1");
+        assert_eq!(resolved.prior_prompt_hash.as_deref(), Some("new-hash"));
+        assert_eq!(
+            resolved.source_session_id.as_deref(),
+            Some("20260711_010000_bbbbbb")
+        );
+    }
+
+    #[test]
+    fn session_id_resolution_reads_metadata() {
+        let root = tempdir().unwrap();
+        let sessions_dir = root.path().join("sessions");
+        let session = sessions_dir.join("20260711_010000_bbbbbb");
+        fs::create_dir_all(&session).unwrap();
+        write_followup_metadata(
+            &session,
+            "20260711_010000_bbbbbb",
+            &ChatgptConversation {
+                id: "conv-2".to_string(),
+                url: "https://chatgpt.com/c/conv-2".to_string(),
+            },
+            "hash-2",
+        )
+        .unwrap();
+
+        let resolved = resolve_followup_target("20260711_010000_bbbbbb", &sessions_dir).unwrap();
+        assert_eq!(resolved.conversation.id, "conv-2");
+        assert_eq!(resolved.prior_prompt_hash.as_deref(), Some("hash-2"));
+        assert_eq!(
+            resolved.source_session_id.as_deref(),
+            Some("20260711_010000_bbbbbb")
+        );
+    }
+}

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -25,6 +25,7 @@ mod chatgpt_web;
 mod chrome_devtools_mcp;
 mod commands;
 mod dev_browser;
+mod followup;
 mod fuzzy;
 mod http;
 mod live_attach;
@@ -289,6 +290,14 @@ struct BrowserRecipeArgs {
     /// Set recipe variables. For ChatGPT, profile_email selects/verifies the target Chrome profile.
     #[arg(long = "var", value_name = "KEY=VALUE")]
     vars: Vec<String>,
+
+    /// Resume from a session id, conversation id, or ChatGPT conversation URL.
+    #[arg(long)]
+    followup: Option<String>,
+
+    /// Allow the same prompt hash to be submitted to the same conversation.
+    #[arg(long)]
+    allow_duplicate_prompt: bool,
 }
 
 #[derive(Args)]
@@ -2314,6 +2323,52 @@ fn browser_recipe_artifact_paths(bundle_path: Option<&Path>) -> Option<ArtifactP
     })
 }
 
+fn maybe_write_followup_session_metadata(
+    recipe_args: &BrowserRecipeArgs,
+    current_prompt_hash: Option<&str>,
+    payload: &Value,
+) {
+    let Some(current_prompt_hash) = current_prompt_hash else {
+        return;
+    };
+    let Some(session_artifacts) = browser_recipe_artifact_paths(recipe_args.bundle.as_deref())
+    else {
+        return;
+    };
+    let Some(conversation_raw) = payload
+        .get("conversation_url")
+        .and_then(Value::as_str)
+        .or_else(|| payload.get("conversation_id").and_then(Value::as_str))
+    else {
+        return;
+    };
+
+    let session_dir = PathBuf::from(session_artifacts.session_dir);
+    let session_id = session_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("session")
+        .to_string();
+    let Ok(conversation) = chatgpt_web::normalize_conversation(conversation_raw) else {
+        eprintln!(
+            "warning: could not normalize followup conversation for metadata {}",
+            session_dir.join("followup.json").display()
+        );
+        return;
+    };
+    if let Err(err) = followup::write_followup_metadata(
+        &session_dir,
+        &session_id,
+        &conversation,
+        current_prompt_hash,
+    ) {
+        eprintln!(
+            "warning: could not write followup metadata {}: {err}",
+            session_dir.join("followup.json").display()
+        );
+    }
+}
+
 fn resolve_dev_browser_delivery_mode(
     recipe_args: &BrowserRecipeArgs,
     recipe_vars: &BTreeMap<String, String>,
@@ -3452,9 +3507,40 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             let profile_dir =
                 browser::resolve_profile_dir(&ctx.browser_defaults, recipe_args.profile.as_ref())?;
             let is_chatgpt = is_chatgpt_recipe(&recipe, &recipe_path);
-            if is_chatgpt {
+            let current_prompt_hash = if is_chatgpt {
                 apply_chatgpt_prompt_default(&recipe_args, &mut recipe_vars)?;
-            }
+                let current_prompt_hash = followup::compute_prompt_hash(
+                    recipe_vars
+                        .get("prompt")
+                        .map(String::as_str)
+                        .unwrap_or_default(),
+                    recipe_args.bundle.as_deref(),
+                )?;
+                if let Some(followup_raw) = recipe_args.followup.as_deref() {
+                    followup::validate_followup_args(
+                        Some(followup_raw),
+                        recipe_vars.get("conversation").map(String::as_str),
+                    )?;
+                    let resolved_followup = followup::resolve_followup_target(
+                        followup_raw,
+                        &yoetz_core::session::session_base_dir(),
+                    )?;
+                    followup::guard_duplicate_prompt(
+                        &current_prompt_hash,
+                        resolved_followup.prior_prompt_hash.as_deref(),
+                        recipe_args.allow_duplicate_prompt,
+                        &resolved_followup.conversation.id,
+                        resolved_followup.source_session_id.as_deref(),
+                    )?;
+                    recipe_vars.insert(
+                        "conversation".to_string(),
+                        resolved_followup.conversation.url.clone(),
+                    );
+                }
+                Some(current_prompt_hash)
+            } else {
+                None
+            };
             let managed_profile_only = profile_forces_managed_browser(
                 recipe_args.profile.as_deref(),
                 recipe_args.cdp.as_deref(),
@@ -3634,6 +3720,13 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                                 | browser::RecipeTransport::AgentBrowser
                         ) {
                             maybe_remember_cdp_target(resolved_cdp_target.as_ref(), format);
+                        }
+                        if is_chatgpt {
+                            maybe_write_followup_session_metadata(
+                                &recipe_args,
+                                current_prompt_hash.as_deref(),
+                                &_payload,
+                            );
                         }
                         return Ok(());
                     }
@@ -5538,6 +5631,8 @@ mod tests {
             cdp: None,
             browser_id: None,
             vars: vec![],
+            followup: None,
+            allow_duplicate_prompt: false,
         };
         let recipe_vars = BTreeMap::new();
         let err = run_recipe_via_chrome_devtools_mcp(
@@ -5570,6 +5665,8 @@ mod tests {
             cdp: None,
             browser_id: None,
             vars: vec![],
+            followup: None,
+            allow_duplicate_prompt: false,
         };
         let recipe_vars = BTreeMap::new();
         let err = run_recipe_via_chrome_devtools_mcp(
@@ -5598,6 +5695,8 @@ mod tests {
             cdp: None,
             browser_id: None,
             vars: vec![],
+            followup: None,
+            allow_duplicate_prompt: false,
         };
         let recipe_vars = BTreeMap::from([("paste".to_string(), "true".to_string())]);
         let err = run_recipe_via_chrome_devtools_mcp(
@@ -5627,6 +5726,8 @@ mod tests {
             cdp: None,
             browser_id: None,
             vars: vec![],
+            followup: None,
+            allow_duplicate_prompt: false,
         };
         let recipe_vars = BTreeMap::new();
         let err = run_recipe_via_chrome_devtools_mcp(
@@ -5656,6 +5757,8 @@ mod tests {
             cdp: None,
             browser_id: None,
             vars: vec![],
+            followup: None,
+            allow_duplicate_prompt: false,
         };
         let recipe_vars = BTreeMap::from([("thread".to_string(), "sideways".to_string())]);
         let err = run_recipe_via_chrome_devtools_mcp(
@@ -5685,6 +5788,8 @@ mod tests {
             cdp: None,
             browser_id: None,
             vars: vec![],
+            followup: None,
+            allow_duplicate_prompt: false,
         };
         let recipe_vars = BTreeMap::from([("thread".to_string(), "reuse".to_string())]);
         let err = run_recipe_via_chrome_devtools_mcp(
@@ -5716,6 +5821,8 @@ mod tests {
             cdp: None,
             browser_id: None,
             vars: vec![],
+            followup: None,
+            allow_duplicate_prompt: false,
         };
         let recipe_vars = BTreeMap::new();
 
@@ -5741,6 +5848,8 @@ mod tests {
             cdp: None,
             browser_id: None,
             vars: vec![],
+            followup: None,
+            allow_duplicate_prompt: false,
         };
         let recipe_vars = BTreeMap::from([("paste".to_string(), "true".to_string())]);
 
@@ -5764,6 +5873,8 @@ mod tests {
             cdp: None,
             browser_id: None,
             vars: vec![],
+            followup: None,
+            allow_duplicate_prompt: false,
         };
         let recipe_vars = BTreeMap::from([
             ("prompt".to_string(), "Review this repo".to_string()),
@@ -5809,6 +5920,8 @@ mod tests {
             cdp: None,
             browser_id: None,
             vars: vec![],
+            followup: None,
+            allow_duplicate_prompt: false,
         };
         let recipe_vars = BTreeMap::from([
             ("model".to_string(), "auto".to_string()),
@@ -5837,6 +5950,8 @@ mod tests {
             cdp: None,
             browser_id: None,
             vars: vec![],
+            followup: None,
+            allow_duplicate_prompt: false,
         };
 
         let recipe_vars = browser::build_recipe_vars(recipe.defaults.as_ref(), &recipe_args.vars)
@@ -5878,6 +5993,8 @@ mod tests {
             cdp: None,
             browser_id: None,
             vars: vec![],
+            followup: None,
+            allow_duplicate_prompt: false,
         };
         let mut recipe_vars = BTreeMap::from([(
             "prompt".to_string(),
@@ -5920,6 +6037,8 @@ mod tests {
             cdp: None,
             browser_id: None,
             vars: vec!["prompt=Explicit prompt".to_string()],
+            followup: None,
+            allow_duplicate_prompt: false,
         };
         let mut recipe_vars =
             BTreeMap::from([("prompt".to_string(), "Explicit prompt".to_string())]);
@@ -5942,6 +6061,8 @@ mod tests {
             cdp: None,
             browser_id: None,
             vars: vec![],
+            followup: None,
+            allow_duplicate_prompt: false,
         };
         let recipe_vars =
             BTreeMap::from([("profile_email".to_string(), "work@example.com".to_string())]);
@@ -5971,6 +6092,8 @@ mod tests {
             cdp: None,
             browser_id: None,
             vars: vec![],
+            followup: None,
+            allow_duplicate_prompt: false,
         };
         let recipe_vars =
             BTreeMap::from([("extension_instance_id".to_string(), "ext_work".to_string())]);
@@ -6000,6 +6123,8 @@ mod tests {
             cdp: None,
             browser_id: None,
             vars: vec![],
+            followup: None,
+            allow_duplicate_prompt: false,
         };
         let recipe_vars =
             BTreeMap::from([("browser_context_id".to_string(), "ctx-work".to_string())]);
@@ -6055,6 +6180,8 @@ mod tests {
             cdp: None,
             browser_id: None,
             vars: vec![],
+            followup: None,
+            allow_duplicate_prompt: false,
         };
         let recipe_vars = BTreeMap::from([("thread".to_string(), "sideways".to_string())]);
         let err = run_recipe_via_dev_browser(
@@ -6083,6 +6210,8 @@ mod tests {
             cdp: None,
             browser_id: None,
             vars: vec![],
+            followup: None,
+            allow_duplicate_prompt: false,
         };
         let recipe_vars = BTreeMap::from([("thread".to_string(), "reuse".to_string())]);
         let err = run_recipe_via_dev_browser(

--- a/crates/yoetz-core/src/session.rs
+++ b/crates/yoetz-core/src/session.rs
@@ -13,8 +13,12 @@ static TS_FORMAT: &[FormatItem<'static>] =
 /// Create a new timestamped session directory under `~/.yoetz/sessions/`.
 pub fn create_session_dir() -> Result<SessionInfo> {
     let root = yoetz_root_dir();
-    fs::create_dir_all(&root).with_context(|| format!("create yoetz dir {}", root.display()))?;
-    chmod_owner_only_dir(&root)?;
+    create_session_dir_in(&root)
+}
+
+pub fn create_session_dir_in(root: &Path) -> Result<SessionInfo> {
+    fs::create_dir_all(root).with_context(|| format!("create yoetz dir {}", root.display()))?;
+    chmod_owner_only_dir(root)?;
 
     let base = root.join("sessions");
     fs::create_dir_all(&base).with_context(|| format!("create sessions dir {}", base.display()))?;
@@ -75,12 +79,15 @@ pub fn write_text(path: &Path, text: &str) -> Result<()> {
 }
 
 pub fn list_sessions() -> Result<Vec<SessionInfo>> {
-    let base = session_base_dir();
+    list_sessions_in(&session_base_dir())
+}
+
+pub fn list_sessions_in(base: &Path) -> Result<Vec<SessionInfo>> {
     if !base.exists() {
         return Ok(Vec::new());
     }
     let mut items = Vec::new();
-    for entry in fs::read_dir(&base).with_context(|| format!("read {}", base.display()))? {
+    for entry in fs::read_dir(base).with_context(|| format!("read {}", base.display()))? {
         let entry = entry?;
         if entry.file_type()?.is_dir() {
             let id = entry.file_name().to_string_lossy().to_string();

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -455,6 +455,14 @@ yoetz browser recipe --recipe chatgpt --bundle "$BUNDLE" --format json
 # new owned tab for that conversation.
 ```
 
+For follow-up resumes, use `--followup <session-id|conversation-id|url>`.
+That path is native-only, is mutually exclusive with `--var conversation=`,
+and `session-id` lookups resume from that session's stored conversation
+metadata. `--allow-duplicate-prompt` is only for intentionally replaying the
+same prompt+bundle hash to the same conversation. A session-id follow-up
+compares against that session's last recorded prompt hash, not the current
+conversation head.
+
 The wait loop reports `completion_reason` in its JSON output:
 - `copy_button` — the strong signal: a copy control rendered on the new
   assistant message (response is fully streamed).


### PR DESCRIPTION
## Summary
- `--followup <session-id|conversation-id|url>` sugar on `yoetz browser recipe` — resolves the conversation from prior session artifacts (native-extension-only, same constraint as `--var conversation=`); mutually exclusive with `--var conversation=`
- Duplicate-prompt guard: every successful ChatGPT run stores a prompt+bundle hash in session `followup.json` (best-effort); a followup matching the base turn's hash is refused with a clear error, overridable via `--allow-duplicate-prompt`
- Scope note: `--followup <session-id>` guards against that session's turn specifically (the caller names the base turn); conversation-id/url form guards against the newest recorded turn
- SKILL.md + CHANGELOG updated

Part of oracle wave 1 (F5). Reviewed by claude over AMQ (spec/oracle-wave-1): approved after docs addition; core findings — newest-first session ordering verified, guard-from-turn-2 via unconditional metadata writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HBwqzHG4ffkEGRgXCiwiG9