### PR TITLE
feat: add current model strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Council runs now write per-model result/error artifacts, include aggregate
   success, failure, cost, and elapsed-time summaries, and support
   `--partial fail` for strict partial-failure exit semantics.
+- ChatGPT browser recipes now support `--model-strategy current` as a
+  drift-window escape hatch that skips picker interaction, reports the pill
+  text best-effort, and preserves the existing pinned `select` path as the
+  default.
 - ChatGPT recipe follow-ups now support native-only resumes via
   `--followup <session-id|conversation-id|url>` plus
   `--allow-duplicate-prompt` for explicit replays. Session-id lookups resolve

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -990,6 +990,7 @@ fn chatgpt_recipe_payload_from_steps(steps: &[Value], fallback_used: bool) -> Va
         transport: "agent-browser".to_string(),
         backend: "agent-browser".to_string(),
         response: response.as_str().unwrap_or_default().to_string(),
+        model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
         model_used: model_used.as_str().map(str::to_owned),
         model_selection_status,
         warnings,
@@ -1587,7 +1588,10 @@ fn run_chatgpt_select_model(
     headed: bool,
 ) -> Result<String> {
     let requested_model = crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL;
-    let function = chatgpt_web::build_model_selection_function(requested_model);
+    let function = chatgpt_web::build_model_selection_function(
+        requested_model,
+        chatgpt_recipe::ChatgptModelStrategy::Select,
+    );
     let expression = chatgpt_web::wrap_function_source_for_json_eval(&function)?;
     let stdout = run_agent_browser_with_connection_timeout(
         vec!["eval".to_string(), expression],

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -969,6 +969,7 @@ pub fn canary(live: bool, selector: ExtensionInstanceSelector<'_>) -> Result<Val
     let spec = ChatgptRecipeSpec {
         bundle_path: Some(bundle_path),
         model: crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL.to_string(),
+        model_strategy: crate::chatgpt_recipe::ChatgptModelStrategy::Select,
         prompt: "Reply with exactly OK.".to_string(),
         browser_context_id: None,
         profile_email: selector.profile_email.map(str::to_string),
@@ -1110,6 +1111,7 @@ fn chatgpt_job_start_payload(spec: &ChatgptRecipeSpec, bundle: &BundleInfo) -> V
         "mime": bundle.mime,
         "prompt": spec.prompt,
         "model": spec.model,
+        "model_strategy": spec.model_strategy,
         "browser_context_id": spec.browser_context_id,
         "profile_email": spec.profile_email,
         "extension_instance_id": spec.extension_instance_id,
@@ -2040,6 +2042,7 @@ fn parse_model_selection_status(value: Option<&str>) -> ChatgptModelSelectionSta
     match value.unwrap_or("unavailable") {
         "selected" => ChatgptModelSelectionStatus::Selected,
         "kept_current" => ChatgptModelSelectionStatus::KeptCurrent,
+        "current" => ChatgptModelSelectionStatus::Current,
         "mismatch" => ChatgptModelSelectionStatus::Mismatch,
         _ => ChatgptModelSelectionStatus::Unavailable,
     }
@@ -3237,6 +3240,7 @@ mod tests {
         let spec = ChatgptRecipeSpec {
             bundle_path: Some(bundle.path.clone()),
             model: crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL.to_string(),
+            model_strategy: crate::chatgpt_recipe::ChatgptModelStrategy::Select,
             prompt: "continue".to_string(),
             browser_context_id: None,
             profile_email: None,

--- a/crates/yoetz-cli/src/chatgpt_recipe.rs
+++ b/crates/yoetz-cli/src/chatgpt_recipe.rs
@@ -1,6 +1,7 @@
 //! ChatGPT recipe output types and terminal-fallback phase markers.
 
 use anyhow::Error as AnyhowError;
+use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::fmt;
@@ -132,11 +133,19 @@ pub enum ChatgptDeliveryMode {
     Paste,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, ValueEnum)]
+#[serde(rename_all = "snake_case")]
+pub enum ChatgptModelStrategy {
+    Select,
+    Current,
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ChatgptModelSelectionStatus {
     Selected,
     KeptCurrent,
+    Current,
     Unavailable,
     Mismatch,
 }
@@ -154,6 +163,7 @@ impl ChatgptDeliveryMode {
 pub struct ChatgptRecipeSpec {
     pub bundle_path: Option<PathBuf>,
     pub model: String,
+    pub model_strategy: ChatgptModelStrategy,
     pub prompt: String,
     pub browser_context_id: Option<String>,
     pub profile_email: Option<String>,
@@ -172,6 +182,7 @@ pub struct ChatgptRecipeOutput {
     pub transport: String,
     pub backend: String,
     pub response: String,
+    pub model_strategy: ChatgptModelStrategy,
     pub model_used: Option<String>,
     pub model_selection_status: ChatgptModelSelectionStatus,
     pub warnings: Vec<String>,
@@ -189,6 +200,7 @@ impl ChatgptRecipeOutput {
             "transport": self.transport,
             "backend": self.backend,
             "response": self.response,
+            "model_strategy": self.model_strategy,
             "model_used": self.model_used,
             "model_selection_status": self.model_selection_status,
             "warnings": self.warnings,
@@ -206,6 +218,7 @@ impl ChatgptRecipeOutput {
             "transport": self.transport,
             "backend": self.backend,
             "response": self.response,
+            "model_strategy": self.model_strategy,
             "model_used": self.model_used,
             "model_selection_status": self.model_selection_status,
             "warnings": self.warnings,
@@ -229,6 +242,7 @@ mod tests {
             transport: "dev-browser".to_string(),
             backend: "dev-browser".to_string(),
             response: "ok".to_string(),
+            model_strategy: ChatgptModelStrategy::Select,
             model_used: Some("GPT-5.6 Sol Pro".to_string()),
             model_selection_status: ChatgptModelSelectionStatus::Selected,
             warnings: vec!["fallback".to_string()],
@@ -244,6 +258,7 @@ mod tests {
         assert_eq!(payload["transport"], "dev-browser");
         assert_eq!(payload["backend"], "dev-browser");
         assert_eq!(payload["response"], "ok");
+        assert_eq!(payload["model_strategy"], "select");
         assert_eq!(payload["model_used"], "GPT-5.6 Sol Pro");
         assert_eq!(payload["model_selection_status"], "selected");
         assert_eq!(payload["warnings"], json!(["fallback"]));

--- a/crates/yoetz-cli/src/chatgpt_web.rs
+++ b/crates/yoetz-cli/src/chatgpt_web.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 use std::path::Path;
 use time::{format_description::FormatItem, macros::format_description, OffsetDateTime};
 
-use crate::chatgpt_recipe::ChatgptModelSelectionStatus;
+use crate::chatgpt_recipe::{ChatgptModelSelectionStatus, ChatgptModelStrategy};
 
 pub const CHATGPT_URL: &str = "https://chatgpt.com/";
 const CHATGPT_LEGACY_HOST: &str = "chat.openai.com";
@@ -322,13 +322,15 @@ pub fn select_reported_chatgpt_model(
     selection: &serde_json::Value,
     requested_model: &str,
 ) -> Option<String> {
-    if !is_verified_sol_pro_selection(selection, requested_model) {
-        return None;
+    if is_current_model_selection(selection, requested_model)
+        || is_verified_sol_pro_selection(selection, requested_model)
+    {
+        return selection
+            .get("modelUsed")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string);
     }
-    selection
-        .get("modelUsed")
-        .and_then(serde_json::Value::as_str)
-        .map(str::to_string)
+    None
 }
 
 pub(crate) fn chatgpt_model_selection_status(
@@ -344,9 +346,30 @@ pub(crate) fn chatgpt_model_selection_status(
             ChatgptModelSelectionStatus::Selected
         }
         "selected" | "selection-mismatch" => ChatgptModelSelectionStatus::Mismatch,
+        "current" if is_current_model_selection(selection, requested_model) => {
+            ChatgptModelSelectionStatus::Current
+        }
+        "current" => ChatgptModelSelectionStatus::Mismatch,
         "missing-selector" | "not-found" => ChatgptModelSelectionStatus::Unavailable,
         _ => ChatgptModelSelectionStatus::Unavailable,
     }
+}
+
+fn is_current_model_selection(selection: &serde_json::Value, requested_model: &str) -> bool {
+    selection.get("status").and_then(serde_json::Value::as_str) == Some("current")
+        && requested_model.trim() == "current"
+        && selection
+            .get("requested")
+            .and_then(serde_json::Value::as_str)
+            == Some("current")
+        && selection
+            .get("familyStatus")
+            .and_then(serde_json::Value::as_str)
+            == Some("skipped")
+        && selection
+            .get("effortStatus")
+            .and_then(serde_json::Value::as_str)
+            == Some("skipped")
 }
 
 fn is_verified_sol_pro_selection(selection: &serde_json::Value, requested_model: &str) -> bool {
@@ -405,15 +428,20 @@ pub fn upload_menu_text_pattern_json() -> String {
     serde_json::to_string(UPLOAD_MENU_TEXT_PATTERN).expect("serialize upload menu text pattern")
 }
 
-pub fn build_model_selection_function(requested_model: &str) -> String {
+pub fn build_model_selection_function(
+    requested_model: &str,
+    model_strategy: ChatgptModelStrategy,
+) -> String {
     let requested_model =
         serde_json::to_string(requested_model).expect("serialize requested model");
+    let model_strategy = serde_json::to_string(&model_strategy).expect("serialize model strategy");
     let model_button_selector = model_selector_button_selector_json();
     let composer_selector = composer_selector_json();
     format!(
         r##"
 async () => {{
   const requested = {requested_model};
+  const strategy = {model_strategy};
   const supported = "gpt-5-6-sol-pro";
   const MODEL_BUTTON_SELECTOR = {model_button_selector};
   const COMPOSER_SELECTOR = {composer_selector};
@@ -612,10 +640,13 @@ async () => {{
   function result(status, pill, state, families, warning = null) {{
     const familyIsVerified = familyVerified(state);
     const effortIsVerified = effortVerified(state);
+    const modelUsed = status === "current"
+      ? (pill ? textOf(pill) : "")
+      : (familyIsVerified && effortIsVerified ? "GPT-5.6 Sol Pro" : null);
     return {{
       requested,
       status,
-      modelUsed: familyIsVerified && effortIsVerified ? "GPT-5.6 Sol Pro" : null,
+      modelUsed,
       familyStatus: familyIsVerified ? "verified" : "unverified",
       effortStatus: effortIsVerified ? "verified" : "unverified",
       pillText: textOf(pill),
@@ -623,6 +654,24 @@ async () => {{
       availableItems: (state?.effortItems || []).map(textOf).filter(Boolean),
       availableFamilies: families || [],
       warning,
+      url: window.location.href || "",
+      title: document.title || ""
+    }};
+  }}
+
+  if (strategy === "current") {{
+    const pill = await waitForPill();
+    return {{
+      requested,
+      status: "current",
+      modelUsed: pill ? textOf(pill) : "",
+      familyStatus: "skipped",
+      effortStatus: "skipped",
+      pillText: pill ? textOf(pill) : "",
+      familyLabel: null,
+      availableItems: [],
+      availableFamilies: [],
+      warning: "model pinning bypassed — answer may come from any model",
       url: window.location.href || "",
       title: document.title || ""
     }};
@@ -1247,6 +1296,21 @@ mod tests {
     }
 
     #[test]
+    fn reported_chatgpt_model_returns_current_pill_text_without_picker_proof() {
+        let selection = serde_json::json!({
+            "status": "current",
+            "requested": "current",
+            "modelUsed": "5.5 Instant",
+            "familyStatus": "skipped",
+            "effortStatus": "skipped"
+        });
+        assert_eq!(
+            select_reported_chatgpt_model(&selection, "current"),
+            Some("5.5 Instant".to_string())
+        );
+    }
+
+    #[test]
     fn chatgpt_model_selection_status_reports_contract_values() {
         assert_eq!(
             chatgpt_model_selection_status(
@@ -1260,6 +1324,19 @@ mod tests {
                 "gpt-5-6-sol-pro"
             ),
             ChatgptModelSelectionStatus::Selected
+        );
+        assert_eq!(
+            chatgpt_model_selection_status(
+                &serde_json::json!({
+                    "status": "current",
+                    "requested": "current",
+                    "modelUsed": "5.5 Instant",
+                    "familyStatus": "skipped",
+                    "effortStatus": "skipped"
+                }),
+                "current"
+            ),
+            ChatgptModelSelectionStatus::Current
         );
         assert_eq!(
             chatgpt_model_selection_status(
@@ -1314,7 +1391,8 @@ mod tests {
 
     #[test]
     fn model_selection_function_requires_verified_sol_family_and_pro_effort() {
-        let script = build_model_selection_function("gpt-5-6-sol-pro");
+        let script =
+            build_model_selection_function("gpt-5-6-sol-pro", ChatgptModelStrategy::Select);
         assert!(script.contains(r#"const requested = "gpt-5-6-sol-pro";"#));
         assert!(script.contains("classList.contains(\"__composer-pill\")"));
         assert!(script.contains(
@@ -1338,6 +1416,17 @@ mod tests {
         assert!(!script.contains("if (families.length === 0 && state.familyTrigger)"));
         assert!(script.contains("await closeMenus"));
         assert!(!script.contains("model-switcher-gpt-5-4"));
+    }
+
+    #[test]
+    fn model_selection_function_current_bypasses_picker() {
+        let script = build_model_selection_function("current", ChatgptModelStrategy::Current);
+        assert!(script.contains(r#"const requested = "current";"#));
+        assert!(script.contains(r#"const strategy = "current";"#));
+        assert!(script.contains(r#"familyStatus: "skipped""#));
+        assert!(script.contains(r#"effortStatus: "skipped""#));
+        assert!(script.contains("model pinning bypassed — answer may come from any model"));
+        assert!(script.contains(r#"if (strategy === "current")"#));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
@@ -848,7 +848,10 @@ fn parse_response_baseline(state: &serde_json::Value) -> Result<ResponseBaseline
 }
 
 fn build_model_selection_script(requested_model: &str) -> String {
-    chatgpt_web::build_model_selection_function(requested_model)
+    chatgpt_web::build_model_selection_function(
+        requested_model,
+        crate::chatgpt_recipe::ChatgptModelStrategy::Select,
+    )
 }
 
 /// Rewrite a CDP attach failure with actionable guidance.

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -681,6 +681,8 @@ pub struct DevBrowserRecipeContext {
     pub bundle_text: Option<String>,
     /// ChatGPT model slug to select.
     pub model: String,
+    /// ChatGPT model selection strategy.
+    pub model_strategy: chatgpt_recipe::ChatgptModelStrategy,
     /// Whether to paste text instead of uploading as file.
     pub paste_mode: bool,
     /// Custom prompt text.
@@ -705,6 +707,7 @@ impl Default for DevBrowserRecipeContext {
             bundle_path: None,
             bundle_text: None,
             model: String::new(),
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             prompt: "Review the attached file and provide your analysis.".to_string(),
             run_id: String::new(),
             paste_mode: false,
@@ -940,19 +943,28 @@ fn classify_dev_browser_page_issue(
     chatgpt_web::detect_auth_issue_text(&haystack, true)
 }
 
-fn build_chatgpt_prepare_script(page_name: &str, model: &str, run_id: &str) -> String {
+fn build_chatgpt_prepare_script(
+    page_name: &str,
+    model: &str,
+    model_strategy: chatgpt_recipe::ChatgptModelStrategy,
+    run_id: &str,
+) -> String {
     let page_name_json = serde_json::to_string(page_name).unwrap();
     let model_json = serde_json::to_string(model).unwrap();
+    let model_strategy_json = serde_json::to_string(&model_strategy).unwrap();
     let marked_url_json = serde_json::to_string(&chatgpt_web::mark_chatgpt_url(run_id)).unwrap();
     let window_name_json =
         serde_json::to_string(&format!("yoetz:{run_id}")).expect("serialize yoetz window name");
-    let model_selection_function_json =
-        serde_json::to_string(&chatgpt_web::build_model_selection_function(model)).unwrap();
+    let model_selection_function_json = serde_json::to_string(
+        &chatgpt_web::build_model_selection_function(model, model_strategy),
+    )
+    .unwrap();
     let composer_selector_json = chatgpt_web::composer_selector_json();
     format!(
         r##"
 const PAGE_NAME = {page_name_json};
 const MODEL = {model_json};
+const MODEL_STRATEGY = {model_strategy_json};
 const MARKED_URL = {marked_url_json};
 const WINDOW_NAME = {window_name_json};
 const MODEL_SELECTION_FUNCTION_SOURCE = {model_selection_function_json};
@@ -1023,7 +1035,22 @@ if (loggedIn && composerReady) {{
   }}, MODEL_SELECTION_FUNCTION_SOURCE);
   const selectionStatus = selection?.status || "unknown";
   modelSelection = selection || null;
-  if (selectionStatus !== "selected") {{
+  if (MODEL_STRATEGY === "current") {{
+    if (selectionStatus !== "current") {{
+      const diagnostics = JSON.stringify({{
+        status: selectionStatus,
+        requested: selection?.requested || MODEL || "",
+        familyStatus: selection?.familyStatus || "skipped",
+        effortStatus: selection?.effortStatus || "skipped",
+        pillText: selection?.pillText || "",
+        warning: selection?.warning || "",
+        availableItems: selection?.availableItems || [],
+        availableFamilies: selection?.availableFamilies || [],
+      }});
+      throw new Error("unexpected model selection status '" + selectionStatus + "' (" + diagnostics + ")");
+    }}
+    selectedModel = selection?.modelUsed ?? "";
+  }} else if (selectionStatus !== "selected") {{
     const diagnostics = JSON.stringify({{
       status: selectionStatus,
       requested: selection?.requested || MODEL || "",
@@ -1045,7 +1072,7 @@ if (loggedIn && composerReady) {{
     }}
     throw new Error("unexpected model selection status '" + selectionStatus + "' (" + diagnostics + ")");
   }}
-  selectedModel = selection?.modelUsed || null;
+  selectedModel = selection?.modelUsed ?? null;
   await page.waitForTimeout(500);
 }}
 console.log(JSON.stringify({{
@@ -1548,7 +1575,12 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<ChatgptRecipe
             ctx.prompt.clone()
         };
 
-        let prepare_script = build_chatgpt_prepare_script(&page_name, &ctx.model, &ctx.run_id);
+        let prepare_script = build_chatgpt_prepare_script(
+            &page_name,
+            &ctx.model,
+            ctx.model_strategy,
+            &ctx.run_id,
+        );
         let prepare_stdout = {
             let attach_attempt_lock = browser::acquire_attach_attempt_lock()?;
             if ctx.show_approval_guidance {
@@ -1974,11 +2006,13 @@ mod tests {
         let script = build_chatgpt_prepare_script(
             "yoetz-chatgpt-test",
             crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL,
+            crate::chatgpt_recipe::ChatgptModelStrategy::Select,
             "run-123",
         );
 
         assert!(script.contains("const PAGE_NAME = \"yoetz-chatgpt-test\";"));
         assert!(script.contains("const MODEL = \"gpt-5-6-sol-pro\";"));
+        assert!(script.contains("const MODEL_STRATEGY = \"select\";"));
         assert!(script.contains("const MARKED_URL = \"https://chatgpt.com/?_yoetz=run-123\";"));
         assert!(script.contains("const WINDOW_NAME = \"yoetz:run-123\";"));
         assert!(
@@ -2005,7 +2039,7 @@ mod tests {
         assert!(script.contains("modelSelection = selection || null;"));
         assert!(!script.contains("modelSelectionStatus ="));
         assert!(script.contains("selectedModel ="));
-        assert!(script.contains("selectedModel = selection?.modelUsed || null;"));
+        assert!(script.contains("selectedModel = selection?.modelUsed ?? null;"));
         assert!(script.contains("modelUsed: selectedModel,"));
         assert!(script.contains("modelSelection,"));
         assert!(script.contains("bodyText"));
@@ -2016,13 +2050,33 @@ mod tests {
 
     #[test]
     fn build_chatgpt_prepare_script_marks_a_yoetz_owned_tab() {
-        let script = build_chatgpt_prepare_script("yoetz-chatgpt-test", "pro", "run-456");
+        let script = build_chatgpt_prepare_script(
+            "yoetz-chatgpt-test",
+            "pro",
+            crate::chatgpt_recipe::ChatgptModelStrategy::Select,
+            "run-456",
+        );
         assert!(script.contains("const MARKED_URL = \"https://chatgpt.com/?_yoetz=run-456\";"));
         assert!(script.contains("const WINDOW_NAME = \"yoetz:run-456\";"));
         assert!(
             script.contains("await page.goto(MARKED_URL, { waitUntil: \"domcontentloaded\" });")
         );
         assert!(script.contains("window.name = name;"));
+    }
+
+    #[test]
+    fn build_chatgpt_prepare_script_current_skips_picker_selection() {
+        let script = build_chatgpt_prepare_script(
+            "yoetz-chatgpt-test",
+            "current",
+            crate::chatgpt_recipe::ChatgptModelStrategy::Current,
+            "run-789",
+        );
+        assert!(script.contains("const MODEL = \"current\";"));
+        assert!(script.contains("const MODEL_STRATEGY = \"current\";"));
+        assert!(script.contains(r#"MODEL_STRATEGY === "current""#));
+        assert!(script.contains(r#"selectedModel = selection?.modelUsed ?? "";"#));
+        assert!(script.contains("model pinning bypassed — answer may come from any model"));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -266,6 +266,10 @@ struct BrowserRecipeArgs {
     #[arg(long)]
     recipe: PathBuf,
 
+    /// Control whether ChatGPT is pinned to Sol+Pro or left on the current model.
+    #[arg(long, value_enum, default_value_t = chatgpt_recipe::ChatgptModelStrategy::Select)]
+    model_strategy: chatgpt_recipe::ChatgptModelStrategy,
+
     /// Explicitly select one browser recipe transport. When omitted, the
     /// chatgpt recipe selects only `chrome-extension-native` if the Yoetz
     /// Chrome extension is installed and reports `connected`; otherwise the
@@ -2055,6 +2059,7 @@ async fn run_recipe_via_chrome_devtools_mcp(
         transport: "chrome-devtools-mcp".to_string(),
         backend: "chrome-devtools-mcp".to_string(),
         response: response.response,
+        model_strategy: recipe_spec.model_strategy,
         model_used: response.model_used,
         model_selection_status,
         warnings: Vec::new(),
@@ -2076,6 +2081,7 @@ async fn run_recipe_via_chrome_devtools_mcp(
                 transport: "chrome-devtools-mcp".to_string(),
                 backend: "chrome-devtools-mcp".to_string(),
                 response: payload["response"].as_str().unwrap_or_default().to_string(),
+                model_strategy: recipe_spec.model_strategy,
                 model_used: payload["model_used"].as_str().map(str::to_owned),
                 model_selection_status,
                 warnings: payload["warnings"]
@@ -2129,7 +2135,13 @@ fn build_chatgpt_recipe_spec(
         .transpose()?;
     Ok(chatgpt_recipe::ChatgptRecipeSpec {
         bundle_path: recipe_args.bundle.clone(),
-        model: chatgpt_recipe::CHATGPT_SOL_PRO_MODEL.to_string(),
+        model: match recipe_args.model_strategy {
+            chatgpt_recipe::ChatgptModelStrategy::Select => {
+                chatgpt_recipe::CHATGPT_SOL_PRO_MODEL.to_string()
+            }
+            chatgpt_recipe::ChatgptModelStrategy::Current => "current".to_string(),
+        },
+        model_strategy: recipe_args.model_strategy,
         prompt: recipe_vars
             .get("prompt")
             .cloned()
@@ -2281,6 +2293,7 @@ fn run_recipe_via_chrome_extension_native(
         transport: browser_extension_native::TRANSPORT_NAME.to_string(),
         backend: browser_extension_native::TRANSPORT_NAME.to_string(),
         response: response.response,
+        model_strategy: recipe_spec.model_strategy,
         model_used: response.model_used,
         model_selection_status: response.model_selection_status,
         warnings: response.warnings,
@@ -2461,6 +2474,7 @@ fn run_recipe_via_dev_browser(
         bundle_path: recipe_spec.bundle_path.clone(),
         bundle_text,
         model: recipe_spec.model.clone(),
+        model_strategy: recipe_spec.model_strategy,
         paste_mode,
         prompt: recipe_spec.prompt.clone(),
         run_id: recipe_spec.run_id.clone(),
@@ -2481,6 +2495,7 @@ fn run_recipe_via_dev_browser(
         transport: "dev-browser".to_string(),
         backend: "dev-browser".to_string(),
         response: response.response,
+        model_strategy: recipe_spec.model_strategy,
         model_used: response.model_used,
         model_selection_status: response.model_selection_status,
         warnings: response.warnings,
@@ -5721,6 +5736,7 @@ mod tests {
             profile: None,
             cdp: None,
             browser_id: None,
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
@@ -5756,6 +5772,7 @@ mod tests {
             profile: Some(PathBuf::from("/tmp/ignored")),
             cdp: None,
             browser_id: None,
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
@@ -5787,6 +5804,7 @@ mod tests {
             profile: None,
             cdp: None,
             browser_id: None,
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
@@ -5819,6 +5837,7 @@ mod tests {
             profile: None,
             cdp: None,
             browser_id: None,
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
@@ -5851,6 +5870,7 @@ mod tests {
             profile: None,
             cdp: None,
             browser_id: None,
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
@@ -5883,6 +5903,7 @@ mod tests {
             profile: None,
             cdp: None,
             browser_id: None,
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
@@ -5917,6 +5938,7 @@ mod tests {
             profile: None,
             cdp: None,
             browser_id: None,
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
@@ -5945,6 +5967,7 @@ mod tests {
             profile: None,
             cdp: None,
             browser_id: None,
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
@@ -5971,6 +5994,7 @@ mod tests {
             profile: None,
             cdp: None,
             browser_id: None,
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
@@ -6019,6 +6043,7 @@ mod tests {
             profile: None,
             cdp: None,
             browser_id: None,
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
@@ -6050,6 +6075,7 @@ mod tests {
             profile: None,
             cdp: None,
             browser_id: None,
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
@@ -6094,6 +6120,7 @@ mod tests {
             profile: None,
             cdp: None,
             browser_id: None,
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
@@ -6139,6 +6166,7 @@ mod tests {
             profile: None,
             cdp: None,
             browser_id: None,
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec!["prompt=Explicit prompt".to_string()],
             followup: None,
             allow_duplicate_prompt: false,
@@ -6164,6 +6192,7 @@ mod tests {
             profile: None,
             cdp: None,
             browser_id: None,
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
@@ -6196,6 +6225,7 @@ mod tests {
             profile: None,
             cdp: None,
             browser_id: None,
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
@@ -6228,6 +6258,7 @@ mod tests {
             profile: None,
             cdp: None,
             browser_id: None,
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
@@ -6255,6 +6286,7 @@ mod tests {
             transport: "dev-browser".to_string(),
             backend: "dev-browser".to_string(),
             response: "ok".to_string(),
+            model_strategy: crate::chatgpt_recipe::ChatgptModelStrategy::Select,
             model_used: Some("GPT-5.6 Sol Pro".to_string()),
             model_selection_status: crate::chatgpt_recipe::ChatgptModelSelectionStatus::Selected,
             warnings: vec!["clipboard fallback".to_string()],
@@ -6286,6 +6318,7 @@ mod tests {
             profile: None,
             cdp: None,
             browser_id: None,
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,
@@ -6317,6 +6350,7 @@ mod tests {
             profile: None,
             cdp: None,
             browser_id: None,
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
             allow_duplicate_prompt: false,

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -303,6 +303,25 @@ function conversationUnavailableError(conversationId, currentConversationId, win
 }
 
 export async function configureModelState(root, job = {}) {
+  if (modelSelectionStrategyForJob(job) === "current") {
+    const modelButton = await waitForModelButton(root, { timeoutMs: 1500, intervalMs: 250 });
+    const pillText = modelControlLabel(modelButton);
+    return {
+      status: "current",
+      model_used: pillText ?? "",
+      requested_model: "current",
+      available_options: [],
+      available_families: [],
+      family_status: "skipped",
+      effort_status: "skipped",
+      pill_text: pillText ?? "",
+      family_label: null,
+      effort_options: [],
+      warning: "model pinning bypassed — answer may come from any model",
+      warnings: []
+    };
+  }
+
   const selection = await selectSolProModel(root, modelSelectionOptionsForJob(job));
   const warnings = selection.warning ? [selection.warning] : [];
   return {
@@ -332,6 +351,12 @@ function modelSelectionOptionsForJob(job = {}) {
     options.intervalMs = intervalMs;
   }
   return options;
+}
+
+function modelSelectionStrategyForJob(job = {}) {
+  return String(job?.model_strategy ?? "select").trim().toLowerCase() === "current"
+    ? "current"
+    : "select";
 }
 
 function modelControlScopes(root) {

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -303,6 +303,7 @@ async function startJob(message) {
       phase: "model_selection",
       side_effect_started: false,
       requested_model: job.model,
+      model_strategy: job.model_strategy,
       model_used: job.model_used,
       model_selection_status: job.model_selection_status,
       model_selection: modelSelection
@@ -478,6 +479,7 @@ async function completeJobWithExtraction(job, extraction) {
       copy_button_count: extraction.copy_button_count ?? 0,
       conversation_id: conversationId,
       conversation_url: conversationUrlForId(conversationId),
+      model_strategy: job.model_strategy ?? "select",
       model_used: job.model_used ?? null,
       model_selection_status: job.model_selection_status ?? "unavailable",
       warnings: [
@@ -1051,7 +1053,8 @@ function normalizeJob(message) {
     capability_token: message.capability_token,
     request_id: message.request_id,
     prompt: payload.prompt ?? "",
-    model: "gpt-5-6-sol-pro",
+    model: payload.model_strategy === "current" ? "current" : "gpt-5-6-sol-pro",
+    model_strategy: payload.model_strategy ?? "select",
     wait_timeout_ms: payload.wait_timeout_ms ?? DEFAULT_WAIT_TIMEOUT_MS,
     wait_interval_ms: payload.wait_interval_ms ?? 30000,
     upload_timeout_ms: payload.upload_timeout_ms ?? 120000,
@@ -1940,6 +1943,11 @@ function nonNegativeFiniteNumber(value) {
 }
 
 function isAcceptableModelSelection(selection) {
+  if (selection?.status === "current") {
+    return selection?.requested_model === "current"
+      && selection?.family_status === "skipped"
+      && selection?.effort_status === "skipped";
+  }
   return selection?.status === "selected"
     && selection?.requested_model === "gpt-5-6-sol-pro"
     && selection?.family_status === "verified"

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -2011,6 +2011,30 @@ test("GPT-5.6 Sol picker fails loudly on the legacy model-switcher DOM", async (
   assert.equal(legacyButton.events.includes("pointerdown"), false);
 });
 
+test("current model strategy waits briefly for the pill and reads it without picker clicks", async () => {
+  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer);
+  const body = new FakeElement("body", {}, "Ask anything").append(form);
+  const doc = new FakeDocument(body);
+  const pill = new FakeElement("button", { "aria-haspopup": "menu", class: "__composer-pill" }, "5.5\nInstant");
+
+  setTimeout(() => {
+    form.append(pill);
+  }, 300);
+
+  const result = await configureModelState(doc, { model_strategy: "current" });
+
+  assert.equal(result.status, "current");
+  assert.equal(result.model_used, "5.5\nInstant");
+  assert.equal(result.requested_model, "current");
+  assert.equal(result.pill_text, "5.5\nInstant");
+  assert.equal(result.family_status, "skipped");
+  assert.equal(result.effort_status, "skipped");
+  assert.deepEqual(result.warnings, []);
+  assert.equal(pill.events.length, 0);
+  assert.equal(pill.clicked, false);
+});
+
 function makeSolPickerFixture({
   family,
   effort,

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -957,6 +957,89 @@ test("service worker fails closed when GPT-5.6 Sol Pro selection is only kept_cu
   }
 });
 
+test("service worker keeps the current-model warning to one final payload entry", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  let tabId = 0;
+  const sentJobs = new Set();
+  const sentToTabs = [];
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        sentToTabs.push(message);
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return {
+              ok: true,
+              payload: currentSelection()
+            };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sentJobs.add(message.job.job_id);
+            return {
+              ok: true,
+              payload: {
+                sent: true,
+                conversation_id: "conv-current-warning"
+              }
+            };
+          case "yoetz_extract_response":
+            return {
+              ok: true,
+              payload: {
+                method: "assistant_dom_fallback",
+                text: sentJobs.has(message.job.job_id) ? "answer" : "",
+                is_generating: false,
+                assistant_count: sentJobs.has(message.job.job_id) ? 1 : 0,
+                copy_button_count: sentJobs.has(message.job.job_id) ? 1 : 0,
+                has_copy_button: sentJobs.has(message.job.job_id),
+                turn_index: sentJobs.has(message.job.job_id) ? 0 : -1,
+                conversation_id: "conv-current-warning"
+              }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?current_warning=${Date.now()}`);
+    port.emit(envelope("job_start", "job_current_warning", {
+      prompt: "prompt",
+      model: "smuggled-value",
+      model_strategy: "current"
+    }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_progress" && message.payload.phase === "ready_for_file"));
+    assert.equal(sentToTabs.find((message) => message.type === "yoetz_configure_model")?.job.model, "current");
+    port.emit(envelope("job_file_chunk", "job_current_warning", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "bundle.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_complete" && message.job_id === "job_current_warning"));
+    const complete = port.messages.find((message) => message.type === "job_complete" && message.job_id === "job_current_warning");
+    assert.equal(complete.payload.model_selection_status, "current");
+    assert.deepEqual(complete.payload.warnings, ["model pinning bypassed — answer may come from any model"]);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker fails closed when GPT-5.6 Sol Pro selection fails", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
@@ -5516,6 +5599,18 @@ function verifiedSolProSelection() {
     requested_model: "gpt-5-6-sol-pro",
     family_status: "verified",
     effort_status: "verified"
+  };
+}
+
+function currentSelection() {
+  return {
+    status: "current",
+    model_used: "5.5 Instant",
+    requested_model: "current",
+    family_status: "skipped",
+    effort_status: "skipped",
+    warning: "model pinning bypassed — answer may come from any model",
+    warnings: []
   };
 }
 

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -372,6 +372,9 @@ for deeper diagnostics. If you specifically need the CDP/browser stack, pass
 `--transport agent-browser`, `--cdp`, `--browser-id`, or a managed `--profile`.
 Do not run a live canary as a routine readiness step before ChatGPT Pro recipe
 runs; reserve it for explicit diagnostics.
+`--model-strategy current` is the drift-window escape hatch: it leaves the
+picker untouched, reports the pill text best-effort, and should not be used for
+routine pinned runs.
 If `doctor` or `inspect` points to a live ChatGPT-side problem and the user
 explicitly wants a diagnostic probe, run
 `yoetz browser extension canary --chatgpt --live`.


### PR DESCRIPTION
F3 implementation: add `--model-strategy current` alongside the existing select path.\n\nChecks:\n- cargo test -p yoetz\n- npm test in extensions/chatgpt-native\n\nLive canaries:\n- current: run_id=20260711T120528Z_cad21f, conversation_id=6a523190-0948-83eb-956d-a945d59a0b71, response=OK, model_strategy=current, model_selection_status=current\n- select: run_id=20260711T120858Z_8a9a4e, conversation_id=6a523266-d834-83eb-8eab-5058287b54e6, response=OK, model_strategy=select, model_selection_status=selected, model_used=GPT-5.6 Sol Pro\n\nHardening note:\n- normalizeJob now derives model from model_strategy, so a smuggled payload.model cannot override the server-side default.\n\nReview note folded in:\n- current-strategy pill read now retries briefly before giving up, still non-blocking and empty-safe\n- current-strategy final payload warning is single-entry only