### PR TITLE
chore: upgrade litellm-rust to v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `litellm-rust` to `v0.3.0`, bringing current embedded model metadata,
+  normalized tool calls, and built-in direct Z.AI routing through `ZAI_API_KEY`.
+
 ### Added
 
 - Persist OpenRouter model creation timestamps and allow trusted config to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,7 +589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1272,8 +1272,8 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litellm-rust"
-version = "0.2.0"
-source = "git+https://github.com/avivsinai/litellm-rust?tag=v0.2.0#ef1906329119c615b4b5cb7f339a64076aea4c07"
+version = "0.3.0"
+source = "git+https://github.com/avivsinai/litellm-rust?tag=v0.3.0#739cb399b4aab147e25910e2737d405e533f6ae3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1637,7 +1637,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1894,7 +1894,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1952,7 +1952,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2249,7 +2249,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2849,7 +2849,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2893,15 +2893,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -2933,28 +2924,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2970,12 +2944,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2986,12 +2954,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3006,22 +2968,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3036,12 +2986,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3052,12 +2996,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3072,12 +3010,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3088,12 +3020,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/README.md
+++ b/README.md
@@ -309,10 +309,11 @@ pinning examples.
 | OpenRouter | Yes | Model-dependent | No | No | No |
 | OpenAI | Yes | Yes | Yes | Yes (Sora) | No |
 | Gemini | Yes | Yes | No | Yes (Veo) | Yes |
+| Z.AI | Yes | Model-dependent | No | No | No |
 | LiteLLM-compatible | Yes | Model-dependent | No | No | No |
 
-Anthropic and xAI models are commonly reached through OpenRouter, but can also
-be configured as direct providers when you need provider-specific routing.
+Anthropic, xAI, and Z.AI models are commonly reached through OpenRouter, but can
+also be configured as direct providers when you need provider-specific routing.
 
 Common API key variables:
 
@@ -323,6 +324,7 @@ Common API key variables:
 | `GEMINI_API_KEY` | Gemini |
 | `ANTHROPIC_API_KEY` | Direct Anthropic-compatible provider configs |
 | `XAI_API_KEY` | Direct xAI/OpenAI-compatible provider configs |
+| `ZAI_API_KEY` | Direct Z.AI/OpenAI-compatible routing |
 | `LITELLM_API_KEY` | LiteLLM proxy |
 
 ## Safety And Trust

--- a/crates/yoetz-cli/Cargo.toml
+++ b/crates/yoetz-cli/Cargo.toml
@@ -21,7 +21,7 @@ workspace = true
 
 [dependencies]
 yoetz-core = { path = "../yoetz-core" }
-litellm-rust = { git = "https://github.com/avivsinai/litellm-rust", tag = "v0.2.0" }
+litellm-rust = { git = "https://github.com/avivsinai/litellm-rust", tag = "v0.3.0" }
 
 anyhow.workspace = true
 dotenvy.workspace = true

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -958,6 +958,7 @@ const BASE_PROTECTED_DOTENV_ENV_VARS: &[&str] = &[
     "GEMINI_API_KEY",
     "OPENROUTER_API_KEY",
     "XAI_API_KEY",
+    "ZAI_API_KEY",
     "LITELLM_API_KEY",
 ];
 
@@ -4684,6 +4685,7 @@ mod tests {
             "YOETZ_BROWSER_CDP",
             "YOETZ_BROWSER_TARGET_PATH",
             "YOETZ_BROWSER_PROFILE",
+            "ZAI_API_KEY",
             "LITELLM_API_KEY",
         ] {
             assert!(


### PR DESCRIPTION
## Summary
- upgrade Yoetz to the released `litellm-rust` v0.3.0 tag
- expose direct Z.AI configuration safely through `ZAI_API_KEY`
- document Z.AI support and the SDK-backed metadata/tool-call improvements

## Verification
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- public tag `v0.3.0` resolves to release commit `739cb399b4aab147e25910e2737d405e533f6ae3`
- Claude peer review: PASS