### PR TITLE
feat: add completion notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `--allow-duplicate-prompt` for explicit replays. Session-id lookups resolve
   stored conversation metadata and fail clearly when a session has no
   follow-up record.
+- Native completion notifications now fire on macOS for long-running `ask`,
+  `council`, and browser recipe runs, with `--no-notify`, `YOETZ_NO_NOTIFY=1`,
+  CI, SSH sessions, and `[notifications] enabled = false` muting them.
 
 ## [0.5.31] - 2026-07-11
 ### Changed

--- a/crates/yoetz-cli/src/commands/ask.rs
+++ b/crates/yoetz-cli/src/commands/ask.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Result};
 
+use crate::notifications;
 use crate::providers::{gemini, openai};
 use crate::{
     apply_capability_warnings, call_litellm, maybe_write_output, normalize_model_name_with_aliases,
@@ -10,6 +11,7 @@ use crate::{
 use crate::{budget, providers, registry};
 use std::env;
 use std::path::PathBuf;
+use std::time::Instant;
 use yoetz_core::bundle::{build_bundle, estimate_tokens, BundleOptions};
 use yoetz_core::media::MediaType;
 use yoetz_core::output::{write_json, write_jsonl, OutputFormat};
@@ -55,6 +57,7 @@ pub(crate) async fn handle_ask(
     args: AskArgs,
     format: OutputFormat,
 ) -> Result<()> {
+    let started_at = Instant::now();
     let prompt = resolve_prompt(args.prompt.clone(), args.prompt_file.clone())?;
     let config = &ctx.config;
     let response_format = resolve_response_format(
@@ -360,6 +363,16 @@ pub(crate) async fn handle_ask(
     write_json_file(&response_json, &result)?;
 
     maybe_write_output(ctx, &result)?;
+    notifications::maybe_notify_completion(
+        &ctx.config,
+        args.no_notify,
+        "ask",
+        result.model.as_deref().unwrap_or("model"),
+        &result.content,
+        started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
+        result.usage.cost_usd,
+        ctx.debug,
+    );
 
     // Omit bundle from stdout to keep JSON output compact (full result is in session file)
     result.bundle = None;

--- a/crates/yoetz-cli/src/commands/council.rs
+++ b/crates/yoetz-cli/src/commands/council.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Result};
 
+use crate::notifications;
 use crate::{
     add_usage, call_litellm, maybe_write_output, normalize_model_name_with_aliases,
     render_bundle_md, resolve_max_output_tokens, resolve_prompt, resolve_provider_from_registry,
@@ -391,6 +392,36 @@ pub(crate) async fn handle_council(
 
     maybe_write_output(ctx, &council)?;
     write_model_artifacts(&session.path, &model_artifacts);
+    let notified_target = if council.summary.total == 1 {
+        council
+            .results
+            .first()
+            .map(|result| result.model.as_str())
+            .unwrap_or("model")
+            .to_string()
+    } else {
+        format!("{} models", council.summary.total)
+    };
+    let notified_preview = council
+        .results
+        .first()
+        .map(|result| result.content.as_str())
+        .unwrap_or("");
+    let notified_cost = council
+        .results
+        .iter()
+        .any(|result| result.usage.cost_usd.is_some())
+        .then_some(council.summary.cost_usd);
+    notifications::maybe_notify_completion(
+        &ctx.config,
+        args.no_notify,
+        "council",
+        &notified_target,
+        notified_preview,
+        started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
+        notified_cost,
+        ctx.debug,
+    );
 
     // Omit bundle from stdout to keep JSON output compact (full result is in session file)
     council.bundle = None;

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -15,7 +15,7 @@ use std::fs;
 use std::io::{self, IsTerminal, Read};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 mod browser;
 mod browser_extension_native;
@@ -30,6 +30,7 @@ mod fuzzy;
 mod http;
 mod live_attach;
 mod live_cdp_daemon;
+mod notifications;
 mod providers;
 mod registry;
 
@@ -183,6 +184,10 @@ struct AskArgs {
 
     #[arg(long)]
     response_schema_name: Option<String>,
+
+    /// Suppress native completion notifications for this run.
+    #[arg(long)]
+    no_notify: bool,
 }
 
 #[derive(Args)]
@@ -298,6 +303,10 @@ struct BrowserRecipeArgs {
     /// Allow the same prompt hash to be submitted to the same conversation.
     #[arg(long)]
     allow_duplicate_prompt: bool,
+
+    /// Suppress native completion notifications for this run.
+    #[arg(long)]
+    no_notify: bool,
 }
 
 #[derive(Args)]
@@ -550,6 +559,10 @@ struct CouncilArgs {
 
     #[arg(long)]
     response_schema_name: Option<String>,
+
+    /// Suppress native completion notifications for this run.
+    #[arg(long)]
+    no_notify: bool,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -2013,6 +2026,7 @@ async fn run_recipe_via_chrome_devtools_mcp(
             "chrome-devtools-mcp transport requires `--bundle`; it does not support inline paste mode"
         ));
     }
+    let started_at = Instant::now();
 
     let recipe_spec = build_chatgpt_recipe_spec(recipe_args, recipe_vars)?;
     let recipe_ctx = chrome_devtools_mcp::DevtoolsMcpRecipeContext {
@@ -2087,6 +2101,14 @@ async fn run_recipe_via_chrome_devtools_mcp(
             println!("{}", payload["response"].as_str().unwrap_or_default());
         }
     }
+    maybe_notify_browser_recipe_completion(
+        ctx,
+        recipe_args.no_notify,
+        recipe_spec.model.as_str(),
+        &payload,
+        started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
+        None,
+    );
 
     Ok(payload)
 }
@@ -2251,6 +2273,7 @@ fn run_recipe_via_chrome_extension_native(
             "chrome-extension-native transport requires `--bundle`; it does not support inline paste mode"
         ));
     }
+    let started_at = Instant::now();
 
     let recipe_spec = build_chatgpt_recipe_spec(recipe_args, recipe_vars)?;
     let response = browser_extension_native::run_chatgpt_recipe(&recipe_spec, format)?;
@@ -2281,6 +2304,14 @@ fn run_recipe_via_chrome_extension_native(
             println!("{}", payload["response"].as_str().unwrap_or_default());
         }
     }
+    maybe_notify_browser_recipe_completion(
+        ctx,
+        recipe_args.no_notify,
+        recipe_spec.model.as_str(),
+        &payload,
+        started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
+        None,
+    );
     Ok(payload)
 }
 
@@ -2415,6 +2446,7 @@ fn run_recipe_via_dev_browser(
             "dev-browser transport does not support `--profile`; use `--cdp` to target a specific Chrome instance/profile"
         ));
     }
+    let started_at = Instant::now();
 
     // The recipe prepare micro-script already verifies ChatGPT login state on the
     // named page. Avoid a separate pre-flight attach here because it can trigger
@@ -2476,6 +2508,14 @@ fn run_recipe_via_dev_browser(
             println!("{}", payload["response"].as_str().unwrap_or_default());
         }
     }
+    maybe_notify_browser_recipe_completion(
+        ctx,
+        recipe_args.no_notify,
+        recipe_spec.model.as_str(),
+        &payload,
+        started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
+        None,
+    );
 
     Ok(payload)
 }
@@ -2522,6 +2562,11 @@ fn run_recipe_via_agent_browser(
     } else {
         browser::BrowserProfileMode::ProfileOnly
     };
+    let recipe_target = recipe
+        .name
+        .clone()
+        .unwrap_or_else(|| "browser recipe".to_string());
+    let started_at = Instant::now();
 
     let needs_bundle_text = recipe.steps.iter().any(|step| {
         step.args
@@ -2557,12 +2602,58 @@ fn run_recipe_via_agent_browser(
         let payload =
             browser::run_recipe_with_live_connection(recipe, recipe_ctx, &connection, format)?;
         maybe_write_output(ctx, &payload)?;
+        maybe_notify_browser_recipe_completion(
+            ctx,
+            recipe_args.no_notify,
+            &recipe_target,
+            &payload,
+            started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
+            None,
+        );
         Ok(payload)
     } else {
         let payload = browser::run_recipe(recipe, recipe_ctx, format)?;
         maybe_write_output(ctx, &payload)?;
+        maybe_notify_browser_recipe_completion(
+            ctx,
+            recipe_args.no_notify,
+            &recipe_target,
+            &payload,
+            started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
+            None,
+        );
         Ok(payload)
     }
+}
+
+fn maybe_notify_browser_recipe_completion(
+    ctx: &AppContext,
+    no_notify: bool,
+    target: &str,
+    payload: &Value,
+    elapsed_ms: u64,
+    cost_usd: Option<f64>,
+) {
+    let preview = payload
+        .get("response")
+        .and_then(Value::as_str)
+        .or_else(|| payload.get("stdout").and_then(Value::as_str))
+        .unwrap_or_default();
+    let resolved_target = payload
+        .get("model_used")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(target);
+    notifications::maybe_notify_completion(
+        &ctx.config,
+        no_notify,
+        "browser recipe",
+        resolved_target,
+        preview,
+        elapsed_ms,
+        cost_usd,
+        ctx.debug,
+    );
 }
 
 fn ensure_chatgpt_extension_scope(chatgpt: bool) -> Result<()> {
@@ -5633,6 +5724,7 @@ mod tests {
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
+            no_notify: false,
         };
         let recipe_vars = BTreeMap::new();
         let err = run_recipe_via_chrome_devtools_mcp(
@@ -5667,6 +5759,7 @@ mod tests {
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
+            no_notify: false,
         };
         let recipe_vars = BTreeMap::new();
         let err = run_recipe_via_chrome_devtools_mcp(
@@ -5697,6 +5790,7 @@ mod tests {
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
+            no_notify: false,
         };
         let recipe_vars = BTreeMap::from([("paste".to_string(), "true".to_string())]);
         let err = run_recipe_via_chrome_devtools_mcp(
@@ -5728,6 +5822,7 @@ mod tests {
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
+            no_notify: false,
         };
         let recipe_vars = BTreeMap::new();
         let err = run_recipe_via_chrome_devtools_mcp(
@@ -5759,6 +5854,7 @@ mod tests {
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
+            no_notify: false,
         };
         let recipe_vars = BTreeMap::from([("thread".to_string(), "sideways".to_string())]);
         let err = run_recipe_via_chrome_devtools_mcp(
@@ -5790,6 +5886,7 @@ mod tests {
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
+            no_notify: false,
         };
         let recipe_vars = BTreeMap::from([("thread".to_string(), "reuse".to_string())]);
         let err = run_recipe_via_chrome_devtools_mcp(
@@ -5823,6 +5920,7 @@ mod tests {
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
+            no_notify: false,
         };
         let recipe_vars = BTreeMap::new();
 
@@ -5850,6 +5948,7 @@ mod tests {
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
+            no_notify: false,
         };
         let recipe_vars = BTreeMap::from([("paste".to_string(), "true".to_string())]);
 
@@ -5875,6 +5974,7 @@ mod tests {
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
+            no_notify: false,
         };
         let recipe_vars = BTreeMap::from([
             ("prompt".to_string(), "Review this repo".to_string()),
@@ -5922,6 +6022,7 @@ mod tests {
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
+            no_notify: false,
         };
         let recipe_vars = BTreeMap::from([
             ("model".to_string(), "auto".to_string()),
@@ -5952,6 +6053,7 @@ mod tests {
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
+            no_notify: false,
         };
 
         let recipe_vars = browser::build_recipe_vars(recipe.defaults.as_ref(), &recipe_args.vars)
@@ -5995,6 +6097,7 @@ mod tests {
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
+            no_notify: false,
         };
         let mut recipe_vars = BTreeMap::from([(
             "prompt".to_string(),
@@ -6039,6 +6142,7 @@ mod tests {
             vars: vec!["prompt=Explicit prompt".to_string()],
             followup: None,
             allow_duplicate_prompt: false,
+            no_notify: false,
         };
         let mut recipe_vars =
             BTreeMap::from([("prompt".to_string(), "Explicit prompt".to_string())]);
@@ -6063,6 +6167,7 @@ mod tests {
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
+            no_notify: false,
         };
         let recipe_vars =
             BTreeMap::from([("profile_email".to_string(), "work@example.com".to_string())]);
@@ -6094,6 +6199,7 @@ mod tests {
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
+            no_notify: false,
         };
         let recipe_vars =
             BTreeMap::from([("extension_instance_id".to_string(), "ext_work".to_string())]);
@@ -6125,6 +6231,7 @@ mod tests {
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
+            no_notify: false,
         };
         let recipe_vars =
             BTreeMap::from([("browser_context_id".to_string(), "ctx-work".to_string())]);
@@ -6182,6 +6289,7 @@ mod tests {
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
+            no_notify: false,
         };
         let recipe_vars = BTreeMap::from([("thread".to_string(), "sideways".to_string())]);
         let err = run_recipe_via_dev_browser(
@@ -6212,6 +6320,7 @@ mod tests {
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
+            no_notify: false,
         };
         let recipe_vars = BTreeMap::from([("thread".to_string(), "reuse".to_string())]);
         let err = run_recipe_via_dev_browser(

--- a/crates/yoetz-cli/src/notifications.rs
+++ b/crates/yoetz-cli/src/notifications.rs
@@ -1,0 +1,202 @@
+use anyhow::Result;
+use std::env;
+use std::process::Command;
+
+use yoetz_core::config::Config;
+
+const DEFAULT_THRESHOLD_SECS: u64 = 60;
+const PREVIEW_LIMIT: usize = 120;
+
+pub(crate) fn should_notify_completion(
+    runtime_ms: u64,
+    threshold_secs: u64,
+    is_macos: bool,
+    muted_by_flag: bool,
+    muted_by_env: bool,
+    muted_by_config: bool,
+) -> bool {
+    if !is_macos {
+        return false;
+    }
+    if muted_by_flag || muted_by_env || muted_by_config {
+        return false;
+    }
+    runtime_ms >= threshold_secs.saturating_mul(1000)
+}
+
+pub(crate) fn notification_threshold_secs(config: &Config) -> u64 {
+    config
+        .notifications
+        .notify_threshold_secs
+        .unwrap_or(DEFAULT_THRESHOLD_SECS)
+}
+
+pub(crate) fn config_mutes_notifications(config: &Config) -> bool {
+    config.notifications.enabled == Some(false)
+}
+
+pub(crate) fn env_mutes_notifications() -> bool {
+    env::var_os("CI").is_some()
+        || env::var_os("SSH_TTY").is_some()
+        || env::var_os("SSH_CONNECTION").is_some()
+        || env::var("YOETZ_NO_NOTIFY").ok().as_deref() == Some("1")
+}
+
+pub(crate) fn sanitize_preview(input: &str) -> String {
+    let collapsed = input
+        .chars()
+        .map(|ch| if ch.is_control() { ' ' } else { ch })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    collapsed.chars().take(PREVIEW_LIMIT).collect()
+}
+
+pub(crate) fn format_elapsed(elapsed_ms: u64) -> String {
+    let seconds = elapsed_ms / 1000;
+    if seconds < 60 {
+        format!("{seconds}s")
+    } else {
+        let minutes = seconds / 60;
+        let remainder = seconds % 60;
+        if remainder == 0 {
+            format!("{minutes}m")
+        } else {
+            format!("{minutes}m {remainder}s")
+        }
+    }
+}
+
+pub(crate) fn maybe_notify_completion(
+    config: &Config,
+    no_notify: bool,
+    command: &str,
+    target: &str,
+    preview: &str,
+    elapsed_ms: u64,
+    cost_usd: Option<f64>,
+    debug: bool,
+) {
+    let threshold_secs = notification_threshold_secs(config);
+    if !should_notify_completion(
+        elapsed_ms,
+        threshold_secs,
+        cfg!(target_os = "macos"),
+        no_notify,
+        env_mutes_notifications(),
+        config_mutes_notifications(config),
+    ) {
+        return;
+    }
+
+    let title = format!("yoetz {command}");
+    let mut subtitle = if target.is_empty() {
+        format_elapsed(elapsed_ms)
+    } else {
+        format!("{target} • {}", format_elapsed(elapsed_ms))
+    };
+    if let Some(cost) = cost_usd {
+        subtitle.push_str(&format!(" • ${cost:.2}"));
+    }
+    let message = {
+        let preview = sanitize_preview(preview);
+        if preview.is_empty() {
+            "(no preview)".to_string()
+        } else {
+            preview
+        }
+    };
+
+    if let Err(err) = send_macos_notification(&title, &subtitle, &message) {
+        if debug {
+            eprintln!("debug: completion notification failed: {err}");
+        }
+    }
+}
+
+fn send_macos_notification(title: &str, subtitle: &str, message: &str) -> Result<()> {
+    if !cfg!(target_os = "macos") {
+        return Ok(());
+    }
+
+    let script = format!(
+        "display notification \"{}\" with title \"{}\" subtitle \"{}\"",
+        escape_applescript_string(message),
+        escape_applescript_string(title),
+        escape_applescript_string(subtitle),
+    );
+
+    let output = Command::new("osascript").arg("-e").arg(script).output()?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(anyhow::anyhow!(
+            "osascript exited with status {}: {}",
+            output.status,
+            stderr.trim()
+        ))
+    }
+}
+
+fn escape_applescript_string(input: &str) -> String {
+    input.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use yoetz_core::config::{Config, NotificationsConfig};
+
+    #[test]
+    fn notify_gate_requires_runtime_threshold_and_no_mutes() {
+        assert!(!should_notify_completion(
+            59_999, 60, true, false, false, false
+        ));
+        assert!(should_notify_completion(
+            60_000, 60, true, false, false, false
+        ));
+        assert!(!should_notify_completion(
+            60_000, 60, false, false, false, false
+        ));
+        assert!(!should_notify_completion(
+            60_000, 60, true, true, false, false
+        ));
+        assert!(!should_notify_completion(
+            60_000, 60, true, false, true, false
+        ));
+        assert!(!should_notify_completion(
+            60_000, 60, true, false, false, true
+        ));
+    }
+
+    #[test]
+    fn preview_is_single_line_and_truncated() {
+        let preview = sanitize_preview("line 1\nline\t2\x07  \n  extra words");
+        assert_eq!(preview, "line 1 line 2 extra words");
+
+        let long = "a".repeat(200);
+        assert_eq!(sanitize_preview(&long).chars().count(), PREVIEW_LIMIT);
+    }
+
+    #[test]
+    fn config_defaults_apply_threshold_and_enable_notifications() {
+        let config = Config::default();
+        assert_eq!(notification_threshold_secs(&config), DEFAULT_THRESHOLD_SECS);
+        assert!(!config_mutes_notifications(&config));
+    }
+
+    #[test]
+    fn config_can_mute_notifications() {
+        let config = Config {
+            notifications: NotificationsConfig {
+                enabled: Some(false),
+                notify_threshold_secs: Some(5),
+            },
+            ..Default::default()
+        };
+        assert!(config_mutes_notifications(&config));
+        assert_eq!(notification_threshold_secs(&config), 5);
+    }
+}

--- a/crates/yoetz-core/src/config.rs
+++ b/crates/yoetz-core/src/config.rs
@@ -249,6 +249,7 @@ model = "gpt-5-4-pro"
                 openrouter_models_url: Some("http://evil.example.com/models".to_string()),
                 ..Default::default()
             }),
+            notifications: None,
             aliases: Some(HashMap::from([(
                 "fast".to_string(),
                 "gpt-5-4-pro".to_string(),
@@ -283,6 +284,7 @@ model = "gpt-5-4-pro"
                 openrouter_models_url: Some("https://openrouter.ai/api/v1/models".to_string()),
                 ..Default::default()
             }),
+            notifications: None,
             aliases: None,
         };
         config.merge(

--- a/crates/yoetz-core/src/config.rs
+++ b/crates/yoetz-core/src/config.rs
@@ -13,6 +13,7 @@ pub struct Config {
     pub defaults: Defaults,
     pub providers: HashMap<String, ProviderConfig>,
     pub registry: RegistryConfig,
+    pub notifications: NotificationsConfig,
     #[serde(default)]
     pub aliases: HashMap<String, String>,
 }
@@ -45,10 +46,17 @@ pub struct RegistryConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct NotificationsConfig {
+    pub enabled: Option<bool>,
+    pub notify_threshold_secs: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct ConfigFile {
     pub defaults: Option<Defaults>,
     pub providers: Option<HashMap<String, ProviderConfig>>,
     pub registry: Option<RegistryConfig>,
+    pub notifications: Option<NotificationsConfig>,
     pub aliases: Option<HashMap<String, String>>,
 }
 
@@ -103,6 +111,9 @@ impl Config {
                     source.display()
                 );
             }
+        }
+        if let Some(notifications) = other.notifications {
+            merge_notifications(&mut self.notifications, notifications);
         }
         if let Some(aliases) = other.aliases {
             if trusted {
@@ -252,6 +263,7 @@ model = "gpt-5-4-pro"
         // Restricted fields skipped
         assert!(config.providers.is_empty());
         assert!(config.registry.openrouter_models_url.is_none());
+        assert!(config.notifications.enabled.is_none());
     }
 
     #[test]
@@ -281,6 +293,24 @@ model = "gpt-5-4-pro"
         assert!(config.providers.contains_key("openai"));
         assert!(config.registry.openrouter_models_url.is_some());
     }
+
+    #[test]
+    fn notifications_merge_from_any_config_scope() {
+        let mut config = Config::default();
+        let file = ConfigFile {
+            defaults: None,
+            providers: None,
+            registry: None,
+            notifications: Some(NotificationsConfig {
+                enabled: Some(false),
+                notify_threshold_secs: Some(90),
+            }),
+            aliases: None,
+        };
+        config.merge(file, false, Path::new("./yoetz.toml"));
+        assert_eq!(config.notifications.enabled, Some(false));
+        assert_eq!(config.notifications.notify_threshold_secs, Some(90));
+    }
 }
 
 fn merge_provider(target: &mut ProviderConfig, other: &ProviderConfig) {
@@ -307,5 +337,14 @@ fn merge_registry(target: &mut RegistryConfig, other: RegistryConfig) {
     }
     if other.auto_sync_secs.is_some() {
         target.auto_sync_secs = other.auto_sync_secs;
+    }
+}
+
+fn merge_notifications(target: &mut NotificationsConfig, other: NotificationsConfig) {
+    if other.enabled.is_some() {
+        target.enabled = other.enabled;
+    }
+    if other.notify_threshold_secs.is_some() {
+        target.notify_threshold_secs = other.notify_threshold_secs;
     }
 }

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -156,6 +156,11 @@ per model under `<session_dir>/models/`. Partial success exits zero by default;
 pass `--partial fail` when any failed model must make the command nonzero while
 still emitting the complete council result.
 
+Long-running `ask`, `council`, and browser recipe runs emit a native macOS
+completion notification after they clear the runtime threshold (default 60s).
+Mute with `--no-notify`, `YOETZ_NO_NOTIFY=1`, CI, SSH, or
+`[notifications] enabled = false` in config.toml.
+
 ## Ask (Single Model)
 
 Quick question with file context:
@@ -176,6 +181,9 @@ yoetz ask -p "Review this" -f "src/*.rs" \
   --provider openrouter --model "$MODEL_ID" \
   --format json
 ```
+
+Long-running `ask` runs use the same native completion notification path and
+respect the same mute rules as `council`.
 
 ## Review
 


### PR DESCRIPTION
Worktree: /Users/avivsinai/MyProjects/yoetz-completion-notifications
Branch: feature/completion-notifications
Commit: 8881e71 feat: add completion notifications
Validation: cargo fmt --all -- --check; cargo test -p yoetz; cargo clippy -p yoetz --all-targets -- -D warnings
Scope: native completion notifications for ask/council/browser recipes, with --no-notify, YOETZ_NO_NOTIFY=1, CI/SSH muting, and config-level disable support.

Rebased onto origin/main before commit, per review request.