### PR TITLE
feat: add Claude Fable 5 browser recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Added a built-in `claude` browser recipe at parity with `chatgpt`, covering
+  `chrome-devtools-mcp`, `dev-browser`, `agent-browser`, and
+  `chrome-extension-native`. It fails closed unless the live picker proves
+  Fable 5, Effort Max, and Thinking on; `--model-strategy current` and
+  `model`/`effort`/`thinking` overrides are rejected.
+- Turned the native extension into one pinned multi-site Yoetz Native Transport
+  package. Site adapters route ChatGPT and Claude jobs, while
+  `hello` and `status` advertise recipe capabilities and reject unknown sites
+  before browser side effects. Existing installations keep the same extension
+  ID and legacy extensions remain ChatGPT-only.
+- Added native-only Claude conversation resume through
+  `--var conversation=<uuid|url>` and `--followup`, with follow-up history keyed
+  by site and conversation ID. Legacy follow-up records default to ChatGPT.
+- Added the `inline_warn_tokens` Claude recipe variable (default 150,000; `0`
+  disables it) to warn when a bundle is likely to use retrieval-backed access.
+  The heuristic does not change existing bundle byte limits.
+- Added `--claude` scope to the native-extension lifecycle and browser checks,
+  including an exact-output `browser extension canary --claude`.
+
+### Changed
+
+- Shared built-in ChatGPT and Claude orchestration behind `BuiltinWebRecipe`;
+  ChatGPT behavior remains locked by its existing suites and live canary.
+- Managed extension syncs now stamp a monotonic fourth version segment so
+  programmatic reloads observe each changed artifact. `status` and `doctor`
+  report `managed_copy_mismatch` for wrong-path or unstamped loads and provide
+  the one-time remove-card/load-unpacked migration instruction.
+- Dev-browser generated scripts are lint-locked to QuickJS-supported locator
+  verbs, and Claude delivery reports truthful `delivery_mode` and
+  `auto_paste_fallback` metadata, including inline fallback when clipboard
+  upload produces no file.
+
+### Fixed
+
+- Hardened Claude's live UI path: jobs stay foreground through upload and
+  accepted send, hidden file inputs use the cross-world native `files` setter,
+  Base UI model selection uses paced state verification with complete
+  diagnostics, and early/full selection return the same accepted result shape.
+- Excluded collapsed Claude thinking/status rows from final response text by
+  sanitizing a cloned response subtree without mutating the live page.
+
 ## [0.5.33] - 2026-07-11
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,8 @@ recipe flows, treat `dev-browser` as a QuickJS/WASM runner, not Node.js:
 - Use named pages via `browser.getPage(name)` / `browser.listPages()` to carry
   state across scripts.
 - Use `console.log(JSON.stringify(...))` as the script-to-Rust IPC boundary.
+- Keep generated scripts within the locator verbs supported by the QuickJS
+  bridge; the script-source lint is the compatibility lock for that surface.
 - Prefer Playwright actions on the page plus Rust orchestration. Do not assume
   Node features such as `require`, arbitrary `fs`, or `fetch`.
 - For contenteditable ChatGPT inputs, use typing APIs such as
@@ -75,6 +77,8 @@ recipe flows, treat `dev-browser` as a QuickJS/WASM runner, not Node.js:
   clipboard paste via `osascript` because QuickJS cannot drive
   `setInputFiles`; this is a dev-browser-specific workaround and is not the
   default upload path. Non-macOS dev-browser runs degrade to inline paste.
+  Always report the actual `delivery_mode` and `auto_paste_fallback`, including
+  inline fallback when a clipboard gesture produces no upload.
 - The QuickJS GC crash recovery in `dev_browser.rs` can salvage stdout from a
   completed script, but recipe correctness must not depend on that recovery.
 
@@ -84,28 +88,62 @@ recipe flows, treat `dev-browser` as a QuickJS/WASM runner, not Node.js:
   yoetz must own behavior for correctness or UX.
 - Extension-free by default. Preferred live-Chrome transport order:
   `chrome-devtools-mcp`, then `dev-browser`, then `agent-browser`.
-- ChatGPT recipe exception: when `yoetz browser extension status --chatgpt`
+- The `claude` recipe mirrors `chatgpt` end to end through the typed contract in
+  `crates/yoetz-cli/src/claude_recipe.rs` and DOM builders in `claude_web.rs`.
+  Its only model target is Fable 5 + Effort Max + Thinking on. Selection is
+  fail-closed: re-read the model radio, `effort-option-max`, and Thinking
+  switch state; a successful click is never proof.
+- Built-in web-recipe exception: when extension status for the selected site
   reports `connected`, `chrome-extension-native` is auto-selected as the only
   default transport and fails closed instead of falling through to CDP
   transports. Opt out with `--transport <other>` or a pinned `transports:` in
   the recipe yaml; CDP fallback after a native failure requires the explicit
-  `--transport chrome-extension-native --allow-cdp-fallback`. Non-ChatGPT
-  recipes and unhealthy/missing extensions are unaffected. Plain
-  `yoetz browser check` follows the same auto-selection; pass an explicit
+  `--transport chrome-extension-native --allow-cdp-fallback`. Other recipes
+  and unhealthy/missing extensions are unaffected. Plain `yoetz browser check`
+  remains ChatGPT-scoped; use `--claude` for Claude. Pass an explicit
   `--transport`, `--cdp`, `--browser-id`, or `--profile` to verify the CDP
   stack instead.
-- Extension lifecycle: `setup --chatgpt` materializes packaged source into the
-  stable `$YOETZ_DIR/chatgpt-native-extension` directory, loaded unpacked in
-  Chrome exactly once; `update --chatgpt` re-syncs the managed copy, reloads
-  the extension, and verifies the loaded version. Never hand-patch the managed
-  directory. Other subcommands (`doctor`, `status`, `inspect`, ...) are listed
-  in `yoetz browser extension --help`.
-- ChatGPT conversation resume uses `--var conversation=<id|url>`
+- The native extension is one pinned multi-site package
+  (`extensions/chatgpt-native/`, display name "Yoetz Native Transport") with
+  adapters under `src/sites/`. `job_start.payload.recipe` selects `chatgpt` or
+  `claude` (missing means ChatGPT; unknown fails before side effects).
+  Extension `hello` advertises `recipes`; derive `claude_ready` from that
+  capability, never from version comparison.
+- Extension lifecycle: `setup --chatgpt` or `setup --claude` materializes the
+  same packaged source into `$YOETZ_DIR/chatgpt-native-extension`. Load that
+  exact directory unpacked in the Chrome profile that hosts the AI sessions;
+  `chrome://extensions` load state is profile-specific. Never load a repo
+  checkout. `update` re-syncs the managed copy with a stamped identity, reloads
+  it, and verifies the loaded version. `status` and `doctor` fail on wrong-path
+  or unstamped loads. Never hand-patch the managed directory.
+- The native host and managed extension directory are machine-global,
+  single-writer state shared by every agent lane. Serialize setup/update/reload
+  operations; concurrent lanes may run recipes only against one frozen loaded
+  artifact.
+- ChatGPT and Claude conversation resume use
+  `--var conversation=<site-specific-id|url>` or `--followup`
   (native-extension only, no automatic context management); callers own the
   resume-vs-fresh decision.
+- Claude attachments may be inline or retrieval-backed. Warn, do not fail,
+  above the `inline_warn_tokens` estimate, and do not raise Yoetz's byte caps:
+  the quality cliff is tokens in context, not file bytes. Claude's upload input
+  is hidden/zero-size, so resolve the exact selector rather than accessibility
+  snapshots; use the native `input.files` setter so page-world handlers observe
+  files assigned from the extension's isolated world.
+- Claude jobs must open active because its SPA may not mount in a never-focused
+  tab. Keep the tab active through upload and accepted send, then restore the
+  previous tab before waiting for the response; ChatGPT jobs remain background.
+  Base UI picker choreography needs settle pacing, attributed pointer-event
+  hover fallback, visibility-gated Thinking reads, and diagnostics for every
+  verification leg. Early-exit and full-selection results must have the same
+  acceptable shape.
+- Claude finality requires the last assistant turn to be non-streaming and no
+  `Stop response` control, with bounded no-progress failure. The copy control
+  is hover-dependent and is not a primary finality anchor. Exclude cloned
+  `group/status` thinking rows from response text without mutating the live DOM.
 - Multiple loaded extension profiles route by `profile_email` when Chrome
   exposes it, else by the stable `extension_instance_id` from
-  `status --chatgpt`.
+  `status --chatgpt` or `status --claude`.
 - Default mode is connect-first: attach to the user's already running Chrome
   before considering cookie sync or managed-profile fallbacks.
 - The daemon is trusted by default. Do not silently recycle live-attach

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Fast CLI for routing code and media work through the right LLM path: direct API
 calls when available, multi-model councils when you need agreement, and browser
-recipes for web-only models such as ChatGPT Pro.
+recipes for web-only models such as ChatGPT Pro and Claude's Fable 5.
 
 Yoetz is built for coding agents and terminal workflows: gitignore-aware
 bundles, structured JSON output, reproducible session artifacts, live model
@@ -258,33 +258,59 @@ Useful agent-facing guarantees:
 
 Agent skill installation options are listed in [Agent Skills](#agent-skills).
 
-## Browser Recipes And ChatGPT Pro
+## Browser Recipes: ChatGPT Pro And Claude
 
 Browser recipes let Yoetz use web-only model surfaces from the terminal. The
 built-in ChatGPT recipe targets GPT-5.6 Sol with Pro intelligence and is
 fail-closed: if Yoetz cannot prove the requested surface is available, it stops
-instead of silently downgrading.
+instead of silently downgrading. The built-in Claude recipe applies the same
+contract to claude.ai with exactly Fable 5, Effort Max, and Thinking enabled.
 
 ```bash
 yoetz browser check --format json
 yoetz browser recipe --recipe chatgpt --bundle ~/.yoetz/sessions/<id>/bundle.md --format json
+yoetz browser check --claude --format json
+yoetz browser recipe --recipe claude --bundle ~/.yoetz/sessions/<id>/bundle.md --format json
 ```
 
-The default browser stack is extension-free unless the ChatGPT native extension
-is installed and connected. When connected, plain `yoetz browser check` uses a
-native dry-run and the ChatGPT recipe selects `chrome-extension-native` as the
-only default transport. Use an explicit `--transport <name>` when you want a
-different browser transport.
+Both recipes support `chrome-devtools-mcp`, `dev-browser`, `agent-browser`, and
+`chrome-extension-native`. The default browser stack is extension-free unless a
+connected native extension advertises the selected site. That recipe then
+selects `chrome-extension-native` as its only default transport and fails
+closed. Use an explicit `--transport <name>` to select another browser
+transport.
 
-Native extension happy path:
+The native path is one pinned multi-site package named Yoetz Native Transport,
+so existing ChatGPT installations keep the same extension ID and
+gain Claude support without re-pairing. Choose the site scope when managing or
+checking it:
 
 ```bash
 yoetz browser extension setup --chatgpt --open-chrome
 yoetz browser extension doctor --chatgpt
 yoetz browser extension status --chatgpt --format json
-yoetz browser check --transport chrome-extension-native --format json
 yoetz browser recipe --recipe chatgpt --transport chrome-extension-native --bundle bundle.md --format json
+
+yoetz browser extension setup --claude --open-chrome
+yoetz browser extension doctor --claude
+yoetz browser extension status --claude --format json
+yoetz browser extension canary --claude
+yoetz browser recipe --recipe claude --transport chrome-extension-native --bundle bundle.md --format json
 ```
+
+Load the managed `$YOETZ_DIR/chatgpt-native-extension` directory unpacked in
+the Chrome profile that hosts the target AI sessions; do not load a repo
+checkout. Setup, update, and reload share machine-global native-host and managed
+extension state, so serialize those operations across agent lanes. Recipe runs
+may proceed concurrently only against one frozen loaded artifact.
+
+Upgrade the installed CLI before another lane runs extension auto-heal after a
+release. An older CLI can overwrite the newer stamped managed copy.
+
+Claude conversation resume supports `--var conversation=<uuid|url>` and
+`--followup` on the native transport. `inline_warn_tokens` defaults to 150,000
+and warns when a bundle is likely to become retrieval-backed; set it to `0` to
+disable the heuristic. This warning does not change Yoetz's byte limits.
 
 The native-host extension transport is currently macOS/Linux-only. Windows CLI
 and Scoop installs work for the API-backed Yoetz flows, but
@@ -293,8 +319,8 @@ registration is implemented.
 
 For multiple loaded Chrome profiles, select the connected bridge with
 `--var extension_instance_id=<id>` from `yoetz browser extension status
---chatgpt`, or opt into `profile_email` routing with `yoetz browser extension
-grant-identity --chatgpt`.
+--chatgpt` (or `--claude`), or opt into `profile_email` routing with
+`yoetz browser extension grant-identity --chatgpt` (or `--claude`).
 
 The detailed browser transport model lives in [ARCHITECTURE.md](ARCHITECTURE.md).
 

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -222,9 +222,12 @@ pub fn use_dev_browser() -> bool {
     crate::dev_browser::has_any_backend()
 }
 
-pub fn recipe_transports(recipe: &Recipe, is_chatgpt: bool) -> Vec<RecipeTransport> {
+pub fn recipe_transports(
+    recipe: &Recipe,
+    builtin_recipe: Option<crate::web_recipe::BuiltinWebRecipe>,
+) -> Vec<RecipeTransport> {
     recipe.transports.clone().unwrap_or_else(|| {
-        if is_chatgpt {
+        if builtin_recipe.is_some() {
             // Chrome 147+ compat waterfall. chrome-devtools-mcp is primary
             // because it is the only tier that works against a running
             // logged-in Chrome 147 default profile (Playwright-based
@@ -252,11 +255,14 @@ pub fn recipe_transports(recipe: &Recipe, is_chatgpt: bool) -> Vec<RecipeTranspo
 /// is unhealthy.
 pub fn maybe_select_extension_native_for_chatgpt(
     transports: Vec<RecipeTransport>,
-    is_chatgpt: bool,
+    builtin_recipe: Option<crate::web_recipe::BuiltinWebRecipe>,
     recipe_transports_pinned: bool,
     extension_connected: bool,
 ) -> Vec<RecipeTransport> {
-    if !is_chatgpt || recipe_transports_pinned || !extension_connected {
+    if builtin_recipe != Some(crate::web_recipe::BuiltinWebRecipe::Chatgpt)
+        || recipe_transports_pinned
+        || !extension_connected
+    {
         return transports;
     }
     vec![RecipeTransport::ChromeExtensionNative]
@@ -7335,7 +7341,7 @@ steps:
         // then dev-browser for Chrome ≤ 146 / Chrome for Testing, then
         // agent-browser for cookie/profile managed flows, then manual.
         assert_eq!(
-            recipe_transports(&recipe, true),
+            recipe_transports(&recipe, Some(crate::web_recipe::BuiltinWebRecipe::Chatgpt)),
             vec![
                 RecipeTransport::ChromeDevtoolsMcp,
                 RecipeTransport::DevBrowser,
@@ -7344,8 +7350,30 @@ steps:
             ]
         );
         assert_eq!(
-            recipe_transports(&recipe, false),
+            recipe_transports(&recipe, None),
             vec![RecipeTransport::AgentBrowser]
+        );
+    }
+
+    #[test]
+    fn recipe_transports_default_to_same_builtin_claude_funnel() {
+        let recipe = serde_yaml_ng::from_str::<Recipe>(
+            r#"
+name: claude
+steps:
+  - action: open
+    args: ["https://claude.ai/new"]
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            recipe_transports(&recipe, Some(crate::web_recipe::BuiltinWebRecipe::Claude)),
+            vec![
+                RecipeTransport::ChromeDevtoolsMcp,
+                RecipeTransport::DevBrowser,
+                RecipeTransport::AgentBrowser,
+                RecipeTransport::Manual,
+            ]
         );
     }
 
@@ -7357,7 +7385,12 @@ steps:
             RecipeTransport::AgentBrowser,
             RecipeTransport::Manual,
         ];
-        let promoted = maybe_select_extension_native_for_chatgpt(base, true, false, true);
+        let promoted = maybe_select_extension_native_for_chatgpt(
+            base,
+            Some(crate::web_recipe::BuiltinWebRecipe::Chatgpt),
+            false,
+            true,
+        );
         assert_eq!(promoted, vec![RecipeTransport::ChromeExtensionNative]);
     }
 
@@ -7367,21 +7400,31 @@ steps:
             RecipeTransport::ChromeDevtoolsMcp,
             RecipeTransport::DevBrowser,
         ];
-        let result = maybe_select_extension_native_for_chatgpt(base.clone(), true, false, false);
+        let result = maybe_select_extension_native_for_chatgpt(
+            base.clone(),
+            Some(crate::web_recipe::BuiltinWebRecipe::Chatgpt),
+            false,
+            false,
+        );
         assert_eq!(result, base);
     }
 
     #[test]
     fn maybe_select_extension_native_noop_when_recipe_pinned_transports() {
         let base = vec![RecipeTransport::ChromeDevtoolsMcp, RecipeTransport::Manual];
-        let result = maybe_select_extension_native_for_chatgpt(base.clone(), true, true, true);
+        let result = maybe_select_extension_native_for_chatgpt(
+            base.clone(),
+            Some(crate::web_recipe::BuiltinWebRecipe::Chatgpt),
+            true,
+            true,
+        );
         assert_eq!(result, base);
     }
 
     #[test]
     fn maybe_select_extension_native_noop_for_non_chatgpt() {
         let base = vec![RecipeTransport::AgentBrowser];
-        let result = maybe_select_extension_native_for_chatgpt(base.clone(), false, false, true);
+        let result = maybe_select_extension_native_for_chatgpt(base.clone(), None, false, true);
         assert_eq!(result, base);
     }
 
@@ -7392,7 +7435,12 @@ steps:
             RecipeTransport::ChromeExtensionNative,
             RecipeTransport::Manual,
         ];
-        let result = maybe_select_extension_native_for_chatgpt(base, true, false, true);
+        let result = maybe_select_extension_native_for_chatgpt(
+            base,
+            Some(crate::web_recipe::BuiltinWebRecipe::Chatgpt),
+            false,
+            true,
+        );
         assert_eq!(result, vec![RecipeTransport::ChromeExtensionNative]);
     }
 
@@ -7468,10 +7516,10 @@ steps:
              chrome-extension-native auto-selection gates correctly"
         );
 
-        let base = recipe_transports(&recipe, true);
+        let base = recipe_transports(&recipe, Some(crate::web_recipe::BuiltinWebRecipe::Chatgpt));
         let promoted = maybe_select_extension_native_for_chatgpt(
             base,
-            true,
+            Some(crate::web_recipe::BuiltinWebRecipe::Chatgpt),
             recipe.transports.is_some(),
             true,
         );
@@ -7482,6 +7530,33 @@ steps:
              auto-select chrome-extension-native and fail closed instead of \
              silently falling through to CDP/dev-browser transports"
         );
+    }
+
+    #[test]
+    fn builtin_claude_recipe_declares_typed_defaults_without_pinning_transports() {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../recipes/claude.yaml");
+        let content = fs::read_to_string(&path).expect("read recipes/claude.yaml");
+        let recipe: Recipe = serde_yaml_ng::from_str(&content).expect("parse claude.yaml");
+        assert!(recipe.transports.is_none());
+        let defaults = recipe.defaults.expect("Claude defaults");
+        assert_eq!(defaults.get("thread").map(String::as_str), Some("fresh"));
+        assert_eq!(
+            defaults.get("inline_warn_tokens").map(String::as_str),
+            Some("150000")
+        );
+        for action in [
+            "claude_select_model",
+            "claude_open_attachment_ui",
+            "claude_upload_bundle",
+            "claude_wait_upload",
+            "claude_send",
+            "claude_wait_response",
+        ] {
+            assert!(
+                content.contains(&format!("- action: {action}")),
+                "missing {action}"
+            );
+        }
     }
 
     #[test]

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -19,6 +19,9 @@ use crate::chrome_devtools_mcp::client::{
     discover_local_chromium_processes, discover_running_chrome_targets, infer_email_hints,
     ChromiumProcessSummary, DevtoolsActivePortFile, RunningChromeTarget,
 };
+use crate::claude_recipe::AnyhowResultExt as ClaudeAnyhowResultExt;
+use crate::web_recipe::{WebModelSelectionStatus, WebRecipeTransportPhase};
+use crate::{claude_recipe, claude_web};
 use yoetz_core::output::{write_json, write_jsonl_event, OutputFormat};
 use yoetz_core::paths::home_dir;
 
@@ -37,6 +40,12 @@ const CHATGPT_SELECT_MODEL_ACTION: &str = "chatgpt_select_model";
 const CHATGPT_OPEN_ATTACHMENT_UI_ACTION: &str = "chatgpt_open_attachment_ui";
 const CHATGPT_UPLOAD_BUNDLE_ACTION: &str = "chatgpt_upload_bundle";
 const CHATGPT_SEND_ACTION: &str = "chatgpt_send";
+const CLAUDE_WAIT_ACTION: &str = "claude_wait_response";
+const CLAUDE_WAIT_UPLOAD_ACTION: &str = "claude_wait_upload";
+const CLAUDE_SELECT_MODEL_ACTION: &str = "claude_select_model";
+const CLAUDE_OPEN_ATTACHMENT_UI_ACTION: &str = "claude_open_attachment_ui";
+const CLAUDE_UPLOAD_BUNDLE_ACTION: &str = "claude_upload_bundle";
+const CLAUDE_SEND_ACTION: &str = "claude_send";
 const CHATGPT_POLL_ATTEMPTS_DEFAULT: usize = 60;
 const CHATGPT_POLL_INTERVAL_MS_DEFAULT: u64 = 30_000;
 const CHATGPT_POLL_TOTAL_TIMEOUT_MS_DEFAULT: u64 = 5_400_000;
@@ -109,6 +118,7 @@ pub struct RecipeContext {
     pub use_stealth: bool,
     pub headed: bool,
     pub vars: BTreeMap<String, String>,
+    pub warnings: Vec<String>,
     /// Target URL for captcha recovery (defaults to CHATGPT_URL).
     pub target_url: String,
 }
@@ -530,12 +540,19 @@ fn run_recipe_with_connection(
         .name
         .as_deref()
         .is_some_and(|name| name.eq_ignore_ascii_case("chatgpt"));
-    let collect_step_events = wants_json || (wants_jsonl && is_chatgpt_recipe);
+    let is_claude_recipe = recipe
+        .name
+        .as_deref()
+        .is_some_and(|name| name.eq_ignore_ascii_case("claude"));
+    let collect_step_events = wants_json || is_claude_recipe || (wants_jsonl && is_chatgpt_recipe);
     let mut events: Vec<Value> = Vec::new();
     let mut headed = ctx.headed;
     let mut pending_chatgpt_send_baseline: Option<ChatgptResponseBaseline> = None;
+    let mut pending_claude_send_baseline: Option<ClaudeResponseBaseline> = None;
     let mut chatgpt_stage = ChatgptRecipeStage::Idle;
+    let mut claude_stage = ClaudeRecipeStage::Idle;
     let mut chatgpt_focus_cache = ChatgptRunTabFocusCache::default();
+    let recipe_started_at = Instant::now();
 
     if let Some(connection) = connection {
         if connection.is_live_attach() {
@@ -821,16 +838,148 @@ fn run_recipe_with_connection(
             continue;
         }
 
+        if action == CLAUDE_SELECT_MODEL_ACTION {
+            let stdout = run_claude_select_model(connection, ctx.use_stealth, headed)
+                .with_context(|| format!("recipe step {idx} ({action}) failed"))?;
+            record_builtin_step_event(
+                &mut events,
+                wants_json,
+                wants_jsonl,
+                collect_step_events,
+                idx,
+                action,
+                step,
+                &stdout,
+            )?;
+            continue;
+        }
+
+        if action == CLAUDE_OPEN_ATTACHMENT_UI_ACTION {
+            let stdout = run_claude_open_attachment_ui(connection, ctx.use_stealth, headed)
+                .with_context(|| format!("recipe step {idx} ({action}) failed"))?;
+            record_builtin_step_event(
+                &mut events,
+                wants_json,
+                wants_jsonl,
+                collect_step_events,
+                idx,
+                action,
+                step,
+                &stdout,
+            )?;
+            continue;
+        }
+
+        if action == CLAUDE_UPLOAD_BUNDLE_ACTION {
+            claude_stage.mark_upload_started();
+            let stdout = run_claude_upload_bundle(&ctx, connection, ctx.use_stealth, headed)
+                .with_claude_phase(WebRecipeTransportPhase::Upload)
+                .with_context(|| format!("recipe step {idx} ({action}) failed"))?;
+            record_builtin_step_event(
+                &mut events,
+                wants_json,
+                wants_jsonl,
+                collect_step_events,
+                idx,
+                action,
+                step,
+                &stdout,
+            )?;
+            continue;
+        }
+
+        if action == CLAUDE_WAIT_UPLOAD_ACTION {
+            claude_stage.mark_upload_started();
+            let stdout = run_claude_wait_upload(
+                &ctx,
+                step.args.as_deref(),
+                connection,
+                ctx.use_stealth,
+                headed,
+            )
+            .with_claude_phase(WebRecipeTransportPhase::Upload)
+            .with_context(|| format!("recipe step {idx} ({action}) failed"))?;
+            record_builtin_step_event(
+                &mut events,
+                wants_json,
+                wants_jsonl,
+                collect_step_events,
+                idx,
+                action,
+                step,
+                &stdout,
+            )?;
+            continue;
+        }
+
+        if action == CLAUDE_SEND_ACTION {
+            let stdout = run_claude_send(connection, ctx.use_stealth, headed)
+                .with_claude_phase(WebRecipeTransportPhase::Send)
+                .with_context(|| format!("recipe step {idx} ({action}) failed"))?;
+            pending_claude_send_baseline = parse_claude_send_baseline_from_stdout(&stdout);
+            claude_stage.mark_send_succeeded();
+            record_builtin_step_event(
+                &mut events,
+                wants_json,
+                wants_jsonl,
+                collect_step_events,
+                idx,
+                action,
+                step,
+                &stdout,
+            )?;
+            continue;
+        }
+
+        if action == CLAUDE_WAIT_ACTION {
+            let interpolated_args: Option<Vec<String>> = step
+                .args
+                .as_ref()
+                .map(|args| {
+                    args.iter()
+                        .map(|arg| interpolate(arg, &ctx, None))
+                        .collect::<Result<Vec<_>>>()
+                })
+                .transpose()
+                .with_claude_phase(WebRecipeTransportPhase::WaitResponse)
+                .with_context(|| format!("recipe step {idx} ({action}) var interpolation"))?;
+            let stdout = run_claude_wait_response(
+                interpolated_args.as_deref(),
+                connection,
+                pending_claude_send_baseline.take(),
+                ctx.use_stealth,
+                headed,
+            )
+            .with_claude_phase(WebRecipeTransportPhase::WaitResponse)
+            .with_context(|| format!("recipe step {idx} ({action}) failed"))?;
+            record_builtin_step_event(
+                &mut events,
+                wants_json,
+                wants_jsonl,
+                collect_step_events,
+                idx,
+                action,
+                step,
+                &stdout,
+            )?;
+            continue;
+        }
+
         if is_chatgpt_recipe && action == "upload" {
             chatgpt_stage.mark_upload_started();
         }
-        let action_terminal_phase = if is_chatgpt_recipe {
-            chatgpt_stage.terminal_phase(action)
-        } else {
-            None
-        };
+        if is_claude_recipe && action == "upload" {
+            claude_stage.mark_upload_started();
+        }
+        let action_terminal_phase = is_chatgpt_recipe
+            .then(|| chatgpt_stage.terminal_phase(action))
+            .flatten();
+        let claude_action_terminal_phase = is_claude_recipe
+            .then(|| claude_stage.terminal_phase(action))
+            .flatten();
         let commands = expand_step(action, step.args.as_deref(), &ctx)
             .map_err(|err| mark_chatgpt_error_after_side_effect(err, action_terminal_phase))
+            .map_err(|err| mark_claude_error_after_side_effect(err, claude_action_terminal_phase))
             .with_context(|| format!("recipe step {idx} ({action}) expand failed"))?;
 
         for args in commands {
@@ -876,18 +1025,24 @@ fn run_recipe_with_connection(
                             step.timeout_ms,
                         )
                         .map_err(|err| {
-                            mark_chatgpt_error_after_side_effect(err, action_terminal_phase)
+                            let err =
+                                mark_chatgpt_error_after_side_effect(err, action_terminal_phase);
+                            mark_claude_error_after_side_effect(err, claude_action_terminal_phase)
                         })?
                     } else {
-                        return Err(mark_chatgpt_error_after_side_effect(
+                        let err = mark_chatgpt_error_after_side_effect(
                             err.context(format!("recipe step {idx} ({action}) failed")),
                             action_terminal_phase,
+                        );
+                        return Err(mark_claude_error_after_side_effect(
+                            err,
+                            claude_action_terminal_phase,
                         ));
                     }
                 }
             };
 
-            if wants_json || wants_jsonl {
+            if wants_json || wants_jsonl || is_claude_recipe {
                 let stdout_value =
                     parse_stdout_json(&stdout).unwrap_or(Value::String(stdout.clone()));
                 let event = json!({
@@ -909,8 +1064,23 @@ fn run_recipe_with_connection(
         }
     }
 
+    let elapsed_ms = recipe_started_at
+        .elapsed()
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64;
     let payload = if is_chatgpt_recipe {
         chatgpt_recipe_payload_from_steps(&events, ctx.fallback_used)
+    } else if is_claude_recipe {
+        claude_recipe_payload_from_steps(
+            &events,
+            ctx.fallback_used,
+            ctx.vars
+                .get("run_id")
+                .map(String::as_str)
+                .unwrap_or_default(),
+            elapsed_ms,
+            &ctx.warnings,
+        )
     } else {
         json!({
             "name": recipe.name,
@@ -948,7 +1118,51 @@ fn run_recipe_with_connection(
         write_jsonl_event(&event)?;
     }
 
+    if wants_jsonl && is_claude_recipe {
+        let mut event = payload.clone();
+        if let Some(object) = event.as_object_mut() {
+            object.remove("status");
+            object.remove("steps");
+            object.insert("type".to_string(), "recipe_complete".into());
+        }
+        write_jsonl_event(&event)?;
+    }
+
+    if !wants_json && !wants_jsonl && is_claude_recipe {
+        println!("{}", payload["response"].as_str().unwrap_or_default());
+    }
+
     Ok(payload)
+}
+
+fn record_builtin_step_event(
+    events: &mut Vec<Value>,
+    wants_json: bool,
+    wants_jsonl: bool,
+    collect_step_events: bool,
+    index: usize,
+    action: &str,
+    step: &RecipeStep,
+    stdout: &str,
+) -> Result<()> {
+    if !wants_json && !wants_jsonl && !collect_step_events {
+        return Ok(());
+    }
+    let stdout_value = parse_stdout_json(stdout).unwrap_or(Value::String(stdout.to_string()));
+    let event = json!({
+        "type": "browser_step",
+        "index": index,
+        "action": action,
+        "args": step.args,
+        "stdout": stdout_value,
+    });
+    if wants_jsonl {
+        write_jsonl_event(&event)?;
+    }
+    if collect_step_events {
+        events.push(event);
+    }
+    Ok(())
 }
 
 fn chatgpt_recipe_payload_from_steps(steps: &[Value], fallback_used: bool) -> Value {
@@ -1002,6 +1216,83 @@ fn chatgpt_recipe_payload_from_steps(steps: &[Value], fallback_used: bool) -> Va
         auto_paste_fallback: false,
         conversation_id: None,
         conversation_url: None,
+    };
+    let mut payload = output.to_value();
+    if let Some(object) = payload.as_object_mut() {
+        object.insert("steps".to_string(), json!(steps));
+    }
+    payload
+}
+
+fn claude_recipe_payload_from_steps(
+    steps: &[Value],
+    fallback_used: bool,
+    run_id: &str,
+    elapsed_ms: u64,
+    preflight_warnings: &[String],
+) -> Value {
+    let mut response = String::new();
+    let mut model_used = None;
+    let mut model_selection_status = WebModelSelectionStatus::Unavailable;
+    let mut warnings = preflight_warnings.to_vec();
+    let mut conversation_id = None;
+    let mut conversation_url = None;
+
+    for step in steps {
+        let action = step
+            .get("action")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let stdout = step.get("stdout").unwrap_or(&Value::Null);
+        if action == CLAUDE_SELECT_MODEL_ACTION {
+            model_used = stdout
+                .get("model_used")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            if let Some(value) = stdout.get("model_selection_status").cloned() {
+                if let Ok(status) = serde_json::from_value(value) {
+                    model_selection_status = status;
+                }
+            }
+        }
+        if action == CLAUDE_WAIT_ACTION {
+            response = stdout
+                .get("response")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            conversation_id = stdout
+                .get("conversation_id")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            conversation_url = stdout
+                .get("conversation_url")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            if let Some(items) = stdout.get("warnings").and_then(Value::as_array) {
+                warnings.extend(
+                    items
+                        .iter()
+                        .filter_map(Value::as_str)
+                        .filter(|value| !value.trim().is_empty())
+                        .map(str::to_string),
+                );
+            }
+        }
+    }
+
+    let output = claude_recipe::ClaudeRecipeOutput {
+        transport: "agent-browser".to_string(),
+        backend: "agent-browser".to_string(),
+        response,
+        model_used,
+        model_selection_status,
+        warnings,
+        fallback_used,
+        conversation_id,
+        conversation_url,
+        run_id: run_id.to_string(),
+        elapsed_ms,
     };
     let mut payload = output.to_value();
     if let Some(object) = payload.as_object_mut() {
@@ -1082,6 +1373,54 @@ fn mark_chatgpt_error_after_side_effect(
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ClaudeRecipeStage {
+    Idle,
+    UploadStarted,
+    SendSucceeded,
+}
+
+impl ClaudeRecipeStage {
+    fn mark_upload_started(&mut self) {
+        if *self == Self::Idle {
+            *self = Self::UploadStarted;
+        }
+    }
+
+    fn mark_send_succeeded(&mut self) {
+        *self = Self::SendSucceeded;
+    }
+
+    fn terminal_phase(self, action: &str) -> Option<WebRecipeTransportPhase> {
+        if self == Self::SendSucceeded {
+            return Some(WebRecipeTransportPhase::WaitResponse);
+        }
+        match action {
+            CLAUDE_WAIT_ACTION => Some(WebRecipeTransportPhase::WaitResponse),
+            CLAUDE_SEND_ACTION => Some(WebRecipeTransportPhase::Send),
+            CLAUDE_WAIT_UPLOAD_ACTION | CLAUDE_UPLOAD_BUNDLE_ACTION | "upload" => {
+                Some(WebRecipeTransportPhase::Upload)
+            }
+            _ if self == Self::UploadStarted => Some(WebRecipeTransportPhase::Upload),
+            _ => None,
+        }
+    }
+}
+
+fn mark_claude_error_after_side_effect(
+    err: anyhow::Error,
+    phase: Option<WebRecipeTransportPhase>,
+) -> anyhow::Error {
+    match phase {
+        Some(phase) => crate::web_recipe::mark_terminal_fallback_phase(
+            err,
+            crate::web_recipe::BuiltinWebRecipe::Claude,
+            phase,
+        ),
+        None => err,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ChatgptSendState {
     Enabled,
     Disabled,
@@ -1101,6 +1440,31 @@ struct ChatgptDomState {
     assistant_last_len: usize,
     /// Error text from scoped toast/alert containers (empty = no error).
     error: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ClaudeResponseBaseline {
+    count: i64,
+    last_length: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ClaudeResponseState {
+    count: i64,
+    last_length: i64,
+    text: String,
+    streaming: bool,
+    stop: bool,
+    thinking: bool,
+    copy_buttons: usize,
+    error: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ClaudeCompletionVerdict {
+    Generating,
+    CopyButton,
+    Idle,
 }
 
 /// Per-poll classification of ChatGPT response state.
@@ -1958,6 +2322,433 @@ fn parse_chatgpt_send_baseline(result: &Value) -> Option<ChatgptResponseBaseline
 fn parse_chatgpt_send_baseline_from_stdout(stdout: &str) -> Option<ChatgptResponseBaseline> {
     let payload = parse_stdout_json(stdout)?;
     parse_chatgpt_send_baseline(&payload)
+}
+
+fn run_claude_dom_function(
+    function_source: &str,
+    connection: Option<&BrowserConnection>,
+    use_stealth: bool,
+    headed: bool,
+) -> Result<Value> {
+    let expression = chatgpt_web::wrap_function_source_for_json_eval(function_source)?;
+    let stdout = run_agent_browser_with_connection_timeout(
+        vec!["eval".to_string(), expression],
+        OutputFormat::Text,
+        connection,
+        use_stealth,
+        headed,
+        Some(CHATGPT_POLL_COMMAND_TIMEOUT_MS_DEFAULT),
+    )?;
+    parse_stdout_json(&stdout).with_context(|| format!("parse Claude DOM action result: {stdout}"))
+}
+
+fn require_claude_status(value: &Value, expected: &[&str], operation: &str) -> Result<()> {
+    let status = value
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    if expected.contains(&status) {
+        return Ok(());
+    }
+    Err(anyhow!(
+        "Claude {operation} failed with status `{status}`; diagnostics={value}"
+    ))
+}
+
+fn hover_claude_effort(
+    connection: Option<&BrowserConnection>,
+    use_stealth: bool,
+    headed: bool,
+) -> Result<()> {
+    let marked = run_claude_dom_function(
+        &claude_web::build_mark_effort_parent_function(),
+        connection,
+        use_stealth,
+        headed,
+    )?;
+    require_claude_status(&marked, &["marked"], "Effort menu discovery")?;
+    let selector = format!("[title='{}']", claude_web::EFFORT_HOVER_MARKER);
+    run_agent_browser_with_connection_timeout(
+        vec!["hover".to_string(), selector],
+        OutputFormat::Text,
+        connection,
+        use_stealth,
+        headed,
+        Some(CHATGPT_POLL_COMMAND_TIMEOUT_MS_DEFAULT),
+    )?;
+    thread::sleep(Duration::from_millis(400));
+    Ok(())
+}
+
+fn open_claude_model_menu(
+    connection: Option<&BrowserConnection>,
+    use_stealth: bool,
+    headed: bool,
+) -> Result<()> {
+    let state = run_claude_dom_function(
+        &claude_web::build_open_model_menu_function(),
+        connection,
+        use_stealth,
+        headed,
+    )?;
+    require_claude_status(&state, &["opened", "opening"], "model menu open")?;
+    thread::sleep(Duration::from_millis(250));
+    Ok(())
+}
+
+fn run_claude_select_model(
+    connection: Option<&BrowserConnection>,
+    use_stealth: bool,
+    headed: bool,
+) -> Result<String> {
+    let readiness = run_claude_dom_function(
+        &claude_web::build_wait_for_composer_function(),
+        connection,
+        use_stealth,
+        headed,
+    )?;
+    match readiness.get("status").and_then(Value::as_str) {
+        Some("ready") => {}
+        Some("login") => bail!("Claude login is required in this browser profile"),
+        Some("challenge") => bail!(
+            "Cloudflare challenge detected on claude.ai; solve it in this browser profile and retry"
+        ),
+        other => {
+            bail!("Claude composer did not become ready; status={other:?}, diagnostics={readiness}")
+        }
+    }
+    open_claude_model_menu(connection, use_stealth, headed)?;
+    let fable = run_claude_dom_function(
+        &claude_web::build_select_fable_function(),
+        connection,
+        use_stealth,
+        headed,
+    )?;
+    require_claude_status(&fable, &["selected"], "Fable 5 selection")?;
+    thread::sleep(Duration::from_millis(300));
+
+    open_claude_model_menu(connection, use_stealth, headed)?;
+    hover_claude_effort(connection, use_stealth, headed)?;
+    let max = run_claude_dom_function(
+        &claude_web::build_select_max_function(),
+        connection,
+        use_stealth,
+        headed,
+    )?;
+    require_claude_status(&max, &["selected"], "Max effort selection")?;
+    thread::sleep(Duration::from_millis(300));
+
+    open_claude_model_menu(connection, use_stealth, headed)?;
+    hover_claude_effort(connection, use_stealth, headed)?;
+    let thinking = run_claude_dom_function(
+        &claude_web::build_ensure_thinking_on_function(),
+        connection,
+        use_stealth,
+        headed,
+    )?;
+    require_claude_status(&thinking, &["already_on", "clicked"], "Thinking enable")?;
+    thread::sleep(Duration::from_millis(300));
+
+    let _ = run_claude_dom_function(
+        &claude_web::build_close_model_menu_function(),
+        connection,
+        use_stealth,
+        headed,
+    );
+    thread::sleep(Duration::from_millis(250));
+    open_claude_model_menu(connection, use_stealth, headed)?;
+    hover_claude_effort(connection, use_stealth, headed)?;
+    let verification = run_claude_dom_function(
+        &claude_web::build_verify_fable_max_thinking_function(),
+        connection,
+        use_stealth,
+        headed,
+    )?;
+    let status = claude_web::model_selection_status(&verification);
+    let _ = run_claude_dom_function(
+        &claude_web::build_close_model_menu_function(),
+        connection,
+        use_stealth,
+        headed,
+    );
+    if status != WebModelSelectionStatus::Selected {
+        bail!(
+            "Claude exact model contract is unavailable or mismatched; required Fable 5 + Max + Thinking on; diagnostics={verification}"
+        );
+    }
+    Ok(json!({
+        "status": "ok",
+        "model_used": claude_recipe::CLAUDE_REPORTED_MODEL,
+        "model_selection_status": status,
+    })
+    .to_string())
+}
+
+fn run_claude_open_attachment_ui(
+    connection: Option<&BrowserConnection>,
+    use_stealth: bool,
+    headed: bool,
+) -> Result<String> {
+    let state = run_claude_dom_function(
+        &claude_web::build_scope_file_input_function(),
+        connection,
+        use_stealth,
+        headed,
+    )?;
+    require_claude_status(&state, &["marked"], "file input discovery")?;
+    Ok(json!({"status":"ok","selector":claude_web::FILE_INPUT_SELECTOR}).to_string())
+}
+
+fn run_claude_upload_bundle(
+    ctx: &RecipeContext,
+    connection: Option<&BrowserConnection>,
+    use_stealth: bool,
+    headed: bool,
+) -> Result<String> {
+    let bundle_path = ctx
+        .bundle_path
+        .as_deref()
+        .context("Claude upload requires `bundle_path` in the recipe context")?;
+    run_claude_open_attachment_ui(connection, use_stealth, headed)?;
+    let selector = format!(
+        "input[data-testid='file-upload'][title='{}']",
+        claude_web::FILE_INPUT_MARKER
+    );
+    run_agent_browser_with_connection_timeout(
+        vec![
+            "upload".to_string(),
+            selector.clone(),
+            bundle_path.to_string(),
+        ],
+        OutputFormat::Text,
+        connection,
+        use_stealth,
+        headed,
+        Some(CHATGPT_POLL_COMMAND_TIMEOUT_MS_DEFAULT),
+    )
+    .with_context(|| format!("upload `{bundle_path}` through {selector}"))?;
+    Ok(json!({"status":"ok","selector":selector}).to_string())
+}
+
+fn run_claude_wait_upload(
+    ctx: &RecipeContext,
+    args: Option<&[String]>,
+    connection: Option<&BrowserConnection>,
+    use_stealth: bool,
+    headed: bool,
+) -> Result<String> {
+    let options = parse_chatgpt_poll_args(CLAUDE_WAIT_UPLOAD_ACTION, args)?;
+    let bundle_path = ctx
+        .bundle_path
+        .as_deref()
+        .context("Claude upload waiter requires `bundle_path` in the recipe context")?;
+    let file_name = Path::new(bundle_path)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .context("Claude bundle path must end in a UTF-8 filename")?;
+    let probe = claude_web::build_attachment_probe_function(file_name)?;
+    let started = Instant::now();
+    let deadline = started + Duration::from_millis(options.timeout_ms);
+    let mut stable_candidates = 0_u8;
+    for attempt in 1..=options.attempts {
+        if Instant::now() >= deadline {
+            break;
+        }
+        if attempt > 1 {
+            thread::sleep(Duration::from_millis(options.interval_ms));
+        }
+        let state = run_claude_dom_function(&probe, connection, use_stealth, headed)?;
+        if state.get("status").and_then(Value::as_str) == Some("candidate") {
+            stable_candidates = stable_candidates.saturating_add(1);
+            if stable_candidates >= 2 {
+                return Ok(json!({"status":"ok","polls":attempt,"attachment":state}).to_string());
+            }
+        } else {
+            stable_candidates = 0;
+        }
+    }
+    Err(anyhow!(
+        "Claude attachment `{file_name}` did not become ready within {}ms",
+        options.timeout_ms
+    ))
+}
+
+fn run_claude_send(
+    connection: Option<&BrowserConnection>,
+    use_stealth: bool,
+    headed: bool,
+) -> Result<String> {
+    let started = Instant::now();
+    loop {
+        let result = run_claude_dom_function(
+            &claude_web::build_send_function(),
+            connection,
+            use_stealth,
+            headed,
+        )?;
+        match result.get("status").and_then(Value::as_str) {
+            Some("sent") => {
+                return Ok(json!({
+                    "status":"ok",
+                    "assistantCountBeforeSend":result.get("assistantCount").and_then(Value::as_i64).unwrap_or(0),
+                    "assistantLastLenBeforeSend":result.get("assistantLastLength").and_then(Value::as_i64).unwrap_or(0),
+                }).to_string());
+            }
+            Some("disabled" | "missing")
+                if started.elapsed() < Duration::from_millis(CHATGPT_SEND_ENABLE_TIMEOUT_MS) =>
+            {
+                thread::sleep(Duration::from_millis(CHATGPT_SEND_ENABLE_POLL_INTERVAL_MS));
+            }
+            _ => bail!("Claude send button did not become enabled; diagnostics={result}"),
+        }
+    }
+}
+
+fn parse_claude_send_baseline_from_stdout(stdout: &str) -> Option<ClaudeResponseBaseline> {
+    let value = parse_stdout_json(stdout)?;
+    Some(ClaudeResponseBaseline {
+        count: value.get("assistantCountBeforeSend")?.as_i64()?,
+        last_length: value.get("assistantLastLenBeforeSend")?.as_i64()?,
+    })
+}
+
+fn parse_claude_response_state(value: &Value) -> Result<ClaudeResponseState> {
+    Ok(ClaudeResponseState {
+        count: value.get("count").and_then(Value::as_i64).unwrap_or(0),
+        last_length: value.get("length").and_then(Value::as_i64).unwrap_or(0),
+        text: value
+            .get("text")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        streaming: value
+            .get("streaming")
+            .and_then(Value::as_bool)
+            .unwrap_or(true),
+        stop: value
+            .get("hasStopButton")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        thinking: value
+            .get("thinking")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        copy_buttons: value
+            .get("copyButtons")
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as usize,
+        error: value
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+    })
+}
+
+fn classify_claude_completion(
+    state: &ClaudeResponseState,
+    baseline: ClaudeResponseBaseline,
+) -> ClaudeCompletionVerdict {
+    if state.streaming || state.stop || state.thinking {
+        return ClaudeCompletionVerdict::Generating;
+    }
+    let grew = state.count > baseline.count
+        || (state.count == baseline.count && state.last_length > baseline.last_length);
+    if !grew || state.last_length == 0 {
+        return ClaudeCompletionVerdict::Generating;
+    }
+    if state.copy_buttons > 0 {
+        ClaudeCompletionVerdict::CopyButton
+    } else {
+        ClaudeCompletionVerdict::Idle
+    }
+}
+
+fn run_claude_wait_response(
+    args: Option<&[String]>,
+    connection: Option<&BrowserConnection>,
+    baseline: Option<ClaudeResponseBaseline>,
+    use_stealth: bool,
+    headed: bool,
+) -> Result<String> {
+    let options = parse_chatgpt_poll_args(CLAUDE_WAIT_ACTION, args)?;
+    let baseline = baseline.context("Claude response wait requires a send baseline")?;
+    let probe = claude_web::build_response_poll_function();
+    let started = Instant::now();
+    let stable_threshold =
+        Duration::from_millis(claude_web::stable_idle_threshold_ms(options.interval_ms));
+    let mut stable_since: Option<Instant> = None;
+    let mut stable_anchor: Option<(i64, i64)> = None;
+    let mut no_progress_polls = 0_u8;
+
+    for attempt in 1..=options.attempts {
+        if started.elapsed() >= Duration::from_millis(options.timeout_ms) {
+            break;
+        }
+        if attempt > 1 {
+            thread::sleep(Duration::from_millis(options.interval_ms));
+        }
+        let value = run_claude_dom_function(&probe, connection, use_stealth, headed)?;
+        let state = parse_claude_response_state(&value)?;
+        if !state.error.is_empty() {
+            bail!("Claude page error: {}", state.error);
+        }
+        let verdict = classify_claude_completion(&state, baseline);
+        let inactive_without_progress = !state.streaming
+            && !state.stop
+            && !state.thinking
+            && verdict == ClaudeCompletionVerdict::Generating;
+        if inactive_without_progress {
+            no_progress_polls = no_progress_polls.saturating_add(1);
+            if no_progress_polls >= 5 {
+                bail!(
+                    "Claude response made no post-send progress for 5 polls after generation became idle"
+                );
+            }
+        } else {
+            no_progress_polls = 0;
+        }
+        match verdict {
+            ClaudeCompletionVerdict::Generating => {
+                stable_since = None;
+                stable_anchor = None;
+            }
+            ClaudeCompletionVerdict::CopyButton | ClaudeCompletionVerdict::Idle => {
+                let anchor = (state.count, state.last_length);
+                let stable_for = match (stable_since, stable_anchor) {
+                    (Some(since), Some(previous)) if previous == anchor => since.elapsed(),
+                    _ => {
+                        stable_since = Some(Instant::now());
+                        stable_anchor = Some(anchor);
+                        Duration::ZERO
+                    }
+                };
+                if stable_for >= stable_threshold {
+                    let url = run_claude_dom_function(
+                        "() => window.location.href || ''",
+                        connection,
+                        use_stealth,
+                        headed,
+                    )?
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string();
+                    let conversation = claude_web::normalize_conversation(&url).ok();
+                    return Ok(json!({
+                        "status":"ok",
+                        "response":state.text,
+                        "conversation_id":conversation.as_ref().map(|value| value.id.clone()),
+                        "conversation_url":conversation.map(|value| value.url),
+                    })
+                    .to_string());
+                }
+            }
+        }
+    }
+    Err(anyhow!(
+        "Claude response did not complete within {}ms",
+        options.timeout_ms
+    ))
 }
 
 fn baseline_dom_state(baseline: ChatgptResponseBaseline) -> ChatgptDomState {
@@ -4118,6 +4909,55 @@ pub fn resolve_auth(profile_dir: &Path, headed: bool) -> Result<BrowserConnectio
     resolve_browser_connection_fallback(profile_dir, headed, CHATGPT_URL)
 }
 
+pub fn resolve_claude_auth(profile_dir: &Path, headed: bool) -> Result<BrowserConnection> {
+    if !profile_dir.exists() {
+        return Err(anyhow!(
+            "browser profile not found at {}. Run `yoetz browser login` to authenticate.",
+            profile_dir.display()
+        ));
+    }
+    let cookie_state = BrowserConnection::CookieState {
+        state_file: state_file(profile_dir),
+    };
+    if matches!(
+        &cookie_state,
+        BrowserConnection::CookieState { state_file } if state_file.exists()
+    ) && check_claude_auth_with_connection(&cookie_state, headed).is_ok()
+    {
+        return Ok(cookie_state);
+    }
+    let profile = BrowserConnection::Profile {
+        profile_dir: profile_dir.to_path_buf(),
+    };
+    check_claude_auth_with_connection(&profile, headed)?;
+    Ok(profile)
+}
+
+pub fn resolve_claude_browser_connection(
+    browser_defaults: &BrowserDefaults,
+    cdp_override: Option<&str>,
+    profile_dir: &Path,
+) -> Result<BrowserConnection> {
+    if let Some(endpoint) = resolve_cdp_endpoint(cdp_override, browser_defaults) {
+        let connection = BrowserConnection::Cdp {
+            endpoint,
+            run_id: None,
+        };
+        match check_claude_auth_with_connection(&connection, false) {
+            Ok(()) => return Ok(connection),
+            Err(err) if should_stop_live_attach_fallback(&err) => return Err(err),
+            Err(_) => {}
+        }
+    }
+    let auto = BrowserConnection::AutoConnect;
+    match check_claude_auth_with_connection(&auto, false) {
+        Ok(()) => return Ok(auto),
+        Err(err) if should_stop_live_attach_fallback(&err) => return Err(err),
+        Err(_) => {}
+    }
+    resolve_claude_auth(profile_dir, false)
+}
+
 pub fn resolve_auth_mode(profile_dir: &Path, headed: bool) -> Result<BrowserProfileMode> {
     match resolve_auth(profile_dir, headed)? {
         BrowserConnection::CookieState { .. } => Ok(BrowserProfileMode::PreferState),
@@ -4128,9 +4968,84 @@ pub fn resolve_auth_mode(profile_dir: &Path, headed: bool) -> Result<BrowserProf
     }
 }
 
+pub fn resolve_claude_auth_mode(profile_dir: &Path, headed: bool) -> Result<BrowserProfileMode> {
+    match resolve_claude_auth(profile_dir, headed)? {
+        BrowserConnection::CookieState { .. } => Ok(BrowserProfileMode::PreferState),
+        BrowserConnection::Profile { .. } => Ok(BrowserProfileMode::ProfileOnly),
+        BrowserConnection::Cdp { .. } | BrowserConnection::AutoConnect => Err(anyhow!(
+            "managed Claude auth mode cannot map a live browser connection"
+        )),
+    }
+}
+
 pub fn check_auth(profile_dir: &Path, headed: bool) -> Result<()> {
     let connection = resolve_auth(profile_dir, headed)?;
     check_auth_with_connection(&connection, headed, CHATGPT_URL)
+}
+
+pub fn check_claude_auth_with_connection(
+    connection: &BrowserConnection,
+    headed: bool,
+) -> Result<()> {
+    if !connection.is_live_attach() {
+        let _ = close_browser_for_connection(connection);
+    }
+    let use_stealth = !connection.is_live_attach();
+    let command_timeout_ms = connection
+        .is_live_attach()
+        .then_some(LIVE_ATTACH_COMMAND_TIMEOUT_MS);
+    let verification_tab = if connection.is_live_attach() {
+        open_live_attach_verification_tab(
+            connection,
+            use_stealth,
+            headed,
+            claude_web::CLAUDE_URL,
+            command_timeout_ms,
+        )?
+    } else {
+        run_agent_browser_with_connection_timeout(
+            vec!["open".to_string(), claude_web::CLAUDE_URL.to_string()],
+            OutputFormat::Text,
+            Some(connection),
+            use_stealth,
+            headed,
+            command_timeout_ms,
+        )?;
+        None
+    };
+    let expression = chatgpt_web::wrap_function_source_for_json_eval(
+        &claude_web::build_wait_for_composer_function(),
+    )?;
+    let result = run_agent_browser_with_connection_timeout(
+        vec!["eval".to_string(), expression],
+        OutputFormat::Text,
+        Some(connection),
+        use_stealth,
+        headed,
+        Some(LIVE_ATTACH_COMMAND_TIMEOUT_MS),
+    )
+    .and_then(|stdout| {
+        parse_stdout_json(&stdout)
+            .with_context(|| format!("parse Claude auth check result: {stdout}"))
+    });
+    close_live_attach_verification_tab(
+        connection,
+        use_stealth,
+        headed,
+        verification_tab.as_ref(),
+        command_timeout_ms,
+    );
+    let state = result?;
+    match state.get("status").and_then(Value::as_str) {
+        Some("ready") => Ok(()),
+        Some("login") => bail!("Claude login is required in this browser profile"),
+        Some("challenge") => bail!(
+            "Cloudflare challenge detected on claude.ai; solve it in this browser profile and retry"
+        ),
+        other => {
+            bail!("Claude composer did not become ready; status={other:?}, diagnostics={state}")
+        }
+    }
 }
 
 fn check_auth_with_connection(
@@ -4978,6 +5893,7 @@ mod tests {
             use_stealth: true,
             headed: false,
             target_url: CHATGPT_URL.to_string(),
+            warnings: Vec::new(),
             vars: BTreeMap::from([(
                 "model".to_string(),
                 crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL.to_string(),
@@ -6984,6 +7900,87 @@ steps:
         assert_eq!(primary_payload["fallback_used"], false);
     }
 
+    #[test]
+    fn claude_recipe_payload_extracts_typed_result_from_literal_actions() {
+        let steps = vec![
+            json!({
+                "type": "browser_step",
+                "action": CLAUDE_SELECT_MODEL_ACTION,
+                "stdout": {
+                    "status": "ok",
+                    "model_used": "Fable 5 Max",
+                    "model_selection_status": "selected"
+                }
+            }),
+            json!({
+                "type": "browser_step",
+                "action": CLAUDE_WAIT_ACTION,
+                "stdout": {
+                    "status": "ok",
+                    "response": "final answer",
+                    "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
+                    "conversation_url": "https://claude.ai/chat/123e4567-e89b-12d3-a456-426614174000"
+                }
+            }),
+        ];
+
+        let payload =
+            claude_recipe_payload_from_steps(&steps, true, "20260718T102228Z_ab12cd", 1234, &[]);
+        assert_eq!(payload["transport"], "agent-browser");
+        assert_eq!(payload["backend"], "agent-browser");
+        assert_eq!(payload["response"], "final answer");
+        assert_eq!(payload["model_used"], "Fable 5 Max");
+        assert_eq!(payload["model_selection_status"], "selected");
+        assert_eq!(payload["fallback_used"], true);
+        assert_eq!(payload["run_id"], "20260718T102228Z_ab12cd");
+        assert_eq!(payload["elapsed_ms"], 1234);
+        assert_eq!(payload["delivery_mode"], "file_upload");
+        assert_eq!(payload["steps"], json!(steps));
+    }
+
+    #[test]
+    fn claude_completion_requires_idle_growth_and_keeps_copy_as_candidate() {
+        let baseline = ClaudeResponseBaseline {
+            count: 1,
+            last_length: 100,
+        };
+        let mut state = parse_claude_response_state(&json!({
+            "count":2,"length":200,"text":"answer","streaming":false,
+            "hasStopButton":false,"thinking":false,"copyButtons":0,"error":""
+        }))
+        .unwrap();
+        assert_eq!(
+            classify_claude_completion(&state, baseline),
+            ClaudeCompletionVerdict::Idle
+        );
+        state.copy_buttons = 1;
+        assert_eq!(
+            classify_claude_completion(&state, baseline),
+            ClaudeCompletionVerdict::CopyButton
+        );
+        state.streaming = true;
+        assert_eq!(
+            classify_claude_completion(&state, baseline),
+            ClaudeCompletionVerdict::Generating
+        );
+    }
+
+    #[test]
+    fn claude_terminal_stage_marks_upload_send_and_wait() {
+        let mut stage = ClaudeRecipeStage::Idle;
+        assert_eq!(stage.terminal_phase(CLAUDE_SELECT_MODEL_ACTION), None);
+        stage.mark_upload_started();
+        assert_eq!(
+            stage.terminal_phase("type"),
+            Some(WebRecipeTransportPhase::Upload)
+        );
+        stage.mark_send_succeeded();
+        assert_eq!(
+            stage.terminal_phase(CLAUDE_WAIT_ACTION),
+            Some(WebRecipeTransportPhase::WaitResponse)
+        );
+    }
+
     fn dom(send: ChatgptSendState, stop: bool, thinking: bool, copy: usize) -> ChatgptDomState {
         ChatgptDomState {
             send_state: send,
@@ -7542,6 +8539,21 @@ steps:
         let content = fs::read_to_string(&path).expect("read recipes/claude.yaml");
         let recipe: Recipe = serde_yaml_ng::from_str(&content).expect("parse claude.yaml");
         assert!(recipe.transports.is_none());
+        let actions = recipe
+            .steps
+            .iter()
+            .filter_map(|step| step.action.as_deref())
+            .collect::<Vec<_>>();
+        for action in [
+            CLAUDE_SELECT_MODEL_ACTION,
+            CLAUDE_OPEN_ATTACHMENT_UI_ACTION,
+            CLAUDE_UPLOAD_BUNDLE_ACTION,
+            CLAUDE_WAIT_UPLOAD_ACTION,
+            CLAUDE_SEND_ACTION,
+            CLAUDE_WAIT_ACTION,
+        ] {
+            assert!(actions.contains(&action), "missing literal action {action}");
+        }
         let defaults = recipe.defaults.expect("Claude defaults");
         assert_eq!(defaults.get("thread").map(String::as_str), Some("fresh"));
         assert_eq!(

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -248,21 +248,18 @@ pub fn recipe_transports(
     })
 }
 
-/// Select `chrome-extension-native` as the only ChatGPT recipe transport when
+/// Select `chrome-extension-native` as the only built-in web recipe transport when
 /// the Yoetz Chrome extension is installed and connected and the recipe author
 /// did not pin their own transport order. The list is returned unchanged for
 /// any other recipe, when the recipe pinned `transports:`, or when the extension
 /// is unhealthy.
-pub fn maybe_select_extension_native_for_chatgpt(
+pub fn maybe_select_extension_native_for_builtin(
     transports: Vec<RecipeTransport>,
     builtin_recipe: Option<crate::web_recipe::BuiltinWebRecipe>,
     recipe_transports_pinned: bool,
     extension_connected: bool,
 ) -> Vec<RecipeTransport> {
-    if builtin_recipe != Some(crate::web_recipe::BuiltinWebRecipe::Chatgpt)
-        || recipe_transports_pinned
-        || !extension_connected
-    {
+    if builtin_recipe.is_none() || recipe_transports_pinned || !extension_connected {
         return transports;
     }
     vec![RecipeTransport::ChromeExtensionNative]
@@ -7378,20 +7375,27 @@ steps:
     }
 
     #[test]
-    fn maybe_select_extension_native_requires_native_only_for_chatgpt_when_connected() {
+    fn maybe_select_extension_native_requires_native_only_for_supported_builtins_when_connected() {
         let base = vec![
             RecipeTransport::ChromeDevtoolsMcp,
             RecipeTransport::DevBrowser,
             RecipeTransport::AgentBrowser,
             RecipeTransport::Manual,
         ];
-        let promoted = maybe_select_extension_native_for_chatgpt(
+        let promoted = maybe_select_extension_native_for_builtin(
             base,
             Some(crate::web_recipe::BuiltinWebRecipe::Chatgpt),
             false,
             true,
         );
         assert_eq!(promoted, vec![RecipeTransport::ChromeExtensionNative]);
+        let claude = maybe_select_extension_native_for_builtin(
+            vec![RecipeTransport::ChromeDevtoolsMcp, RecipeTransport::Manual],
+            Some(crate::web_recipe::BuiltinWebRecipe::Claude),
+            false,
+            true,
+        );
+        assert_eq!(claude, vec![RecipeTransport::ChromeExtensionNative]);
     }
 
     #[test]
@@ -7400,7 +7404,7 @@ steps:
             RecipeTransport::ChromeDevtoolsMcp,
             RecipeTransport::DevBrowser,
         ];
-        let result = maybe_select_extension_native_for_chatgpt(
+        let result = maybe_select_extension_native_for_builtin(
             base.clone(),
             Some(crate::web_recipe::BuiltinWebRecipe::Chatgpt),
             false,
@@ -7412,7 +7416,7 @@ steps:
     #[test]
     fn maybe_select_extension_native_noop_when_recipe_pinned_transports() {
         let base = vec![RecipeTransport::ChromeDevtoolsMcp, RecipeTransport::Manual];
-        let result = maybe_select_extension_native_for_chatgpt(
+        let result = maybe_select_extension_native_for_builtin(
             base.clone(),
             Some(crate::web_recipe::BuiltinWebRecipe::Chatgpt),
             true,
@@ -7424,7 +7428,7 @@ steps:
     #[test]
     fn maybe_select_extension_native_noop_for_non_chatgpt() {
         let base = vec![RecipeTransport::AgentBrowser];
-        let result = maybe_select_extension_native_for_chatgpt(base.clone(), None, false, true);
+        let result = maybe_select_extension_native_for_builtin(base.clone(), None, false, true);
         assert_eq!(result, base);
     }
 
@@ -7435,7 +7439,7 @@ steps:
             RecipeTransport::ChromeExtensionNative,
             RecipeTransport::Manual,
         ];
-        let result = maybe_select_extension_native_for_chatgpt(
+        let result = maybe_select_extension_native_for_builtin(
             base,
             Some(crate::web_recipe::BuiltinWebRecipe::Chatgpt),
             false,
@@ -7517,7 +7521,7 @@ steps:
         );
 
         let base = recipe_transports(&recipe, Some(crate::web_recipe::BuiltinWebRecipe::Chatgpt));
-        let promoted = maybe_select_extension_native_for_chatgpt(
+        let promoted = maybe_select_extension_native_for_builtin(
             base,
             Some(crate::web_recipe::BuiltinWebRecipe::Chatgpt),
             recipe.transports.is_some(),

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -314,7 +314,7 @@ pub fn prepare_managed_chatgpt_extension() -> Result<ManagedExtensionUpdateResul
     let mut result = sync_managed_chatgpt_extension_from(&source_dir, &extension_dir)?;
     let legacy_dir = legacy_loaded_chatgpt_extension_dir()?;
     if legacy_dir.exists() && !paths_refer_to_same_location(&legacy_dir, &extension_dir) {
-        sync_managed_chatgpt_extension_from(&source_dir, &legacy_dir).with_context(|| {
+        sync_extension_dir_exact(&extension_dir, &legacy_dir).with_context(|| {
             format!(
                 "sync legacy loaded ChatGPT native extension directory {}",
                 legacy_dir.display()
@@ -346,11 +346,6 @@ fn sync_managed_chatgpt_extension_from(
         });
     }
 
-    let parent = extension_dir
-        .parent()
-        .context("managed extension directory must have a parent")?;
-    fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
-    ensure_replaceable_extension_dir(extension_dir)?;
     if !managed_chatgpt_extension_needs_sync(source_dir, extension_dir)? {
         return Ok(ManagedExtensionUpdateResult {
             status: "current",
@@ -362,6 +357,53 @@ fn sync_managed_chatgpt_extension_from(
         });
     }
 
+    let source_version = required_extension_manifest_version(source_dir)?;
+    let stamped_version = next_managed_extension_version(
+        &source_version,
+        extension_manifest_version(extension_dir).as_deref(),
+    )?;
+    let copied_files =
+        copy_extension_dir_atomically(source_dir, extension_dir, Some(stamped_version.as_str()))?;
+
+    Ok(ManagedExtensionUpdateResult {
+        status: "updated",
+        source_dir: source_dir.to_path_buf(),
+        extension_dir: extension_dir.to_path_buf(),
+        loaded_extension_dirs: vec![extension_dir.to_path_buf()],
+        manifest_version: Some(stamped_version),
+        copied_files,
+    })
+}
+
+fn sync_extension_dir_exact(source_dir: &Path, extension_dir: &Path) -> Result<usize> {
+    if !is_chatgpt_extension_source_dir(source_dir) {
+        bail!(
+            "ChatGPT native extension source is incomplete: {}",
+            source_dir.display()
+        );
+    }
+    if paths_refer_to_same_location(source_dir, extension_dir) {
+        return Ok(0);
+    }
+    if is_chatgpt_extension_source_dir(extension_dir)
+        && extension_dir_fingerprint(source_dir, None)?
+            == extension_dir_fingerprint(extension_dir, None)?
+    {
+        return Ok(0);
+    }
+    copy_extension_dir_atomically(source_dir, extension_dir, None)
+}
+
+fn copy_extension_dir_atomically(
+    source_dir: &Path,
+    extension_dir: &Path,
+    stamped_version: Option<&str>,
+) -> Result<usize> {
+    let parent = extension_dir
+        .parent()
+        .context("managed extension directory must have a parent")?;
+    fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    ensure_replaceable_extension_dir(extension_dir)?;
     let name = extension_dir
         .file_name()
         .and_then(|value| value.to_str())
@@ -379,6 +421,9 @@ fn sync_managed_chatgpt_extension_from(
 
     let copied_files = copy_extension_dir_contents(source_dir, &temp_dir)
         .with_context(|| format!("copy extension source from {}", source_dir.display()))?;
+    if let Some(version) = stamped_version {
+        write_extension_manifest_version(&temp_dir, version)?;
+    }
     if !is_chatgpt_extension_source_dir(&temp_dir) {
         let _ = fs::remove_dir_all(&temp_dir);
         bail!(
@@ -411,22 +456,26 @@ fn sync_managed_chatgpt_extension_from(
         fs::remove_dir_all(&backup_dir)
             .with_context(|| format!("remove old managed extension {}", backup_dir.display()))?;
     }
-
-    Ok(ManagedExtensionUpdateResult {
-        status: "updated",
-        source_dir: source_dir.to_path_buf(),
-        extension_dir: extension_dir.to_path_buf(),
-        loaded_extension_dirs: vec![extension_dir.to_path_buf()],
-        manifest_version: extension_manifest_version(extension_dir),
-        copied_files,
-    })
+    Ok(copied_files)
 }
 
 fn managed_chatgpt_extension_needs_sync(source_dir: &Path, extension_dir: &Path) -> Result<bool> {
     if !is_chatgpt_extension_source_dir(extension_dir) {
         return Ok(true);
     }
-    Ok(extension_dir_fingerprint(source_dir)? != extension_dir_fingerprint(extension_dir)?)
+    let source_version = required_extension_manifest_version(source_dir)?;
+    if managed_extension_counter(
+        &source_version,
+        extension_manifest_version(extension_dir).as_deref(),
+    )
+    .is_none()
+    {
+        return Ok(true);
+    }
+    Ok(
+        extension_dir_fingerprint(source_dir, Some(&source_version))?
+            != extension_dir_fingerprint(extension_dir, Some(&source_version))?,
+    )
 }
 
 fn paths_refer_to_same_location(left: &Path, right: &Path) -> bool {
@@ -500,11 +549,24 @@ fn count_regular_files(root: &Path) -> Result<usize> {
     Ok(extension_file_paths(root)?.len())
 }
 
-fn extension_dir_fingerprint(root: &Path) -> Result<Vec<(PathBuf, String)>> {
+fn extension_dir_fingerprint(
+    root: &Path,
+    manifest_version_override: Option<&str>,
+) -> Result<Vec<(PathBuf, String)>> {
     let mut files = Vec::new();
     for relative in extension_file_paths(root)? {
-        let bytes = fs::read(root.join(&relative))
+        let path = root.join(&relative);
+        let mut bytes = fs::read(&path)
             .with_context(|| format!("read extension file {}", root.join(&relative).display()))?;
+        if relative == Path::new("manifest.json") {
+            let mut manifest = serde_json::from_slice::<Value>(&bytes)
+                .with_context(|| format!("parse extension manifest {}", path.display()))?;
+            if let Some(version) = manifest_version_override {
+                manifest["version"] = Value::String(version.to_string());
+            }
+            bytes = serde_json::to_vec(&manifest)
+                .with_context(|| format!("normalize extension manifest {}", path.display()))?;
+        }
         let mut hash = Sha256::new();
         hash.update(&bytes);
         files.push((relative, hex::encode(hash.finalize())));
@@ -555,12 +617,88 @@ fn extension_manifest_version(extension_dir: &Path) -> Option<String> {
         .map(str::to_string)
 }
 
+fn required_extension_manifest_version(extension_dir: &Path) -> Result<String> {
+    extension_manifest_version(extension_dir).with_context(|| {
+        format!(
+            "extension manifest has no version: {}",
+            extension_dir.join("manifest.json").display()
+        )
+    })
+}
+
+fn chrome_extension_version_parts(version: &str) -> Option<Vec<u16>> {
+    let parts = version
+        .trim()
+        .split('.')
+        .map(str::parse::<u16>)
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .ok()?;
+    (1..=4).contains(&parts.len()).then_some(parts)
+}
+
+fn cli_version_prefix() -> Option<[u16; 3]> {
+    let parts = chrome_extension_version_parts(YOETZ_CLI_VERSION)?;
+    (parts.len() >= 3).then(|| [parts[0], parts[1], parts[2]])
+}
+
+fn extension_version_is_cli_compatible(version: &str) -> bool {
+    let Some(expected) = cli_version_prefix() else {
+        return version.trim() == YOETZ_CLI_VERSION;
+    };
+    let Some(parts) = chrome_extension_version_parts(version) else {
+        return false;
+    };
+    parts.len() >= 3 && parts[..3] == expected
+}
+
+fn managed_extension_counter(source_version: &str, managed_version: Option<&str>) -> Option<u16> {
+    let source_parts = chrome_extension_version_parts(source_version)?;
+    if source_parts.len() != 3 {
+        return None;
+    }
+    let managed_parts = chrome_extension_version_parts(managed_version?)?;
+    (managed_parts.len() == 4 && managed_parts[..3] == source_parts[..3]).then(|| managed_parts[3])
+}
+
+fn next_managed_extension_version(
+    source_version: &str,
+    current_managed_version: Option<&str>,
+) -> Result<String> {
+    let source_parts = chrome_extension_version_parts(source_version).with_context(|| {
+        format!("extension version `{source_version}` is not a valid Chrome extension version")
+    })?;
+    if source_parts.len() != 3 {
+        bail!(
+            "managed extension source version must have exactly three components, got `{source_version}`"
+        );
+    }
+    let counter = managed_extension_counter(source_version, current_managed_version)
+        .unwrap_or(0)
+        .checked_add(1)
+        .context("managed extension version counter exhausted at 65535")?;
+    Ok(format!("{source_version}.{counter}"))
+}
+
+fn write_extension_manifest_version(extension_dir: &Path, version: &str) -> Result<()> {
+    let manifest_path = extension_dir.join("manifest.json");
+    let text = fs::read_to_string(&manifest_path)
+        .with_context(|| format!("read extension manifest {}", manifest_path.display()))?;
+    let mut manifest = serde_json::from_str::<Value>(&text)
+        .with_context(|| format!("parse extension manifest {}", manifest_path.display()))?;
+    manifest["version"] = Value::String(version.to_string());
+    let mut rendered = serde_json::to_string_pretty(&manifest)
+        .with_context(|| format!("render extension manifest {}", manifest_path.display()))?;
+    rendered.push('\n');
+    fs::write(&manifest_path, rendered)
+        .with_context(|| format!("write extension manifest {}", manifest_path.display()))
+}
+
 fn extension_version_skew_message(
     extension_version: Option<&str>,
     site_flag: Option<&str>,
 ) -> Option<String> {
     let extension_version = extension_version?.trim();
-    if extension_version.is_empty() || extension_version == YOETZ_CLI_VERSION {
+    if extension_version.is_empty() || extension_version_is_cli_compatible(extension_version) {
         return None;
     }
     let update_hint = match site_flag {
@@ -569,6 +707,53 @@ fn extension_version_skew_message(
     };
     Some(format!(
         "loaded chrome-extension-native extension version {extension_version} does not match yoetz CLI {YOETZ_CLI_VERSION}; run {update_hint}"
+    ))
+}
+
+fn managed_extension_identity_message(
+    observed_version: Option<&str>,
+    expected_version: Option<&str>,
+    managed_dir: &Path,
+) -> Option<String> {
+    let observed = observed_version?.trim();
+    let expected = expected_version?.trim();
+    if observed.is_empty() || expected.is_empty() {
+        return None;
+    }
+    let observed_parts = chrome_extension_version_parts(observed);
+    let expected_parts = chrome_extension_version_parts(expected);
+    if expected_parts.as_ref().is_none_or(|parts| parts.len() != 4) {
+        return Some(format!(
+            "managed extension copy at {} has no stamped sync identity; run `yoetz browser extension update --chatgpt` or `yoetz browser extension update --claude` to initialize it",
+            managed_dir.display()
+        ));
+    }
+    if observed == expected {
+        return None;
+    }
+    if observed_parts
+        .as_ref()
+        .is_some_and(|parts| parts.len() == 3)
+        && expected_parts
+            .as_ref()
+            .is_some_and(|parts| parts.len() == 4)
+    {
+        return Some(format!(
+            "Chrome is running a non-managed copy of the Yoetz extension; one-time migration: remove the Yoetz card in chrome://extensions, then Load unpacked {}",
+            managed_dir.display()
+        ));
+    }
+    if extension_version_is_cli_compatible(observed)
+        && extension_version_is_cli_compatible(expected)
+    {
+        return Some(format!(
+            "Chrome is running a stale managed copy of the Yoetz extension (loaded {observed}, expected {expected}); run `yoetz browser extension update --chatgpt` or `yoetz browser extension update --claude`, or reload {} in chrome://extensions",
+            managed_dir.display()
+        ));
+    }
+    Some(format!(
+        "loaded Yoetz extension version {observed} does not match managed copy {expected} at {}; run `yoetz browser extension update --chatgpt` or `yoetz browser extension update --claude`",
+        managed_dir.display()
     ))
 }
 
@@ -632,6 +817,17 @@ pub fn status() -> Result<ExtensionStatus> {
     let version_mismatch = protocol_version_mismatch
         .clone()
         .or_else(|| extension_version_mismatch.clone());
+    let managed_extension_dir = managed_chatgpt_extension_dir()?;
+    let managed_extension_version = extension_manifest_version(&managed_extension_dir);
+    let managed_copy_mismatch = hello_seen
+        .then(|| {
+            managed_extension_identity_message(
+                extension_version.as_deref(),
+                managed_extension_version.as_deref(),
+                &managed_extension_dir,
+            )
+        })
+        .flatten();
     let manual_handoff = status_value
         .as_ref()
         .and_then(|value| value.get("last_manual_handoff"))
@@ -639,6 +835,8 @@ pub fn status() -> Result<ExtensionStatus> {
         .is_some();
     let status = if version_mismatch.is_some() {
         "version_mismatch"
+    } else if managed_copy_mismatch.is_some() {
+        "managed_copy_mismatch"
     } else if manual_handoff {
         "manual_handoff"
     } else if socket_reachable && hello_seen {
@@ -670,6 +868,9 @@ pub fn status() -> Result<ExtensionStatus> {
             .map(str::to_string)
             .or_else(|| version_mismatch.clone())
             .unwrap_or_else(|| "extension/native protocol version mismatch".to_string()),
+        "managed_copy_mismatch" => managed_copy_mismatch
+            .clone()
+            .unwrap_or_else(|| "loaded extension does not match the managed copy".to_string()),
         "manual_handoff" => status_value
             .as_ref()
             .and_then(|value| value.get("last_manual_handoff"))
@@ -791,6 +992,50 @@ pub fn doctor() -> Result<DoctorReport> {
                 "extension_instance_id",
             )
         });
+    let managed_extension_dir = managed_chatgpt_extension_dir()?;
+    let managed_extension_version = extension_manifest_version(&managed_extension_dir);
+    let managed_copy_mismatch = managed_extension_identity_message(
+        observed_extension_version.as_deref(),
+        managed_extension_version.as_deref(),
+        &managed_extension_dir,
+    );
+    let managed_copy_check = match (
+        observed_extension_version.as_deref(),
+        managed_extension_version.as_deref(),
+        managed_copy_mismatch.as_deref(),
+    ) {
+        (_, _, Some(message)) => DoctorCheck {
+            name: "managed_extension_copy",
+            ok: false,
+            detail: message.to_string(),
+        },
+        (Some(observed), Some(expected), None) if observed == expected => DoctorCheck {
+            name: "managed_extension_copy",
+            ok: true,
+            detail: format!(
+                "loaded managed extension version {expected} from {}",
+                managed_extension_dir.display()
+            ),
+        },
+        (None, _, None) => DoctorCheck {
+            name: "managed_extension_copy",
+            ok: false,
+            detail: "no extension version observed".to_string(),
+        },
+        (_, None, None) => DoctorCheck {
+            name: "managed_extension_copy",
+            ok: true,
+            detail: format!(
+                "managed extension copy has not been prepared at {}",
+                managed_extension_dir.display()
+            ),
+        },
+        _ => DoctorCheck {
+            name: "managed_extension_copy",
+            ok: false,
+            detail: "loaded extension identity could not be verified".to_string(),
+        },
+    };
     let version_detail = status_value
         .as_ref()
         .and_then(|value| value.get("version_mismatch"))
@@ -799,6 +1044,7 @@ pub fn doctor() -> Result<DoctorReport> {
         .or_else(|| extension_version_mismatch.clone())
         .unwrap_or_else(|| {
             observed_extension_version
+                .as_deref()
                 .map(|version| {
                     format!(
                         "protocol_version={PROTOCOL_VERSION}, cli_version={YOETZ_CLI_VERSION}, extension_version={version}"
@@ -839,6 +1085,7 @@ pub fn doctor() -> Result<DoctorReport> {
                 && extension_version_mismatch.is_none(),
             detail: version_detail,
         },
+        managed_copy_check,
         DoctorCheck {
             name: "extension_instance_id",
             ok: extension_instance_id.is_some(),
@@ -982,11 +1229,20 @@ pub fn update_extension(
     let paths = extension_paths()?;
     let previous_instance = select_extension_instance(&paths, selector)?;
     let update = prepare_managed_chatgpt_extension()?;
+    let expected_version = update
+        .manifest_version
+        .as_deref()
+        .context("managed extension copy has no stamped manifest version")?;
+    ensure_reload_can_reach_managed_copy(
+        &previous_instance,
+        expected_version,
+        &update.extension_dir,
+    )?;
     let reload = reload_extension(selector)?;
     let instance = wait_for_extension_update(
         &paths,
         selector,
-        YOETZ_CLI_VERSION,
+        expected_version,
         recipe.as_str(),
         &previous_instance.native_instance_id,
     )
@@ -1184,6 +1440,7 @@ pub fn run_chatgpt_recipe(
             Err(err) => eprintln!("warning: automatic extension update failed: {err:#}"),
         }
     }
+    ensure_instance_matches_managed_copy(&instance)?;
     let token = read_capability_token(&paths.token_path)?;
     let mut stream = connect_socket(&instance.socket_path).with_context(|| {
         format!(
@@ -1252,6 +1509,7 @@ pub fn run_claude_recipe(
             Err(err) => eprintln!("warning: automatic extension update failed: {err:#}"),
         }
     }
+    ensure_instance_matches_managed_copy(&instance)?;
     // Capability is checked on the exact routed extension instance after any
     // best-effort heal and before opening the socket or emitting job_start.
     ensure_instance_supports_recipe(&instance, "claude")?;
@@ -1688,9 +1946,60 @@ fn auto_heal_extension_version_skew(
     if chatgpt_extension_source_dir().is_none() {
         return Ok(None);
     }
-    prepare_managed_chatgpt_extension()?;
+    let previous_instance = select_extension_instance(paths, selector)?;
+    let update = prepare_managed_chatgpt_extension()?;
+    let expected_version = update
+        .manifest_version
+        .as_deref()
+        .context("managed extension copy has no stamped manifest version")?;
+    ensure_reload_can_reach_managed_copy(
+        &previous_instance,
+        expected_version,
+        &update.extension_dir,
+    )?;
     reload_extension(selector)?;
-    wait_for_extension_version(paths, selector, YOETZ_CLI_VERSION).map(Some)
+    wait_for_extension_version(paths, selector, expected_version).map(Some)
+}
+
+fn ensure_reload_can_reach_managed_copy(
+    instance: &ExtensionInstanceStatus,
+    expected_version: &str,
+    managed_dir: &Path,
+) -> Result<()> {
+    let observed_parts = instance
+        .extension_version
+        .as_deref()
+        .and_then(chrome_extension_version_parts);
+    let expected_parts = chrome_extension_version_parts(expected_version);
+    if observed_parts
+        .as_ref()
+        .is_some_and(|parts| parts.len() == 3)
+        && expected_parts
+            .as_ref()
+            .is_some_and(|parts| parts.len() == 4)
+    {
+        if let Some(message) = managed_extension_identity_message(
+            instance.extension_version.as_deref(),
+            Some(expected_version),
+            managed_dir,
+        ) {
+            bail!(message);
+        }
+    }
+    Ok(())
+}
+
+fn ensure_instance_matches_managed_copy(instance: &ExtensionInstanceStatus) -> Result<()> {
+    let managed_dir = managed_chatgpt_extension_dir()?;
+    let expected_version = extension_manifest_version(&managed_dir);
+    if let Some(message) = managed_extension_identity_message(
+        instance.extension_version.as_deref(),
+        expected_version.as_deref(),
+        &managed_dir,
+    ) {
+        bail!(message);
+    }
+    Ok(())
 }
 
 fn wait_for_extension_version(
@@ -3648,12 +3957,13 @@ mod tests {
 
     #[test]
     fn extension_update_readiness_requires_new_instance_version_and_recipe() {
+        let expected_version = format!("{YOETZ_CLI_VERSION}.7");
         let mut instance = ExtensionInstanceStatus {
             native_instance_id: "native_before".to_string(),
             socket_path: PathBuf::from("/tmp/claude.sock"),
             pid: 1,
             extension_instance_id: Some("ext_claude".to_string()),
-            extension_version: Some(YOETZ_CLI_VERSION.to_string()),
+            extension_version: Some(expected_version.clone()),
             profile_email: None,
             profile_id: None,
             recipes: vec!["chatgpt".to_string(), "claude".to_string()],
@@ -3663,7 +3973,7 @@ mod tests {
 
         assert!(!extension_update_is_active(
             &instance,
-            YOETZ_CLI_VERSION,
+            &expected_version,
             "claude",
             "native_before"
         ));
@@ -3672,7 +3982,7 @@ mod tests {
         instance.recipes = vec!["chatgpt".to_string()];
         assert!(!extension_update_is_active(
             &instance,
-            YOETZ_CLI_VERSION,
+            &expected_version,
             "claude",
             "native_before"
         ));
@@ -3680,7 +3990,7 @@ mod tests {
         instance.recipes.push("claude".to_string());
         assert!(extension_update_is_active(
             &instance,
-            YOETZ_CLI_VERSION,
+            &expected_version,
             "claude",
             "native_before"
         ));
@@ -4227,6 +4537,69 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
+    #[serial]
+    fn status_and_doctor_reject_non_managed_loaded_copy() {
+        use std::os::unix::net::UnixListener;
+
+        let dir = TempDir::new().unwrap();
+        let _manifest_guard = EnvGuard::set(
+            "YOETZ_CHROME_NATIVE_MESSAGING_DIR",
+            &dir.path().join("native-hosts"),
+        );
+        let state = dir.path().join("state");
+        let _state_guard = EnvGuard::set("YOETZ_DIR", &state);
+        write_extension_source_fixture(
+            &state.join("chatgpt-native-extension"),
+            &format!("{YOETZ_CLI_VERSION}.9"),
+        );
+        let paths = extension_paths().unwrap();
+        fs::create_dir_all(&paths.instances_dir).unwrap();
+        let socket = dir.path().join("work.sock");
+        let _listener = UnixListener::bind(&socket).unwrap();
+        write_instance_fixture(
+            &paths,
+            ExtensionInstanceStatus {
+                native_instance_id: "native_work".to_string(),
+                socket_path: socket,
+                pid: process::id(),
+                extension_instance_id: Some("ext_123".to_string()),
+                extension_version: Some(YOETZ_CLI_VERSION.to_string()),
+                profile_email: Some("work@example.com".to_string()),
+                profile_id: Some("gaia_123".to_string()),
+                recipes: vec!["chatgpt".to_string(), "claude".to_string()],
+                protocol_version: PROTOCOL_VERSION,
+                last_seen_ms: 1234,
+            },
+        );
+
+        let payload = status().unwrap();
+        assert_eq!(payload.status, "managed_copy_mismatch");
+        assert!(payload.detail.contains("non-managed copy"));
+        assert!(payload.detail.contains("remove the Yoetz card"));
+        assert!(payload.detail.contains(&format!(
+            "Load unpacked {}",
+            managed_chatgpt_extension_dir().unwrap().display()
+        )));
+
+        let report = doctor().unwrap();
+        let version_compatible = report
+            .checks
+            .iter()
+            .find(|check| check.name == "version_compatible")
+            .unwrap();
+        assert!(version_compatible.ok);
+        let managed_copy = report
+            .checks
+            .iter()
+            .find(|check| check.name == "managed_extension_copy")
+            .unwrap();
+        assert!(!managed_copy.ok);
+        assert!(managed_copy.detail.contains("non-managed copy"));
+        assert!(!report.ok);
+    }
+
+    #[test]
     #[serial]
     fn managed_extension_dir_uses_stable_yoetz_state_dir() {
         let dir = TempDir::new().unwrap();
@@ -4245,10 +4618,10 @@ mod tests {
     fn sync_managed_extension_replaces_stale_copy_atomically() {
         let dir = TempDir::new().unwrap();
         let source = dir.path().join("source");
-        write_extension_source_fixture(&source, "fresh");
+        write_extension_source_fixture(&source, YOETZ_CLI_VERSION);
         let target = dir.path().join("managed");
         fs::create_dir_all(target.join("src")).unwrap();
-        fs::write(target.join("manifest.json"), r#"{"version":"stale"}"#).unwrap();
+        fs::write(target.join("manifest.json"), r#"{"version":"0.5.32"}"#).unwrap();
         fs::write(target.join("src").join("stale.js"), "stale").unwrap();
 
         let result = sync_managed_chatgpt_extension_from(&source, &target).unwrap();
@@ -4257,14 +4630,58 @@ mod tests {
         assert_eq!(result.source_dir, source);
         assert_eq!(result.extension_dir, target);
         assert_eq!(
-            fs::read_to_string(result.extension_dir.join("manifest.json")).unwrap(),
-            r#"{"version":"fresh"}"#
+            extension_manifest_version(&result.extension_dir).as_deref(),
+            Some(format!("{YOETZ_CLI_VERSION}.1").as_str())
+        );
+        assert_eq!(
+            fs::read_to_string(source.join("manifest.json")).unwrap(),
+            format!(r#"{{"version":"{YOETZ_CLI_VERSION}"}}"#)
+        );
+        assert_eq!(
+            result.manifest_version.as_deref(),
+            Some(format!("{YOETZ_CLI_VERSION}.1").as_str())
         );
         assert_eq!(
             fs::read_to_string(result.extension_dir.join("src").join("service-worker.js")).unwrap(),
-            "service-worker:fresh"
+            format!("service-worker:{YOETZ_CLI_VERSION}")
         );
         assert!(!result.extension_dir.join("src").join("stale.js").exists());
+    }
+
+    #[test]
+    #[serial]
+    fn managed_extension_stamp_increments_only_when_source_changes() {
+        let dir = TempDir::new().unwrap();
+        let source = dir.path().join("source");
+        write_extension_source_fixture(&source, YOETZ_CLI_VERSION);
+        let target = dir.path().join("managed");
+        let first_version = format!("{YOETZ_CLI_VERSION}.1");
+        let second_version = format!("{YOETZ_CLI_VERSION}.2");
+
+        let first = sync_managed_chatgpt_extension_from(&source, &target).unwrap();
+        assert_eq!(
+            first.manifest_version.as_deref(),
+            Some(first_version.as_str())
+        );
+
+        fs::write(
+            source.join("src").join("service-worker.js"),
+            "service-worker:changed",
+        )
+        .unwrap();
+        let second = sync_managed_chatgpt_extension_from(&source, &target).unwrap();
+        assert_eq!(second.status, "updated");
+        assert_eq!(
+            second.manifest_version.as_deref(),
+            Some(second_version.as_str())
+        );
+
+        let current = sync_managed_chatgpt_extension_from(&source, &target).unwrap();
+        assert_eq!(current.status, "current");
+        assert_eq!(
+            current.manifest_version.as_deref(),
+            Some(second_version.as_str())
+        );
     }
 
     #[test]
@@ -4272,7 +4689,7 @@ mod tests {
     fn prepare_managed_extension_materializes_from_discovered_source() {
         let dir = TempDir::new().unwrap();
         let source = dir.path().join("source");
-        write_extension_source_fixture(&source, "prepared");
+        write_extension_source_fixture(&source, YOETZ_CLI_VERSION);
         let state = dir.path().join("state");
         let _source_guard = EnvGuard::set(CHATGPT_EXTENSION_DIR_ENV, &source);
         let _state_guard = EnvGuard::set("YOETZ_DIR", &state);
@@ -4289,10 +4706,10 @@ mod tests {
     fn prepare_managed_extension_refreshes_legacy_loaded_unpacked_dir_when_present() {
         let dir = TempDir::new().unwrap();
         let source = dir.path().join("source");
-        write_extension_source_fixture(&source, "fresh");
+        write_extension_source_fixture(&source, YOETZ_CLI_VERSION);
         let state = dir.path().join("state");
         let legacy_loaded = state.join("chrome-extension-native").join("unpacked");
-        write_extension_source_fixture(&legacy_loaded, "stale");
+        write_extension_source_fixture(&legacy_loaded, "0.5.32");
         let _source_guard = EnvGuard::set(CHATGPT_EXTENSION_DIR_ENV, &source);
         let _state_guard = EnvGuard::set("YOETZ_DIR", &state);
 
@@ -4303,12 +4720,53 @@ mod tests {
         assert!(result.loaded_extension_dirs.contains(&legacy_loaded));
         assert_eq!(
             fs::read_to_string(legacy_loaded.join("manifest.json")).unwrap(),
-            r#"{"version":"fresh"}"#
+            fs::read_to_string(result.extension_dir.join("manifest.json")).unwrap()
         );
         assert_eq!(
             fs::read_to_string(legacy_loaded.join("src").join("service-worker.js")).unwrap(),
-            "service-worker:fresh"
+            format!("service-worker:{YOETZ_CLI_VERSION}")
         );
+    }
+
+    #[test]
+    fn managed_extension_versions_are_cli_compatible_but_identity_exact() {
+        let managed_version = format!("{YOETZ_CLI_VERSION}.42");
+        let stale_managed_version = format!("{YOETZ_CLI_VERSION}.41");
+        assert!(extension_version_skew_message(Some(&managed_version), None).is_none());
+        assert!(extension_version_skew_message(Some("not-a-version"), None).is_some());
+
+        let unstamped = managed_extension_identity_message(
+            Some(YOETZ_CLI_VERSION),
+            Some(YOETZ_CLI_VERSION),
+            Path::new("/managed/extension"),
+        )
+        .unwrap();
+        assert!(unstamped.contains("no stamped sync identity"));
+        assert!(unstamped.contains("extension update"));
+
+        assert!(managed_extension_identity_message(
+            Some(&managed_version),
+            Some(&managed_version),
+            Path::new("/managed/extension")
+        )
+        .is_none());
+        let source_copy = managed_extension_identity_message(
+            Some(YOETZ_CLI_VERSION),
+            Some(&managed_version),
+            Path::new("/managed/extension"),
+        )
+        .unwrap();
+        assert!(source_copy.contains("non-managed copy"));
+        assert!(source_copy.contains("remove the Yoetz card"));
+        assert!(source_copy.contains("Load unpacked /managed/extension"));
+
+        let stale_copy = managed_extension_identity_message(
+            Some(&stale_managed_version),
+            Some(&managed_version),
+            Path::new("/managed/extension"),
+        )
+        .unwrap();
+        assert!(stale_copy.contains("stale managed copy"));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -1010,17 +1010,7 @@ pub fn update_extension(
     }))
 }
 
-pub fn bridge_check(selector: ExtensionInstanceSelector<'_>) -> Result<Value> {
-    let response = send_control_job("reconnect", json!({ "intent": "bridge_check" }), selector)?;
-    Ok(json!({
-        "status": "ok",
-        "transport": TRANSPORT_NAME,
-        "live": false,
-        "response": response.payload,
-    }))
-}
-
-fn bridge_check_for_recipe(
+pub fn bridge_check_for_recipe(
     selector: ExtensionInstanceSelector<'_>,
     recipe: BuiltinWebRecipe,
 ) -> Result<Value> {
@@ -1037,6 +1027,25 @@ fn bridge_check_for_recipe(
         "live": false,
         "response": response.payload,
     }))
+}
+
+fn instance_advertises_recipe(
+    instance: &ExtensionInstanceStatus,
+    recipe: BuiltinWebRecipe,
+) -> bool {
+    instance
+        .recipes
+        .iter()
+        .any(|value| value == recipe.as_str())
+}
+
+pub fn recipe_ready(
+    selector: ExtensionInstanceSelector<'_>,
+    recipe: BuiltinWebRecipe,
+) -> Result<bool> {
+    let paths = extension_paths()?;
+    let instance = select_extension_instance(&paths, selector)?;
+    Ok(instance_advertises_recipe(&instance, recipe))
 }
 
 pub fn canary(
@@ -4135,6 +4144,30 @@ mod tests {
             extension_hello.detail,
             "extension_version=0.2.0, extension_instance_id=ext_123, chrome_profile_email=work@example.com"
         );
+    }
+
+    #[test]
+    fn selected_instance_capability_is_recipe_exact() {
+        let instance = ExtensionInstanceStatus {
+            native_instance_id: "native_1".to_string(),
+            socket_path: PathBuf::from("/tmp/native_1.sock"),
+            pid: process::id(),
+            extension_instance_id: Some("ext_1".to_string()),
+            extension_version: Some("0.5.33".to_string()),
+            profile_email: None,
+            profile_id: None,
+            recipes: vec!["chatgpt".to_string()],
+            protocol_version: PROTOCOL_VERSION,
+            last_seen_ms: 1,
+        };
+        assert!(instance_advertises_recipe(
+            &instance,
+            BuiltinWebRecipe::Chatgpt
+        ));
+        assert!(!instance_advertises_recipe(
+            &instance,
+            BuiltinWebRecipe::Claude
+        ));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -18,6 +18,8 @@ use thiserror::Error;
 use crate::chatgpt_recipe::{
     ChatgptModelSelectionStatus, ChatgptRecipeSpec, ChatgptTransportPhase,
 };
+use crate::claude_recipe::ClaudeRecipeSpec;
+use crate::web_recipe::BuiltinWebRecipe;
 use yoetz_core::output::{write_jsonl, OutputFormat};
 use yoetz_core::paths::home_dir;
 
@@ -553,13 +555,20 @@ fn extension_manifest_version(extension_dir: &Path) -> Option<String> {
         .map(str::to_string)
 }
 
-fn extension_version_skew_message(extension_version: Option<&str>) -> Option<String> {
+fn extension_version_skew_message(
+    extension_version: Option<&str>,
+    site_flag: Option<&str>,
+) -> Option<String> {
     let extension_version = extension_version?.trim();
     if extension_version.is_empty() || extension_version == YOETZ_CLI_VERSION {
         return None;
     }
+    let update_hint = match site_flag {
+        Some(site_flag) => format!("`yoetz browser extension update {site_flag}`"),
+        None => "`yoetz browser extension update --chatgpt` or `yoetz browser extension update --claude`".to_string(),
+    };
     Some(format!(
-        "loaded chrome-extension-native extension version {extension_version} does not match yoetz CLI {YOETZ_CLI_VERSION}; run `yoetz browser extension update --chatgpt`"
+        "loaded chrome-extension-native extension version {extension_version} does not match yoetz CLI {YOETZ_CLI_VERSION}; run {update_hint}"
     ))
 }
 
@@ -618,7 +627,8 @@ pub fn status() -> Result<ExtensionStatus> {
         .and_then(|value| value.get("version_mismatch"))
         .and_then(Value::as_str)
         .map(str::to_string);
-    let extension_version_mismatch = extension_version_skew_message(extension_version.as_deref());
+    let extension_version_mismatch =
+        extension_version_skew_message(extension_version.as_deref(), None);
     let version_mismatch = protocol_version_mismatch
         .clone()
         .or_else(|| extension_version_mismatch.clone());
@@ -771,7 +781,7 @@ pub fn doctor() -> Result<DoctorReport> {
             legacy_extension_status_string(legacy_hello_seen, extension_value, "extension_version")
         });
     let extension_version_mismatch =
-        extension_version_skew_message(observed_extension_version.as_deref());
+        extension_version_skew_message(observed_extension_version.as_deref(), None);
     let extension_instance_id = latest_instance_with_hello
         .and_then(|instance| instance.extension_instance_id.clone())
         .or_else(|| {
@@ -847,25 +857,39 @@ pub fn doctor() -> Result<DoctorReport> {
     Ok(DoctorReport { ok, checks })
 }
 
-pub fn doctor_with_auth_probe(selector: ExtensionInstanceSelector<'_>) -> Result<DoctorReport> {
+pub fn doctor_with_auth_probe(
+    selector: ExtensionInstanceSelector<'_>,
+    recipe: BuiltinWebRecipe,
+) -> Result<DoctorReport> {
     let mut report = doctor()?;
-    report.checks.push(chatgpt_auth_doctor_check(selector));
+    report.checks.push(site_auth_doctor_check(selector, recipe));
     report.ok = report.checks.iter().all(|check| check.ok);
     Ok(report)
 }
 
-fn chatgpt_auth_doctor_check(selector: ExtensionInstanceSelector<'_>) -> DoctorCheck {
-    match chatgpt_auth_probe(selector) {
-        Ok(payload) => chatgpt_auth_doctor_check_from_payload(&payload),
+fn site_auth_doctor_check(
+    selector: ExtensionInstanceSelector<'_>,
+    recipe: BuiltinWebRecipe,
+) -> DoctorCheck {
+    match site_auth_probe(selector, recipe) {
+        Ok(payload) => auth_doctor_check_from_payload(&payload, recipe),
         Err(error) => DoctorCheck {
-            name: "chatgpt_auth",
-            ok: true,
+            name: match recipe {
+                BuiltinWebRecipe::Chatgpt => "chatgpt_auth",
+                BuiltinWebRecipe::Claude => "claude_auth",
+            },
+            ok: recipe == BuiltinWebRecipe::Chatgpt,
             detail: format!("status=probe_unavailable, auth probe unavailable: {error}"),
         },
     }
 }
 
+#[cfg(test)]
 fn chatgpt_auth_doctor_check_from_payload(payload: &Value) -> DoctorCheck {
+    auth_doctor_check_from_payload(payload, BuiltinWebRecipe::Chatgpt)
+}
+
+fn auth_doctor_check_from_payload(payload: &Value, recipe: BuiltinWebRecipe) -> DoctorCheck {
     let status = payload
         .get("status")
         .and_then(Value::as_str)
@@ -892,7 +916,10 @@ fn chatgpt_auth_doctor_check_from_payload(payload: &Value) -> DoctorCheck {
         detail.push(format!("url={url}"));
     }
     DoctorCheck {
-        name: "chatgpt_auth",
+        name: match recipe {
+            BuiltinWebRecipe::Chatgpt => "chatgpt_auth",
+            BuiltinWebRecipe::Claude => "claude_auth",
+        },
         ok: authenticated || !is_confirmed_unusable_chatgpt_auth_status(status),
         detail: detail.join(", "),
     }
@@ -906,11 +933,15 @@ fn is_confirmed_unusable_chatgpt_auth_status(status: &str) -> bool {
     )
 }
 
-pub fn chatgpt_auth_probe(selector: ExtensionInstanceSelector<'_>) -> Result<Value> {
-    let response = send_control_job(
+pub fn site_auth_probe(
+    selector: ExtensionInstanceSelector<'_>,
+    recipe: BuiltinWebRecipe,
+) -> Result<Value> {
+    let response = send_site_control_job(
         "reconnect",
-        json!({ "intent": "doctor_auth_probe" }),
+        json!({ "intent": "doctor_auth_probe", "recipe": recipe.as_str() }),
         selector,
+        recipe,
     )?;
     Ok(response.payload)
 }
@@ -974,34 +1005,82 @@ pub fn bridge_check(selector: ExtensionInstanceSelector<'_>) -> Result<Value> {
     }))
 }
 
-pub fn canary(live: bool, selector: ExtensionInstanceSelector<'_>) -> Result<Value> {
+fn bridge_check_for_recipe(
+    selector: ExtensionInstanceSelector<'_>,
+    recipe: BuiltinWebRecipe,
+) -> Result<Value> {
+    let response = send_site_control_job(
+        "reconnect",
+        json!({ "intent": "bridge_check", "recipe": recipe.as_str() }),
+        selector,
+        recipe,
+    )?;
+    Ok(json!({
+        "status": "ok",
+        "transport": TRANSPORT_NAME,
+        "recipe": recipe.as_str(),
+        "live": false,
+        "response": response.payload,
+    }))
+}
+
+pub fn canary(
+    live: bool,
+    selector: ExtensionInstanceSelector<'_>,
+    recipe: BuiltinWebRecipe,
+) -> Result<Value> {
     if !live {
-        return bridge_check(selector);
+        return bridge_check_for_recipe(selector, recipe);
     }
     let dir = tempfile::tempdir()?;
-    let bundle_path = dir.path().join("yoetz-chatgpt-native-canary.md");
+    let bundle_path = dir
+        .path()
+        .join(format!("yoetz-{}-native-canary.md", recipe.as_str()));
     fs::write(&bundle_path, "Reply with exactly OK.\n")?;
-    let spec = ChatgptRecipeSpec {
-        bundle_path: Some(bundle_path),
-        model: crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL.to_string(),
-        model_strategy: crate::chatgpt_recipe::ChatgptModelStrategy::Select,
-        prompt: "Reply with exactly OK.".to_string(),
-        browser_context_id: None,
-        profile_email: selector.profile_email.map(str::to_string),
-        extension_instance_id: selector.extension_instance_id.map(str::to_string),
-        extension_profile_id: selector.extension_profile_id.map(str::to_string),
-        conversation_id: None,
-        run_id: new_id("canary"),
-        wait_timeout_ms: 180_000,
-        wait_interval_ms: 1_000,
-        upload_timeout_ms: 30_000,
-        send_timeout_ms: 120_000,
+    let response = match recipe {
+        BuiltinWebRecipe::Chatgpt => run_chatgpt_recipe(
+            &ChatgptRecipeSpec {
+                bundle_path: Some(bundle_path),
+                model: crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL.to_string(),
+                model_strategy: crate::chatgpt_recipe::ChatgptModelStrategy::Select,
+                prompt: "Reply with exactly OK.".to_string(),
+                browser_context_id: None,
+                profile_email: selector.profile_email.map(str::to_string),
+                extension_instance_id: selector.extension_instance_id.map(str::to_string),
+                extension_profile_id: selector.extension_profile_id.map(str::to_string),
+                conversation_id: None,
+                run_id: new_id("canary"),
+                wait_timeout_ms: 180_000,
+                wait_interval_ms: 1_000,
+                upload_timeout_ms: 30_000,
+                send_timeout_ms: 120_000,
+            },
+            OutputFormat::Json,
+        )?,
+        BuiltinWebRecipe::Claude => run_claude_recipe(
+            &ClaudeRecipeSpec {
+                bundle_path: Some(bundle_path),
+                prompt: "Reply with exactly OK.".to_string(),
+                browser_context_id: None,
+                profile_email: selector.profile_email.map(str::to_string),
+                extension_instance_id: selector.extension_instance_id.map(str::to_string),
+                extension_profile_id: selector.extension_profile_id.map(str::to_string),
+                conversation_id: None,
+                run_id: new_id("canary"),
+                wait_timeout_ms: 180_000,
+                wait_interval_ms: 1_000,
+                upload_timeout_ms: 30_000,
+                send_timeout_ms: 120_000,
+                warnings: Vec::new(),
+            },
+            OutputFormat::Json,
+        )?,
     };
-    let response = run_chatgpt_recipe(&spec, OutputFormat::Json)?;
     validate_canary_response(&response.response)?;
     Ok(json!({
         "status": "ok",
         "transport": TRANSPORT_NAME,
+        "recipe": recipe.as_str(),
         "live": true,
         "expected_response": "OK",
         "response": response.response,
@@ -1011,15 +1090,25 @@ pub fn canary(live: bool, selector: ExtensionInstanceSelector<'_>) -> Result<Val
     }))
 }
 
-pub fn inspect_run(run_id: &str, selector: ExtensionInstanceSelector<'_>) -> Result<Value> {
+pub fn inspect_run(
+    run_id: &str,
+    selector: ExtensionInstanceSelector<'_>,
+    recipe: BuiltinWebRecipe,
+) -> Result<Value> {
     let trimmed = run_id.trim();
     if trimmed.is_empty() {
         bail!("--run-id is required");
     }
-    let response = send_control_job("inspect_run", json!({ "run_id": trimmed }), selector)?;
+    let response = send_site_control_job(
+        "inspect_run",
+        json!({ "run_id": trimmed, "recipe": recipe.as_str() }),
+        selector,
+        recipe,
+    )?;
     Ok(json!({
         "status": "ok",
         "transport": TRANSPORT_NAME,
+        "recipe": recipe.as_str(),
         "response": response.payload,
     }))
 }
@@ -1051,7 +1140,9 @@ pub fn run_chatgpt_recipe(
             extension_profile_id: spec.extension_profile_id.as_deref(),
         },
     )?;
-    if let Some(message) = extension_version_skew_message(instance.extension_version.as_deref()) {
+    if let Some(message) =
+        extension_version_skew_message(instance.extension_version.as_deref(), Some("--chatgpt"))
+    {
         eprintln!("warning: {message}");
         let selector = ExtensionInstanceSelector {
             profile_email: spec.profile_email.as_deref(),
@@ -1106,6 +1197,77 @@ pub fn run_chatgpt_recipe(
     }
 }
 
+pub fn run_claude_recipe(
+    spec: &ClaudeRecipeSpec,
+    format: OutputFormat,
+) -> Result<ExtensionRecipeResult> {
+    let bundle_path = spec
+        .bundle_path
+        .as_deref()
+        .context("chrome-extension-native transport requires `--bundle`")?;
+    let bundle = validate_bundle_path(bundle_path)?;
+    let paths = extension_paths()?;
+    let selector = ExtensionInstanceSelector {
+        profile_email: spec.profile_email.as_deref(),
+        extension_instance_id: spec.extension_instance_id.as_deref(),
+        extension_profile_id: spec.extension_profile_id.as_deref(),
+    };
+    let mut instance = select_extension_instance(&paths, selector)?;
+    if let Some(message) =
+        extension_version_skew_message(instance.extension_version.as_deref(), Some("--claude"))
+    {
+        eprintln!("warning: {message}");
+        match auto_heal_extension_version_skew(&paths, selector) {
+            Ok(Some(healed_instance)) => {
+                eprintln!(
+                    "info: refreshed and reloaded chrome-extension-native extension from packaged source"
+                );
+                instance = healed_instance;
+            }
+            Ok(None) => {}
+            Err(err) => eprintln!("warning: automatic extension update failed: {err:#}"),
+        }
+    }
+    // Capability is checked on the exact routed extension instance after any
+    // best-effort heal and before opening the socket or emitting job_start.
+    ensure_instance_supports_recipe(&instance, "claude")?;
+    let token = read_capability_token(&paths.token_path)?;
+    let mut stream = connect_socket(&instance.socket_path).with_context(|| {
+        format!(
+            "chrome-extension-native bridge is not connected at {}. Run `yoetz browser extension doctor --claude`, then open Chrome with the Yoetz extension enabled.",
+            instance.socket_path.display()
+        )
+    })?;
+    stream.set_read_timeout(Some(
+        Duration::from_millis(spec.wait_timeout_ms).saturating_add(RECIPE_READ_GRACE),
+    ))?;
+
+    let job_id = new_id("job");
+    let start = ProtocolEnvelope::new(
+        "job_start",
+        Some(job_id),
+        Some(spec.run_id.clone()),
+        claude_job_start_payload(spec, &bundle),
+    )
+    .with_token(token);
+    write_json_frame(&mut stream, &start)?;
+
+    loop {
+        let envelope = read_json_frame(&mut stream)?;
+        validate_inbound_envelope(&envelope)?;
+        match envelope.kind.as_str() {
+            "job_progress" => emit_progress(format, &envelope)?,
+            "job_complete" => return parse_recipe_result(envelope),
+            "job_error" => return Err(job_error_for_recipe(envelope, BuiltinWebRecipe::Claude)),
+            other => {
+                if matches!(format, OutputFormat::Text | OutputFormat::Markdown) {
+                    eprintln!("info: ignored chrome-extension-native event `{other}`");
+                }
+            }
+        }
+    }
+}
+
 pub fn serve_native_host_chatgpt() -> Result<()> {
     #[cfg(unix)]
     {
@@ -1127,6 +1289,28 @@ fn chatgpt_job_start_payload(spec: &ChatgptRecipeSpec, bundle: &BundleInfo) -> V
         "prompt": spec.prompt,
         "model": spec.model,
         "model_strategy": spec.model_strategy,
+        "browser_context_id": spec.browser_context_id,
+        "profile_email": spec.profile_email,
+        "extension_instance_id": spec.extension_instance_id,
+        "extension_profile_id": spec.extension_profile_id,
+        "conversation_id": spec.conversation_id,
+        "wait_timeout_ms": spec.wait_timeout_ms,
+        "wait_interval_ms": spec.wait_interval_ms,
+        "upload_timeout_ms": spec.upload_timeout_ms,
+        "send_timeout_ms": spec.send_timeout_ms,
+    })
+}
+
+fn claude_job_start_payload(spec: &ClaudeRecipeSpec, bundle: &BundleInfo) -> Value {
+    json!({
+        "recipe": "claude",
+        "bundle_path": bundle.path,
+        "file_name": bundle.file_name,
+        "bundle_size": bundle.size,
+        "mime": bundle.mime,
+        "prompt": spec.prompt,
+        "model": crate::claude_recipe::CLAUDE_FABLE_MAX_MODEL,
+        "model_strategy": "select",
         "browser_context_id": spec.browser_context_id,
         "profile_email": spec.profile_email,
         "extension_instance_id": spec.extension_instance_id,
@@ -1458,6 +1642,19 @@ fn select_extension_instance(
             observed_extension_profiles(&instances)
         ),
     }
+}
+
+fn ensure_instance_supports_recipe(instance: &ExtensionInstanceStatus, recipe: &str) -> Result<()> {
+    if instance.recipes.iter().any(|value| value == recipe) {
+        return Ok(());
+    }
+    bail!(
+        "selected chrome-extension-native instance {} does not advertise recipe `{recipe}`; refusing before job_start. Run `yoetz browser extension update --{recipe}` and reload the selected Chrome profile",
+        instance
+            .extension_instance_id
+            .as_deref()
+            .unwrap_or(instance.native_instance_id.as_str())
+    )
 }
 
 fn auto_heal_extension_version_skew(
@@ -1927,8 +2124,29 @@ fn send_control_job(
     payload: Value,
     selector: ExtensionInstanceSelector<'_>,
 ) -> Result<ProtocolEnvelope> {
+    send_control_job_with_recipe(kind, payload, selector, None)
+}
+
+fn send_site_control_job(
+    kind: &str,
+    payload: Value,
+    selector: ExtensionInstanceSelector<'_>,
+    recipe: BuiltinWebRecipe,
+) -> Result<ProtocolEnvelope> {
+    send_control_job_with_recipe(kind, payload, selector, Some(recipe.as_str()))
+}
+
+fn send_control_job_with_recipe(
+    kind: &str,
+    payload: Value,
+    selector: ExtensionInstanceSelector<'_>,
+    required_recipe: Option<&str>,
+) -> Result<ProtocolEnvelope> {
     let paths = extension_paths()?;
     let instance = select_extension_instance(&paths, selector)?;
+    if let Some(recipe) = required_recipe {
+        ensure_instance_supports_recipe(&instance, recipe)?;
+    }
     let token = read_capability_token(&paths.token_path)?;
     let job_id = new_id(kind);
     let mut stream = connect_socket(&instance.socket_path).with_context(|| {
@@ -2081,6 +2299,10 @@ fn parse_model_selection_status(value: Option<&str>) -> ChatgptModelSelectionSta
 }
 
 fn job_error(envelope: ProtocolEnvelope) -> anyhow::Error {
+    job_error_for_recipe(envelope, BuiltinWebRecipe::Chatgpt)
+}
+
+fn job_error_for_recipe(envelope: ProtocolEnvelope, recipe: BuiltinWebRecipe) -> anyhow::Error {
     let message = job_error_message(&envelope.payload);
     let phase = envelope.payload.get("phase").and_then(Value::as_str);
     let side_effect_started = envelope
@@ -2092,21 +2314,12 @@ fn job_error(envelope: ProtocolEnvelope) -> anyhow::Error {
     if !side_effect_started {
         return err;
     }
-    match phase {
-        Some("upload") => {
-            crate::chatgpt_recipe::mark_terminal_fallback_phase(err, ChatgptTransportPhase::Upload)
-        }
-        Some("send") => {
-            crate::chatgpt_recipe::mark_terminal_fallback_phase(err, ChatgptTransportPhase::Send)
-        }
-        Some("wait_response") => crate::chatgpt_recipe::mark_terminal_fallback_phase(
-            err,
-            ChatgptTransportPhase::WaitResponse,
-        ),
-        _ => {
-            crate::chatgpt_recipe::mark_terminal_fallback_phase(err, ChatgptTransportPhase::Upload)
-        }
-    }
+    let phase = match phase {
+        Some("send") => ChatgptTransportPhase::Send,
+        Some("wait_response") => ChatgptTransportPhase::WaitResponse,
+        _ => ChatgptTransportPhase::Upload,
+    };
+    crate::web_recipe::mark_terminal_fallback_phase(err, recipe, phase)
 }
 
 fn job_error_message(payload: &Value) -> String {
@@ -3292,6 +3505,69 @@ mod tests {
         let payload = chatgpt_job_start_payload(&spec, &bundle);
 
         assert_eq!(payload["conversation_id"], "conv-123");
+    }
+
+    #[test]
+    fn claude_job_start_payload_carries_recipe_model_and_conversation() {
+        let bundle = BundleInfo {
+            path: PathBuf::from("/tmp/yoetz-bundle.md"),
+            file_name: "yoetz-bundle.md".to_string(),
+            size: 42,
+            mime: "text/markdown".to_string(),
+        };
+        let conversation_id = "123e4567-e89b-12d3-a456-426614174000";
+        let spec = crate::claude_recipe::ClaudeRecipeSpec {
+            bundle_path: Some(bundle.path.clone()),
+            prompt: "continue".to_string(),
+            browser_context_id: None,
+            profile_email: None,
+            extension_instance_id: Some("ext_claude".to_string()),
+            extension_profile_id: None,
+            conversation_id: Some(conversation_id.to_string()),
+            run_id: "run-claude".to_string(),
+            wait_timeout_ms: 10_000,
+            wait_interval_ms: 1_000,
+            upload_timeout_ms: 2_000,
+            send_timeout_ms: 3_000,
+            warnings: vec!["size warning".to_string()],
+        };
+
+        let payload = claude_job_start_payload(&spec, &bundle);
+
+        assert_eq!(payload["recipe"], "claude");
+        assert_eq!(
+            payload["model"],
+            crate::claude_recipe::CLAUDE_FABLE_MAX_MODEL
+        );
+        assert_eq!(payload["model_strategy"], "select");
+        assert_eq!(payload["conversation_id"], conversation_id);
+        assert_eq!(payload["extension_instance_id"], "ext_claude");
+    }
+
+    #[test]
+    fn selected_instance_capability_gate_is_recipe_specific_and_legacy_safe() {
+        let mut instance = ExtensionInstanceStatus {
+            native_instance_id: "native_claude".to_string(),
+            socket_path: PathBuf::from("/tmp/claude.sock"),
+            pid: 1,
+            extension_instance_id: Some("ext_claude".to_string()),
+            extension_version: Some("0.5.33".to_string()),
+            profile_email: None,
+            profile_id: None,
+            recipes: vec!["chatgpt".to_string()],
+            protocol_version: PROTOCOL_VERSION,
+            last_seen_ms: 1,
+        };
+
+        ensure_instance_supports_recipe(&instance, "chatgpt").unwrap();
+        let error = ensure_instance_supports_recipe(&instance, "claude").unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("does not advertise recipe `claude`"));
+        assert!(error.to_string().contains("before job_start"));
+
+        instance.recipes.push("claude".to_string());
+        ensure_instance_supports_recipe(&instance, "claude").unwrap();
     }
 
     #[test]

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -975,12 +975,27 @@ pub fn reload_extension(selector: ExtensionInstanceSelector<'_>) -> Result<Value
     }))
 }
 
-pub fn update_extension(selector: ExtensionInstanceSelector<'_>) -> Result<Value> {
+pub fn update_extension(
+    selector: ExtensionInstanceSelector<'_>,
+    recipe: BuiltinWebRecipe,
+) -> Result<Value> {
+    let paths = extension_paths()?;
+    let previous_instance = select_extension_instance(&paths, selector)?;
     let update = prepare_managed_chatgpt_extension()?;
     let reload = reload_extension(selector)?;
-    let paths = extension_paths()?;
-    let instance = wait_for_extension_version(&paths, selector, YOETZ_CLI_VERSION)
-        .context("wait for reloaded extension to report the current CLI version")?;
+    let instance = wait_for_extension_update(
+        &paths,
+        selector,
+        YOETZ_CLI_VERSION,
+        recipe.as_str(),
+        &previous_instance.native_instance_id,
+    )
+    .with_context(|| {
+        format!(
+            "managed extension source {} was copied, but the loaded extension did not activate the requested site capability",
+            update.source_dir.display()
+        )
+    })?;
     Ok(json!({
         "status": "updated",
         "transport": TRANSPORT_NAME,
@@ -1696,6 +1711,58 @@ fn wait_for_extension_version(
         }
         thread::sleep(EXTENSION_RELOAD_VERIFY_INTERVAL);
     }
+}
+
+fn wait_for_extension_update(
+    paths: &ExtensionPaths,
+    selector: ExtensionInstanceSelector<'_>,
+    expected_version: &str,
+    expected_recipe: &str,
+    previous_native_instance_id: &str,
+) -> Result<ExtensionInstanceStatus> {
+    let deadline = Instant::now() + EXTENSION_RELOAD_VERIFY_TIMEOUT;
+    loop {
+        let current_state = match select_extension_instance(paths, selector) {
+            Ok(instance)
+                if extension_update_is_active(
+                    &instance,
+                    expected_version,
+                    expected_recipe,
+                    previous_native_instance_id,
+                ) =>
+            {
+                return Ok(instance)
+            }
+            Ok(instance) => format!(
+                "native_instance_id={}, extension_version={}, recipes={:?}",
+                instance.native_instance_id,
+                instance.extension_version.as_deref().unwrap_or("<unknown>"),
+                instance.recipes
+            ),
+            Err(err) => err.to_string(),
+        };
+        if Instant::now() >= deadline {
+            bail!(
+                "timed out waiting for a new chrome-extension-native instance to advertise recipe `{expected_recipe}` at extension version {expected_version}; last state: {current_state}. Chrome may retain a same-version unpacked module cache: open chrome://extensions, click Reload for `Yoetz Native Transport`, then run `yoetz browser extension status --{expected_recipe}`"
+            );
+        }
+        thread::sleep(EXTENSION_RELOAD_VERIFY_INTERVAL);
+    }
+}
+
+fn extension_update_is_active(
+    instance: &ExtensionInstanceStatus,
+    expected_version: &str,
+    expected_recipe: &str,
+    previous_native_instance_id: &str,
+) -> bool {
+    instance.native_instance_id != previous_native_instance_id
+        && instance.extension_version.as_deref() == Some(expected_version)
+        && instance_has_extension_hello(instance)
+        && instance
+            .recipes
+            .iter()
+            .any(|recipe| recipe == expected_recipe)
 }
 
 fn non_empty_selector(value: Option<&str>) -> Option<&str> {
@@ -3568,6 +3635,54 @@ mod tests {
 
         instance.recipes.push("claude".to_string());
         ensure_instance_supports_recipe(&instance, "claude").unwrap();
+    }
+
+    #[test]
+    fn extension_update_readiness_requires_new_instance_version_and_recipe() {
+        let mut instance = ExtensionInstanceStatus {
+            native_instance_id: "native_before".to_string(),
+            socket_path: PathBuf::from("/tmp/claude.sock"),
+            pid: 1,
+            extension_instance_id: Some("ext_claude".to_string()),
+            extension_version: Some(YOETZ_CLI_VERSION.to_string()),
+            profile_email: None,
+            profile_id: None,
+            recipes: vec!["chatgpt".to_string(), "claude".to_string()],
+            protocol_version: PROTOCOL_VERSION,
+            last_seen_ms: 1,
+        };
+
+        assert!(!extension_update_is_active(
+            &instance,
+            YOETZ_CLI_VERSION,
+            "claude",
+            "native_before"
+        ));
+
+        instance.native_instance_id = "native_after".to_string();
+        instance.recipes = vec!["chatgpt".to_string()];
+        assert!(!extension_update_is_active(
+            &instance,
+            YOETZ_CLI_VERSION,
+            "claude",
+            "native_before"
+        ));
+
+        instance.recipes.push("claude".to_string());
+        assert!(extension_update_is_active(
+            &instance,
+            YOETZ_CLI_VERSION,
+            "claude",
+            "native_before"
+        ));
+
+        instance.extension_version = Some("0.0.0".to_string());
+        assert!(!extension_update_is_active(
+            &instance,
+            YOETZ_CLI_VERSION,
+            "claude",
+            "native_before"
+        ));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -46,6 +46,10 @@ const EXTENSION_RELOAD_VERIFY_INTERVAL: Duration = Duration::from_millis(250);
 #[cfg(unix)]
 const MAX_UNIX_SOCKET_PATH_BYTES: usize = 100;
 
+fn default_extension_recipes() -> Vec<String> {
+    vec!["chatgpt".to_string()]
+}
+
 #[derive(Debug, Error)]
 #[error("frame is too large: {len} bytes, max {max} bytes")]
 struct FrameTooLargeError {
@@ -90,6 +94,8 @@ pub struct ExtensionStatus {
     pub status_file_present: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub connected_instances: Vec<ExtensionInstanceStatus>,
+    pub recipes: Vec<String>,
+    pub claude_ready: bool,
     pub protocol_version: u32,
     pub detail: String,
 }
@@ -107,6 +113,8 @@ pub struct ExtensionInstanceStatus {
     pub profile_email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub profile_id: Option<String>,
+    #[serde(default = "default_extension_recipes")]
+    pub recipes: Vec<String>,
     pub protocol_version: u32,
     pub last_seen_ms: u128,
 }
@@ -600,6 +608,11 @@ pub fn status() -> Result<ExtensionStatus> {
         .or_else(|| {
             legacy_extension_status_string(legacy_hello_seen, extension_value, "profile_id")
         });
+    let recipes = latest_instance_with_hello
+        .map(|instance| instance.recipes.clone())
+        .unwrap_or_else(|| legacy_extension_recipes(extension_value));
+    let claude_ready =
+        socket_reachable && hello_seen && recipes.iter().any(|recipe| recipe == "claude");
     let protocol_version_mismatch = status_value
         .as_ref()
         .and_then(|value| value.get("version_mismatch"))
@@ -677,6 +690,8 @@ pub fn status() -> Result<ExtensionStatus> {
         status_path: paths.status_path,
         status_file_present,
         connected_instances,
+        recipes,
+        claude_ready,
         protocol_version: PROTOCOL_VERSION,
         detail,
     })
@@ -1233,6 +1248,22 @@ fn legacy_extension_status_string(
     }
 }
 
+fn legacy_extension_recipes(
+    extension_value: Option<&serde_json::Map<String, Value>>,
+) -> Vec<String> {
+    let Some(value) = extension_value.and_then(|value| value.get("recipes")) else {
+        return default_extension_recipes();
+    };
+    let Some(values) = value.as_array() else {
+        return Vec::new();
+    };
+    values
+        .iter()
+        .filter_map(Value::as_str)
+        .map(str::to_string)
+        .collect()
+}
+
 fn status_file_has_extension_hello(
     extension_value: Option<&serde_json::Map<String, Value>>,
 ) -> bool {
@@ -1531,6 +1562,7 @@ fn connect_legacy_socket_instance(paths: &ExtensionPaths) -> Result<ExtensionIns
         extension_version: None,
         profile_email: None,
         profile_id: None,
+        recipes: default_extension_recipes(),
         protocol_version: PROTOCOL_VERSION,
         last_seen_ms: 0,
     })
@@ -3035,6 +3067,7 @@ mod native_host_unix {
                         "extension_instance_id": envelope.payload.get("extension_instance_id").cloned().unwrap_or(Value::Null),
                         "profile_email": envelope.payload.get("profile_email").cloned().unwrap_or(Value::Null),
                         "profile_id": envelope.payload.get("profile_id").cloned().unwrap_or(Value::Null),
+                        "recipes": envelope.payload.get("recipes").cloned().unwrap_or_else(|| json!(default_extension_recipes())),
                         "seen_at_ms": now_millis(),
                     },
                     "version_mismatch": Value::Null,
@@ -3063,6 +3096,7 @@ mod native_host_unix {
                     "extension_version": envelope.payload.get("extension_version").cloned().unwrap_or(Value::Null),
                     "profile_email": envelope.payload.get("profile_email").cloned().unwrap_or(Value::Null),
                     "profile_id": envelope.payload.get("profile_id").cloned().unwrap_or(Value::Null),
+                    "recipes": envelope.payload.get("recipes").cloned().unwrap_or_else(|| json!(default_extension_recipes())),
                     "protocol_version": envelope.payload.get("protocol_version").cloned().unwrap_or(json!(PROTOCOL_VERSION)),
                 }),
             ),
@@ -3085,6 +3119,7 @@ mod native_host_unix {
             "extension_version": Value::Null,
             "profile_email": Value::Null,
             "profile_id": Value::Null,
+            "recipes": default_extension_recipes(),
             "protocol_version": PROTOCOL_VERSION,
             "last_seen_ms": now_millis(),
         });
@@ -3640,6 +3675,8 @@ mod tests {
         assert!(!payload.hello_seen);
         assert_eq!(payload.extension_version, None);
         assert_eq!(payload.extension_instance_id, None);
+        assert_eq!(payload.recipes, vec!["chatgpt"]);
+        assert!(!payload.claude_ready);
 
         let extension_hello = doctor()
             .unwrap()
@@ -3677,6 +3714,7 @@ mod tests {
                 extension_version: Some("0.2.0".to_string()),
                 profile_email: Some("work@example.com".to_string()),
                 profile_id: Some("gaia_123".to_string()),
+                recipes: vec!["chatgpt".to_string(), "claude".to_string()],
                 protocol_version: PROTOCOL_VERSION,
                 last_seen_ms: 1234,
             },
@@ -3692,6 +3730,8 @@ mod tests {
             Some("work@example.com")
         );
         assert_eq!(payload.extension_profile_id.as_deref(), Some("gaia_123"));
+        assert_eq!(payload.recipes, vec!["chatgpt", "claude"]);
+        assert!(payload.claude_ready);
 
         let extension_hello = doctor()
             .unwrap()
@@ -3732,6 +3772,7 @@ mod tests {
                 extension_version: Some("0.5.13".to_string()),
                 profile_email: Some("work@example.com".to_string()),
                 profile_id: Some("gaia_123".to_string()),
+                recipes: default_extension_recipes(),
                 protocol_version: PROTOCOL_VERSION,
                 last_seen_ms: 1234,
             },
@@ -3872,6 +3913,7 @@ mod tests {
                 extension_version: Some(YOETZ_CLI_VERSION.to_string()),
                 profile_email: None,
                 profile_id: None,
+                recipes: default_extension_recipes(),
                 protocol_version: PROTOCOL_VERSION,
                 last_seen_ms: 1,
             },
@@ -3915,6 +3957,7 @@ mod tests {
                 extension_version: Some("0.4.0".to_string()),
                 profile_email: Some("stale@example.com".to_string()),
                 profile_id: Some("stale_profile".to_string()),
+                recipes: default_extension_recipes(),
                 protocol_version: PROTOCOL_VERSION,
                 last_seen_ms: 1234,
             },
@@ -3959,6 +4002,7 @@ mod tests {
                 extension_version: Some("0.4.0".to_string()),
                 profile_email: Some("work@example.com".to_string()),
                 profile_id: Some("work_profile".to_string()),
+                recipes: default_extension_recipes(),
                 protocol_version: PROTOCOL_VERSION,
                 last_seen_ms: 2,
             },
@@ -3973,6 +4017,7 @@ mod tests {
                 extension_version: Some("0.4.0".to_string()),
                 profile_email: Some("personal@example.com".to_string()),
                 profile_id: Some("personal_profile".to_string()),
+                recipes: default_extension_recipes(),
                 protocol_version: PROTOCOL_VERSION,
                 last_seen_ms: 1,
             },
@@ -4023,6 +4068,7 @@ mod tests {
                 extension_version: Some("0.4.0".to_string()),
                 profile_email: None,
                 profile_id: None,
+                recipes: default_extension_recipes(),
                 protocol_version: PROTOCOL_VERSION,
                 last_seen_ms: 2,
             },
@@ -4037,6 +4083,7 @@ mod tests {
                 extension_version: Some("0.4.0".to_string()),
                 profile_email: None,
                 profile_id: None,
+                recipes: default_extension_recipes(),
                 protocol_version: PROTOCOL_VERSION,
                 last_seen_ms: 1,
             },

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -3567,12 +3567,13 @@ mod native_host_unix {
             return;
         }
         match envelope.payload.get("phase").and_then(Value::as_str) {
-            Some(
-                "tab_opened" | "model_selection" | "tab_grouped" | "ready_for_file"
-                | "file_uploaded",
-            ) => {
+            Some("tab_opened" | "tab_grouped" | "ready_for_file" | "file_uploaded") => {
                 client.side_effect_started = true;
                 client.fallback_phase = Some("upload");
+            }
+            Some("model_selection") => {
+                client.side_effect_started = true;
+                client.fallback_phase = Some("model_selection");
             }
             Some("prompt_sent") => {
                 client.side_effect_started = true;
@@ -3814,6 +3815,37 @@ mod native_host_unix {
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis()
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn model_selection_progress_preserves_the_diagnostic_phase() {
+            let (stream, _peer) = UnixStream::pair().unwrap();
+            let mut client = ClientJob {
+                stream,
+                job_id: "job_model".to_string(),
+                run_id: Some("run_model".to_string()),
+                chunks: Vec::new(),
+                next_chunk: 0,
+                side_effect_started: false,
+                fallback_phase: None,
+                cancel_on_disconnect: true,
+            };
+            let envelope = ProtocolEnvelope::new(
+                "job_progress",
+                Some("job_model".to_string()),
+                Some("run_model".to_string()),
+                json!({ "phase": "model_selection" }),
+            );
+
+            update_client_effect_state(&mut client, &envelope);
+
+            assert!(client.side_effect_started);
+            assert_eq!(client.fallback_phase, Some("model_selection"));
+        }
     }
 }
 

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -148,8 +148,12 @@ pub struct ExtensionRecipeResult {
 pub struct ManagedExtensionUpdateResult {
     pub status: &'static str,
     pub source_dir: PathBuf,
+    pub source_version: String,
+    pub source_provenance: &'static str,
     pub extension_dir: PathBuf,
     pub loaded_extension_dirs: Vec<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_manifest_version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub manifest_version: Option<String>,
     pub copied_files: usize,
@@ -335,13 +339,20 @@ fn sync_managed_chatgpt_extension_from(
             source_dir.display()
         );
     }
+    let source_version = required_extension_manifest_version(source_dir)?;
+    let source_provenance = extension_source_provenance(source_dir);
+    ensure_extension_source_matches_cli(source_dir, &source_version, source_provenance)?;
+    let previous_manifest_version = extension_manifest_version(extension_dir);
     if paths_refer_to_same_location(source_dir, extension_dir) {
         return Ok(ManagedExtensionUpdateResult {
             status: "current",
             source_dir: source_dir.to_path_buf(),
+            source_version,
+            source_provenance,
             extension_dir: extension_dir.to_path_buf(),
             loaded_extension_dirs: vec![extension_dir.to_path_buf()],
-            manifest_version: extension_manifest_version(extension_dir),
+            previous_manifest_version: previous_manifest_version.clone(),
+            manifest_version: previous_manifest_version,
             copied_files: count_regular_files(extension_dir)?,
         });
     }
@@ -350,26 +361,36 @@ fn sync_managed_chatgpt_extension_from(
         return Ok(ManagedExtensionUpdateResult {
             status: "current",
             source_dir: source_dir.to_path_buf(),
+            source_version,
+            source_provenance,
             extension_dir: extension_dir.to_path_buf(),
             loaded_extension_dirs: vec![extension_dir.to_path_buf()],
-            manifest_version: extension_manifest_version(extension_dir),
+            previous_manifest_version: previous_manifest_version.clone(),
+            manifest_version: previous_manifest_version,
             copied_files: 0,
         });
     }
 
-    let source_version = required_extension_manifest_version(source_dir)?;
-    let stamped_version = next_managed_extension_version(
-        &source_version,
-        extension_manifest_version(extension_dir).as_deref(),
-    )?;
+    let stamped_version =
+        next_managed_extension_version(&source_version, previous_manifest_version.as_deref())?;
+    let status = if is_chatgpt_extension_source_dir(extension_dir)
+        && previous_manifest_version.as_deref() == Some(source_version.as_str())
+    {
+        "restamped"
+    } else {
+        "updated"
+    };
     let copied_files =
         copy_extension_dir_atomically(source_dir, extension_dir, Some(stamped_version.as_str()))?;
 
     Ok(ManagedExtensionUpdateResult {
-        status: "updated",
+        status,
         source_dir: source_dir.to_path_buf(),
+        source_version,
+        source_provenance,
         extension_dir: extension_dir.to_path_buf(),
         loaded_extension_dirs: vec![extension_dir.to_path_buf()],
+        previous_manifest_version,
         manifest_version: Some(stamped_version),
         copied_files,
     })
@@ -624,6 +645,82 @@ fn required_extension_manifest_version(extension_dir: &Path) -> Result<String> {
             extension_dir.join("manifest.json").display()
         )
     })
+}
+
+fn extension_source_provenance(source_dir: &Path) -> &'static str {
+    if env::var(CHATGPT_EXTENSION_DIR_ENV)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .is_some_and(|value| paths_refer_to_same_location(source_dir, Path::new(value.trim())))
+    {
+        return "environment_override";
+    }
+    if env::current_dir()
+        .ok()
+        .map(|cwd| cwd.join("extensions").join("chatgpt-native"))
+        .is_some_and(|candidate| paths_refer_to_same_location(source_dir, &candidate))
+    {
+        return "working_directory";
+    }
+    let crate_source = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("extensions")
+        .join("chatgpt-native");
+    if paths_refer_to_same_location(source_dir, &crate_source) {
+        return "source_checkout";
+    }
+    if let Ok(exe) = env::current_exe() {
+        if let Some(prefix) = exe.parent().and_then(Path::parent) {
+            for candidate in [
+                prefix
+                    .join("share")
+                    .join("yoetz")
+                    .join("extensions")
+                    .join("chatgpt-native"),
+                prefix.join("share").join("yoetz").join("chatgpt-native"),
+            ] {
+                if paths_refer_to_same_location(source_dir, &candidate) {
+                    return "installed_share";
+                }
+            }
+        }
+    }
+    "explicit_path"
+}
+
+fn ensure_extension_source_matches_cli(
+    source_dir: &Path,
+    source_version: &str,
+    source_provenance: &str,
+) -> Result<()> {
+    let source_parts = chrome_extension_version_parts(source_version).with_context(|| {
+        format!("extension source version `{source_version}` is not a valid Chrome version")
+    })?;
+    let cli_parts = chrome_extension_version_parts(YOETZ_CLI_VERSION).with_context(|| {
+        format!("yoetz CLI version `{YOETZ_CLI_VERSION}` is not a valid Chrome version")
+    })?;
+    if source_parts.len() != 3 {
+        bail!(
+            "refusing to sync extension source version `{source_version}` from {} ({source_provenance}); source versions must have exactly three components for yoetz CLI {YOETZ_CLI_VERSION}",
+            source_dir.display()
+        );
+    }
+    if cli_parts.len() < 3 {
+        bail!("yoetz CLI version `{YOETZ_CLI_VERSION}` must have at least three components");
+    }
+    if source_parts[..3] == cli_parts[..3] {
+        return Ok(());
+    }
+    let relationship = if source_parts[..3] < cli_parts[..3] {
+        "older than"
+    } else {
+        "newer than"
+    };
+    bail!(
+        "refusing to sync extension source version {source_version} from {} ({source_provenance}); it is {relationship} yoetz CLI {YOETZ_CLI_VERSION}",
+        source_dir.display()
+    )
 }
 
 fn chrome_extension_version_parts(version: &str) -> Option<Vec<u16>> {
@@ -1233,11 +1330,7 @@ pub fn update_extension(
         .manifest_version
         .as_deref()
         .context("managed extension copy has no stamped manifest version")?;
-    ensure_reload_can_reach_managed_copy(
-        &previous_instance,
-        expected_version,
-        &update.extension_dir,
-    )?;
+    ensure_reload_can_reach_managed_copy(&previous_instance, &update)?;
     let reload = reload_extension(selector)?;
     let instance = wait_for_extension_update(
         &paths,
@@ -1257,7 +1350,10 @@ pub fn update_extension(
         "transport": TRANSPORT_NAME,
         "extension_dir": update.extension_dir,
         "source_dir": update.source_dir,
+        "source_version": update.source_version,
+        "source_provenance": update.source_provenance,
         "loaded_extension_dirs": update.loaded_extension_dirs,
+        "previous_manifest_version": update.previous_manifest_version,
         "manifest_version": update.manifest_version,
         "copy_status": update.status,
         "copied_files": update.copied_files,
@@ -1952,20 +2048,19 @@ fn auto_heal_extension_version_skew(
         .manifest_version
         .as_deref()
         .context("managed extension copy has no stamped manifest version")?;
-    ensure_reload_can_reach_managed_copy(
-        &previous_instance,
-        expected_version,
-        &update.extension_dir,
-    )?;
+    ensure_reload_can_reach_managed_copy(&previous_instance, &update)?;
     reload_extension(selector)?;
     wait_for_extension_version(paths, selector, expected_version).map(Some)
 }
 
 fn ensure_reload_can_reach_managed_copy(
     instance: &ExtensionInstanceStatus,
-    expected_version: &str,
-    managed_dir: &Path,
+    update: &ManagedExtensionUpdateResult,
 ) -> Result<()> {
+    let expected_version = update
+        .manifest_version
+        .as_deref()
+        .context("managed extension copy has no stamped manifest version")?;
     let observed_parts = instance
         .extension_version
         .as_deref()
@@ -1978,10 +2073,18 @@ fn ensure_reload_can_reach_managed_copy(
             .as_ref()
             .is_some_and(|parts| parts.len() == 4)
     {
+        // A 3-part live version that exactly matches the managed path before
+        // this restamp is the clobbered-managed case: reload still reaches the
+        // same path, so do not misclassify it as a separately loaded source copy.
+        let restamped_loaded_managed_copy = update.status == "restamped"
+            && instance.extension_version.as_deref() == update.previous_manifest_version.as_deref();
+        if restamped_loaded_managed_copy {
+            return Ok(());
+        }
         if let Some(message) = managed_extension_identity_message(
             instance.extension_version.as_deref(),
             Some(expected_version),
-            managed_dir,
+            &update.extension_dir,
         ) {
             bail!(message);
         }
@@ -4682,6 +4785,73 @@ mod tests {
 
     #[test]
     #[serial]
+    fn sync_managed_extension_rejects_an_older_source_before_mutation() {
+        let dir = TempDir::new().unwrap();
+        let source = dir.path().join("source");
+        write_extension_source_fixture(&source, "0.5.32");
+        let target = dir.path().join("managed");
+        write_extension_source_fixture(&target, YOETZ_CLI_VERSION);
+        fs::write(
+            target.join("src").join("sentinel.js"),
+            "keep-newer-managed-copy",
+        )
+        .unwrap();
+
+        let err = sync_managed_chatgpt_extension_from(&source, &target).unwrap_err();
+
+        let message = format!("{err:#}");
+        assert!(message.contains("refusing to sync"));
+        assert!(message.contains("0.5.32"));
+        assert!(message.contains(YOETZ_CLI_VERSION));
+        assert!(message.contains(source.to_string_lossy().as_ref()));
+        assert_eq!(
+            fs::read_to_string(target.join("src").join("sentinel.js")).unwrap(),
+            "keep-newer-managed-copy"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn sync_managed_extension_classifies_an_unstamped_managed_target_as_restamped() {
+        let dir = TempDir::new().unwrap();
+        let source = dir.path().join("source");
+        write_extension_source_fixture(&source, YOETZ_CLI_VERSION);
+        fs::write(
+            source.join("src").join("service-worker.js"),
+            "service-worker:new-source",
+        )
+        .unwrap();
+        let target = dir.path().join("managed");
+        write_extension_source_fixture(&target, YOETZ_CLI_VERSION);
+
+        let result = sync_managed_chatgpt_extension_from(&source, &target).unwrap();
+
+        assert_eq!(result.status, "restamped");
+        assert_eq!(
+            result.manifest_version.as_deref(),
+            Some(format!("{YOETZ_CLI_VERSION}.1").as_str())
+        );
+        assert_eq!(
+            result.previous_manifest_version.as_deref(),
+            Some(YOETZ_CLI_VERSION)
+        );
+        let loaded_before_restamp = ExtensionInstanceStatus {
+            native_instance_id: "native_restamped".to_string(),
+            socket_path: dir.path().join("native.sock"),
+            pid: process::id(),
+            extension_instance_id: Some("ext_restamped".to_string()),
+            extension_version: result.previous_manifest_version.clone(),
+            profile_email: None,
+            profile_id: None,
+            recipes: default_extension_recipes(),
+            protocol_version: PROTOCOL_VERSION,
+            last_seen_ms: 1,
+        };
+        assert!(ensure_reload_can_reach_managed_copy(&loaded_before_restamp, &result).is_ok());
+    }
+
+    #[test]
+    #[serial]
     fn managed_extension_stamp_increments_only_when_source_changes() {
         let dir = TempDir::new().unwrap();
         let source = dir.path().join("source");
@@ -4731,6 +4901,9 @@ mod tests {
         assert_eq!(result.source_dir, source.canonicalize().unwrap());
         assert_eq!(result.extension_dir, state.join("chatgpt-native-extension"));
         assert!(is_chatgpt_extension_source_dir(&result.extension_dir));
+        let payload = serde_json::to_value(&result).unwrap();
+        assert_eq!(payload["source_version"], YOETZ_CLI_VERSION);
+        assert_eq!(payload["source_provenance"], "environment_override");
     }
 
     #[test]

--- a/crates/yoetz-cli/src/chatgpt_recipe.rs
+++ b/crates/yoetz-cli/src/chatgpt_recipe.rs
@@ -1,20 +1,16 @@
 //! ChatGPT recipe output types and terminal-fallback phase markers.
 
 use anyhow::Error as AnyhowError;
-use clap::ValueEnum;
-use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::fmt;
 use std::path::PathBuf;
 
-pub const CHATGPT_SOL_PRO_MODEL: &str = "gpt-5-6-sol-pro";
+use crate::web_recipe::{self, BuiltinWebRecipe};
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum ChatgptTransportPhase {
-    Upload,
-    Send,
-    WaitResponse,
-}
+pub type ChatgptTransportPhase = web_recipe::WebRecipeTransportPhase;
+pub type ChatgptModelStrategy = web_recipe::WebModelStrategy;
+pub type ChatgptModelSelectionStatus = web_recipe::WebModelSelectionStatus;
+
+pub const CHATGPT_SOL_PRO_MODEL: &str = "gpt-5-6-sol-pro";
 
 pub(crate) trait AnyhowResultExt<T> {
     fn with_chatgpt_phase(self, phase: ChatgptTransportPhase) -> Result<T, AnyhowError>;
@@ -26,43 +22,13 @@ impl<T> AnyhowResultExt<T> for Result<T, AnyhowError> {
     }
 }
 
-impl fmt::Display for ChatgptTransportPhase {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            Self::Upload => "upload",
-            Self::Send => "send",
-            Self::WaitResponse => "wait_response",
-        })
-    }
-}
-
-#[derive(Debug, thiserror::Error)]
-#[error(
-    "ChatGPT {phase} phase failed after browser side effects; automatic transport fallback is disabled"
-)]
-pub struct ChatgptTerminalFallbackError {
-    phase: ChatgptTransportPhase,
-}
-
-impl ChatgptTerminalFallbackError {
-    pub fn phase(&self) -> ChatgptTransportPhase {
-        self.phase
-    }
-}
-
 pub fn mark_terminal_fallback_phase(err: AnyhowError, phase: ChatgptTransportPhase) -> AnyhowError {
-    err.context(ChatgptTerminalFallbackError { phase })
+    web_recipe::mark_terminal_fallback_phase(err, BuiltinWebRecipe::Chatgpt, phase)
 }
 
 pub fn terminal_fallback_phase(err: &AnyhowError) -> Option<ChatgptTransportPhase> {
-    if let Some(marker) = err.downcast_ref::<ChatgptTerminalFallbackError>() {
-        return Some(marker.phase());
-    }
-
-    for cause in err.chain() {
-        if let Some(marker) = cause.downcast_ref::<ChatgptTerminalFallbackError>() {
-            return Some(marker.phase());
-        }
+    if let Some((BuiltinWebRecipe::Chatgpt, phase)) = web_recipe::terminal_fallback_marker(err) {
+        return Some(phase);
     }
 
     classify_terminal_fallback_phase_message(&format!("{err:#}"))
@@ -131,23 +97,6 @@ pub(crate) fn classify_terminal_fallback_phase_message(
 pub enum ChatgptDeliveryMode {
     FileUpload,
     Paste,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, ValueEnum)]
-#[serde(rename_all = "snake_case")]
-pub enum ChatgptModelStrategy {
-    Select,
-    Current,
-}
-
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ChatgptModelSelectionStatus {
-    Selected,
-    KeptCurrent,
-    Current,
-    Unavailable,
-    Mismatch,
 }
 
 impl ChatgptDeliveryMode {

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/claude.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/claude.rs
@@ -1,0 +1,701 @@
+//! Claude Fable 5 / Max / Thinking recipe over the live Chrome CDP client.
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde_json::Value;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use super::client::{is_external_create_target_block_error, ChromeCdpClient};
+use super::DevtoolsMcpRecipeContext;
+use crate::claude_recipe::{self, AnyhowResultExt};
+use crate::claude_web;
+use crate::web_recipe::{WebModelSelectionStatus, WebRecipeTransportPhase};
+
+const NO_PROGRESS_POLL_LIMIT: u8 = 5;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClaudeRunResult {
+    pub response: String,
+    pub model_used: Option<String>,
+    pub model_selection_status: WebModelSelectionStatus,
+    pub conversation_id: Option<String>,
+    pub conversation_url: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ResponseBaseline {
+    count: i64,
+    last_length: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ResponseState {
+    count: i64,
+    last_length: i64,
+    text: String,
+    streaming: bool,
+    stop: bool,
+    thinking: bool,
+    copy_buttons: usize,
+    error: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CompletionVerdict {
+    Generating,
+    CopyButton,
+    Idle,
+}
+
+pub async fn run(ctx: &DevtoolsMcpRecipeContext) -> Result<ClaudeRunResult> {
+    if claude_recipe::canonical_fable_max_model(&ctx.model).is_none() {
+        bail!(
+            "Claude CDP recipe requires model `{}` (alias `{}`); got `{}`",
+            claude_recipe::CLAUDE_FABLE_MAX_MODEL,
+            claude_recipe::CLAUDE_FABLE_MAX_ALIAS,
+            ctx.model
+        );
+    }
+    let bundle_path = ctx.bundle_path.as_deref().ok_or_else(|| {
+        anyhow!("Claude recipe requires `--bundle`; CDP uploads a file attachment")
+    })?;
+    let mut client = crate::chrome_devtools_mcp::chatgpt::connect_client_with_attach_attempt_lock(
+        ctx.cdp_endpoint.as_deref(),
+        ctx.show_approval_guidance,
+    )
+    .await?;
+    let browser_context_id = client
+        .resolve_browser_context_id(
+            ctx.browser_context_id.as_deref(),
+            ctx.profile_email.as_deref(),
+        )
+        .context("resolve Chrome browser context for Claude")?;
+    run_with_client(&mut client, ctx, bundle_path, browser_context_id.as_deref()).await
+}
+
+async fn run_with_client(
+    client: &mut ChromeCdpClient,
+    ctx: &DevtoolsMcpRecipeContext,
+    bundle_path: &Path,
+    browser_context_id: Option<&str>,
+) -> Result<ClaudeRunResult> {
+    let marked_url = claude_web::mark_claude_url(&ctx.run_id)?;
+    open_claude_page(client, &marked_url, browser_context_id)
+        .await
+        .with_context(|| format!("open yoetz-owned Claude page `{marked_url}`"))?;
+    client
+        .evaluate_script(&claude_web::build_set_window_name_js(&ctx.run_id)?, vec![])
+        .await
+        .context("mark yoetz-owned Claude tab with window.name")?;
+
+    wait_for_composer(client).await?;
+    let model_selection = select_fable_max_thinking(client).await?;
+    if model_selection != WebModelSelectionStatus::Selected {
+        bail!("Claude Fable 5 / Max / Thinking selection was not verified")
+    }
+
+    upload_bundle(client, bundle_path, ctx.upload_timeout_ms)
+        .await
+        .with_claude_phase(WebRecipeTransportPhase::Upload)
+        .context("upload bundle to Claude")?;
+
+    client
+        .evaluate_script(&claude_web::build_focus_composer_function(), vec![])
+        .await
+        .with_claude_phase(WebRecipeTransportPhase::Send)
+        .context("focus Claude composer after upload")?;
+    client
+        .type_text(&ctx.prompt, None)
+        .await
+        .with_claude_phase(WebRecipeTransportPhase::Send)
+        .context("type prompt into Claude composer")?;
+    let send = client
+        .evaluate_script(&claude_web::build_send_function(), vec![])
+        .await
+        .with_claude_phase(WebRecipeTransportPhase::Send)
+        .context("click enabled Claude send button")?;
+    if send.get("status").and_then(Value::as_str) != Some("sent") {
+        bail!("could not find an enabled Claude send button; diagnostics={send}")
+    }
+    let baseline = ResponseBaseline {
+        count: send
+            .get("assistantCount")
+            .and_then(Value::as_i64)
+            .unwrap_or(0),
+        last_length: send
+            .get("assistantLastLength")
+            .and_then(Value::as_i64)
+            .unwrap_or(0),
+    };
+
+    let response = poll_for_response(
+        client,
+        baseline,
+        ctx.response_timeout_ms,
+        ctx.response_poll_interval_ms,
+    )
+    .await
+    .with_claude_phase(WebRecipeTransportPhase::WaitResponse)
+    .context("stable-idle polling for Claude response")?;
+    let conversation = read_conversation(client).await?;
+
+    Ok(ClaudeRunResult {
+        response,
+        model_used: Some(claude_recipe::CLAUDE_REPORTED_MODEL.to_string()),
+        model_selection_status: model_selection,
+        conversation_id: conversation.as_ref().map(|value| value.id.clone()),
+        conversation_url: conversation.map(|value| value.url),
+    })
+}
+
+async fn open_claude_page(
+    client: &ChromeCdpClient,
+    marked_url: &str,
+    browser_context_id: Option<&str>,
+) -> Result<()> {
+    match client
+        .new_page("about:blank", false, 30_000, browser_context_id)
+        .await
+    {
+        Ok(_) => client
+            .navigate_page(marked_url, 30_000)
+            .await
+            .map(|_| ())
+            .with_context(|| format!("navigate blank Chrome target to `{marked_url}`")),
+        Err(err) if is_external_create_target_block_error(&err) => client
+            .open_recipe_page_via_existing_site_anchor(
+                marked_url,
+                "claude.ai",
+                false,
+                30_000,
+                browser_context_id,
+            )
+            .await
+            .map(|_| ())
+            .context("recover Claude page open through an existing safe Chrome anchor"),
+        Err(err) => Err(err),
+    }
+}
+
+async fn wait_for_composer(client: &ChromeCdpClient) -> Result<()> {
+    let state = client
+        .evaluate_script(&claude_web::build_wait_for_composer_function(), vec![])
+        .await
+        .context("wait for Claude composer")?;
+    match state.get("status").and_then(Value::as_str) {
+        Some("ready") => Ok(()),
+        Some("login") => bail!("Claude login is required in the attached Chrome profile"),
+        Some("challenge") => bail!(
+            "Cloudflare challenge detected on claude.ai; solve it in the attached Chrome window and retry"
+        ),
+        other => bail!("Claude composer did not become ready; status={other:?}, diagnostics={state}"),
+    }
+}
+
+async fn select_fable_max_thinking(client: &ChromeCdpClient) -> Result<WebModelSelectionStatus> {
+    open_model_menu(client).await?;
+    let fable = client
+        .evaluate_script(&claude_web::build_select_fable_function(), vec![])
+        .await
+        .context("select Fable 5 from Claude model menu")?;
+    require_status(&fable, "selected", "Fable 5", "options")?;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    open_effort_submenu(client).await?;
+    let max = client
+        .evaluate_script(&claude_web::build_select_max_function(), vec![])
+        .await
+        .context("select Max from Claude effort submenu")?;
+    require_status(&max, "selected", "Max effort", "effortOptions")?;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    open_effort_submenu(client).await?;
+    let thinking = client
+        .evaluate_script(&claude_web::build_ensure_thinking_on_function(), vec![])
+        .await
+        .context("enable Claude Thinking")?;
+    match thinking.get("status").and_then(Value::as_str) {
+        Some("already_on" | "clicked") => {}
+        _ => bail!("Claude Thinking switch was unavailable; diagnostics={thinking}"),
+    }
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // A successful click is not proof. Close, re-open, hover again, and read
+    // the selected model, selected effort, and Thinking switch postconditions.
+    client
+        .evaluate_script(&claude_web::build_close_model_menu_function(), vec![])
+        .await
+        .context("close Claude model menu before verification")?;
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    open_effort_submenu(client).await?;
+    let verification = client
+        .evaluate_script(
+            &claude_web::build_verify_fable_max_thinking_function(),
+            vec![],
+        )
+        .await
+        .context("verify Claude Fable 5 / Max / Thinking postconditions")?;
+    let status = claude_web::model_selection_status(&verification);
+    if status != WebModelSelectionStatus::Selected {
+        bail!(
+            "Claude exact model contract is unavailable or mismatched; required Fable 5 + Max + Thinking on; diagnostics={verification}"
+        );
+    }
+    client
+        .evaluate_script(&claude_web::build_close_model_menu_function(), vec![])
+        .await
+        .context("close Claude model menu after verification")?;
+    Ok(status)
+}
+
+async fn open_model_menu(client: &ChromeCdpClient) -> Result<()> {
+    let result = client
+        .evaluate_script(&claude_web::build_open_model_menu_function(), vec![])
+        .await
+        .context("open Claude model menu")?;
+    if matches!(
+        result.get("status").and_then(Value::as_str),
+        Some("opened" | "opening")
+    ) {
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        Ok(())
+    } else {
+        bail!("Claude model selector was unavailable; diagnostics={result}")
+    }
+}
+
+async fn open_effort_submenu(client: &ChromeCdpClient) -> Result<()> {
+    open_model_menu(client).await?;
+    let marked = client
+        .evaluate_script(&claude_web::build_mark_effort_parent_function(), vec![])
+        .await
+        .context("mark Claude Effort menu trigger")?;
+    require_status(&marked, "marked", "Effort menu", "options")?;
+    let snapshot = client
+        .take_snapshot(false)
+        .await
+        .context("snapshot marked Claude Effort menu trigger")?;
+    let effort_text = marked
+        .get("text")
+        .and_then(Value::as_str)
+        .unwrap_or("Effort");
+    let uid = snapshot
+        .find_uid_by_role_and_text("menuitem", effort_text)
+        .or_else(|| snapshot.find_uid_by_role_and_text("menuitem", "Effort"))
+        .or_else(|| snapshot.find_uid_by_text(claude_web::EFFORT_HOVER_MARKER))
+        .ok_or_else(|| anyhow!("marked Claude Effort menu trigger was missing from snapshot"))?;
+    client
+        .hover(&uid)
+        .await
+        .context("dispatch real CDP mouse movement over Claude Effort menu trigger")?;
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    Ok(())
+}
+
+fn require_status(
+    value: &Value,
+    expected: &str,
+    operation: &str,
+    diagnostics_key: &str,
+) -> Result<()> {
+    if value.get("status").and_then(Value::as_str) == Some(expected) {
+        return Ok(());
+    }
+    bail!(
+        "Claude {operation} is unavailable; {}={}",
+        diagnostics_key,
+        value.get(diagnostics_key).cloned().unwrap_or(Value::Null)
+    )
+}
+
+async fn upload_bundle(
+    client: &ChromeCdpClient,
+    bundle_path: &Path,
+    timeout_ms: u64,
+) -> Result<()> {
+    let file_name = bundle_path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .context("Claude bundle path must end in a UTF-8 filename")?;
+    let scope = client
+        .evaluate_script(&claude_web::build_scope_file_input_function(), vec![])
+        .await
+        .context("scope Claude composer file input")?;
+    require_status(&scope, "marked", "file input", "selector")?;
+    let snapshot = client
+        .take_snapshot(false)
+        .await
+        .context("snapshot Claude file input")?;
+    let uid = snapshot
+        .find_marked_file_input_uid(claude_web::FILE_INPUT_MARKER)
+        .ok_or_else(|| anyhow!("marked Claude file input was missing from snapshot"))?;
+    client
+        .upload_file(&uid, bundle_path)
+        .await
+        .context("upload file through Claude composer input")?;
+
+    let probe = claude_web::build_attachment_probe_function(file_name)?;
+    let deadline = Instant::now() + Duration::from_millis(timeout_ms);
+    let mut stable_ready_ticks = 0_u8;
+    loop {
+        let state = client
+            .evaluate_script(&probe, vec![])
+            .await
+            .context("probe Claude attachment readiness")?;
+        if update_attachment_stability(&mut stable_ready_ticks, &state) {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            bail!("Claude attachment `{file_name}` did not become ready within {timeout_ms}ms; diagnostics={state}");
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+fn update_attachment_stability(stable_ready_ticks: &mut u8, state: &Value) -> bool {
+    if state.get("status").and_then(Value::as_str) == Some("candidate") {
+        *stable_ready_ticks = stable_ready_ticks.saturating_add(1);
+    } else {
+        *stable_ready_ticks = 0;
+    }
+    *stable_ready_ticks >= 2
+}
+
+async fn poll_for_response(
+    client: &ChromeCdpClient,
+    baseline: ResponseBaseline,
+    timeout_ms: u64,
+    poll_interval_ms: u64,
+) -> Result<String> {
+    let script = claude_web::build_response_poll_function();
+    let started = Instant::now();
+    let stable_threshold_ms = claude_web::stable_idle_threshold_ms(poll_interval_ms);
+    let mut stable_since: Option<Instant> = None;
+    let mut stable_anchor: Option<(i64, i64)> = None;
+    let mut no_progress_polls = 0_u8;
+
+    loop {
+        if started.elapsed() > Duration::from_millis(timeout_ms) {
+            bail!("Claude response did not complete within {timeout_ms}ms");
+        }
+        tokio::time::sleep(Duration::from_millis(poll_interval_ms)).await;
+        let value = client
+            .evaluate_script(&script, vec![])
+            .await
+            .context("poll Claude response state")?;
+        let state = parse_response_state(&value)?;
+        if !state.error.is_empty() {
+            bail!("Claude page error: {}", state.error);
+        }
+        if update_no_progress_stall(&mut no_progress_polls, &state, baseline) {
+            bail!(
+                "Claude response made no post-send progress for {NO_PROGRESS_POLL_LIMIT} polls after generation became idle; baseline_count={}, baseline_length={}, observed_count={}, observed_length={}, poll_interval_ms={poll_interval_ms}",
+                baseline.count,
+                baseline.last_length,
+                state.count,
+                state.last_length,
+            );
+        }
+        match classify_completion(&state, baseline) {
+            CompletionVerdict::Generating => {
+                stable_since = None;
+                stable_anchor = None;
+            }
+            CompletionVerdict::CopyButton | CompletionVerdict::Idle => {
+                let anchor = (state.count, state.last_length);
+                let stable_for = match (stable_since, stable_anchor) {
+                    (Some(since), Some(previous)) if previous == anchor => since.elapsed(),
+                    _ => {
+                        stable_since = Some(Instant::now());
+                        stable_anchor = Some(anchor);
+                        Duration::ZERO
+                    }
+                };
+                if stable_for >= Duration::from_millis(stable_threshold_ms) {
+                    if state.text.is_empty() {
+                        bail!("Claude stable-idle reached but response text was empty");
+                    }
+                    return Ok(state.text);
+                }
+            }
+        }
+    }
+}
+
+fn update_no_progress_stall(
+    stalled_polls: &mut u8,
+    state: &ResponseState,
+    baseline: ResponseBaseline,
+) -> bool {
+    let inactive_without_progress = !state.streaming
+        && !state.stop
+        && !state.thinking
+        && classify_completion(state, baseline) == CompletionVerdict::Generating;
+    if inactive_without_progress {
+        *stalled_polls = stalled_polls.saturating_add(1);
+    } else {
+        *stalled_polls = 0;
+    }
+    *stalled_polls >= NO_PROGRESS_POLL_LIMIT
+}
+
+fn parse_response_state(value: &Value) -> Result<ResponseState> {
+    let send_state = value
+        .get("sendState")
+        .and_then(Value::as_str)
+        .unwrap_or("missing");
+    if !matches!(send_state, "enabled" | "disabled" | "missing") {
+        bail!("invalid Claude send state `{send_state}`")
+    }
+    Ok(ResponseState {
+        count: value.get("count").and_then(Value::as_i64).unwrap_or(0),
+        last_length: value.get("length").and_then(Value::as_i64).unwrap_or(0),
+        text: value
+            .get("text")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+        streaming: value
+            .get("streaming")
+            .and_then(Value::as_bool)
+            .unwrap_or(true),
+        stop: value
+            .get("hasStopButton")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        thinking: value
+            .get("thinking")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        copy_buttons: value
+            .get("copyButtons")
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as usize,
+        error: value
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+    })
+}
+
+fn classify_completion(state: &ResponseState, baseline: ResponseBaseline) -> CompletionVerdict {
+    if state.streaming || state.stop || state.thinking {
+        return CompletionVerdict::Generating;
+    }
+    let new_turn = state.count > baseline.count;
+    let same_turn_grew = state.count == baseline.count && state.last_length > baseline.last_length;
+    if !(new_turn || same_turn_grew) || state.last_length == 0 {
+        return CompletionVerdict::Generating;
+    }
+    if state.copy_buttons > 0 {
+        CompletionVerdict::CopyButton
+    } else {
+        CompletionVerdict::Idle
+    }
+}
+
+async fn read_conversation(
+    client: &ChromeCdpClient,
+) -> Result<Option<crate::web_recipe::WebConversation>> {
+    let value = client
+        .evaluate_script("() => window.location.href || ''", vec![])
+        .await
+        .context("read Claude conversation URL")?;
+    let Some(url) = value.as_str() else {
+        return Ok(None);
+    };
+    match claude_web::normalize_conversation(url) {
+        Ok(conversation) => Ok(Some(conversation)),
+        Err(_) => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn baseline() -> ResponseBaseline {
+        ResponseBaseline {
+            count: 1,
+            last_length: 100,
+        }
+    }
+
+    #[test]
+    fn completion_fails_closed_while_streaming_stopping_or_thinking() {
+        let mut state = ResponseState {
+            count: 2,
+            last_length: 200,
+            text: "answer".to_string(),
+            streaming: false,
+            stop: false,
+            thinking: false,
+            copy_buttons: 0,
+            error: String::new(),
+        };
+        for field in ["streaming", "stop", "thinking"] {
+            match field {
+                "streaming" => state.streaming = true,
+                "stop" => state.stop = true,
+                "thinking" => state.thinking = true,
+                _ => unreachable!(),
+            }
+            assert_eq!(
+                classify_completion(&state, baseline()),
+                CompletionVerdict::Generating
+            );
+            state.streaming = false;
+            state.stop = false;
+            state.thinking = false;
+        }
+    }
+
+    #[test]
+    fn disabled_send_with_post_send_growth_is_idle() {
+        let state = parse_response_state(&json!({
+            "count":2,"length":200,"text":"answer","streaming":false,
+            "sendState":"disabled","hasStopButton":false,"thinking":false,"copyButtons":0,"error":""
+        }))
+        .unwrap();
+
+        assert_eq!(
+            classify_completion(&state, baseline()),
+            CompletionVerdict::Idle
+        );
+    }
+
+    #[test]
+    fn completion_requires_monotonic_post_send_growth() {
+        let stale = parse_response_state(&json!({
+            "count":1,"length":100,"text":"old","streaming":false,
+            "sendState":"missing","hasStopButton":false,"thinking":false,"copyButtons":0,"error":""
+        }))
+        .unwrap();
+        assert_eq!(
+            classify_completion(&stale, baseline()),
+            CompletionVerdict::Generating
+        );
+        let grown = ResponseState {
+            last_length: 101,
+            text: "grown".into(),
+            ..stale
+        };
+        assert_eq!(
+            classify_completion(&grown, baseline()),
+            CompletionVerdict::Idle
+        );
+    }
+
+    #[test]
+    fn idle_no_progress_fast_fails_after_bounded_polls_and_resets_on_activity() {
+        let stale = parse_response_state(&json!({
+            "count":1,"length":100,"text":"old","streaming":false,
+            "sendState":"missing","hasStopButton":false,"thinking":false,"copyButtons":0,"error":""
+        }))
+        .unwrap();
+        let mut stalled_polls = 0;
+        for _ in 1..NO_PROGRESS_POLL_LIMIT {
+            assert!(!update_no_progress_stall(
+                &mut stalled_polls,
+                &stale,
+                baseline()
+            ));
+        }
+        assert!(update_no_progress_stall(
+            &mut stalled_polls,
+            &stale,
+            baseline()
+        ));
+
+        let active = ResponseState {
+            streaming: true,
+            ..stale
+        };
+        assert!(!update_no_progress_stall(
+            &mut stalled_polls,
+            &active,
+            baseline()
+        ));
+        assert_eq!(stalled_polls, 0);
+    }
+
+    #[test]
+    fn empty_new_turn_is_no_progress_but_completed_growth_is_not() {
+        let empty = parse_response_state(&json!({
+            "count":2,"length":0,"text":"","streaming":false,
+            "sendState":"missing","hasStopButton":false,"thinking":false,"copyButtons":0,"error":""
+        }))
+        .unwrap();
+        let mut stalled_polls = NO_PROGRESS_POLL_LIMIT - 1;
+        assert!(update_no_progress_stall(
+            &mut stalled_polls,
+            &empty,
+            baseline()
+        ));
+
+        let complete = ResponseState {
+            last_length: 101,
+            text: "grown".into(),
+            ..empty
+        };
+        assert!(!update_no_progress_stall(
+            &mut stalled_polls,
+            &complete,
+            baseline()
+        ));
+        assert_eq!(stalled_polls, 0);
+    }
+
+    #[test]
+    fn copy_button_is_only_a_candidate_after_idle_and_growth() {
+        let state = ResponseState {
+            count: 2,
+            last_length: 200,
+            text: "answer".into(),
+            streaming: false,
+            stop: false,
+            thinking: false,
+            copy_buttons: 1,
+            error: String::new(),
+        };
+        assert_eq!(
+            classify_completion(&state, baseline()),
+            CompletionVerdict::CopyButton
+        );
+    }
+
+    #[test]
+    fn model_diagnostics_are_actionable() {
+        let value = json!({"status":"unavailable","options":["Opus 4.8","Sonnet 5"]});
+        let err = require_status(&value, "selected", "Fable 5", "options").unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("Fable 5"));
+        assert!(message.contains("Opus 4.8"));
+    }
+
+    #[test]
+    fn attachment_requires_two_consecutive_named_enabled_candidates() {
+        let candidate = json!({"status":"candidate"});
+        let pending = json!({"status":"pending"});
+        let mut ticks = 0;
+        assert!(!update_attachment_stability(&mut ticks, &candidate));
+        assert_eq!(ticks, 1);
+        assert!(!update_attachment_stability(&mut ticks, &pending));
+        assert_eq!(ticks, 0);
+        assert!(!update_attachment_stability(&mut ticks, &candidate));
+        assert!(update_attachment_stability(&mut ticks, &candidate));
+    }
+
+    #[tokio::test]
+    async fn run_rejects_non_fable_model_before_browser_attach() {
+        let ctx = DevtoolsMcpRecipeContext {
+            model: "current".to_string(),
+            bundle_path: Some("bundle.md".into()),
+            ..DevtoolsMcpRecipeContext::default()
+        };
+        let err = run(&ctx).await.unwrap_err();
+        assert!(err.to_string().contains("fable-5-max"));
+    }
+}

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/claude.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/claude.rs
@@ -73,6 +73,22 @@ pub async fn run(ctx: &DevtoolsMcpRecipeContext) -> Result<ClaudeRunResult> {
     run_with_client(&mut client, ctx, bundle_path, browser_context_id.as_deref()).await
 }
 
+pub async fn check_auth(cdp_endpoint: Option<&str>, show_approval_guidance: bool) -> Result<()> {
+    let client = crate::chrome_devtools_mcp::chatgpt::connect_client_with_attach_attempt_lock(
+        cdp_endpoint,
+        show_approval_guidance,
+    )
+    .await?;
+    let run_id = claude_web::generate_run_id();
+    let marked_url = claude_web::mark_claude_url(&run_id)?;
+    open_claude_page(&client, &marked_url, None)
+        .await
+        .context("open Claude auth-check page")?;
+    let result = wait_for_composer(&client).await;
+    let _ = client.close_selected_page(false);
+    result
+}
+
 async fn run_with_client(
     client: &mut ChromeCdpClient,
     ctx: &DevtoolsMcpRecipeContext,

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/claude.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/claude.rs
@@ -300,12 +300,36 @@ async fn open_effort_submenu(client: &ChromeCdpClient) -> Result<()> {
         .or_else(|| snapshot.find_uid_by_role_and_text("menuitem", "Effort"))
         .or_else(|| snapshot.find_uid_by_text(claude_web::EFFORT_HOVER_MARKER))
         .ok_or_else(|| anyhow!("marked Claude Effort menu trigger was missing from snapshot"))?;
-    client
+    let physical_hover_error = client
         .hover(&uid)
         .await
-        .context("dispatch real CDP mouse movement over Claude Effort menu trigger")?;
+        .err()
+        .map(|error| error.to_string());
     tokio::time::sleep(Duration::from_millis(400)).await;
-    Ok(())
+    let hover = client
+        .evaluate_script(&claude_web::build_open_effort_submenu_function(), vec![])
+        .await
+        .context("verify Claude Effort submenu or dispatch DOM hover fallback")?;
+    match hover.get("status").and_then(Value::as_str) {
+        Some("already_open") => Ok(()),
+        Some("dispatched") => {
+            tokio::time::sleep(Duration::from_millis(400)).await;
+            let verification = client
+                .evaluate_script(&claude_web::build_open_effort_submenu_function(), vec![])
+                .await
+                .context("verify Claude Effort submenu after DOM hover fallback")?;
+            if verification.get("status").and_then(Value::as_str) == Some("already_open") {
+                Ok(())
+            } else {
+                bail!(
+                    "Claude Effort submenu did not open after physical and DOM hover; physicalHoverError={physical_hover_error:?}, diagnostics={verification}"
+                )
+            }
+        }
+        _ => bail!(
+            "Claude Effort submenu hover target was unavailable; physicalHoverError={physical_hover_error:?}, diagnostics={hover}"
+        ),
+    }
 }
 
 fn require_status(
@@ -337,18 +361,11 @@ async fn upload_bundle(
         .evaluate_script(&claude_web::build_scope_file_input_function(), vec![])
         .await
         .context("scope Claude composer file input")?;
-    require_status(&scope, "marked", "file input", "selector")?;
-    let snapshot = client
-        .take_snapshot(false)
-        .await
-        .context("snapshot Claude file input")?;
-    let uid = snapshot
-        .find_marked_file_input_uid(claude_web::FILE_INPUT_MARKER)
-        .ok_or_else(|| anyhow!("marked Claude file input was missing from snapshot"))?;
+    require_status(&scope, "marked", "file input", "count")?;
     client
-        .upload_file(&uid, bundle_path)
+        .upload_file_by_selector(claude_web::FILE_INPUT_SELECTOR, bundle_path)
         .await
-        .context("upload file through Claude composer input")?;
+        .context("upload file through hidden Claude composer input")?;
 
     let probe = claude_web::build_attachment_probe_function(file_name)?;
     let deadline = Instant::now() + Duration::from_millis(timeout_ms);

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
@@ -169,6 +169,26 @@ impl Snapshot {
         })
     }
 
+    pub fn find_uid_by_role_and_text(&self, role: &str, text: &str) -> Option<String> {
+        let wanted_role = role.trim();
+        let wanted_text = text.trim().to_ascii_lowercase();
+        if wanted_role.is_empty() || wanted_text.is_empty() {
+            return None;
+        }
+
+        walk_snapshot(&self.raw, &mut |node| {
+            if node.get("role").and_then(Value::as_str) != Some(wanted_role)
+                || !node_contains_text(node, &wanted_text)
+            {
+                return None;
+            }
+
+            node.get("id")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        })
+    }
+
     pub fn find_uid_by_text(&self, text: &str) -> Option<String> {
         let wanted = text.trim().to_ascii_lowercase();
         if wanted.is_empty() {
@@ -586,6 +606,52 @@ impl ChromeCdpClient {
         })
     }
 
+    /// Open a recipe-owned sibling tab through an already attached tab from
+    /// the same site. The anchor is never navigated or otherwise mutated.
+    pub async fn open_recipe_page_via_existing_site_anchor(
+        &self,
+        url: &str,
+        site_host: &str,
+        background: bool,
+        timeout_ms: u64,
+        browser_context_id: Option<&str>,
+    ) -> Result<NewPageResult> {
+        let targets = self
+            .wait_for_recovery_anchor_candidates(browser_context_id, timeout_ms.min(3_000))
+            .await?;
+        let anchor = targets
+            .iter()
+            .find(|target| url_has_host(&target.url, site_host))
+            .or_else(|| {
+                targets
+                    .iter()
+                    .filter_map(|target| context_tab_reuse_rank(&target.url).map(|rank| (rank, target)))
+                    .min_by_key(|(rank, _)| *rank)
+                    .map(|(_, target)| target)
+            })
+            .ok_or_else(|| {
+                anyhow!(
+                    "{} has no existing `{site_host}` or yoetz-safe tab to use as a window.open anchor for `{url}`",
+                    browser_context_label(browser_context_id)
+                )
+            })?;
+        let tab = self
+            .open_page_via_anchor_target(
+                anchor,
+                url,
+                background,
+                timeout_ms,
+                browser_context_id,
+                "existing same-site recipe tab",
+            )
+            .await?;
+        configure_tab_timeout(&tab, timeout_ms);
+        self.set_selected_tab(tab.clone());
+        Ok(NewPageResult {
+            page_id: tab.get_target_id().to_string(),
+        })
+    }
+
     pub async fn select_chatgpt_page_for_probe(
         &self,
         timeout_ms: u64,
@@ -667,6 +733,17 @@ impl ChromeCdpClient {
                 .click()
                 .with_context(|| format!("double-clicking snapshot element `{uid}` failed"))?;
         }
+        Ok(())
+    }
+
+    /// Dispatch a real CDP mouse-moved event over a snapshot element. This is
+    /// required for hover-only menus that ignore synthetic JavaScript events.
+    pub async fn hover(&self, uid: &str) -> Result<()> {
+        let tab = self.selected_tab()?;
+        let element = find_snapshot_element(&tab, uid)?;
+        element
+            .move_mouse_over()
+            .with_context(|| format!("moving mouse over snapshot element `{uid}` failed"))?;
         Ok(())
     }
 
@@ -2486,6 +2563,13 @@ fn is_chatgpt_url(url: &str) -> bool {
     )
 }
 
+fn url_has_host(url: &str, expected_host: &str) -> bool {
+    Url::parse(url)
+        .ok()
+        .and_then(|parsed| parsed.host_str().map(str::to_owned))
+        .is_some_and(|host| host.eq_ignore_ascii_case(expected_host))
+}
+
 fn yoetz_run_id_from_url(url: &str) -> Option<String> {
     let parsed = Url::parse(url).ok()?;
     parsed
@@ -3500,6 +3584,27 @@ mod tests {
     }
 
     #[test]
+    fn snapshot_find_uid_by_role_and_text_uses_visible_text_when_aria_name_differs() {
+        let snapshot = Snapshot {
+            raw: json!({
+                "id": "root",
+                "role": "root_web_area",
+                "children": [{
+                    "id": "effort-trigger",
+                    "role": "menuitem",
+                    "name": "Change effort level",
+                    "text": "Effort High"
+                }]
+            }),
+        };
+
+        assert_eq!(
+            snapshot.find_uid_by_role_and_text("menuitem", "Effort"),
+            Some("effort-trigger".to_owned())
+        );
+    }
+
+    #[test]
     fn snapshot_find_uid_by_text_searches_all_string_fields() {
         let snapshot = snapshot_fixture();
         assert_eq!(
@@ -3866,6 +3971,16 @@ mod tests {
         assert!(is_chatgpt_title(Some("ChatGPT Workspace")));
         assert!(!is_chatgpt_title(Some("Notes about ChatGPT pricing")));
         assert!(!is_chatgpt_title(Some("Docs")));
+    }
+
+    #[test]
+    fn generic_recipe_anchor_host_match_is_exact() {
+        assert!(url_has_host("https://claude.ai/chat/example", "claude.ai"));
+        assert!(!url_has_host(
+            "https://claude.ai.evil.example/chat/example",
+            "claude.ai"
+        ));
+        assert!(!url_has_host("https://chatgpt.com/", "claude.ai"));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
@@ -760,22 +760,14 @@ impl ChromeCdpClient {
 
     pub async fn upload_file(&self, uid: &str, file_path: &Path) -> Result<()> {
         let tab = self.selected_tab()?;
-        let file_path = file_path
-            .canonicalize()
-            .with_context(|| format!("resolving upload path `{}` failed", file_path.display()))?;
-        let file_path = file_path.to_str().ok_or_else(|| {
-            anyhow!(
-                "upload_file path is not valid UTF-8: {}",
-                file_path.display()
-            )
-        })?;
+        let file_path = canonical_upload_path(file_path)?;
 
         let _ = tab.set_file_chooser_dialog_interception(true, None);
         if let Ok(element) = find_snapshot_element(&tab, uid) {
             if element.tag_name.eq_ignore_ascii_case("input")
                 && element.get_attribute_value("type")?.as_deref() == Some("file")
             {
-                let result = inject_files_on_input(&tab, &element, file_path, uid);
+                let result = inject_files_on_input(&tab, &element, &file_path, uid);
                 let _ = tab.set_file_chooser_dialog_interception(false, None);
                 return result;
             }
@@ -796,7 +788,30 @@ impl ChromeCdpClient {
                 "no composer-scoped file input (`{marker_selector}`) was available after clicking the upload affordance"
             )
         })?;
-        let result = inject_files_on_input(&tab, &input, file_path, uid);
+        let result = inject_files_on_input(&tab, &input, &file_path, uid);
+        let _ = tab.set_file_chooser_dialog_interception(false, None);
+        result
+    }
+
+    /// Upload through an exact CSS selector without relying on the accessibility
+    /// snapshot. This is required for intentionally hidden file inputs that are
+    /// present in the DOM but omitted from the snapshot tree.
+    pub async fn upload_file_by_selector(&self, selector: &str, file_path: &Path) -> Result<()> {
+        let tab = self.selected_tab()?;
+        let file_path = canonical_upload_path(file_path)?;
+
+        let _ = tab.set_file_chooser_dialog_interception(true, None);
+        let result = (|| -> Result<()> {
+            let input = tab
+                .find_element(selector)
+                .with_context(|| format!("file input `{selector}` was not present in the DOM"))?;
+            if !input.tag_name.eq_ignore_ascii_case("input")
+                || input.get_attribute_value("type")?.as_deref() != Some("file")
+            {
+                bail!("upload selector `{selector}` did not resolve to an input[type=file]");
+            }
+            inject_files_on_input(&tab, &input, &file_path, selector)
+        })();
         let _ = tab.set_file_chooser_dialog_interception(false, None);
         result
     }
@@ -1885,6 +1900,18 @@ fn inject_files_on_input(
             }
         }
     }
+}
+
+fn canonical_upload_path(file_path: &Path) -> Result<String> {
+    let file_path = file_path
+        .canonicalize()
+        .with_context(|| format!("resolving upload path `{}` failed", file_path.display()))?;
+    file_path.to_str().map(ToOwned::to_owned).ok_or_else(|| {
+        anyhow!(
+            "upload_file path is not valid UTF-8: {}",
+            file_path.display()
+        )
+    })
 }
 
 fn resolve_browser_websocket(parsed: &Url) -> Result<String> {

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/mod.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/mod.rs
@@ -33,11 +33,7 @@
 pub mod client;
 
 pub mod chatgpt;
-
-// `pub mod claude;` and `pub mod gemini;` land after the chatgpt recipe is
-// proven end-to-end against live Chrome 147. They share the same seven-step
-// shape (new_page → focus → upload → type → click → wait → extract) with
-// per-LLM selectors — trivial to add once the client plumbing is verified.
+pub mod claude;
 
 use crate::chatgpt_web;
 use anyhow::Result;

--- a/crates/yoetz-cli/src/claude_recipe.rs
+++ b/crates/yoetz-cli/src/claude_recipe.rs
@@ -1,0 +1,139 @@
+//! Claude recipe contract and preflight policy.
+
+use anyhow::{Context, Error as AnyhowError, Result};
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::web_recipe::{self, BuiltinWebRecipe, WebModelSelectionStatus, WebRecipeTransportPhase};
+
+pub const CLAUDE_FABLE_MAX_MODEL: &str = "fable-5-max";
+pub const CLAUDE_FABLE_MAX_ALIAS: &str = "fable-max";
+pub const CLAUDE_REPORTED_MODEL: &str = "Fable 5 Max";
+pub const DEFAULT_INLINE_WARN_TOKENS: usize = 150_000;
+
+pub fn canonical_fable_max_model(value: &str) -> Option<&'static str> {
+    matches!(
+        value.trim(),
+        CLAUDE_FABLE_MAX_MODEL | CLAUDE_FABLE_MAX_ALIAS
+    )
+    .then_some(CLAUDE_FABLE_MAX_MODEL)
+}
+
+pub(crate) trait AnyhowResultExt<T> {
+    fn with_claude_phase(self, phase: WebRecipeTransportPhase) -> Result<T, AnyhowError>;
+}
+
+impl<T> AnyhowResultExt<T> for Result<T, AnyhowError> {
+    fn with_claude_phase(self, phase: WebRecipeTransportPhase) -> Result<T, AnyhowError> {
+        self.map_err(|err| {
+            web_recipe::mark_terminal_fallback_phase(err, BuiltinWebRecipe::Claude, phase)
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClaudeRecipeSpec {
+    pub bundle_path: Option<PathBuf>,
+    pub prompt: String,
+    pub browser_context_id: Option<String>,
+    pub profile_email: Option<String>,
+    pub run_id: String,
+    pub wait_timeout_ms: u64,
+    pub wait_interval_ms: u64,
+    pub upload_timeout_ms: u64,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClaudeRecipeOutput {
+    pub transport: String,
+    pub backend: String,
+    pub response: String,
+    pub model_used: Option<String>,
+    pub model_selection_status: WebModelSelectionStatus,
+    pub warnings: Vec<String>,
+    pub fallback_used: bool,
+    pub conversation_id: Option<String>,
+    pub conversation_url: Option<String>,
+    pub run_id: String,
+    pub elapsed_ms: u64,
+}
+
+impl ClaudeRecipeOutput {
+    pub fn to_value(&self) -> Value {
+        json!({
+            "status": "ok",
+            "transport": self.transport,
+            "backend": self.backend,
+            "response": self.response,
+            "model_strategy": "select",
+            "model_used": self.model_used,
+            "model_selection_status": self.model_selection_status,
+            "warnings": self.warnings,
+            "fallback_used": self.fallback_used,
+            "delivery_mode": "file_upload",
+            "auto_paste_fallback": false,
+            "conversation_id": self.conversation_id,
+            "conversation_url": self.conversation_url,
+            "run_id": self.run_id,
+            "elapsed_ms": self.elapsed_ms,
+        })
+    }
+
+    pub fn to_recipe_complete_event(&self) -> Value {
+        let mut value = self.to_value();
+        value["type"] = Value::String("recipe_complete".to_string());
+        value
+            .as_object_mut()
+            .expect("output is an object")
+            .remove("status");
+        value
+    }
+}
+
+pub fn inline_size_warnings(
+    bundle_path: Option<&Path>,
+    inline_warn_tokens: usize,
+) -> Result<Vec<String>> {
+    let Some(bundle_path) = bundle_path else {
+        return Ok(Vec::new());
+    };
+    if inline_warn_tokens == 0 {
+        return Ok(Vec::new());
+    }
+
+    let contents = fs::read_to_string(bundle_path).with_context(|| {
+        format!(
+            "read Claude bundle {} for token estimate",
+            bundle_path.display()
+        )
+    })?;
+    let estimated_tokens = yoetz_core::bundle::estimate_tokens(contents.chars().count());
+    if estimated_tokens <= inline_warn_tokens {
+        return Ok(Vec::new());
+    }
+
+    Ok(vec![format!(
+        "Claude bundle is estimated {estimated_tokens} tokens, above the {inline_warn_tokens}-token heuristic inline-quality threshold; claude.ai may use retrieval-backed access, which can degrade holistic review quality. Consider trimming the bundle or accepting search-style access."
+    )])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_model_aliases_canonicalize_and_other_models_fail_closed() {
+        assert_eq!(
+            canonical_fable_max_model("fable-5-max"),
+            Some(CLAUDE_FABLE_MAX_MODEL)
+        );
+        assert_eq!(
+            canonical_fable_max_model("fable-max"),
+            Some(CLAUDE_FABLE_MAX_MODEL)
+        );
+        assert_eq!(canonical_fable_max_model("current"), None);
+        assert_eq!(canonical_fable_max_model("opus-4.8"), None);
+    }
+}

--- a/crates/yoetz-cli/src/claude_recipe.rs
+++ b/crates/yoetz-cli/src/claude_recipe.rs
@@ -38,10 +38,14 @@ pub struct ClaudeRecipeSpec {
     pub prompt: String,
     pub browser_context_id: Option<String>,
     pub profile_email: Option<String>,
+    pub extension_instance_id: Option<String>,
+    pub extension_profile_id: Option<String>,
+    pub conversation_id: Option<String>,
     pub run_id: String,
     pub wait_timeout_ms: u64,
     pub wait_interval_ms: u64,
     pub upload_timeout_ms: u64,
+    pub send_timeout_ms: u64,
     pub warnings: Vec<String>,
 }
 

--- a/crates/yoetz-cli/src/claude_web.rs
+++ b/crates/yoetz-cli/src/claude_web.rs
@@ -1,0 +1,450 @@
+//! Shared claude.ai contracts and DOM-script builders for browser transports.
+
+use anyhow::{anyhow, bail, Result};
+use serde_json::Value;
+
+use crate::web_recipe::{WebConversation, WebModelSelectionStatus};
+
+pub const CLAUDE_URL: &str = "https://claude.ai/new";
+pub const COMPOSER_SELECTOR: &str = "[data-testid='chat-input']";
+pub const MODEL_SELECTOR: &str = "[data-testid='model-selector-dropdown']";
+pub const FILE_INPUT_SELECTOR: &str = "input[data-testid='file-upload']";
+pub const ATTACHMENT_SELECTOR: &str = "[data-testid='file-thumbnail']";
+pub const COPY_ACTION_SELECTOR: &str = "[data-testid='action-bar-copy']";
+pub const EFFORT_TRIGGER_SELECTOR: &str = "[data-testid='effort-menu-trigger']";
+pub const EFFORT_HOVER_MARKER: &str = "yoetz-claude-effort-target";
+pub const FILE_INPUT_MARKER: &str = "yoetz-claude-upload-target";
+pub const STABLE_IDLE_FLOOR_MS: u64 = 90_000;
+pub const STABLE_IDLE_INTERVAL_MULTIPLIER: u64 = 3;
+
+pub fn stable_idle_threshold_ms(interval_ms: u64) -> u64 {
+    interval_ms
+        .saturating_mul(STABLE_IDLE_INTERVAL_MULTIPLIER)
+        .max(STABLE_IDLE_FLOOR_MS)
+}
+
+pub fn generate_run_id() -> String {
+    crate::chatgpt_web::generate_run_id()
+}
+
+pub fn validate_thread_mode(raw: Option<&str>) -> Result<()> {
+    match raw.map(str::trim).filter(|value| !value.is_empty()) {
+        None | Some("fresh") => Ok(()),
+        Some(other) => bail!(
+            "Claude chrome-devtools-mcp supports only `thread=fresh`; got `{other}`. Conversation resume is native-extension-only"
+        ),
+    }
+}
+
+pub fn normalize_conversation(raw: &str) -> Result<WebConversation> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        bail!("Claude conversation must not be empty");
+    }
+    let id = if raw.contains("://") {
+        conversation_id_from_url(raw)?
+    } else {
+        raw.to_string()
+    };
+    validate_conversation_id(&id)?;
+    Ok(WebConversation {
+        url: conversation_url(&id),
+        id,
+    })
+}
+
+pub fn conversation_url(conversation_id: &str) -> String {
+    format!("https://claude.ai/chat/{conversation_id}")
+}
+
+fn conversation_id_from_url(raw: &str) -> Result<String> {
+    let prefix = "https://claude.ai/chat/";
+    if !raw.starts_with(prefix) {
+        bail!("Claude conversation URL must use https://claude.ai/chat/<uuid>");
+    }
+    let id = &raw[prefix.len()..];
+    if id.contains(['?', '#', '/']) {
+        bail!("Claude conversation URL must not contain a query or fragment");
+    }
+    Ok(id.to_string())
+}
+
+fn validate_conversation_id(id: &str) -> Result<()> {
+    let bytes = id.as_bytes();
+    let valid = bytes.len() == 36
+        && [8, 13, 18, 23]
+            .into_iter()
+            .all(|index| bytes[index] == b'-')
+        && bytes
+            .iter()
+            .enumerate()
+            .all(|(index, byte)| [8, 13, 18, 23].contains(&index) || byte.is_ascii_hexdigit());
+    if !valid {
+        bail!("Claude conversation id must be a UUID");
+    }
+    Ok(())
+}
+
+pub fn mark_claude_url(run_id: &str) -> Result<String> {
+    crate::chatgpt_web::validate_run_id(run_id)
+        .map_err(|_| anyhow!("invalid Claude run id `{run_id}`"))?;
+    Ok(format!("{CLAUDE_URL}?_yoetz={run_id}"))
+}
+
+pub fn build_set_window_name_js(run_id: &str) -> Result<String> {
+    crate::chatgpt_web::validate_run_id(run_id)
+        .map_err(|_| anyhow!("invalid Claude run id `{run_id}`"))?;
+    let marker = serde_json::to_string(&format!("yoetz:{run_id}"))?;
+    Ok(format!(
+        "() => {{ window.name = {marker}; return window.name; }}"
+    ))
+}
+
+pub fn build_wait_for_composer_function() -> String {
+    format!(
+        r##"async () => {{
+  const deadline = Date.now() + 20000;
+  const read = () => {{
+    const composer = document.querySelector({composer});
+    const url = window.location.href || "";
+    const title = document.title || "";
+    const bodyText = String(document.body?.innerText || "").replace(/\s+/g, " ").trim().slice(0, 300);
+    const haystack = `${{title}} ${{bodyText}}`.toLowerCase();
+    if (composer) return {{ status: "ready", url, title, bodyText }};
+    if (/cloudflare|checking your browser|attention required|security check|just a moment|verify you are human|cf-chl/.test(haystack))
+      return {{ status: "challenge", url, title, bodyText }};
+    if (/log in|login|sign in|sign up|continue with google|\/login|\/oauth/.test(`${{haystack}} ${{url.toLowerCase()}}`))
+      return {{ status: "login", url, title, bodyText }};
+    return {{ status: "pending", url, title, bodyText }};
+  }};
+  let state = read();
+  while (state.status === "pending" && Date.now() < deadline) {{
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    state = read();
+  }}
+  if (state.status === "pending") state.status = "timeout";
+  return state;
+}}"##,
+        composer = serde_json::to_string(COMPOSER_SELECTOR).expect("selector JSON")
+    )
+}
+
+pub fn build_open_model_menu_function() -> String {
+    format!(
+        r##"() => {{
+  const button = document.querySelector({selector});
+  if (!button) return {{ status: "missing", diagnostics: {{ selector: {selector} }} }};
+  if (button.getAttribute("aria-expanded") !== "true") button.click();
+  return {{ status: button.getAttribute("aria-expanded") === "true" ? "opened" : "opening", label: (button.innerText || button.textContent || "").trim() }};
+}}"##,
+        selector = serde_json::to_string(MODEL_SELECTOR).expect("selector JSON")
+    )
+}
+
+pub fn build_close_model_menu_function() -> String {
+    format!(
+        r##"() => {{
+  const button = document.querySelector({selector});
+  if (!button) return {{ status: "missing" }};
+  if (button.getAttribute("aria-expanded") === "true") button.click();
+  return {{ status: "closed" }};
+}}"##,
+        selector = serde_json::to_string(MODEL_SELECTOR).expect("selector JSON")
+    )
+}
+
+pub fn build_select_fable_function() -> String {
+    r##"() => {
+  const visible = (el) => !!el && el.getClientRects().length > 0;
+  const normalize = (value) => String(value || "").replace(/\s+/g, " ").trim();
+  const options = Array.from(document.querySelectorAll("[role='menuitemradio']"))
+    .filter(visible)
+    .map((el) => ({ el, text: normalize(el.innerText || el.textContent) }))
+    .filter(({ text }) => text);
+  const fable = options.find(({ text }) => text.toLowerCase().startsWith("fable 5"));
+  if (!fable) return { status: "unavailable", options: options.map(({ text }) => text).slice(0, 40) };
+  fable.el.click();
+  return { status: "selected", selected: fable.text, options: options.map(({ text }) => text).slice(0, 40) };
+}"##.to_string()
+}
+
+/// Mark the visible Effort parent row so the CDP driver can dispatch a real
+/// mouse-moved event to it. JS-synthesized hover is not sufficient for Radix.
+pub fn build_mark_effort_parent_function() -> String {
+    format!(
+        r##"() => {{
+  const visible = (el) => !!el && el.getClientRects().length > 0;
+  const normalize = (value) => String(value || "").replace(/\s+/g, " ").trim();
+  document.querySelectorAll(`[title='{marker}']`).forEach((el) => el.removeAttribute("title"));
+  const options = Array.from(document.querySelectorAll("[role='menuitem'], [role='menuitemradio']"))
+    .filter(visible)
+    .map((el) => ({{ el, text: normalize(el.innerText || el.textContent) }}))
+    .filter(({{ text }}) => text);
+  const effort = document.querySelector("{effort_trigger}");
+  const effortText = normalize(effort?.innerText || effort?.textContent);
+  if (!effort) return {{ status: "unavailable", options: options.map(({{ text }}) => text).slice(0, 40) }};
+  effort.setAttribute("title", "{marker}");
+  return {{ status: "marked", marker: "{marker}", text: effortText, options: options.map(({{ text }}) => text).slice(0, 40) }};
+}}"##,
+        marker = EFFORT_HOVER_MARKER,
+        effort_trigger = EFFORT_TRIGGER_SELECTOR,
+    )
+}
+
+pub fn build_select_max_function() -> String {
+    r##"() => {
+  const visible = (el) => !!el && el.getClientRects().length > 0;
+  const normalize = (value) => String(value || "").replace(/\s+/g, " ").trim();
+  const options = Array.from(document.querySelectorAll("[role='menuitemradio'][data-testid^='effort-option-']"))
+    .filter(visible)
+    .map((el) => ({ el, text: normalize(el.innerText || el.textContent) }))
+    .filter(({ text }) => /^(Low|Medium|High|Extra|Max)(?:\b|$)/i.test(text));
+  const max = document.querySelector("[role='menuitemradio'][data-testid='effort-option-max']");
+  if (!max) return { status: "unavailable", effortOptions: options.map(({ text }) => text) };
+  const selected = normalize(max.innerText || max.textContent);
+  max.click();
+  return { status: "selected", selected, effortOptions: options.map(({ text }) => text) };
+}"##.to_string()
+}
+
+pub fn build_ensure_thinking_on_function() -> String {
+    r##"() => {
+  const visible = (el) => !!el && el.getClientRects().length > 0;
+  const normalize = (value) => String(value || "").replace(/\s+/g, " ").trim();
+  const switches = Array.from(document.querySelectorAll("span[role='switch'][aria-checked]"))
+    .filter(visible);
+  const thinking = switches.find((el) => /Thinking/i.test(normalize(
+    el.getAttribute("aria-label") || el.closest("[role='menuitem']")?.innerText || el.parentElement?.innerText
+  )));
+  if (!thinking) return { status: "unavailable", switches: switches.map((el) => normalize(el.getAttribute("aria-label") || el.parentElement?.innerText)).slice(0, 20) };
+  const before = thinking.getAttribute("aria-checked");
+  if (before !== "true") thinking.click();
+  return { status: before === "true" ? "already_on" : "clicked", before };
+}"##.to_string()
+}
+
+pub fn build_verify_fable_max_thinking_function() -> String {
+    format!(
+        r##"() => {{
+  const visible = (el) => !!el && el.getClientRects().length > 0;
+  const normalize = (value) => String(value || "").replace(/\s+/g, " ").trim();
+  const modelChip = normalize(document.querySelector({model_selector})?.innerText || document.querySelector({model_selector})?.textContent);
+  const visibleText = Array.from(document.querySelectorAll("[role='menuitem'], [role='menuitemradio'], button, [role='switch']"))
+    .filter(visible).map((el) => normalize(el.innerText || el.textContent)).filter(Boolean);
+  const effortChip = Array.from(document.querySelectorAll("button, [role='button']"))
+    .filter(visible).map((el) => normalize(el.innerText || el.textContent))
+    .find((text) => /^(Low|Medium|High|Extra|Max)(?:\b|$)/i.test(text)) || "";
+  const modelSelected = Array.from(document.querySelectorAll("[role='menuitemradio'][aria-checked='true']"))
+    .some((el) => normalize(el.innerText || el.textContent).toLowerCase().startsWith("fable 5"));
+  const maxOption = document.querySelector("[role='menuitemradio'][data-testid='effort-option-max']");
+  const switches = Array.from(document.querySelectorAll("span[role='switch'][aria-checked]"))
+    .filter(visible);
+  const thinking = switches.find((el) => /Thinking/i.test(normalize(
+    el.getAttribute("aria-label") || el.closest("[role='menuitem']")?.innerText || el.parentElement?.innerText
+  )));
+  const thinkingChecked = thinking?.getAttribute("aria-checked") === "true";
+  const modelVerified = modelSelected && /\bFable 5\b/i.test(modelChip);
+  const maxVerified = maxOption?.getAttribute("aria-checked") === "true" && /\bMax\b/i.test(modelChip);
+  return {{
+    status: modelVerified && maxVerified && thinkingChecked ? "selected" : "mismatch",
+    modelVerified, maxVerified, thinkingChecked, modelChip, effortChip,
+    options: visibleText.slice(0, 50),
+    thinkingAriaChecked: thinking?.getAttribute("aria-checked") || null,
+  }};
+}}"##,
+        model_selector = serde_json::to_string(MODEL_SELECTOR).expect("selector JSON")
+    )
+}
+
+pub fn model_selection_status(value: &Value) -> WebModelSelectionStatus {
+    match value.get("status").and_then(Value::as_str) {
+        Some("selected")
+            if value.get("modelVerified").and_then(Value::as_bool) == Some(true)
+                && value.get("maxVerified").and_then(Value::as_bool) == Some(true)
+                && value.get("thinkingChecked").and_then(Value::as_bool) == Some(true) =>
+        {
+            WebModelSelectionStatus::Selected
+        }
+        Some("unavailable") => WebModelSelectionStatus::Unavailable,
+        _ => WebModelSelectionStatus::Mismatch,
+    }
+}
+
+pub fn build_scope_file_input_function() -> String {
+    format!(
+        r##"() => {{
+  const input = document.querySelector({selector});
+  if (!input) return {{ status: "missing", selector: {selector} }};
+  input.setAttribute("title", "{marker}");
+  return {{ status: "marked", marker: "{marker}" }};
+}}"##,
+        selector = serde_json::to_string(FILE_INPUT_SELECTOR).expect("selector JSON"),
+        marker = FILE_INPUT_MARKER
+    )
+}
+
+pub fn build_attachment_probe_function(file_name: &str) -> Result<String> {
+    let file_name = serde_json::to_string(file_name)?;
+    Ok(format!(
+        r##"() => {{
+  const expected = {file_name};
+  const nodes = Array.from(document.querySelectorAll("{attachment_selector}"));
+  const labels = nodes.map((node) => String(node.querySelector("h3")?.textContent || "").trim());
+  const matched = nodes.find((node) =>
+    String(node.querySelector("h3")?.textContent || "").trim() === expected &&
+    !!node.querySelector("button[aria-label='Remove']")
+  );
+  const send = document.querySelector("button[aria-label='Send message']");
+  const sendEnabled = !!send && !send.disabled && send.getAttribute("aria-disabled") !== "true";
+  return {{ status: matched && sendEnabled ? "candidate" : "pending", count: nodes.length, labels, sendEnabled }};
+}}"##,
+        attachment_selector = ATTACHMENT_SELECTOR
+    ))
+}
+
+pub fn build_focus_composer_function() -> String {
+    format!(
+        "() => {{ const el = document.querySelector({}); if (el) el.focus(); return !!el; }}",
+        serde_json::to_string(COMPOSER_SELECTOR).expect("selector JSON")
+    )
+}
+
+pub fn build_send_function() -> String {
+    format!(
+        r##"() => {{
+  const assistantRoots = Array.from(document.querySelectorAll("[data-is-streaming]"));
+  const copyButtons = document.querySelectorAll("{copy_selector}").length;
+  const candidates = Array.from(document.querySelectorAll("button"));
+  const send = document.querySelector("button[aria-label='Send message']");
+  const diagnostics = {{ buttonLabels: candidates.filter((el) => el.getClientRects().length > 0).map((el) => `${{el.getAttribute("aria-label") || ""}} ${{el.getAttribute("data-testid") || ""}} ${{el.innerText || ""}}`.trim()).filter(Boolean).slice(0, 40) }};
+  if (!send) return {{ status: "missing", assistantCount: assistantRoots.length, assistantLastLength: 0, copyButtons, diagnostics }};
+  if (send.disabled || send.getAttribute("aria-disabled") === "true") return {{ status: "disabled", assistantCount: assistantRoots.length, assistantLastLength: 0, copyButtons, diagnostics }};
+  const last = assistantRoots.at(-1);
+  const lastBody = last?.querySelector?.(".font-claude-response");
+  const assistantLastLength = String(lastBody?.innerText || lastBody?.textContent || "").trim().length;
+  send.click();
+  return {{ status: "sent", assistantCount: assistantRoots.length, assistantLastLength, copyButtons, diagnostics }};
+}}"##,
+        copy_selector = COPY_ACTION_SELECTOR
+    )
+}
+
+pub fn build_response_poll_function() -> String {
+    format!(
+        r##"() => {{
+  const visible = (el) => !!el && el.getClientRects().length > 0;
+  const copyButtons = Array.from(document.querySelectorAll("{copy_selector}")).filter(visible);
+  const nodes = Array.from(document.querySelectorAll("[data-is-streaming]"));
+  const last = nodes.at(-1) || null;
+  const turn = last?.closest?.("[data-testid*='turn'], article") || last;
+  const stop = document.querySelector("button[aria-label='Stop response']");
+  const thinking = last?.getAttribute?.("data-is-streaming") === "true" &&
+    !!last?.querySelector?.("button[class*='group/status']");
+  const streaming = !!stop || last?.getAttribute?.("data-is-streaming") === "true";
+  const send = document.querySelector("button[aria-label='Send message']");
+  const text = String(last?.querySelector?.(".font-claude-response")?.innerText || last?.querySelector?.(".font-claude-response")?.textContent || "").trim();
+  const err = Array.from(document.querySelectorAll("[role='alert'], [data-testid*='error']")).find(visible);
+  return {{
+    count: nodes.length, length: text.length, text, streaming,
+    sendState: !send ? "missing" : send.disabled || send.getAttribute("aria-disabled") === "true" ? "disabled" : "enabled",
+    hasStopButton: !!stop, thinking,
+    copyButtons: turn ? Array.from(turn.querySelectorAll("{copy_selector}")).filter(visible).length : copyButtons.length,
+    error: String(err?.innerText || "").trim().slice(0, 300),
+  }};
+}}"##,
+        copy_selector = COPY_ACTION_SELECTOR
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn stable_idle_has_ninety_second_floor() {
+        assert_eq!(stable_idle_threshold_ms(1_000), 90_000);
+        assert_eq!(stable_idle_threshold_ms(40_000), 120_000);
+    }
+
+    #[test]
+    fn normalizes_uuid_and_exact_https_claude_url() {
+        let id = "123e4567-e89b-12d3-a456-426614174000";
+        for raw in [id, &format!("https://claude.ai/chat/{id}")] {
+            assert_eq!(normalize_conversation(raw).unwrap().id, id);
+        }
+        for raw in [
+            "http://claude.ai/chat/123e4567-e89b-12d3-a456-426614174000",
+            "https://evil.example/chat/123e4567-e89b-12d3-a456-426614174000",
+            "https://claude.ai/chat/123e4567-e89b-12d3-a456-426614174000/extra",
+            "not-a-uuid",
+        ] {
+            assert!(normalize_conversation(raw).is_err(), "accepted {raw}");
+        }
+    }
+
+    #[test]
+    fn marker_url_and_window_name_are_run_scoped() {
+        let run = "20260718T102228Z_ab12cd";
+        assert_eq!(
+            mark_claude_url(run).unwrap(),
+            format!("https://claude.ai/new?_yoetz={run}")
+        );
+        assert!(build_set_window_name_js(run)
+            .unwrap()
+            .contains(&format!("window.name = \"yoetz:{run}\"")));
+    }
+
+    #[test]
+    fn model_scripts_bind_fable_max_real_hover_and_thinking_postcondition() {
+        assert!(build_open_model_menu_function().contains("model-selector-dropdown"));
+        assert!(build_select_fable_function().contains("fable 5"));
+        assert!(build_mark_effort_parent_function().contains(EFFORT_HOVER_MARKER));
+        assert!(build_select_max_function().contains("Max"));
+        let thinking = build_ensure_thinking_on_function();
+        assert!(thinking.contains("Thinking"));
+        assert!(thinking.contains("aria-checked"));
+        let verify = build_verify_fable_max_thinking_function();
+        assert!(verify.contains("modelVerified && maxVerified && thinkingChecked"));
+    }
+
+    #[test]
+    fn selected_status_requires_all_three_verified_postconditions() {
+        let selected = json!({"status":"selected","modelVerified":true,"maxVerified":true,"thinkingChecked":true});
+        assert_eq!(
+            model_selection_status(&selected),
+            WebModelSelectionStatus::Selected
+        );
+        for key in ["modelVerified", "maxVerified", "thinkingChecked"] {
+            let mut mismatch = selected.clone();
+            mismatch[key] = Value::Bool(false);
+            assert_eq!(
+                model_selection_status(&mismatch),
+                WebModelSelectionStatus::Mismatch
+            );
+        }
+        assert_eq!(
+            model_selection_status(&json!({"status":"unavailable"})),
+            WebModelSelectionStatus::Unavailable
+        );
+    }
+
+    #[test]
+    fn upload_send_and_response_scripts_use_claude_testids() {
+        assert!(build_scope_file_input_function().contains("file-upload"));
+        let attachment = build_attachment_probe_function("bundle.md").unwrap();
+        assert!(attachment.contains("file-thumbnail"));
+        assert!(attachment.contains("querySelector(\"h3\")"));
+        assert!(attachment.contains("button[aria-label='Remove']"));
+        assert!(attachment.contains("sendEnabled ? \"candidate\""));
+        let send = build_send_function();
+        assert!(send.contains("assistantCount"));
+        assert!(send.contains(".font-claude-response"));
+        assert!(send.contains("status: \"sent\""));
+        let poll = build_response_poll_function();
+        assert!(poll.contains("action-bar-copy"));
+        assert!(poll.contains("data-is-streaming"));
+        assert!(poll.contains("group/status"));
+        assert!(poll.contains("thinking"));
+    }
+}

--- a/crates/yoetz-cli/src/claude_web.rs
+++ b/crates/yoetz-cli/src/claude_web.rs
@@ -168,8 +168,8 @@ pub fn build_select_fable_function() -> String {
 }"##.to_string()
 }
 
-/// Mark the visible Effort parent row so the CDP driver can dispatch a real
-/// mouse-moved event to it. JS-synthesized hover is not sufficient for Radix.
+/// Mark the visible Effort parent row so the CDP driver can try a physical
+/// mouse move before falling back to the DOM hover sequence below.
 pub fn build_mark_effort_parent_function() -> String {
     format!(
         r##"() => {{
@@ -187,6 +187,44 @@ pub fn build_mark_effort_parent_function() -> String {
   return {{ status: "marked", marker: "{marker}", text: effortText, options: options.map(({{ text }}) => text).slice(0, 40) }};
 }}"##,
         marker = EFFORT_HOVER_MARKER,
+        effort_trigger = EFFORT_TRIGGER_SELECTOR,
+    )
+}
+
+/// Open Claude's Effort submenu with the attributed pointer/mouse sequence
+/// used by the native extension. Claude's Base UI hover intent can ignore a
+/// single physical mouse teleport while the model menu is still animating.
+pub fn build_open_effort_submenu_function() -> String {
+    format!(
+        r##"() => {{
+  const visible = (el) => !!el && el.getClientRects().length > 0;
+  const normalize = (value) => String(value || "").replace(/\s+/g, " ").trim();
+  const effortOptions = () => Array.from(document.querySelectorAll("[role='menuitemradio'][data-testid^='effort-option-']"))
+    .filter(visible)
+    .map((el) => normalize(el.innerText || el.textContent))
+    .filter(Boolean);
+  const existing = effortOptions();
+  if (existing.length > 0) return {{ status: "already_open", effortOptions: existing }};
+  const effort = document.querySelector("{effort_trigger}");
+  if (!visible(effort)) return {{ status: "unavailable", effortOptions: existing }};
+  const rect = effort.getBoundingClientRect?.() || {{ left: 0, top: 0, width: 1, height: 1 }};
+  const clientX = Number(rect.left || 0) + Math.max(1, Number(rect.width || 1) / 2);
+  const clientY = Number(rect.top || 0) + Math.max(1, Number(rect.height || 1) / 2);
+  for (const type of ["pointerover", "pointerenter", "pointermove", "mouseover", "mouseenter", "mousemove"]) {{
+    const pointer = type.startsWith("pointer") && typeof globalThis.PointerEvent !== "undefined";
+    const EventType = pointer ? globalThis.PointerEvent : globalThis.MouseEvent;
+    if (typeof EventType !== "function") continue;
+    effort.dispatchEvent(new EventType(type, {{
+      bubbles: true,
+      cancelable: true,
+      view: globalThis.window,
+      clientX,
+      clientY,
+      ...(pointer ? {{ pointerType: "mouse", pointerId: 1, isPrimary: true }} : {{}})
+    }}));
+  }}
+  return {{ status: "dispatched", effort: normalize(effort.innerText || effort.textContent), effortOptions: existing }};
+}}"##,
         effort_trigger = EFFORT_TRIGGER_SELECTOR,
     )
 }
@@ -273,10 +311,11 @@ pub fn model_selection_status(value: &Value) -> WebModelSelectionStatus {
 pub fn build_scope_file_input_function() -> String {
     format!(
         r##"() => {{
-  const input = document.querySelector({selector});
-  if (!input) return {{ status: "missing", selector: {selector} }};
+  const inputs = Array.from(document.querySelectorAll({selector}));
+  if (inputs.length !== 1) return {{ status: "unavailable", selector: {selector}, count: inputs.length }};
+  const input = inputs[0];
   input.setAttribute("title", "{marker}");
-  return {{ status: "marked", marker: "{marker}" }};
+  return {{ status: "marked", marker: "{marker}", count: inputs.length }};
 }}"##,
         selector = serde_json::to_string(FILE_INPUT_SELECTOR).expect("selector JSON"),
         marker = FILE_INPUT_MARKER
@@ -400,10 +439,23 @@ mod tests {
     }
 
     #[test]
-    fn model_scripts_bind_fable_max_real_hover_and_thinking_postcondition() {
+    fn model_scripts_bind_fable_max_hover_fallback_and_thinking_postcondition() {
         assert!(build_open_model_menu_function().contains("model-selector-dropdown"));
         assert!(build_select_fable_function().contains("fable 5"));
         assert!(build_mark_effort_parent_function().contains(EFFORT_HOVER_MARKER));
+        let hover = build_open_effort_submenu_function();
+        for event in [
+            "pointerover",
+            "pointerenter",
+            "pointermove",
+            "mouseover",
+            "mouseenter",
+            "mousemove",
+        ] {
+            assert!(hover.contains(event));
+        }
+        assert!(hover.contains("already_open"));
+        assert!(hover.contains("effort-option-"));
         assert!(build_select_max_function().contains("Max"));
         let thinking = build_ensure_thinking_on_function();
         assert!(thinking.contains("Thinking"));
@@ -435,7 +487,11 @@ mod tests {
 
     #[test]
     fn upload_send_and_response_scripts_use_claude_testids() {
-        assert!(build_scope_file_input_function().contains("file-upload"));
+        let scope = build_scope_file_input_function();
+        assert!(scope.contains("file-upload"));
+        assert!(scope.contains("querySelectorAll"));
+        assert!(scope.contains("inputs.length !== 1"));
+        assert!(scope.contains("count: inputs.length"));
         let attachment = build_attachment_probe_function("bundle.md").unwrap();
         assert!(attachment.contains("file-thumbnail"));
         assert!(attachment.contains("pasted content"));

--- a/crates/yoetz-cli/src/claude_web.rs
+++ b/crates/yoetz-cli/src/claude_web.rs
@@ -294,9 +294,13 @@ pub fn build_attachment_probe_function(file_name: &str) -> Result<String> {
     String(node.querySelector("h3")?.textContent || "").trim() === expected &&
     !!node.querySelector("button[aria-label='Remove']")
   );
+  const pastedContent = nodes.find((node) =>
+    String(node.querySelector("h3")?.textContent || node.textContent || "").replace(/\s+/g, " ").trim().toLowerCase().includes("pasted content") &&
+    !!node.querySelector("button[aria-label='Remove']")
+  );
   const send = document.querySelector("button[aria-label='Send message']");
   const sendEnabled = !!send && !send.disabled && send.getAttribute("aria-disabled") !== "true";
-  return {{ status: matched && sendEnabled ? "candidate" : "pending", count: nodes.length, labels, sendEnabled }};
+  return {{ status: (matched || pastedContent) && sendEnabled ? "candidate" : "pending", count: nodes.length, labels, sendEnabled, pastedContent: !!pastedContent }};
 }}"##,
         attachment_selector = ATTACHMENT_SELECTOR
     ))
@@ -434,6 +438,7 @@ mod tests {
         assert!(build_scope_file_input_function().contains("file-upload"));
         let attachment = build_attachment_probe_function("bundle.md").unwrap();
         assert!(attachment.contains("file-thumbnail"));
+        assert!(attachment.contains("pasted content"));
         assert!(attachment.contains("querySelector(\"h3\")"));
         assert!(attachment.contains("button[aria-label='Remove']"));
         assert!(attachment.contains("sendEnabled ? \"candidate\""));

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -13,7 +13,7 @@
 //! - Daemon-managed browser instances with auto-reconnect
 //! - Single script executes batch operations (fewer IPC round-trips)
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use reqwest::Url;
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -31,7 +31,9 @@ use std::time::{Duration, Instant};
 use yoetz_core::paths::home_dir;
 
 use crate::chatgpt_recipe::AnyhowResultExt;
-use crate::{browser, chatgpt_recipe, chatgpt_web};
+use crate::claude_recipe::AnyhowResultExt as ClaudeAnyhowResultExt;
+use crate::web_recipe::{WebModelSelectionStatus, WebRecipeTransportPhase};
+use crate::{browser, chatgpt_recipe, chatgpt_web, claude_recipe, claude_web};
 
 /// Cached dev-browser resolution.
 static DEV_BROWSER: OnceLock<String> = OnceLock::new();
@@ -55,6 +57,10 @@ const CHATGPT_SEND_TIMEOUT_MS_DEFAULT: u64 = 120_000;
 const CHATGPT_BROWSER_NAME: &str = "yoetz-chatgpt";
 const CHATGPT_AUTH_PROBE_PAGE_NAME: &str = "yoetz-chatgpt-main";
 const CHATGPT_RECIPE_PAGE_NAME_PREFIX: &str = "yoetz-chatgpt-run";
+const CLAUDE_BROWSER_NAME: &str = "yoetz-claude";
+const CLAUDE_AUTH_PROBE_PAGE_NAME: &str = "yoetz-claude-main";
+const CLAUDE_RECIPE_PAGE_NAME_PREFIX: &str = "yoetz-claude-run";
+const CLAUDE_NO_PROGRESS_POLL_LIMIT: u8 = 5;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ChatgptPollSettings {
@@ -68,6 +74,17 @@ pub struct ChatgptRecipeRunResult {
     pub model_used: Option<String>,
     pub model_selection_status: chatgpt_recipe::ChatgptModelSelectionStatus,
     pub warnings: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ClaudeRecipeRunResult {
+    pub response: String,
+    pub model_used: Option<String>,
+    pub model_selection_status: WebModelSelectionStatus,
+    pub warnings: Vec<String>,
+    pub conversation_id: Option<String>,
+    pub conversation_url: Option<String>,
+    pub used_clipboard: bool,
 }
 
 impl Default for ChatgptPollSettings {
@@ -699,6 +716,19 @@ pub struct DevBrowserRecipeContext {
     pub cdp_endpoint: Option<String>,
     /// Whether to print interactive Chrome-approval guidance to stderr.
     pub show_approval_guidance: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct ClaudeDevBrowserRecipeContext {
+    pub bundle_path: Option<PathBuf>,
+    pub prompt: String,
+    pub run_id: String,
+    pub poll_settings: ChatgptPollSettings,
+    pub cdp_endpoint: Option<String>,
+    pub show_approval_guidance: bool,
+    pub upload_timeout_ms: u64,
+    pub send_timeout_ms: u64,
+    pub warnings: Vec<String>,
 }
 
 impl Default for DevBrowserRecipeContext {
@@ -1450,6 +1480,258 @@ console.log(JSON.stringify({{
     )
 }
 
+fn build_claude_prepare_script(page_name: &str, run_id: &str) -> String {
+    let page_name_json = serde_json::to_string(page_name).expect("page name JSON");
+    let marked_url_json = serde_json::to_string(
+        &claude_web::mark_claude_url(run_id).expect("validated Claude run id"),
+    )
+    .expect("Claude URL JSON");
+    let window_name_json =
+        serde_json::to_string(&format!("yoetz:{run_id}")).expect("window name JSON");
+    let wait_function_json = serde_json::to_string(&claude_web::build_wait_for_composer_function())
+        .expect("wait function JSON");
+    format!(
+        r#"
+const PAGE_NAME = {page_name_json};
+const MARKED_URL = {marked_url_json};
+const WINDOW_NAME = {window_name_json};
+const WAIT_FUNCTION_SOURCE = {wait_function_json};
+const page = await browser.getPage(PAGE_NAME);
+await page.goto(MARKED_URL, {{ waitUntil: "domcontentloaded" }});
+await page.waitForTimeout(800);
+await page.evaluate((name) => {{ window.name = name; return window.name; }}, WINDOW_NAME);
+const state = await page.evaluate((source) => eval("(" + source + ")")(), WAIT_FUNCTION_SOURCE);
+console.log(JSON.stringify(state));
+"#
+    )
+}
+
+fn build_claude_model_script(page_name: &str) -> String {
+    let page_name_json = serde_json::to_string(page_name).expect("page name JSON");
+    let open_json = serde_json::to_string(&claude_web::build_open_model_menu_function())
+        .expect("open model function JSON");
+    let close_json = serde_json::to_string(&claude_web::build_close_model_menu_function())
+        .expect("close model function JSON");
+    let fable_json = serde_json::to_string(&claude_web::build_select_fable_function())
+        .expect("Fable function JSON");
+    let mark_effort_json = serde_json::to_string(&claude_web::build_mark_effort_parent_function())
+        .expect("mark effort function JSON");
+    let max_json =
+        serde_json::to_string(&claude_web::build_select_max_function()).expect("Max function JSON");
+    let thinking_json = serde_json::to_string(&claude_web::build_ensure_thinking_on_function())
+        .expect("Thinking function JSON");
+    let verify_json =
+        serde_json::to_string(&claude_web::build_verify_fable_max_thinking_function())
+            .expect("verification function JSON");
+    let effort_selector_json =
+        serde_json::to_string(&format!("[title='{}']", claude_web::EFFORT_HOVER_MARKER))
+            .expect("effort selector JSON");
+    format!(
+        r#"
+const PAGE_NAME = {page_name_json};
+const OPEN = {open_json};
+const CLOSE = {close_json};
+const SELECT_FABLE = {fable_json};
+const MARK_EFFORT = {mark_effort_json};
+const SELECT_MAX = {max_json};
+const ENABLE_THINKING = {thinking_json};
+const VERIFY = {verify_json};
+const EFFORT_SELECTOR = {effort_selector_json};
+const page = await browser.getPage(PAGE_NAME);
+let state = await page.evaluate((source) => eval("(" + source + ")")(), OPEN);
+if (!['opened', 'opening'].includes(state?.status)) {{
+  console.log(JSON.stringify({{ status: 'error', error: 'Claude model selector unavailable', diagnostics: state }}));
+  return;
+}}
+await page.waitForTimeout(250);
+state = await page.evaluate((source) => eval("(" + source + ")")(), SELECT_FABLE);
+if (state?.status !== 'selected') {{
+  console.log(JSON.stringify({{ status: 'unavailable', error: 'Fable 5 is unavailable', diagnostics: state }}));
+  return;
+}}
+await page.waitForTimeout(300);
+await page.evaluate((source) => eval("(" + source + ")")(), OPEN);
+state = await page.evaluate((source) => eval("(" + source + ")")(), MARK_EFFORT);
+if (state?.status !== 'marked') {{
+  console.log(JSON.stringify({{ status: 'unavailable', error: 'Claude Effort menu unavailable', diagnostics: state }}));
+  return;
+}}
+await page.locator(EFFORT_SELECTOR).first().hover();
+await page.waitForTimeout(400);
+state = await page.evaluate((source) => eval("(" + source + ")")(), SELECT_MAX);
+if (state?.status !== 'selected') {{
+  console.log(JSON.stringify({{ status: 'unavailable', error: 'Claude Max effort unavailable', diagnostics: state }}));
+  return;
+}}
+await page.waitForTimeout(300);
+await page.evaluate((source) => eval("(" + source + ")")(), OPEN);
+await page.evaluate((source) => eval("(" + source + ")")(), MARK_EFFORT);
+await page.locator(EFFORT_SELECTOR).first().hover();
+await page.waitForTimeout(400);
+state = await page.evaluate((source) => eval("(" + source + ")")(), ENABLE_THINKING);
+if (!['already_on', 'clicked'].includes(state?.status)) {{
+  console.log(JSON.stringify({{ status: 'unavailable', error: 'Claude Thinking switch unavailable', diagnostics: state }}));
+  return;
+}}
+await page.waitForTimeout(300);
+await page.evaluate((source) => eval("(" + source + ")")(), CLOSE);
+await page.waitForTimeout(250);
+await page.evaluate((source) => eval("(" + source + ")")(), OPEN);
+state = await page.evaluate((source) => eval("(" + source + ")")(), MARK_EFFORT);
+if (state?.status !== 'marked') {{
+  console.log(JSON.stringify({{ status: 'unavailable', error: 'Claude Effort menu unavailable during verification', diagnostics: state }}));
+  return;
+}}
+await page.locator(EFFORT_SELECTOR).first().hover();
+await page.waitForTimeout(400);
+const verification = await page.evaluate((source) => eval("(" + source + ")")(), VERIFY);
+await page.evaluate((source) => eval("(" + source + ")")(), CLOSE);
+console.log(JSON.stringify(verification));
+"#
+    )
+}
+
+fn build_claude_delivery_script(
+    page_name: &str,
+    delivery_text: &str,
+    bundle_file_name: Option<&str>,
+    use_clipboard: bool,
+    upload_timeout_ms: u64,
+    send_timeout_ms: u64,
+) -> String {
+    let page_name_json = serde_json::to_string(page_name).expect("page name JSON");
+    let delivery_text_json = serde_json::to_string(delivery_text).expect("delivery text JSON");
+    let bundle_name_json = serde_json::to_string(&bundle_file_name).expect("bundle file name JSON");
+    let composer_json =
+        serde_json::to_string(claude_web::COMPOSER_SELECTOR).expect("composer selector JSON");
+    let send_json =
+        serde_json::to_string(&claude_web::build_send_function()).expect("send function JSON");
+    let attachment_json = bundle_file_name
+        .map(claude_web::build_attachment_probe_function)
+        .transpose()
+        .expect("attachment probe")
+        .map(|source| serde_json::to_string(&source).expect("attachment probe JSON"))
+        .unwrap_or_else(|| "null".to_string());
+    format!(
+        r#"
+const PAGE_NAME = {page_name_json};
+const DELIVERY_TEXT = {delivery_text_json};
+const BUNDLE_FILE_NAME = {bundle_name_json};
+const USE_CLIPBOARD = {use_clipboard};
+const UPLOAD_TIMEOUT_MS = {upload_timeout_ms};
+const SEND_TIMEOUT_MS = {send_timeout_ms};
+const COMPOSER_SELECTOR = {composer_json};
+const SEND_FUNCTION_SOURCE = {send_json};
+const ATTACHMENT_FUNCTION_SOURCE = {attachment_json};
+const page = await browser.getPage(PAGE_NAME);
+const composer = page.locator(COMPOSER_SELECTOR).first();
+await composer.waitFor({{ state: "visible", timeout: 20000 }});
+await composer.click();
+if (USE_CLIPBOARD) {{
+  await page.keyboard.press("Meta+V");
+  const deadline = Date.now() + UPLOAD_TIMEOUT_MS;
+  let ready = false;
+  let lastState = null;
+  while (Date.now() < deadline) {{
+    lastState = ATTACHMENT_FUNCTION_SOURCE
+      ? await page.evaluate((source) => eval("(" + source + ")")(), ATTACHMENT_FUNCTION_SOURCE)
+      : null;
+    const composerLength = await composer.evaluate((el) => String(el.innerText || el.textContent || '').trim().length);
+    if (lastState?.status === 'candidate' || lastState?.pastedContent || composerLength > 0) {{ ready = true; break; }}
+    await page.waitForTimeout(250);
+  }}
+  if (!ready) {{
+    console.log(JSON.stringify({{ status: 'error', phase: 'upload', error: 'Claude clipboard paste did not become inline content or a pasted content attachment', diagnostics: lastState }}));
+    return;
+  }}
+  await composer.pressSequentially("\n\n" + DELIVERY_TEXT, {{ delay: 5 }});
+}} else {{
+  await composer.pressSequentially(DELIVERY_TEXT, {{ delay: 1 }});
+}}
+const enableDeadline = Date.now() + SEND_TIMEOUT_MS;
+let send = null;
+while (Date.now() < enableDeadline) {{
+  send = await page.evaluate((source) => eval("(" + source + ")")(), SEND_FUNCTION_SOURCE);
+  if (send?.status === 'sent') break;
+  if (!['disabled', 'missing'].includes(send?.status)) break;
+  await page.waitForTimeout(250);
+}}
+if (send?.status !== 'sent') {{
+  console.log(JSON.stringify({{ status: 'error', phase: 'send', error: 'Claude send button did not become enabled', diagnostics: send }}));
+  return;
+}}
+console.log(JSON.stringify({{
+  status: 'sent',
+  assistantCountBeforeSend: send.assistantCount || 0,
+  assistantLastLenBeforeSend: send.assistantLastLength || 0,
+  copyButtonsBeforeSend: send.copyButtons || 0,
+  bundleFileName: BUNDLE_FILE_NAME,
+}}));
+"#
+    )
+}
+
+fn build_claude_poll_script(
+    page_name: &str,
+    assistant_count_before_send: i64,
+    assistant_last_len_before_send: i64,
+    poll_settings: ChatgptPollSettings,
+) -> String {
+    let page_name_json = serde_json::to_string(page_name).expect("page name JSON");
+    let probe_json = serde_json::to_string(&claude_web::build_response_poll_function())
+        .expect("response probe JSON");
+    let stable_idle_threshold_ms = claude_web::stable_idle_threshold_ms(poll_settings.interval_ms);
+    format!(
+        r#"
+const PAGE_NAME = {page_name_json};
+const BASELINE_COUNT = {assistant_count_before_send};
+const BASELINE_LENGTH = {assistant_last_len_before_send};
+const POLL_TIMEOUT_MS = {poll_timeout_ms};
+const POLL_INTERVAL_MS = {poll_interval_ms};
+const STABLE_IDLE_THRESHOLD_MS = {stable_idle_threshold_ms};
+const NO_PROGRESS_POLL_LIMIT = {no_progress_limit};
+const PROBE_FUNCTION_SOURCE = {probe_json};
+const page = await browser.getPage(PAGE_NAME);
+const started = Date.now();
+let stableSince = null;
+let stableKey = null;
+let noProgressPolls = 0;
+while (Date.now() - started < POLL_TIMEOUT_MS) {{
+  await page.waitForTimeout(POLL_INTERVAL_MS);
+  const state = await page.evaluate((source) => eval("(" + source + ")")(), PROBE_FUNCTION_SOURCE);
+  if (state?.error) {{
+    console.log(JSON.stringify({{ status: 'error', error: 'Claude page error: ' + state.error }}));
+    return;
+  }}
+  const inactive = !state?.streaming && !state?.hasStopButton && !state?.thinking;
+  const grew = Number(state?.count || 0) > BASELINE_COUNT ||
+    (Number(state?.count || 0) === BASELINE_COUNT && Number(state?.length || 0) > BASELINE_LENGTH);
+  const candidate = inactive && grew && Number(state?.length || 0) > 0;
+  if (inactive && !grew) noProgressPolls += 1; else noProgressPolls = 0;
+  if (noProgressPolls >= NO_PROGRESS_POLL_LIMIT) {{
+    console.log(JSON.stringify({{ status: 'error', error: 'Claude response made no post-send progress after generation became idle', diagnostics: state }}));
+    return;
+  }}
+  if (!candidate) {{ stableSince = null; stableKey = null; continue; }}
+  const key = `${{state.count}}:${{state.length}}:${{String(state.text || '').slice(-256)}}`;
+  if (stableKey !== key) {{ stableKey = key; stableSince = Date.now(); continue; }}
+  if (stableSince !== null && Date.now() - stableSince >= STABLE_IDLE_THRESHOLD_MS) {{
+    console.log(JSON.stringify({{
+      status: 'ok', response: state.text, url: await page.url(),
+      stable_for_ms: Date.now() - stableSince,
+      stable_idle_threshold_ms: STABLE_IDLE_THRESHOLD_MS,
+    }}));
+    return;
+  }}
+}}
+console.log(JSON.stringify({{ status: 'timeout', error: `Claude response timed out after ${{POLL_TIMEOUT_MS}}ms` }}));
+"#,
+        poll_timeout_ms = poll_settings.timeout_ms,
+        poll_interval_ms = poll_settings.interval_ms,
+        no_progress_limit = CLAUDE_NO_PROGRESS_POLL_LIMIT,
+    )
+}
+
 fn parse_chatgpt_recipe_result(
     stdout: &str,
     poll_timeout_ms: u64,
@@ -1716,6 +1998,264 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<ChatgptRecipe
         model_used,
         model_selection_status,
         warnings,
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn stage_macos_clipboard_from_file(path: &Path) -> Result<()> {
+    let mut bundle = fs::File::open(path)
+        .with_context(|| format!("open Claude bundle for clipboard: {}", path.display()))?;
+    let mut child = Command::new("/usr/bin/pbcopy")
+        .stdin(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("stage Claude bundle on the macOS clipboard")?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .context("open pbcopy stdin for Claude bundle")?;
+    std::io::copy(&mut bundle, &mut stdin).context("write Claude bundle to the macOS clipboard")?;
+    drop(stdin);
+    let output = child
+        .wait_with_output()
+        .context("wait for macOS clipboard staging")?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(anyhow!(
+        "could not stage Claude bundle on the macOS clipboard: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    ))
+}
+
+fn claude_delivery_text(
+    bundle_path: &Path,
+    prompt: &str,
+    warnings: &mut Vec<String>,
+) -> Result<(String, bool)> {
+    #[cfg(target_os = "macos")]
+    {
+        stage_macos_clipboard_from_file(bundle_path)?;
+        warnings.push(
+            "dev-browser delivered the Claude bundle through the macOS clipboard because the QuickJS transport cannot drive a file input; claude.ai may convert large pastes into a pasted content attachment."
+                .to_string(),
+        );
+        Ok((prompt.to_string(), true))
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let bundle = fs::read_to_string(bundle_path).with_context(|| {
+            format!(
+                "read Claude bundle {} for dev-browser inline delivery",
+                bundle_path.display()
+            )
+        })?;
+        warnings.push(
+            "dev-browser cannot drive Claude file inputs on this platform; the bundle was inserted inline and may be slow or exceed composer limits. Use chrome-devtools-mcp or chrome-extension-native for file upload."
+                .to_string(),
+        );
+        Ok((format!("{prompt}\n\n{bundle}"), false))
+    }
+}
+
+fn parse_claude_poll_result(stdout: &str, timeout_ms: u64) -> Result<(String, Option<String>)> {
+    let value: Value = serde_json::from_str(stdout.trim())
+        .with_context(|| format!("parse Claude dev-browser response result: {stdout}"))?;
+    match value.get("status").and_then(Value::as_str) {
+        Some("ok") => {
+            let response = value
+                .get("response")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .context("Claude stable-idle result did not contain response text")?;
+            Ok((
+                response.to_string(),
+                value.get("url").and_then(Value::as_str).map(str::to_string),
+            ))
+        }
+        Some("error") => Err(anyhow!(
+            "{}",
+            value
+                .get("error")
+                .and_then(Value::as_str)
+                .unwrap_or("Claude response polling failed")
+        )),
+        Some("timeout") => {
+            let message = value
+                .get("error")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .unwrap_or_else(|| {
+                    format!("Claude response polling timed out after {timeout_ms}ms")
+                });
+            Err(anyhow!(message))
+        }
+        other => Err(anyhow!(
+            "unexpected Claude dev-browser response status {other:?}: {value}"
+        )),
+    }
+}
+
+pub fn ensure_claude_auth_with_page_check_and_endpoint(cdp_endpoint: Option<&str>) -> Result<()> {
+    let run_id = claude_web::generate_run_id();
+    let script = build_claude_prepare_script(CLAUDE_AUTH_PROBE_PAGE_NAME, &run_id);
+    eprintln!("info: probing Claude auth state via dev-browser");
+    let stdout = run_script_connect_with_browser_and_endpoint(
+        &script,
+        Some(60),
+        Some(CLAUDE_BROWSER_NAME),
+        cdp_endpoint,
+    )
+    .map_err(maybe_add_dev_browser_connect_guidance)?;
+    let state: Value = serde_json::from_str(stdout.trim())
+        .with_context(|| format!("parse Claude auth probe result: {stdout}"))?;
+    match state.get("status").and_then(Value::as_str) {
+        Some("ready") => Ok(()),
+        Some("login") => Err(anyhow!(
+            "Claude login is required in the attached Chrome profile"
+        )),
+        Some("challenge") => Err(anyhow!(
+            "Cloudflare challenge detected on claude.ai; solve it in the attached Chrome window and retry"
+        )),
+        other => Err(anyhow!(
+            "Claude did not finish loading the composer; status={other:?}, diagnostics={state}"
+        )),
+    }
+}
+
+/// Run the Claude fallback through small QuickJS scripts. Rust owns phase
+/// orchestration and every script communicates through one JSON stdout value.
+pub fn run_claude_recipe(ctx: &ClaudeDevBrowserRecipeContext) -> Result<ClaudeRecipeRunResult> {
+    let bundle_path = ctx
+        .bundle_path
+        .as_deref()
+        .context("Claude dev-browser transport requires `--bundle`")?;
+    let bundle_file_name = bundle_path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .context("Claude bundle path must end in a UTF-8 filename")?;
+    let mut warnings = ctx.warnings.clone();
+    let (delivery_text, use_clipboard) =
+        claude_delivery_text(bundle_path, &ctx.prompt, &mut warnings)?;
+    let page_name = format!("{}-{}", CLAUDE_RECIPE_PAGE_NAME_PREFIX, ctx.run_id);
+    let cdp_endpoint = ctx.cdp_endpoint.as_deref();
+    let run_script = |script: &str, timeout_secs: Option<u64>| {
+        run_script_connect_with_browser_and_endpoint(
+            script,
+            timeout_secs,
+            Some(CLAUDE_BROWSER_NAME),
+            cdp_endpoint,
+        )
+    };
+
+    let prepare_script = build_claude_prepare_script(&page_name, &ctx.run_id);
+    let prepare_stdout = {
+        let attach_attempt_lock = browser::acquire_attach_attempt_lock()?;
+        if ctx.show_approval_guidance {
+            if attach_attempt_lock.waited() {
+                eprintln!(
+                    "info: another yoetz process is already starting a Chrome attach attempt; waiting before trying Claude via dev-browser"
+                );
+            }
+            eprintln!(
+                "info: connecting to Chrome — if prompted, click Allow in Chrome's remote debugging dialog"
+            );
+        }
+        run_script(&prepare_script, Some(60)).map_err(maybe_add_dev_browser_connect_guidance)?
+    };
+    let prepare: Value = serde_json::from_str(prepare_stdout.trim())
+        .with_context(|| format!("parse Claude prepare result: {prepare_stdout}"))?;
+    match prepare.get("status").and_then(Value::as_str) {
+        Some("ready") => {}
+        Some("login") => bail!("Claude login is required in the attached Chrome profile"),
+        Some("challenge") => bail!(
+            "Cloudflare challenge detected on claude.ai; solve it in the attached Chrome window and retry"
+        ),
+        other => bail!(
+            "Claude composer did not become ready; status={other:?}, diagnostics={prepare}"
+        ),
+    }
+
+    let model_script = build_claude_model_script(&page_name);
+    let model_stdout = run_script(&model_script, Some(120))?;
+    let model: Value = serde_json::from_str(model_stdout.trim())
+        .with_context(|| format!("parse Claude model selection result: {model_stdout}"))?;
+    let model_selection_status = claude_web::model_selection_status(&model);
+    if model_selection_status != WebModelSelectionStatus::Selected {
+        bail!(
+            "Claude exact model contract is unavailable or mismatched; required Fable 5 + Max + Thinking on; diagnostics={model}"
+        );
+    }
+
+    let delivery_script = build_claude_delivery_script(
+        &page_name,
+        &delivery_text,
+        Some(bundle_file_name),
+        use_clipboard,
+        ctx.upload_timeout_ms,
+        ctx.send_timeout_ms,
+    );
+    let delivery_stdout = run_script(
+        &delivery_script,
+        Some(chatgpt_script_timeout_secs(
+            ctx.upload_timeout_ms.saturating_add(ctx.send_timeout_ms),
+        )),
+    )
+    .with_claude_phase(WebRecipeTransportPhase::Upload)?;
+    let delivery: Value = serde_json::from_str(delivery_stdout.trim())
+        .with_context(|| format!("parse Claude delivery result: {delivery_stdout}"))?;
+    if delivery.get("status").and_then(Value::as_str) != Some("sent") {
+        let error = anyhow!(
+            "{}; diagnostics={delivery}",
+            delivery
+                .get("error")
+                .and_then(Value::as_str)
+                .unwrap_or("Claude delivery failed")
+        );
+        return if delivery.get("phase").and_then(Value::as_str) == Some("send") {
+            Err(error).with_claude_phase(WebRecipeTransportPhase::Send)
+        } else {
+            Err(error).with_claude_phase(WebRecipeTransportPhase::Upload)
+        };
+    }
+    let baseline_count = delivery
+        .get("assistantCountBeforeSend")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    let baseline_length = delivery
+        .get("assistantLastLenBeforeSend")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+
+    let poll_script = build_claude_poll_script(
+        &page_name,
+        baseline_count,
+        baseline_length,
+        ctx.poll_settings,
+    );
+    let poll_stdout = run_script(
+        &poll_script,
+        Some(chatgpt_script_timeout_secs(ctx.poll_settings.timeout_ms)),
+    )
+    .with_claude_phase(WebRecipeTransportPhase::WaitResponse)?;
+    let (response, conversation_url) =
+        parse_claude_poll_result(&poll_stdout, ctx.poll_settings.timeout_ms)
+            .with_claude_phase(WebRecipeTransportPhase::WaitResponse)?;
+    let conversation = conversation_url
+        .as_deref()
+        .and_then(|url| claude_web::normalize_conversation(url).ok());
+    for warning in &warnings {
+        eprintln!("warn: {warning}");
+    }
+    Ok(ClaudeRecipeRunResult {
+        response,
+        model_used: Some(claude_recipe::CLAUDE_REPORTED_MODEL.to_string()),
+        model_selection_status,
+        warnings,
+        conversation_id: conversation.as_ref().map(|value| value.id.clone()),
+        conversation_url: conversation.map(|value| value.url),
+        used_clipboard: use_clipboard,
     })
 }
 
@@ -2101,6 +2641,47 @@ mod tests {
         assert_eq!(CHATGPT_AUTH_PROBE_PAGE_NAME, "yoetz-chatgpt-main");
         assert_eq!(CHATGPT_RECIPE_PAGE_NAME_PREFIX, "yoetz-chatgpt-run");
         assert!(!CHATGPT_AUTH_PROBE_PAGE_NAME.contains("pid"));
+    }
+
+    #[test]
+    fn claude_recipe_uses_named_page_json_micro_scripts() {
+        let prepare = build_claude_prepare_script("yoetz-claude-test", "20260718T102228Z_ab12cd");
+        assert!(prepare.contains("const PAGE_NAME = \"yoetz-claude-test\";"));
+        assert!(prepare.contains("await browser.getPage(PAGE_NAME)"));
+        assert!(prepare.contains("console.log(JSON.stringify"));
+        assert!(!prepare.contains("require("));
+        assert!(!prepare.contains("fetch("));
+
+        let model = build_claude_model_script("yoetz-claude-test");
+        assert!(model.contains("Fable 5"));
+        assert!(model.contains("effort-option-max"));
+        assert!(model.contains("aria-checked"));
+        assert!(model.contains(".hover()"));
+        assert!(model.contains("Effort menu unavailable during verification"));
+
+        let delivery = build_claude_delivery_script(
+            "yoetz-claude-test",
+            "Review this bundle.",
+            Some("bundle.md"),
+            true,
+            120_000,
+            120_000,
+        );
+        assert!(delivery.contains("Meta+V"));
+        assert!(delivery.contains("pasted content"));
+        assert!(delivery.contains("pressSequentially"));
+
+        let poll = build_claude_poll_script(
+            "yoetz-claude-test",
+            2,
+            100,
+            ChatgptPollSettings {
+                timeout_ms: 540_000,
+                interval_ms: 30_000,
+            },
+        );
+        assert!(poll.contains("STABLE_IDLE_THRESHOLD_MS"));
+        assert!(poll.contains("console.log(JSON.stringify"));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -1516,6 +1516,8 @@ fn build_claude_model_script(page_name: &str) -> String {
         .expect("Fable function JSON");
     let mark_effort_json = serde_json::to_string(&claude_web::build_mark_effort_parent_function())
         .expect("mark effort function JSON");
+    let open_effort_json = serde_json::to_string(&claude_web::build_open_effort_submenu_function())
+        .expect("open effort function JSON");
     let max_json =
         serde_json::to_string(&claude_web::build_select_max_function()).expect("Max function JSON");
     let thinking_json = serde_json::to_string(&claude_web::build_ensure_thinking_on_function())
@@ -1523,9 +1525,6 @@ fn build_claude_model_script(page_name: &str) -> String {
     let verify_json =
         serde_json::to_string(&claude_web::build_verify_fable_max_thinking_function())
             .expect("verification function JSON");
-    let effort_selector_json =
-        serde_json::to_string(&format!("[title='{}']", claude_web::EFFORT_HOVER_MARKER))
-            .expect("effort selector JSON");
     format!(
         r#"
 const PAGE_NAME = {page_name_json};
@@ -1533,10 +1532,10 @@ const OPEN = {open_json};
 const CLOSE = {close_json};
 const SELECT_FABLE = {fable_json};
 const MARK_EFFORT = {mark_effort_json};
+const OPEN_EFFORT = {open_effort_json};
 const SELECT_MAX = {max_json};
 const ENABLE_THINKING = {thinking_json};
 const VERIFY = {verify_json};
-const EFFORT_SELECTOR = {effort_selector_json};
 const page = await browser.getPage(PAGE_NAME);
 let state = await page.evaluate((source) => eval("(" + source + ")")(), OPEN);
 if (!['opened', 'opening'].includes(state?.status)) {{
@@ -1556,7 +1555,11 @@ if (state?.status !== 'marked') {{
   console.log(JSON.stringify({{ status: 'unavailable', error: 'Claude Effort menu unavailable', diagnostics: state }}));
   return;
 }}
-await page.locator(EFFORT_SELECTOR).first().hover();
+state = await page.evaluate((source) => eval("(" + source + ")")(), OPEN_EFFORT);
+if (!['already_open', 'dispatched'].includes(state?.status)) {{
+  console.log(JSON.stringify({{ status: 'unavailable', error: 'Claude Effort menu hover target unavailable', diagnostics: state }}));
+  return;
+}}
 await page.waitForTimeout(400);
 state = await page.evaluate((source) => eval("(" + source + ")")(), SELECT_MAX);
 if (state?.status !== 'selected') {{
@@ -1566,7 +1569,11 @@ if (state?.status !== 'selected') {{
 await page.waitForTimeout(300);
 await page.evaluate((source) => eval("(" + source + ")")(), OPEN);
 await page.evaluate((source) => eval("(" + source + ")")(), MARK_EFFORT);
-await page.locator(EFFORT_SELECTOR).first().hover();
+state = await page.evaluate((source) => eval("(" + source + ")")(), OPEN_EFFORT);
+if (!['already_open', 'dispatched'].includes(state?.status)) {{
+  console.log(JSON.stringify({{ status: 'unavailable', error: 'Claude Effort menu hover target unavailable', diagnostics: state }}));
+  return;
+}}
 await page.waitForTimeout(400);
 state = await page.evaluate((source) => eval("(" + source + ")")(), ENABLE_THINKING);
 if (!['already_on', 'clicked'].includes(state?.status)) {{
@@ -1582,7 +1589,11 @@ if (state?.status !== 'marked') {{
   console.log(JSON.stringify({{ status: 'unavailable', error: 'Claude Effort menu unavailable during verification', diagnostics: state }}));
   return;
 }}
-await page.locator(EFFORT_SELECTOR).first().hover();
+state = await page.evaluate((source) => eval("(" + source + ")")(), OPEN_EFFORT);
+if (!['already_open', 'dispatched'].includes(state?.status)) {{
+  console.log(JSON.stringify({{ status: 'unavailable', error: 'Claude Effort menu hover target unavailable during verification', diagnostics: state }}));
+  return;
+}}
 await page.waitForTimeout(400);
 const verification = await page.evaluate((source) => eval("(" + source + ")")(), VERIFY);
 await page.evaluate((source) => eval("(" + source + ")")(), CLOSE);
@@ -1596,12 +1607,15 @@ fn build_claude_delivery_script(
     delivery_text: &str,
     bundle_file_name: Option<&str>,
     use_clipboard: bool,
+    inline_fallback_text: Option<&str>,
     upload_timeout_ms: u64,
     send_timeout_ms: u64,
 ) -> String {
     let page_name_json = serde_json::to_string(page_name).expect("page name JSON");
     let delivery_text_json = serde_json::to_string(delivery_text).expect("delivery text JSON");
     let bundle_name_json = serde_json::to_string(&bundle_file_name).expect("bundle file name JSON");
+    let inline_fallback_json =
+        serde_json::to_string(&inline_fallback_text).expect("inline fallback JSON");
     let composer_json =
         serde_json::to_string(claude_web::COMPOSER_SELECTOR).expect("composer selector JSON");
     let send_json =
@@ -1618,6 +1632,7 @@ const PAGE_NAME = {page_name_json};
 const DELIVERY_TEXT = {delivery_text_json};
 const BUNDLE_FILE_NAME = {bundle_name_json};
 const USE_CLIPBOARD = {use_clipboard};
+const INLINE_FALLBACK_TEXT = {inline_fallback_json};
 const UPLOAD_TIMEOUT_MS = {upload_timeout_ms};
 const SEND_TIMEOUT_MS = {send_timeout_ms};
 const COMPOSER_SELECTOR = {composer_json};
@@ -1627,6 +1642,8 @@ const page = await browser.getPage(PAGE_NAME);
 const composer = page.locator(COMPOSER_SELECTOR).first();
 await composer.waitFor({{ state: "visible", timeout: 20000 }});
 await composer.click();
+let usedClipboard = false;
+let usedInlineFallback = false;
 if (USE_CLIPBOARD) {{
   await page.keyboard.press("Meta+V");
   const deadline = Date.now() + UPLOAD_TIMEOUT_MS;
@@ -1636,15 +1653,33 @@ if (USE_CLIPBOARD) {{
     lastState = ATTACHMENT_FUNCTION_SOURCE
       ? await page.evaluate((source) => eval("(" + source + ")")(), ATTACHMENT_FUNCTION_SOURCE)
       : null;
-    const composerLength = await composer.evaluate((el) => String(el.innerText || el.textContent || '').trim().length);
+    const composerLength = await page.evaluate((selector) => {{
+      const el = document.querySelector(selector);
+      return String(el?.innerText || el?.textContent || '').trim().length;
+    }}, COMPOSER_SELECTOR);
     if (lastState?.status === 'candidate' || lastState?.pastedContent || composerLength > 0) {{ ready = true; break; }}
     await page.waitForTimeout(250);
   }}
+  if (!ready && INLINE_FALLBACK_TEXT) {{
+    await composer.pressSequentially(INLINE_FALLBACK_TEXT, {{ delay: 1 }});
+    const inlineDeadline = Date.now() + SEND_TIMEOUT_MS;
+    while (Date.now() < inlineDeadline) {{
+      const composerLength = await page.evaluate((selector) => {{
+        const el = document.querySelector(selector);
+        return String(el?.innerText || el?.textContent || '').trim().length;
+      }}, COMPOSER_SELECTOR);
+      if (composerLength > 0) {{ ready = true; usedInlineFallback = true; break; }}
+      await page.waitForTimeout(250);
+    }}
+  }}
   if (!ready) {{
-    console.log(JSON.stringify({{ status: 'error', phase: 'upload', error: 'Claude clipboard paste did not become inline content or a pasted content attachment', diagnostics: lastState }}));
+    console.log(JSON.stringify({{ status: 'error', phase: 'upload', error: 'Claude clipboard paste and inline fallback did not become composer content', diagnostics: lastState }}));
     return;
   }}
-  await composer.pressSequentially("\n\n" + DELIVERY_TEXT, {{ delay: 5 }});
+  if (!usedInlineFallback) {{
+    usedClipboard = true;
+    await composer.pressSequentially("\n\n" + DELIVERY_TEXT, {{ delay: 5 }});
+  }}
 }} else {{
   await composer.pressSequentially(DELIVERY_TEXT, {{ delay: 1 }});
 }}
@@ -1666,6 +1701,7 @@ console.log(JSON.stringify({{
   assistantLastLenBeforeSend: send.assistantLastLength || 0,
   copyButtonsBeforeSend: send.copyButtons || 0,
   bundleFileName: BUNDLE_FILE_NAME,
+  usedClipboard,
 }}));
 "#
     )
@@ -2031,16 +2067,22 @@ fn stage_macos_clipboard_from_file(path: &Path) -> Result<()> {
 fn claude_delivery_text(
     bundle_path: &Path,
     prompt: &str,
-    warnings: &mut Vec<String>,
-) -> Result<(String, bool)> {
+    _warnings: &mut Vec<String>,
+) -> Result<(String, bool, Option<String>)> {
     #[cfg(target_os = "macos")]
     {
+        let bundle = fs::read_to_string(bundle_path).with_context(|| {
+            format!(
+                "read Claude bundle {} for inline clipboard fallback",
+                bundle_path.display()
+            )
+        })?;
         stage_macos_clipboard_from_file(bundle_path)?;
-        warnings.push(
-            "dev-browser delivered the Claude bundle through the macOS clipboard because the QuickJS transport cannot drive a file input; claude.ai may convert large pastes into a pasted content attachment."
-                .to_string(),
-        );
-        Ok((prompt.to_string(), true))
+        Ok((
+            prompt.to_string(),
+            true,
+            Some(format!("{prompt}\n\n{bundle}")),
+        ))
     }
 
     #[cfg(not(target_os = "macos"))]
@@ -2051,11 +2093,11 @@ fn claude_delivery_text(
                 bundle_path.display()
             )
         })?;
-        warnings.push(
+        _warnings.push(
             "dev-browser cannot drive Claude file inputs on this platform; the bundle was inserted inline and may be slow or exceed composer limits. Use chrome-devtools-mcp or chrome-extension-native for file upload."
                 .to_string(),
         );
-        Ok((format!("{prompt}\n\n{bundle}"), false))
+        Ok((format!("{prompt}\n\n{bundle}"), false, None))
     }
 }
 
@@ -2136,7 +2178,7 @@ pub fn run_claude_recipe(ctx: &ClaudeDevBrowserRecipeContext) -> Result<ClaudeRe
         .and_then(|value| value.to_str())
         .context("Claude bundle path must end in a UTF-8 filename")?;
     let mut warnings = ctx.warnings.clone();
-    let (delivery_text, use_clipboard) =
+    let (delivery_text, use_clipboard, inline_fallback_text) =
         claude_delivery_text(bundle_path, &ctx.prompt, &mut warnings)?;
     let page_name = format!("{}-{}", CLAUDE_RECIPE_PAGE_NAME_PREFIX, ctx.run_id);
     let cdp_endpoint = ctx.cdp_endpoint.as_deref();
@@ -2193,6 +2235,7 @@ pub fn run_claude_recipe(ctx: &ClaudeDevBrowserRecipeContext) -> Result<ClaudeRe
         &delivery_text,
         Some(bundle_file_name),
         use_clipboard,
+        inline_fallback_text.as_deref(),
         ctx.upload_timeout_ms,
         ctx.send_timeout_ms,
     );
@@ -2218,6 +2261,21 @@ pub fn run_claude_recipe(ctx: &ClaudeDevBrowserRecipeContext) -> Result<ClaudeRe
         } else {
             Err(error).with_claude_phase(WebRecipeTransportPhase::Upload)
         };
+    }
+    let used_clipboard = delivery
+        .get("usedClipboard")
+        .and_then(Value::as_bool)
+        .unwrap_or(use_clipboard);
+    if used_clipboard {
+        warnings.push(
+            "dev-browser delivered the Claude bundle through the macOS clipboard because the QuickJS transport cannot drive a file input; claude.ai may convert large pastes into a pasted content attachment."
+                .to_string(),
+        );
+    } else if use_clipboard {
+        warnings.push(
+            "Claude ignored the macOS clipboard paste, so dev-browser inserted the bundle inline; this may be slow or exceed composer limits. Use chrome-devtools-mcp or chrome-extension-native for file upload."
+                .to_string(),
+        );
     }
     let baseline_count = delivery
         .get("assistantCountBeforeSend")
@@ -2255,7 +2313,7 @@ pub fn run_claude_recipe(ctx: &ClaudeDevBrowserRecipeContext) -> Result<ClaudeRe
         warnings,
         conversation_id: conversation.as_ref().map(|value| value.id.clone()),
         conversation_url: conversation.map(|value| value.url),
-        used_clipboard: use_clipboard,
+        used_clipboard,
     })
 }
 
@@ -2656,7 +2714,10 @@ mod tests {
         assert!(model.contains("Fable 5"));
         assert!(model.contains("effort-option-max"));
         assert!(model.contains("aria-checked"));
-        assert!(model.contains(".hover()"));
+        assert!(!model.contains(".hover()"));
+        assert!(model.contains("pointerover"));
+        assert!(model.contains("pointerenter"));
+        assert!(model.contains("mousemove"));
         assert!(model.contains("Effort menu unavailable during verification"));
 
         let delivery = build_claude_delivery_script(
@@ -2664,12 +2725,18 @@ mod tests {
             "Review this bundle.",
             Some("bundle.md"),
             true,
+            Some("Review this bundle.\n\n# Bundle"),
             120_000,
             120_000,
         );
         assert!(delivery.contains("Meta+V"));
         assert!(delivery.contains("pasted content"));
+        assert!(delivery.contains("INLINE_FALLBACK_TEXT"));
+        assert!(delivery.contains("usedInlineFallback"));
+        assert!(delivery.contains("usedClipboard"));
         assert!(delivery.contains("pressSequentially"));
+        assert!(!delivery.contains("composer.evaluate"));
+        assert!(delivery.contains("page.evaluate((selector)"));
 
         let poll = build_claude_poll_script(
             "yoetz-claude-test",
@@ -2682,6 +2749,31 @@ mod tests {
         );
         assert!(poll.contains("STABLE_IDLE_THRESHOLD_MS"));
         assert!(poll.contains("console.log(JSON.stringify"));
+
+        let scripts = [&prepare, &model, &delivery, &poll];
+        let locator_lines = scripts
+            .iter()
+            .flat_map(|script| script.lines())
+            .map(str::trim)
+            .filter(|line| line.contains(".locator("))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            locator_lines,
+            vec!["const composer = page.locator(COMPOSER_SELECTOR).first();"]
+        );
+        for line in scripts
+            .iter()
+            .flat_map(|script| script.lines())
+            .map(str::trim)
+            .filter(|line| line.contains("composer."))
+        {
+            assert!(
+                line.starts_with("await composer.waitFor(")
+                    || line.starts_with("await composer.click(")
+                    || line.starts_with("await composer.pressSequentially("),
+                "unsupported Claude dev-browser locator method: {line}"
+            );
+        }
     }
 
     #[test]

--- a/crates/yoetz-cli/src/followup.rs
+++ b/crates/yoetz-cli/src/followup.rs
@@ -4,12 +4,16 @@ use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+#[cfg(test)]
 use crate::chatgpt_web::{self, ChatgptConversation};
+use crate::web_recipe::{BuiltinWebRecipe, WebConversation};
 use yoetz_core::session::{list_sessions_in, write_json};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct FollowupMetadata {
     pub session_id: String,
+    #[serde(default)]
+    pub recipe: BuiltinWebRecipe,
     pub conversation_id: String,
     pub conversation_url: String,
     pub prompt_hash: String,
@@ -17,31 +21,62 @@ pub(crate) struct FollowupMetadata {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ResolvedFollowup {
-    pub conversation: ChatgptConversation,
+    pub recipe: BuiltinWebRecipe,
+    pub conversation: WebConversation,
     pub source_session_id: Option<String>,
     pub prior_prompt_hash: Option<String>,
 }
 
+#[cfg(test)]
 pub(crate) fn resolve_followup_target(raw: &str, sessions_base: &Path) -> Result<ResolvedFollowup> {
+    resolve_followup_target_for_recipe(raw, sessions_base, BuiltinWebRecipe::Chatgpt, |value| {
+        let conversation = chatgpt_web::normalize_conversation(value)?;
+        Ok(WebConversation {
+            id: conversation.id,
+            url: conversation.url,
+        })
+    })
+}
+
+pub(crate) fn resolve_followup_target_for_recipe<F>(
+    raw: &str,
+    sessions_base: &Path,
+    recipe: BuiltinWebRecipe,
+    normalize: F,
+) -> Result<ResolvedFollowup>
+where
+    F: Fn(&str) -> Result<WebConversation>,
+{
     let sessions = list_sessions_in(sessions_base)?;
     if let Some(session) = sessions.iter().find(|session| session.id == raw) {
         let metadata = read_followup_metadata(&session.path)?.ok_or_else(|| {
             anyhow!(
-                "session `{}` does not contain followup metadata; followup only works for ChatGPT browser recipe runs that wrote session metadata",
-                session.id
+                "session `{}` does not contain followup metadata; followup only works for browser recipe runs that wrote session metadata",
+                session.id,
             )
         })?;
-        let conversation = chatgpt_web::normalize_conversation(&metadata.conversation_id)?;
+        if metadata.recipe != recipe {
+            bail!(
+                "session `{}` belongs to the `{}` browser recipe and cannot be used as a `{}` followup",
+                session.id,
+                metadata.recipe.as_str(),
+                recipe.as_str(),
+            );
+        }
+        let conversation = normalize(&metadata.conversation_url)?;
         return Ok(ResolvedFollowup {
+            recipe,
             conversation,
             source_session_id: Some(metadata.session_id),
             prior_prompt_hash: Some(metadata.prompt_hash),
         });
     }
 
-    let conversation = chatgpt_web::normalize_conversation(raw)?;
-    let previous = find_latest_followup_metadata_for_conversation(&conversation.id, &sessions)?;
+    let conversation = normalize(raw)?;
+    let previous =
+        find_latest_followup_metadata_for_conversation(recipe, &conversation.id, &sessions)?;
     Ok(ResolvedFollowup {
+        recipe,
         conversation,
         source_session_id: previous
             .as_ref()
@@ -103,15 +138,36 @@ pub(crate) fn validate_followup_args(
     Ok(())
 }
 
+#[cfg(test)]
 pub(crate) fn write_followup_metadata(
     session_dir: &Path,
     session_id: &str,
     conversation: &ChatgptConversation,
     prompt_hash: &str,
 ) -> Result<()> {
+    write_followup_metadata_for_recipe(
+        session_dir,
+        session_id,
+        BuiltinWebRecipe::Chatgpt,
+        &WebConversation {
+            id: conversation.id.clone(),
+            url: conversation.url.clone(),
+        },
+        prompt_hash,
+    )
+}
+
+pub(crate) fn write_followup_metadata_for_recipe(
+    session_dir: &Path,
+    session_id: &str,
+    recipe: BuiltinWebRecipe,
+    conversation: &WebConversation,
+    prompt_hash: &str,
+) -> Result<()> {
     let path = followup_metadata_path(session_dir);
     let metadata = FollowupMetadata {
         session_id: session_id.to_string(),
+        recipe,
         conversation_id: conversation.id.clone(),
         conversation_url: conversation.url.clone(),
         prompt_hash: prompt_hash.to_string(),
@@ -137,12 +193,13 @@ fn followup_metadata_path(session_dir: &Path) -> PathBuf {
 }
 
 fn find_latest_followup_metadata_for_conversation(
+    recipe: BuiltinWebRecipe,
     conversation_id: &str,
     sessions: &[yoetz_core::types::SessionInfo],
 ) -> Result<Option<FollowupMetadata>> {
     for session in sessions {
         if let Some(metadata) = read_followup_metadata(&session.path)? {
-            if metadata.conversation_id == conversation_id {
+            if metadata.recipe == recipe && metadata.conversation_id == conversation_id {
                 return Ok(Some(metadata));
             }
         }
@@ -262,6 +319,76 @@ mod tests {
         assert_eq!(
             resolved.source_session_id.as_deref(),
             Some("20260711_010000_bbbbbb")
+        );
+    }
+
+    #[test]
+    fn legacy_followup_metadata_defaults_to_chatgpt() {
+        let root = tempdir().unwrap();
+        fs::write(
+            root.path().join("followup.json"),
+            r#"{
+              "session_id": "legacy-session",
+              "conversation_id": "conv-legacy",
+              "conversation_url": "https://chatgpt.com/c/conv-legacy",
+              "prompt_hash": "legacy-hash"
+            }"#,
+        )
+        .unwrap();
+
+        let metadata = read_followup_metadata(root.path()).unwrap().unwrap();
+        assert_eq!(metadata.recipe, BuiltinWebRecipe::Chatgpt);
+    }
+
+    #[test]
+    fn direct_followup_lookup_is_keyed_by_recipe_and_conversation_id() {
+        let root = tempdir().unwrap();
+        let sessions_dir = root.path().join("sessions");
+        let chatgpt_session = sessions_dir.join("20260711_000000_chatgpt");
+        let claude_session = sessions_dir.join("20260711_010000_claude");
+        fs::create_dir_all(&chatgpt_session).unwrap();
+        fs::create_dir_all(&claude_session).unwrap();
+        write_followup_metadata_for_recipe(
+            &chatgpt_session,
+            "20260711_000000_chatgpt",
+            BuiltinWebRecipe::Chatgpt,
+            &WebConversation {
+                id: "shared-id".to_string(),
+                url: "https://chatgpt.com/c/shared-id".to_string(),
+            },
+            "chatgpt-hash",
+        )
+        .unwrap();
+        write_followup_metadata_for_recipe(
+            &claude_session,
+            "20260711_010000_claude",
+            BuiltinWebRecipe::Claude,
+            &WebConversation {
+                id: "shared-id".to_string(),
+                url: "https://claude.ai/chat/shared-id".to_string(),
+            },
+            "claude-hash",
+        )
+        .unwrap();
+
+        let resolved = resolve_followup_target_for_recipe(
+            "shared-id",
+            &sessions_dir,
+            BuiltinWebRecipe::Claude,
+            |raw| {
+                Ok(WebConversation {
+                    id: raw.to_string(),
+                    url: format!("https://claude.ai/chat/{raw}"),
+                })
+            },
+        )
+        .unwrap();
+
+        assert_eq!(resolved.recipe, BuiltinWebRecipe::Claude);
+        assert_eq!(resolved.prior_prompt_hash.as_deref(), Some("claude-hash"));
+        assert_eq!(
+            resolved.source_session_id.as_deref(),
+            Some("20260711_010000_claude")
         );
     }
 }

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -330,6 +330,12 @@ struct BrowserLoginArgs {
 
 #[derive(Args)]
 struct BrowserCheckArgs {
+    /// Check ChatGPT browser readiness (default when no site flag is passed).
+    #[arg(long, conflicts_with = "claude")]
+    chatgpt: bool,
+    /// Check Claude browser readiness and capability selection.
+    #[arg(long, conflicts_with = "chatgpt")]
+    claude: bool,
     #[arg(long)]
     profile: Option<PathBuf>,
     /// Select the browser check transport. Use chrome-extension-native to check
@@ -344,7 +350,7 @@ struct BrowserCheckArgs {
     #[arg(long)]
     browser_id: Option<String>,
     /// Route an extension-native check to a Chrome profile email reported by
-    /// `yoetz browser extension status --chatgpt`.
+    /// `yoetz browser extension status --chatgpt` or `--claude`.
     #[arg(long, alias = "profile_email")]
     profile_email: Option<String>,
     /// Route an extension-native check to the stable extension instance id.
@@ -353,6 +359,14 @@ struct BrowserCheckArgs {
     /// Route an extension-native check to a Chrome extension profile id.
     #[arg(long, alias = "extension_profile_id")]
     extension_profile_id: Option<String>,
+}
+
+fn browser_check_site_scope(args: &BrowserCheckArgs) -> Result<web_recipe::BuiltinWebRecipe> {
+    match (args.chatgpt, args.claude) {
+        (false, false) | (true, false) => Ok(web_recipe::BuiltinWebRecipe::Chatgpt),
+        (false, true) => Ok(web_recipe::BuiltinWebRecipe::Claude),
+        (true, true) => bail!("--chatgpt and --claude are mutually exclusive"),
+    }
 }
 
 #[derive(Args)]
@@ -1615,12 +1629,6 @@ fn maybe_print_running_profile_auto_connect_preference(
 /// treated as not available for auto-selection. The probe is filesystem-local
 /// (status file + Unix socket reachability) and is cheap enough to run on
 /// every `yoetz browser recipe` invocation.
-fn extension_status_connected_for_auto_selection() -> bool {
-    browser_extension_native::status()
-        .map(|status| status.status == "connected")
-        .unwrap_or(false)
-}
-
 fn extension_recipe_ready_for_auto_selection(recipe: Option<web_recipe::BuiltinWebRecipe>) -> bool {
     browser_extension_native::status()
         .map(|status| {
@@ -1653,11 +1661,17 @@ fn maybe_print_auto_selected_extension_native_transport(
 
 fn auto_selected_browser_check_extension_native_notice(
     auto_selected: bool,
-) -> Option<&'static str> {
+    recipe: web_recipe::BuiltinWebRecipe,
+) -> Option<String> {
     if auto_selected {
-        Some(
-            "info: auto-selected chrome-extension-native for browser check because the Yoetz Chrome extension is installed and connected (pass --transport chrome-devtools-mcp, --transport dev-browser, --transport agent-browser, --cdp, --browser-id, or --profile to check the CDP/browser stack)",
-        )
+        Some(match recipe {
+            web_recipe::BuiltinWebRecipe::Chatgpt =>
+                "info: auto-selected chrome-extension-native for browser check because the Yoetz Chrome extension is installed and connected (pass --transport chrome-devtools-mcp, --transport dev-browser, --transport agent-browser, --cdp, --browser-id, or --profile to check the CDP/browser stack)".to_string(),
+            web_recipe::BuiltinWebRecipe::Claude => format!(
+                "info: auto-selected chrome-extension-native for Claude browser check because the selected Yoetz extension instance advertises `{}` (pass --transport chrome-devtools-mcp, --transport dev-browser, --transport agent-browser, --cdp, --browser-id, or --profile to check the CDP/browser stack)",
+                recipe.as_str(),
+            ),
+        })
     } else {
         None
     }
@@ -1666,11 +1680,13 @@ fn auto_selected_browser_check_extension_native_notice(
 fn maybe_print_auto_selected_browser_check_extension_native(
     auto_selected: bool,
     format: OutputFormat,
+    recipe: web_recipe::BuiltinWebRecipe,
 ) {
     if !matches!(format, OutputFormat::Text | OutputFormat::Markdown) {
         return;
     }
-    if let Some(notice) = auto_selected_browser_check_extension_native_notice(auto_selected) {
+    if let Some(notice) = auto_selected_browser_check_extension_native_notice(auto_selected, recipe)
+    {
         eprintln!("{notice}");
     }
 }
@@ -1809,6 +1825,27 @@ fn browser_check_live_method(target: Option<&browser::ResolvedCdpTarget>) -> Str
     }
 }
 
+async fn ensure_browser_check_site_via_chrome_devtools(
+    recipe: web_recipe::BuiltinWebRecipe,
+    target: Option<&browser::ResolvedCdpTarget>,
+    show_approval_guidance: bool,
+) -> Result<()> {
+    match recipe {
+        web_recipe::BuiltinWebRecipe::Chatgpt => {
+            live_attach::ensure_chatgpt_session(target, None, None, show_approval_guidance)
+                .await
+                .map(|_| ())
+        }
+        web_recipe::BuiltinWebRecipe::Claude => {
+            chrome_devtools_mcp::claude::check_auth(
+                target.map(|value| value.endpoint.as_str()),
+                show_approval_guidance,
+            )
+            .await
+        }
+    }
+}
+
 fn remember_browser_check_live_attach_failure(slot: &mut Option<String>, err: &anyhow::Error) {
     if slot.is_none() && browser::is_chrome_cdp_unreachable_error(err) {
         *slot = Some(format!("{err:#}"));
@@ -1879,10 +1916,26 @@ fn check_args_have_extension_selector(args: &BrowserCheckArgs) -> bool {
             .is_some_and(|value| !value.trim().is_empty())
 }
 
+fn browser_check_extension_recipe_ready(
+    args: &BrowserCheckArgs,
+    recipe: web_recipe::BuiltinWebRecipe,
+) -> bool {
+    browser_extension_native::recipe_ready(
+        extension_selector_from_parts(
+            args.profile_email.as_ref(),
+            args.extension_instance_id.as_ref(),
+            args.extension_profile_id.as_ref(),
+        ),
+        recipe,
+    )
+    .unwrap_or(false)
+}
+
 fn handle_browser_extension_native_check(
     args: &BrowserCheckArgs,
     format: OutputFormat,
     auto_selected: bool,
+    recipe: web_recipe::BuiltinWebRecipe,
 ) -> Result<()> {
     if args.profile.is_some() || args.cdp.is_some() || args.browser_id.is_some() {
         bail!(
@@ -1894,21 +1947,22 @@ fn handle_browser_extension_native_check(
         args.extension_instance_id.as_ref(),
         args.extension_profile_id.as_ref(),
     );
-    let bridge = browser_extension_native::bridge_check(selector)?;
+    let bridge = browser_extension_native::bridge_check_for_recipe(selector, recipe)?;
     let payload = json!({
         "status": "ok",
         "method": "extension_native_dry_run",
         "transport": browser_extension_native::TRANSPORT_NAME,
         "auto_selected": auto_selected,
         "live": false,
+        "recipe": recipe.as_str(),
         "extension": bridge,
     });
     match format {
         OutputFormat::Json => write_json(&payload),
         OutputFormat::Jsonl => write_jsonl("browser.check", &payload),
         OutputFormat::Text | OutputFormat::Markdown => {
-            maybe_print_auto_selected_browser_check_extension_native(auto_selected, format);
-            for line in browser_extension_native_check_text_lines() {
+            maybe_print_auto_selected_browser_check_extension_native(auto_selected, format, recipe);
+            for line in browser_extension_native_check_text_lines(recipe) {
                 println!("{line}");
             }
             Ok(())
@@ -1916,11 +1970,17 @@ fn handle_browser_extension_native_check(
     }
 }
 
-fn browser_extension_native_check_text_lines() -> [&'static str; 2] {
-    [
-        "Browser extension bridge ready via chrome-extension-native (dry-run bridge check; no CDP approval).",
-        "No live canary is required before normal ChatGPT Pro recipe runs.",
-    ]
+fn browser_extension_native_check_text_lines(recipe: web_recipe::BuiltinWebRecipe) -> [String; 2] {
+    match recipe {
+        web_recipe::BuiltinWebRecipe::Chatgpt => [
+            "Browser extension bridge ready via chrome-extension-native (dry-run bridge check; no CDP approval).".to_string(),
+            "No live canary is required before normal ChatGPT Pro recipe runs.".to_string(),
+        ],
+        web_recipe::BuiltinWebRecipe::Claude => [
+            "Claude extension bridge ready via chrome-extension-native (dry-run bridge check; no CDP approval).".to_string(),
+            "The selected extension instance advertises the `claude` recipe capability.".to_string(),
+        ],
+    }
 }
 
 fn browser_check_should_auto_select_extension_native(
@@ -2747,11 +2807,24 @@ fn run_recipe_via_dev_browser<R: IntoBuiltinWebRecipe>(
     cdp_endpoint: Option<&str>,
     format: OutputFormat,
     builtin_recipe: R,
+    preflight_warnings: &[String],
     fallback_used: bool,
 ) -> Result<Value> {
-    if builtin_recipe.into_builtin_web_recipe() != Some(web_recipe::BuiltinWebRecipe::Chatgpt) {
+    let builtin_recipe = builtin_recipe.into_builtin_web_recipe();
+    if builtin_recipe == Some(web_recipe::BuiltinWebRecipe::Claude) {
+        return run_claude_recipe_via_dev_browser(
+            ctx,
+            recipe_args,
+            recipe_vars,
+            cdp_endpoint,
+            format,
+            preflight_warnings,
+            fallback_used,
+        );
+    }
+    if builtin_recipe != Some(web_recipe::BuiltinWebRecipe::Chatgpt) {
         return Err(anyhow!(
-            "dev-browser transport currently supports only the built-in `chatgpt` recipe"
+            "dev-browser transport supports only built-in web recipes"
         ));
     }
     chatgpt_web::validate_thread_mode(recipe_vars.get("thread").map(String::as_str))?;
@@ -2836,6 +2909,90 @@ fn run_recipe_via_dev_browser<R: IntoBuiltinWebRecipe>(
     Ok(payload)
 }
 
+fn run_claude_recipe_via_dev_browser(
+    ctx: &AppContext,
+    recipe_args: &BrowserRecipeArgs,
+    recipe_vars: &BTreeMap<String, String>,
+    cdp_endpoint: Option<&str>,
+    format: OutputFormat,
+    preflight_warnings: &[String],
+    fallback_used: bool,
+) -> Result<Value> {
+    claude_web::validate_thread_mode(recipe_vars.get("thread").map(String::as_str))?;
+    if recipe_args.profile.is_some() {
+        return Err(anyhow!(
+            "dev-browser transport does not support `--profile`; use `--cdp` to target a specific Chrome instance/profile"
+        ));
+    }
+    let started_at = Instant::now();
+    let recipe_spec = build_claude_recipe_spec(recipe_args, recipe_vars, preflight_warnings)?;
+    let recipe_ctx = dev_browser::ClaudeDevBrowserRecipeContext {
+        bundle_path: recipe_spec.bundle_path.clone(),
+        prompt: recipe_spec.prompt.clone(),
+        run_id: recipe_spec.run_id.clone(),
+        poll_settings: dev_browser::ChatgptPollSettings {
+            timeout_ms: recipe_spec.wait_timeout_ms,
+            interval_ms: recipe_spec.wait_interval_ms,
+        },
+        cdp_endpoint: cdp_endpoint.map(str::to_owned),
+        show_approval_guidance: matches!(format, OutputFormat::Text | OutputFormat::Markdown),
+        upload_timeout_ms: recipe_spec.upload_timeout_ms,
+        send_timeout_ms: recipe_spec.send_timeout_ms,
+        warnings: recipe_spec.warnings.clone(),
+    };
+    let response = dev_browser::run_claude_recipe(&recipe_ctx)?;
+    let (delivery_mode, auto_paste_fallback) =
+        claude_dev_browser_delivery_metadata(response.used_clipboard);
+    let elapsed_ms = started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+    let output = claude_recipe::ClaudeRecipeOutput {
+        transport: "dev-browser".to_string(),
+        backend: "dev-browser".to_string(),
+        response: response.response,
+        model_used: response.model_used,
+        model_selection_status: response.model_selection_status,
+        warnings: response.warnings,
+        fallback_used,
+        conversation_id: response.conversation_id,
+        conversation_url: response.conversation_url,
+        run_id: recipe_spec.run_id,
+        elapsed_ms,
+    };
+    let mut payload = output.to_value();
+    payload["delivery_mode"] = Value::String(delivery_mode.to_string());
+    payload["auto_paste_fallback"] = Value::Bool(auto_paste_fallback);
+    attach_browser_recipe_artifacts(&mut payload, recipe_args.bundle.as_deref())?;
+    maybe_write_output(ctx, &payload)?;
+    match format {
+        OutputFormat::Json => write_json(&payload)?,
+        OutputFormat::Jsonl => {
+            let mut event = output.to_recipe_complete_event();
+            event["delivery_mode"] = Value::String(delivery_mode.to_string());
+            event["auto_paste_fallback"] = Value::Bool(auto_paste_fallback);
+            write_jsonl("browser.recipe", &event)?;
+        }
+        OutputFormat::Text | OutputFormat::Markdown => {
+            println!("{}", payload["response"].as_str().unwrap_or_default());
+        }
+    }
+    maybe_notify_browser_recipe_completion(
+        ctx,
+        recipe_args.no_notify,
+        claude_recipe::CLAUDE_REPORTED_MODEL,
+        &payload,
+        elapsed_ms,
+        None,
+    );
+    Ok(payload)
+}
+
+fn claude_dev_browser_delivery_metadata(used_clipboard: bool) -> (&'static str, bool) {
+    if used_clipboard {
+        ("paste", true)
+    } else {
+        ("inline", false)
+    }
+}
+
 fn run_recipe_via_agent_browser<R: IntoBuiltinWebRecipe>(
     ctx: &AppContext,
     recipe: browser::Recipe,
@@ -2844,18 +3001,20 @@ fn run_recipe_via_agent_browser<R: IntoBuiltinWebRecipe>(
     profile_dir: PathBuf,
     format: OutputFormat,
     builtin_recipe: R,
+    preflight_warnings: &[String],
     fallback_used: bool,
     prefer_auto_connect: bool,
     selected_cdp_target: &mut Option<browser::ResolvedCdpTarget>,
 ) -> Result<Value> {
     let builtin_recipe = builtin_recipe.into_builtin_web_recipe();
-    if builtin_recipe == Some(web_recipe::BuiltinWebRecipe::Claude) {
-        return Err(anyhow!(
-            "agent-browser transport for the built-in `claude` recipe is reserved for Wave 3; Wave 1 supports chrome-devtools-mcp"
-        ));
-    }
     let is_chatgpt = builtin_recipe == Some(web_recipe::BuiltinWebRecipe::Chatgpt);
-    let needs_auth = is_chatgpt;
+    let is_claude = builtin_recipe == Some(web_recipe::BuiltinWebRecipe::Claude);
+    let needs_auth = is_chatgpt || is_claude;
+    let target_url = if is_claude {
+        claude_web::CLAUDE_URL
+    } else {
+        browser::CHATGPT_URL
+    };
     let live_connection = if needs_auth {
         if profile_forces_managed_browser(
             recipe_args.profile.as_deref(),
@@ -2881,7 +3040,11 @@ fn run_recipe_via_agent_browser<R: IntoBuiltinWebRecipe>(
     let profile_mode = if live_connection.is_some() {
         browser::BrowserProfileMode::ProfileOnly
     } else if needs_auth {
-        browser::resolve_auth_mode(&profile_dir, /* headed */ false)?
+        if is_claude {
+            browser::resolve_claude_auth_mode(&profile_dir, /* headed */ false)?
+        } else {
+            browser::resolve_auth_mode(&profile_dir, /* headed */ false)?
+        }
     } else {
         browser::BrowserProfileMode::ProfileOnly
     };
@@ -2917,7 +3080,8 @@ fn run_recipe_via_agent_browser<R: IntoBuiltinWebRecipe>(
         fallback_used,
         use_stealth: needs_auth,
         headed: needs_auth,
-        target_url: browser::CHATGPT_URL.to_string(),
+        target_url: target_url.to_string(),
+        warnings: preflight_warnings.to_vec(),
         vars: recipe_vars,
     };
 
@@ -3532,6 +3696,11 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             }
         }
         BrowserCommand::Check(check_args) => {
+            let check_recipe = browser_check_site_scope(&check_args)?;
+            let check_target_url = match check_recipe {
+                web_recipe::BuiltinWebRecipe::Chatgpt => browser::CHATGPT_URL,
+                web_recipe::BuiltinWebRecipe::Claude => claude_web::CLAUDE_URL,
+            };
             let requested_transport = check_args.transport;
             let managed_profile_only = profile_forces_managed_browser(
                 check_args.profile.as_deref(),
@@ -3544,7 +3713,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 requested_transport,
                 managed_profile_only,
                 explicit_browser_target,
-                extension_status_connected_for_auto_selection(),
+                browser_check_extension_recipe_ready(&check_args, check_recipe),
             );
             if requested_transport == Some(browser::RecipeTransport::ChromeExtensionNative)
                 || auto_select_extension_native
@@ -3553,6 +3722,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                     &check_args,
                     format,
                     auto_select_extension_native,
+                    check_recipe,
                 );
             }
             if check_args_have_extension_selector(&check_args) {
@@ -3578,10 +3748,9 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                     .as_ref()
                     .map(|target| target.endpoint.as_str())
                     .expect("explicit browser target should resolve");
-                live_attach::ensure_chatgpt_session(
+                ensure_browser_check_site_via_chrome_devtools(
+                    check_recipe,
                     resolved_cdp_target.as_ref(),
-                    None,
-                    None,
                     show_approval_guidance,
                 )
                 .await
@@ -3589,6 +3758,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 maybe_remember_cdp_target(resolved_cdp_target.as_ref(), format);
                 let payload = json!({
                     "status": "ok",
+                    "recipe": check_recipe.as_str(),
                     "method": if check_args.cdp.is_some() {
                         format!("cdp: {cdp_url}")
                     } else {
@@ -3604,7 +3774,8 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                     OutputFormat::Jsonl => write_jsonl("browser.check", &payload),
                     OutputFormat::Text | OutputFormat::Markdown => {
                         println!(
-                            "Browser authenticated via {} (chrome-devtools-mcp)",
+                            "{} browser authenticated via {} (chrome-devtools-mcp)",
+                            check_recipe.display_name(),
                             if check_args.cdp.is_some() {
                                 format!("cdp: {cdp_url}")
                             } else {
@@ -3645,10 +3816,9 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             for transport in transports {
                 match transport {
                     BrowserCheckTransport::ChromeDevtoolsMcp => {
-                        match live_attach::ensure_chatgpt_session(
+                        match ensure_browser_check_site_via_chrome_devtools(
+                            check_recipe,
                             resolved_cdp_target.as_ref(),
-                            None,
-                            None,
                             show_approval_guidance,
                         )
                         .await
@@ -3659,6 +3829,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                                     browser_check_live_method(resolved_cdp_target.as_ref());
                                 let payload = json!({
                                     "status": "ok",
+                                    "recipe": check_recipe.as_str(),
                                     "method": method,
                                     "transport": browser_check_transport_name(transport),
                                 });
@@ -3667,7 +3838,8 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                                     OutputFormat::Jsonl => write_jsonl("browser.check", &payload),
                                     OutputFormat::Text | OutputFormat::Markdown => {
                                         println!(
-                                            "Browser authenticated via {} ({})",
+                                            "{} browser authenticated via {} ({})",
+                                            check_recipe.display_name(),
                                             payload["method"].as_str().unwrap_or("auto_connect"),
                                             browser_check_transport_name(transport)
                                         );
@@ -3720,12 +3892,23 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         let cdp_endpoint = resolved_cdp_target
                             .as_ref()
                             .map(|target| target.endpoint.as_str());
-                        match dev_browser::ensure_chatgpt_auth_with_page_check_and_endpoint(
-                            cdp_endpoint,
-                        ) {
+                        let auth_result = match check_recipe {
+                            web_recipe::BuiltinWebRecipe::Chatgpt => {
+                                dev_browser::ensure_chatgpt_auth_with_page_check_and_endpoint(
+                                    cdp_endpoint,
+                                )
+                            }
+                            web_recipe::BuiltinWebRecipe::Claude => {
+                                dev_browser::ensure_claude_auth_with_page_check_and_endpoint(
+                                    cdp_endpoint,
+                                )
+                            }
+                        };
+                        match auth_result {
                             Ok(()) => {
                                 let payload = json!({
                                     "status": "ok",
+                                    "recipe": check_recipe.as_str(),
                                     "method": if cdp_endpoint.is_some() {
                                         "cdp"
                                     } else {
@@ -3739,7 +3922,8 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                                     OutputFormat::Jsonl => write_jsonl("browser.check", &payload),
                                     OutputFormat::Text | OutputFormat::Markdown => {
                                         println!(
-                                            "Browser authenticated via {} ({})",
+                                            "{} browser authenticated via {} ({})",
+                                            check_recipe.display_name(),
                                             payload["method"].as_str().unwrap_or("auto_connect"),
                                             browser_check_transport_name(transport)
                                         );
@@ -3784,9 +3968,22 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                     }
                     BrowserCheckTransport::AgentBrowser => {
                         let connection = if managed_profile_only {
-                            browser::resolve_auth(&profile_dir, /* headed */ false)?
+                            if check_recipe == web_recipe::BuiltinWebRecipe::Claude {
+                                browser::resolve_claude_auth(&profile_dir, /* headed */ false)?
+                            } else {
+                                browser::resolve_auth(&profile_dir, /* headed */ false)?
+                            }
                         } else if prefer_auto_connect {
-                            browser::try_auto_connect("https://chatgpt.com/").map_err(|e| {
+                            let auto_connect_result =
+                                if check_recipe == web_recipe::BuiltinWebRecipe::Claude {
+                                    browser::check_claude_auth_with_connection(
+                                        &browser::BrowserConnection::AutoConnect,
+                                        false,
+                                    )
+                                } else {
+                                    browser::try_auto_connect(check_target_url)
+                                };
+                            auto_connect_result.map_err(|e| {
                                 if let Some(recovery) = default_daemon_recovery_error(Some(&e)) {
                                     return recovery;
                                 }
@@ -3802,13 +3999,21 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                             let fallback_cdp = resolved_cdp_target
                                 .as_ref()
                                 .map(|target| target.endpoint.as_str());
-                            browser::resolve_browser_connection(
-                                &ctx.browser_defaults,
-                                fallback_cdp.or(check_args.cdp.as_deref()),
-                                &profile_dir,
-                                "https://chatgpt.com/",
-                            )
-                            .map_err(|e| {
+                            let resolved = if check_recipe == web_recipe::BuiltinWebRecipe::Claude {
+                                browser::resolve_claude_browser_connection(
+                                    &ctx.browser_defaults,
+                                    fallback_cdp.or(check_args.cdp.as_deref()),
+                                    &profile_dir,
+                                )
+                            } else {
+                                browser::resolve_browser_connection(
+                                    &ctx.browser_defaults,
+                                    fallback_cdp.or(check_args.cdp.as_deref()),
+                                    &profile_dir,
+                                    check_target_url,
+                                )
+                            };
+                            resolved.map_err(|e| {
                                 if let Some(recovery) = default_daemon_recovery_error(Some(&e)) {
                                     return recovery;
                                 }
@@ -3830,6 +4035,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         };
                         let payload = json!({
                             "status": "ok",
+                            "recipe": check_recipe.as_str(),
                             "profile": profile_dir.to_string_lossy(),
                             "method": method,
                             "transport": browser_check_transport_name(transport),
@@ -3842,7 +4048,8 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                             OutputFormat::Jsonl => write_jsonl("browser.check", &payload),
                             OutputFormat::Text | OutputFormat::Markdown => {
                                 println!(
-                                    "Browser authenticated via {} ({})",
+                                    "{} browser authenticated via {} ({})",
+                                    check_recipe.display_name(),
                                     payload["method"].as_str().unwrap_or("auto_connect"),
                                     browser_check_transport_name(transport)
                                 );
@@ -4160,6 +4367,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         cdp_endpoint.as_deref(),
                         format,
                         builtin_recipe,
+                        &preflight_warnings,
                         fallback_used,
                     ),
                     browser::RecipeTransport::AgentBrowser => run_recipe_via_agent_browser(
@@ -4170,6 +4378,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         profile_dir.clone(),
                         format,
                         builtin_recipe,
+                        &preflight_warnings,
                         fallback_used,
                         prefer_auto_connect,
                         &mut resolved_cdp_target,
@@ -5994,6 +6203,39 @@ mod tests {
     }
 
     #[test]
+    fn browser_check_site_scope_defaults_chatgpt_and_accepts_claude() {
+        let default = BrowserCheckArgs {
+            profile: None,
+            transport: None,
+            cdp: None,
+            browser_id: None,
+            profile_email: None,
+            extension_instance_id: None,
+            extension_profile_id: None,
+            chatgpt: false,
+            claude: false,
+        };
+        assert_eq!(
+            browser_check_site_scope(&default).unwrap(),
+            web_recipe::BuiltinWebRecipe::Chatgpt
+        );
+        let claude = BrowserCheckArgs {
+            claude: true,
+            ..default
+        };
+        assert_eq!(
+            browser_check_site_scope(&claude).unwrap(),
+            web_recipe::BuiltinWebRecipe::Claude
+        );
+        let both = BrowserCheckArgs {
+            chatgpt: true,
+            claude: true,
+            ..claude
+        };
+        assert!(browser_check_site_scope(&both).is_err());
+    }
+
+    #[test]
     fn browser_check_native_auto_selection_respects_explicit_targets() {
         assert!(browser_check_should_auto_select_extension_native(
             None, false, false, true
@@ -6038,18 +6280,29 @@ mod tests {
 
     #[test]
     fn browser_extension_native_check_text_avoids_live_canary_nudge() {
-        let text = browser_extension_native_check_text_lines().join("\n");
+        let text = browser_extension_native_check_text_lines(web_recipe::BuiltinWebRecipe::Claude)
+            .join("\n");
         assert!(text.contains("dry-run bridge check"));
-        assert!(text.contains("No live canary is required"));
+        assert!(text.contains("advertises the `claude` recipe capability"));
         assert!(!text.contains("dry-run canary"));
         assert!(!text.contains("For a live ChatGPT auth probe"));
     }
 
     #[test]
     fn browser_extension_native_check_notice_explains_auto_selection() {
-        assert!(auto_selected_browser_check_extension_native_notice(false).is_none());
-        let notice = auto_selected_browser_check_extension_native_notice(true).unwrap();
+        assert!(auto_selected_browser_check_extension_native_notice(
+            false,
+            web_recipe::BuiltinWebRecipe::Claude,
+        )
+        .is_none());
+        let notice = auto_selected_browser_check_extension_native_notice(
+            true,
+            web_recipe::BuiltinWebRecipe::Claude,
+        )
+        .unwrap();
         assert!(notice.contains("auto-selected chrome-extension-native"));
+        assert!(notice.contains("Claude"));
+        assert!(notice.contains("`claude`"));
         assert!(notice.contains("--transport chrome-devtools-mcp"));
         assert!(notice.contains("--cdp"));
     }
@@ -6909,12 +7162,57 @@ mod tests {
             None,
             OutputFormat::Text,
             /* is_chatgpt */ true,
+            &[],
             /* fallback_used */ false,
         )
         .unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("thread"));
         assert!(msg.contains("fresh"));
+    }
+
+    #[test]
+    fn run_recipe_via_dev_browser_routes_claude_before_validating_delivery() {
+        let recipe_args = BrowserRecipeArgs {
+            recipe: PathBuf::from("recipes/claude.yaml"),
+            transport: Some(browser::RecipeTransport::DevBrowser),
+            allow_cdp_fallback: false,
+            bundle: Some(PathBuf::from("/tmp/claude-bundle.md")),
+            profile: None,
+            cdp: None,
+            browser_id: None,
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
+            vars: vec![],
+            followup: None,
+            allow_duplicate_prompt: false,
+            no_notify: false,
+        };
+        let recipe_vars = BTreeMap::from([("thread".to_string(), "sideways".to_string())]);
+        let err = run_recipe_via_dev_browser(
+            &test_app_context(),
+            &recipe_args,
+            &recipe_vars,
+            None,
+            OutputFormat::Text,
+            Some(web_recipe::BuiltinWebRecipe::Claude),
+            &[],
+            false,
+        )
+        .unwrap_err();
+
+        let message = err.to_string();
+        assert!(message.contains("thread"));
+        assert!(message.contains("fresh"));
+        assert!(!message.contains("dev-browser transport supports only built-in web recipes"));
+    }
+
+    #[test]
+    fn claude_dev_browser_delivery_metadata_tracks_clipboard_use() {
+        assert_eq!(claude_dev_browser_delivery_metadata(true), ("paste", true));
+        assert_eq!(
+            claude_dev_browser_delivery_metadata(false),
+            ("inline", false)
+        );
     }
 
     #[test]
@@ -6941,6 +7239,7 @@ mod tests {
             None,
             OutputFormat::Text,
             /* is_chatgpt */ true,
+            &[],
             /* fallback_used */ false,
         )
         .unwrap_err();

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -3177,6 +3177,8 @@ fn handle_browser_extension(
             let extension_update = browser_extension_native::prepare_managed_chatgpt_extension()?;
             let extension_dir = extension_update.extension_dir.clone();
             let source_dir = extension_update.source_dir.clone();
+            let source_version = extension_update.source_version.clone();
+            let source_provenance = extension_update.source_provenance;
             let opened_chrome = if args.open_chrome {
                 open_chrome_extensions_page()?;
                 true
@@ -3190,6 +3192,8 @@ fn handle_browser_extension(
                 "extension_id": browser_extension_native::EXTENSION_ID,
                 "extension_dir": extension_dir,
                 "source_dir": source_dir,
+                "source_version": source_version,
+                "source_provenance": source_provenance,
                 "extension_copy": extension_update,
                 "extension_dir_env": browser_extension_native::CHATGPT_EXTENSION_DIR_ENV,
                 "chrome_extensions_url": browser_extension_native::CHROME_EXTENSIONS_URL,
@@ -3382,6 +3386,14 @@ fn format_extension_setup(payload: &Value, recipe: web_recipe::BuiltinWebRecipe)
         .get("source_dir")
         .and_then(Value::as_str)
         .unwrap_or("<unknown>");
+    let source_version = payload
+        .get("source_version")
+        .and_then(Value::as_str)
+        .unwrap_or("<unknown>");
+    let source_provenance = payload
+        .get("source_provenance")
+        .and_then(Value::as_str)
+        .unwrap_or("<unknown>");
     let copy_status = payload
         .get("extension_copy")
         .and_then(|value| value.get("status"))
@@ -3402,6 +3414,8 @@ fn format_extension_setup(payload: &Value, recipe: web_recipe::BuiltinWebRecipe)
         format!("extension_id: {}", browser_extension_native::EXTENSION_ID),
         format!("extension_dir: {extension_dir}"),
         format!("source_dir: {source_dir}"),
+        format!("source_version: {source_version}"),
+        format!("source_provenance: {source_provenance}"),
         format!("extension_copy: {copy_status}"),
         format!("chrome_extensions_url: {}", browser_extension_native::CHROME_EXTENSIONS_URL),
         format!("opened_chrome: {opened}"),

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -3091,7 +3091,7 @@ fn handle_browser_extension(
             )
         }
         BrowserExtensionCommand::Update(args) => {
-            extension_site_scope(args.chatgpt, args.claude)?;
+            let recipe = extension_site_scope(args.chatgpt, args.claude)?;
             let selector = extension_selector_from_parts(
                 args.profile_email.as_ref(),
                 args.extension_instance_id.as_ref(),
@@ -3099,7 +3099,7 @@ fn handle_browser_extension(
             );
             (
                 "browser.extension.update",
-                browser_extension_native::update_extension(selector)?,
+                browser_extension_native::update_extension(selector, recipe)?,
             )
         }
         BrowserExtensionCommand::Canary(args) => {

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -406,12 +406,16 @@ enum BrowserExtensionCommand {
 struct BrowserExtensionScopeArgs {
     #[arg(long)]
     chatgpt: bool,
+    #[arg(long)]
+    claude: bool,
 }
 
 #[derive(Args)]
 struct BrowserExtensionSetupArgs {
     #[arg(long)]
     chatgpt: bool,
+    #[arg(long)]
+    claude: bool,
 
     /// Open chrome://extensions after preparing the native host.
     #[arg(long)]
@@ -422,16 +426,18 @@ struct BrowserExtensionSetupArgs {
 struct BrowserExtensionMaintenanceArgs {
     #[arg(long)]
     chatgpt: bool,
+    #[arg(long)]
+    claude: bool,
 
-    /// Route to a Chrome profile email reported by `status --chatgpt`.
+    /// Route to a Chrome profile email reported by extension status.
     #[arg(long, alias = "profile_email")]
     profile_email: Option<String>,
 
-    /// Route to the stable extension instance id reported by `status --chatgpt`.
+    /// Route to the stable extension instance id reported by extension status.
     #[arg(long, alias = "extension_instance_id")]
     extension_instance_id: Option<String>,
 
-    /// Route to a Chrome extension profile id reported by `status --chatgpt`.
+    /// Route to a Chrome extension profile id reported by extension status.
     #[arg(long, alias = "extension_profile_id")]
     extension_profile_id: Option<String>,
 }
@@ -440,20 +446,22 @@ struct BrowserExtensionMaintenanceArgs {
 struct BrowserExtensionCanaryArgs {
     #[arg(long)]
     chatgpt: bool,
+    #[arg(long)]
+    claude: bool,
 
-    /// Run a real ChatGPT canary job. Without this flag, this is a dry-run bridge probe.
+    /// Run a real site canary job. Without this flag, this is a dry-run bridge probe.
     #[arg(long)]
     live: bool,
 
-    /// Route to a Chrome profile email reported by `status --chatgpt`.
+    /// Route to a Chrome profile email reported by extension status.
     #[arg(long, alias = "profile_email")]
     profile_email: Option<String>,
 
-    /// Route to the stable extension instance id reported by `status --chatgpt`.
+    /// Route to the stable extension instance id reported by extension status.
     #[arg(long, alias = "extension_instance_id")]
     extension_instance_id: Option<String>,
 
-    /// Route to a Chrome extension profile id reported by `status --chatgpt`.
+    /// Route to a Chrome extension profile id reported by extension status.
     #[arg(long, alias = "extension_profile_id")]
     extension_profile_id: Option<String>,
 }
@@ -462,20 +470,22 @@ struct BrowserExtensionCanaryArgs {
 struct BrowserExtensionInspectArgs {
     #[arg(long)]
     chatgpt: bool,
+    #[arg(long)]
+    claude: bool,
 
     /// Yoetz run id from a failed/manual-recovery browser recipe message.
     #[arg(long, alias = "run_id")]
     run_id: String,
 
-    /// Route to a Chrome profile email reported by `status --chatgpt`.
+    /// Route to a Chrome profile email reported by extension status.
     #[arg(long, alias = "profile_email")]
     profile_email: Option<String>,
 
-    /// Route to the stable extension instance id reported by `status --chatgpt`.
+    /// Route to the stable extension instance id reported by extension status.
     #[arg(long, alias = "extension_instance_id")]
     extension_instance_id: Option<String>,
 
-    /// Route to a Chrome extension profile id reported by `status --chatgpt`.
+    /// Route to a Chrome extension profile id reported by extension status.
     #[arg(long, alias = "extension_profile_id")]
     extension_profile_id: Option<String>,
 }
@@ -1210,8 +1220,8 @@ fn recipe_transports_with_explicit_override<R: IntoBuiltinWebRecipe>(
         return Ok(transports);
     };
     if matches!(requested, browser::RecipeTransport::ChromeExtensionNative) {
-        if builtin_recipe != Some(web_recipe::BuiltinWebRecipe::Chatgpt) {
-            bail!("chrome-extension-native transport currently supports only the built-in `chatgpt` recipe");
+        if builtin_recipe.is_none() {
+            bail!("chrome-extension-native transport supports only built-in web recipes");
         }
         let mut selected = vec![browser::RecipeTransport::ChromeExtensionNative];
         if allow_cdp_fallback {
@@ -1255,7 +1265,7 @@ fn recipe_should_auto_select_extension_native<R: IntoBuiltinWebRecipe>(
 ) -> bool {
     let builtin_recipe = builtin_recipe.into_builtin_web_recipe();
     requested_transport.is_none()
-        && builtin_recipe == Some(web_recipe::BuiltinWebRecipe::Chatgpt)
+        && builtin_recipe.is_some()
         && !recipe_transports_pinned
         && !managed_profile_only
         && !explicit_browser_target
@@ -1550,7 +1560,7 @@ fn ensure_chatgpt_transport_constraints_allow_any<R: IntoBuiltinWebRecipe>(
         let setup = if recipe == web_recipe::BuiltinWebRecipe::Chatgpt {
             "Install the Yoetz Chrome extension (`yoetz browser extension setup --chatgpt`) or pass --transport chrome-extension-native."
         } else {
-            "Claude native-extension conversation support is not available in Wave 1; start a fresh Claude run without conversation/followup."
+            "Install or update the Yoetz Chrome extension (`yoetz browser extension setup --claude`) so the selected instance advertises Claude support."
         };
         bail!(
             "{} conversation requires chrome-extension-native; {requested} is not compatible. {setup}",
@@ -1608,6 +1618,19 @@ fn maybe_print_running_profile_auto_connect_preference(
 fn extension_status_connected_for_auto_selection() -> bool {
     browser_extension_native::status()
         .map(|status| status.status == "connected")
+        .unwrap_or(false)
+}
+
+fn extension_recipe_ready_for_auto_selection(recipe: Option<web_recipe::BuiltinWebRecipe>) -> bool {
+    browser_extension_native::status()
+        .map(|status| {
+            status.status == "connected"
+                && match recipe {
+                    Some(web_recipe::BuiltinWebRecipe::Claude) => status.claude_ready,
+                    Some(web_recipe::BuiltinWebRecipe::Chatgpt) => true,
+                    None => false,
+                }
+        })
         .unwrap_or(false)
 }
 
@@ -2324,7 +2347,12 @@ fn build_claude_recipe_spec(
     let poll_settings = dev_browser::resolve_chatgpt_poll_settings(recipe_vars)?;
     let upload_timeout_ms =
         dev_browser::resolve_chatgpt_upload_timeout_ms(recipe_vars, recipe_args.bundle.as_deref())?;
+    let send_timeout_ms = dev_browser::resolve_chatgpt_send_timeout_ms(recipe_vars)?;
     claude_web::validate_thread_mode(recipe_vars.get("thread").map(String::as_str))?;
+    let conversation = recipe_vars
+        .get("conversation")
+        .map(|value| claude_web::normalize_conversation(value))
+        .transpose()?;
     Ok(claude_recipe::ClaudeRecipeSpec {
         bundle_path: recipe_args.bundle.clone(),
         prompt: recipe_vars
@@ -2339,6 +2367,15 @@ fn build_claude_recipe_spec(
             .get("profile_email")
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty()),
+        extension_instance_id: recipe_vars
+            .get("extension_instance_id")
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty()),
+        extension_profile_id: recipe_vars
+            .get("extension_profile_id")
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty()),
+        conversation_id: conversation.map(|value| value.id),
         run_id: recipe_vars
             .get("run_id")
             .cloned()
@@ -2347,6 +2384,7 @@ fn build_claude_recipe_spec(
         wait_timeout_ms: poll_settings.timeout_ms,
         wait_interval_ms: poll_settings.interval_ms,
         upload_timeout_ms,
+        send_timeout_ms,
         warnings: warnings.to_vec(),
     })
 }
@@ -2464,13 +2502,14 @@ fn run_recipe_via_chrome_extension_native<R: IntoBuiltinWebRecipe>(
     recipe_vars: &BTreeMap<String, String>,
     format: OutputFormat,
     builtin_recipe: R,
+    preflight_warnings: &[String],
     fallback_used: bool,
 ) -> Result<Value> {
-    if builtin_recipe.into_builtin_web_recipe() != Some(web_recipe::BuiltinWebRecipe::Chatgpt) {
+    let Some(builtin_recipe) = builtin_recipe.into_builtin_web_recipe() else {
         return Err(anyhow!(
-            "chrome-extension-native transport currently supports only the built-in `chatgpt` recipe"
+            "chrome-extension-native transport supports only built-in web recipes"
         ));
-    }
+    };
     if recipe_args.profile.is_some()
         || recipe_args.cdp.is_some()
         || recipe_args.browser_id.is_some()
@@ -2499,23 +2538,58 @@ fn run_recipe_via_chrome_extension_native<R: IntoBuiltinWebRecipe>(
     }
     let started_at = Instant::now();
 
-    let recipe_spec = build_chatgpt_recipe_spec(recipe_args, recipe_vars)?;
-    let response = browser_extension_native::run_chatgpt_recipe(&recipe_spec, format)?;
-    let output = chatgpt_recipe::ChatgptRecipeOutput {
-        transport: browser_extension_native::TRANSPORT_NAME.to_string(),
-        backend: browser_extension_native::TRANSPORT_NAME.to_string(),
-        response: response.response,
-        model_strategy: recipe_spec.model_strategy,
-        model_used: response.model_used,
-        model_selection_status: response.model_selection_status,
-        warnings: response.warnings,
-        fallback_used,
-        delivery_mode: chatgpt_recipe::ChatgptDeliveryMode::FileUpload,
-        auto_paste_fallback: false,
-        conversation_id: response.conversation_id,
-        conversation_url: response.conversation_url,
+    let (mut payload, jsonl_event, notification_target) = match builtin_recipe {
+        web_recipe::BuiltinWebRecipe::Chatgpt => {
+            let recipe_spec = build_chatgpt_recipe_spec(recipe_args, recipe_vars)?;
+            let response = browser_extension_native::run_chatgpt_recipe(&recipe_spec, format)?;
+            let output = chatgpt_recipe::ChatgptRecipeOutput {
+                transport: browser_extension_native::TRANSPORT_NAME.to_string(),
+                backend: browser_extension_native::TRANSPORT_NAME.to_string(),
+                response: response.response,
+                model_strategy: recipe_spec.model_strategy,
+                model_used: response.model_used,
+                model_selection_status: response.model_selection_status,
+                warnings: response.warnings,
+                fallback_used,
+                delivery_mode: chatgpt_recipe::ChatgptDeliveryMode::FileUpload,
+                auto_paste_fallback: false,
+                conversation_id: response.conversation_id,
+                conversation_url: response.conversation_url,
+            };
+            (
+                output.to_value(),
+                output.to_recipe_complete_event(),
+                recipe_spec.model,
+            )
+        }
+        web_recipe::BuiltinWebRecipe::Claude => {
+            let recipe_spec =
+                build_claude_recipe_spec(recipe_args, recipe_vars, preflight_warnings)?;
+            let response = browser_extension_native::run_claude_recipe(&recipe_spec, format)?;
+            let mut warnings = recipe_spec.warnings.clone();
+            warnings.extend(response.warnings);
+            warnings.sort();
+            warnings.dedup();
+            let output = claude_recipe::ClaudeRecipeOutput {
+                transport: browser_extension_native::TRANSPORT_NAME.to_string(),
+                backend: browser_extension_native::TRANSPORT_NAME.to_string(),
+                response: response.response,
+                model_used: response.model_used,
+                model_selection_status: response.model_selection_status,
+                warnings,
+                fallback_used,
+                conversation_id: response.conversation_id,
+                conversation_url: response.conversation_url,
+                run_id: recipe_spec.run_id,
+                elapsed_ms: started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
+            };
+            (
+                output.to_value(),
+                output.to_recipe_complete_event(),
+                claude_recipe::CLAUDE_REPORTED_MODEL.to_string(),
+            )
+        }
     };
-    let mut payload = output.to_value();
     attach_browser_recipe_artifacts(&mut payload, recipe_args.bundle.as_deref())?;
     maybe_write_output(ctx, &payload)?;
     match format {
@@ -2523,7 +2597,7 @@ fn run_recipe_via_chrome_extension_native<R: IntoBuiltinWebRecipe>(
             write_json(&payload)?;
         }
         OutputFormat::Jsonl => {
-            write_jsonl("browser.recipe", &output.to_recipe_complete_event())?;
+            write_jsonl("browser.recipe", &jsonl_event)?;
         }
         OutputFormat::Text | OutputFormat::Markdown => {
             println!("{}", payload["response"].as_str().unwrap_or_default());
@@ -2532,7 +2606,7 @@ fn run_recipe_via_chrome_extension_native<R: IntoBuiltinWebRecipe>(
     maybe_notify_browser_recipe_completion(
         ctx,
         recipe_args.no_notify,
-        recipe_spec.model.as_str(),
+        notification_target.as_str(),
         &payload,
         started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
         None,
@@ -2905,11 +2979,13 @@ fn maybe_notify_browser_recipe_completion(
     );
 }
 
-fn ensure_chatgpt_extension_scope(chatgpt: bool) -> Result<()> {
-    if !chatgpt {
-        bail!("chrome-extension-native V1 is ChatGPT-only; pass --chatgpt");
+fn extension_site_scope(chatgpt: bool, claude: bool) -> Result<web_recipe::BuiltinWebRecipe> {
+    match (chatgpt, claude) {
+        (true, false) => Ok(web_recipe::BuiltinWebRecipe::Chatgpt),
+        (false, true) => Ok(web_recipe::BuiltinWebRecipe::Claude),
+        (false, false) => bail!("pass exactly one site scope: --chatgpt or --claude"),
+        (true, true) => bail!("--chatgpt and --claude are mutually exclusive"),
     }
-    Ok(())
 }
 
 fn extension_selector_from_parts<'a>(
@@ -2932,7 +3008,7 @@ fn handle_browser_extension(
     let mut text_output = None;
     let (kind, payload) = match args.command {
         BrowserExtensionCommand::Setup(args) => {
-            ensure_chatgpt_extension_scope(args.chatgpt)?;
+            let recipe = extension_site_scope(args.chatgpt, args.claude)?;
             let install = browser_extension_native::install_host()?;
             let extension_update = browser_extension_native::prepare_managed_chatgpt_extension()?;
             let extension_dir = extension_update.extension_dir.clone();
@@ -2960,38 +3036,38 @@ fn handle_browser_extension(
                     "enable Developer mode",
                     "click Load unpacked",
                     "select extension_dir",
-                    "run yoetz browser extension doctor --chatgpt"
+                    format!("run yoetz browser extension doctor --{}", recipe.as_str())
                 ],
             });
-            text_output = Some(format_extension_setup(&payload));
+            text_output = Some(format_extension_setup(&payload, recipe));
             ("browser.extension.setup", payload)
         }
         BrowserExtensionCommand::InstallHost(args) => {
-            ensure_chatgpt_extension_scope(args.chatgpt)?;
+            extension_site_scope(args.chatgpt, args.claude)?;
             (
                 "browser.extension.install_host",
                 serde_json::to_value(browser_extension_native::install_host()?)?,
             )
         }
         BrowserExtensionCommand::Status(args) => {
-            ensure_chatgpt_extension_scope(args.chatgpt)?;
+            let recipe = extension_site_scope(args.chatgpt, args.claude)?;
             let status = browser_extension_native::status()?;
-            text_output = Some(format_extension_status(&status));
+            text_output = Some(format_extension_status(&status, recipe));
             ("browser.extension.status", serde_json::to_value(status)?)
         }
         BrowserExtensionCommand::Doctor(args) => {
-            ensure_chatgpt_extension_scope(args.chatgpt)?;
+            let recipe = extension_site_scope(args.chatgpt, args.claude)?;
             let selector = extension_selector_from_parts(
                 args.profile_email.as_ref(),
                 args.extension_instance_id.as_ref(),
                 args.extension_profile_id.as_ref(),
             );
-            let report = browser_extension_native::doctor_with_auth_probe(selector)?;
-            text_output = Some(format_extension_doctor(&report));
+            let report = browser_extension_native::doctor_with_auth_probe(selector, recipe)?;
+            text_output = Some(format_extension_doctor(&report, recipe));
             ("browser.extension.doctor", serde_json::to_value(report)?)
         }
         BrowserExtensionCommand::Reconnect(args) => {
-            ensure_chatgpt_extension_scope(args.chatgpt)?;
+            extension_site_scope(args.chatgpt, args.claude)?;
             let selector = extension_selector_from_parts(
                 args.profile_email.as_ref(),
                 args.extension_instance_id.as_ref(),
@@ -3003,7 +3079,7 @@ fn handle_browser_extension(
             )
         }
         BrowserExtensionCommand::Reload(args) => {
-            ensure_chatgpt_extension_scope(args.chatgpt)?;
+            extension_site_scope(args.chatgpt, args.claude)?;
             let selector = extension_selector_from_parts(
                 args.profile_email.as_ref(),
                 args.extension_instance_id.as_ref(),
@@ -3015,7 +3091,7 @@ fn handle_browser_extension(
             )
         }
         BrowserExtensionCommand::Update(args) => {
-            ensure_chatgpt_extension_scope(args.chatgpt)?;
+            extension_site_scope(args.chatgpt, args.claude)?;
             let selector = extension_selector_from_parts(
                 args.profile_email.as_ref(),
                 args.extension_instance_id.as_ref(),
@@ -3027,7 +3103,7 @@ fn handle_browser_extension(
             )
         }
         BrowserExtensionCommand::Canary(args) => {
-            ensure_chatgpt_extension_scope(args.chatgpt)?;
+            let recipe = extension_site_scope(args.chatgpt, args.claude)?;
             let selector = extension_selector_from_parts(
                 args.profile_email.as_ref(),
                 args.extension_instance_id.as_ref(),
@@ -3035,11 +3111,11 @@ fn handle_browser_extension(
             );
             (
                 "browser.extension.canary",
-                browser_extension_native::canary(args.live, selector)?,
+                browser_extension_native::canary(args.live, selector, recipe)?,
             )
         }
         BrowserExtensionCommand::Inspect(args) => {
-            ensure_chatgpt_extension_scope(args.chatgpt)?;
+            let recipe = extension_site_scope(args.chatgpt, args.claude)?;
             let selector = extension_selector_from_parts(
                 args.profile_email.as_ref(),
                 args.extension_instance_id.as_ref(),
@@ -3047,11 +3123,11 @@ fn handle_browser_extension(
             );
             (
                 "browser.extension.inspect",
-                browser_extension_native::inspect_run(&args.run_id, selector)?,
+                browser_extension_native::inspect_run(&args.run_id, selector, recipe)?,
             )
         }
         BrowserExtensionCommand::GrantIdentity(args) => {
-            ensure_chatgpt_extension_scope(args.chatgpt)?;
+            extension_site_scope(args.chatgpt, args.claude)?;
             let selector = extension_selector_from_parts(
                 args.profile_email.as_ref(),
                 args.extension_instance_id.as_ref(),
@@ -3111,7 +3187,14 @@ fn open_chrome_extensions_page() -> Result<()> {
     Ok(())
 }
 
-fn format_extension_setup(payload: &Value) -> String {
+fn extension_site_display_name(recipe: web_recipe::BuiltinWebRecipe) -> &'static str {
+    match recipe {
+        web_recipe::BuiltinWebRecipe::Chatgpt => "ChatGPT",
+        web_recipe::BuiltinWebRecipe::Claude => "Claude",
+    }
+}
+
+fn format_extension_setup(payload: &Value, recipe: web_recipe::BuiltinWebRecipe) -> String {
     let extension_dir = payload
         .get("extension_dir")
         .and_then(Value::as_str)
@@ -3147,7 +3230,10 @@ fn format_extension_setup(payload: &Value) -> String {
         .unwrap_or("<unknown>");
 
     let mut lines = vec![
-        "Yoetz ChatGPT native extension setup prepared.".to_string(),
+        format!(
+            "Yoetz native extension setup prepared for {}.",
+            extension_site_display_name(recipe)
+        ),
         format!("native_host_manifest: {native_manifest}"),
         format!("extension_id: {}", browser_extension_native::EXTENSION_ID),
         format!("extension_dir: {extension_dir}"),
@@ -3156,7 +3242,10 @@ fn format_extension_setup(payload: &Value) -> String {
         format!("chrome_extensions_url: {}", browser_extension_native::CHROME_EXTENSIONS_URL),
         format!("opened_chrome: {opened}"),
         format!("current_bridge_status: {status}"),
-        "next: in Chrome, enable Developer mode, click Load unpacked, select extension_dir, then run `yoetz browser extension doctor --chatgpt`.".to_string(),
+        format!(
+            "next: in Chrome, enable Developer mode, click Load unpacked, select extension_dir, then run `yoetz browser extension doctor --{}`.",
+            recipe.as_str()
+        ),
     ];
     if payload
         .get("extension_dir")
@@ -3171,9 +3260,23 @@ fn format_extension_setup(payload: &Value) -> String {
     lines.join("\n")
 }
 
-fn format_extension_status(status: &browser_extension_native::ExtensionStatus) -> String {
+fn format_extension_status(
+    status: &browser_extension_native::ExtensionStatus,
+    recipe: web_recipe::BuiltinWebRecipe,
+) -> String {
+    let recipe_ready = status.status == "connected"
+        && status
+            .recipes
+            .iter()
+            .any(|candidate| candidate == recipe.as_str());
     let mut lines = vec![
-        format!("Yoetz ChatGPT native extension: {}", status.status),
+        format!(
+            "Yoetz native extension for {}: {}",
+            extension_site_display_name(recipe),
+            status.status
+        ),
+        format!("site_scope: {}", recipe.as_str()),
+        format!("site_ready: {}", if recipe_ready { "yes" } else { "no" }),
         format!("detail: {}", status.detail),
         format!("extension_id: {}", status.extension_id),
         format!(
@@ -3248,9 +3351,13 @@ fn format_extension_status(status: &browser_extension_native::ExtensionStatus) -
     lines.join("\n")
 }
 
-fn format_extension_doctor(report: &browser_extension_native::DoctorReport) -> String {
+fn format_extension_doctor(
+    report: &browser_extension_native::DoctorReport,
+    recipe: web_recipe::BuiltinWebRecipe,
+) -> String {
     let mut lines = vec![format!(
-        "Yoetz ChatGPT native extension doctor: {}",
+        "Yoetz native extension doctor for {}: {}",
+        extension_site_display_name(recipe),
         if report.ok { "ok" } else { "failed" }
     )];
     for check in &report.checks {
@@ -3292,7 +3399,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
     match args.command {
         BrowserCommand::LiveAttachDaemon(_) => live_attach::serve_daemon().await,
         BrowserCommand::ChromeNativeHost(args) => {
-            ensure_chatgpt_extension_scope(args.chatgpt)?;
+            extension_site_scope(args.chatgpt, false)?;
             browser_extension_native::serve_native_host_chatgpt()
         }
         BrowserCommand::Exec(exec) => {
@@ -3914,7 +4021,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 recipe_transports_pinned,
                 managed_profile_only,
                 explicit_browser_target,
-                extension_status_connected_for_auto_selection(),
+                extension_recipe_ready_for_auto_selection(builtin_recipe),
             );
             let extension_native_will_route =
                 requested_extension_native || extension_auto_selection_eligible;
@@ -3925,13 +4032,10 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             );
             if recipe_uses_extension_instance_selector(&recipe_vars) && !extension_native_will_route
             {
-                if is_claude {
-                    bail!("extension_instance_id and extension_profile_id require Claude chrome-extension-native support, which is not available in Wave 1")
-                } else {
-                    bail!(
-                        "extension_instance_id and extension_profile_id selectors require chrome-extension-native; install the Yoetz Chrome extension (`yoetz browser extension setup --chatgpt`) or pass --transport chrome-extension-native"
-                    );
-                }
+                let site_flag = if is_claude { "--claude" } else { "--chatgpt" };
+                bail!(
+                    "extension_instance_id and extension_profile_id selectors require chrome-extension-native; install or update the Yoetz Chrome extension (`yoetz browser extension setup {site_flag}`) or pass --transport chrome-extension-native"
+                );
             }
             if is_chatgpt {
                 chatgpt_web::validate_thread_mode(recipe_vars.get("thread").map(String::as_str))?;
@@ -3971,7 +4075,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 ),
             )?;
             maybe_print_auto_selected_cdp_target(resolved_cdp_target.as_ref(), format);
-            let base_transports = browser::maybe_select_extension_native_for_chatgpt(
+            let base_transports = browser::maybe_select_extension_native_for_builtin(
                 browser::recipe_transports(&recipe, builtin_recipe),
                 builtin_recipe,
                 recipe_transports_pinned,
@@ -4090,6 +4194,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                             &recipe_vars,
                             format,
                             builtin_recipe,
+                            &preflight_warnings,
                             fallback_used,
                         )
                     }
@@ -5362,6 +5467,20 @@ mod tests {
     }
 
     #[test]
+    fn explicit_chrome_extension_transport_accepts_claude_builtin() {
+        assert_eq!(
+            recipe_transports_with_explicit_override(
+                vec![browser::RecipeTransport::ChromeDevtoolsMcp],
+                Some(browser::RecipeTransport::ChromeExtensionNative),
+                false,
+                Some(web_recipe::BuiltinWebRecipe::Claude),
+            )
+            .unwrap(),
+            vec![browser::RecipeTransport::ChromeExtensionNative]
+        );
+    }
+
+    #[test]
     fn explicit_chrome_extension_transport_cdp_fallback_is_opt_in() {
         let default = vec![
             browser::RecipeTransport::ChromeDevtoolsMcp,
@@ -5432,6 +5551,14 @@ mod tests {
         ));
         assert!(!recipe_should_auto_select_extension_native(
             None, false, false, false, false, true
+        ));
+        assert!(recipe_should_auto_select_extension_native(
+            None,
+            Some(web_recipe::BuiltinWebRecipe::Claude),
+            false,
+            false,
+            false,
+            true,
         ));
     }
 
@@ -6480,7 +6607,7 @@ mod tests {
     }
 
     #[test]
-    fn claude_conversation_is_rejected_before_non_native_side_effects_in_wave_one() {
+    fn claude_conversation_requires_native_extension_capability() {
         let vars = BTreeMap::from([(
             "conversation".to_string(),
             "123e4567-e89b-12d3-a456-426614174000".to_string(),
@@ -6505,7 +6632,7 @@ mod tests {
         .unwrap_err();
         let message = err.to_string();
         assert!(message.contains("Claude conversation requires chrome-extension-native"));
-        assert!(message.contains("not available in Wave 1"));
+        assert!(message.contains("setup --claude"));
     }
 
     #[test]
@@ -6654,6 +6781,7 @@ mod tests {
             &recipe_vars,
             OutputFormat::Json,
             true,
+            &[],
             false,
         )
         .unwrap_err();
@@ -6687,6 +6815,7 @@ mod tests {
             &recipe_vars,
             OutputFormat::Json,
             true,
+            &[],
             false,
         )
         .unwrap_err();
@@ -6720,6 +6849,7 @@ mod tests {
             &recipe_vars,
             OutputFormat::Json,
             true,
+            &[],
             false,
         )
         .unwrap_err();

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -23,6 +23,8 @@ mod budget;
 mod chatgpt_recipe;
 mod chatgpt_web;
 mod chrome_devtools_mcp;
+mod claude_recipe;
+mod claude_web;
 mod commands;
 mod dev_browser;
 mod followup;
@@ -33,6 +35,7 @@ mod live_cdp_daemon;
 mod notifications;
 mod providers;
 mod registry;
+mod web_recipe;
 
 use yoetz_core::config::Config;
 use yoetz_core::media::{MediaInput, MediaType};
@@ -1146,15 +1149,11 @@ fn handle_session(ctx: &AppContext, args: SessionArgs, format: OutputFormat) -> 
     }
 }
 
-fn is_chatgpt_recipe(recipe: &browser::Recipe, recipe_path: &Path) -> bool {
-    recipe
-        .name
-        .as_deref()
-        .is_some_and(|name| name.eq_ignore_ascii_case("chatgpt"))
-        || recipe_path
-            .to_string_lossy()
-            .to_lowercase()
-            .contains("chatgpt")
+fn builtin_web_recipe(
+    recipe: &browser::Recipe,
+    recipe_path: &Path,
+) -> Option<web_recipe::BuiltinWebRecipe> {
+    web_recipe::BuiltinWebRecipe::detect(recipe.name.as_deref(), recipe_path)
 }
 
 fn recipe_transport_name(transport: browser::RecipeTransport) -> &'static str {
@@ -1180,12 +1179,30 @@ fn parse_recipe_transport_flag(value: &str) -> Result<browser::RecipeTransport, 
     }
 }
 
-fn recipe_transports_with_explicit_override(
+trait IntoBuiltinWebRecipe {
+    fn into_builtin_web_recipe(self) -> Option<web_recipe::BuiltinWebRecipe>;
+}
+
+impl IntoBuiltinWebRecipe for Option<web_recipe::BuiltinWebRecipe> {
+    fn into_builtin_web_recipe(self) -> Option<web_recipe::BuiltinWebRecipe> {
+        self
+    }
+}
+
+#[cfg(test)]
+impl IntoBuiltinWebRecipe for bool {
+    fn into_builtin_web_recipe(self) -> Option<web_recipe::BuiltinWebRecipe> {
+        self.then_some(web_recipe::BuiltinWebRecipe::Chatgpt)
+    }
+}
+
+fn recipe_transports_with_explicit_override<R: IntoBuiltinWebRecipe>(
     transports: Vec<browser::RecipeTransport>,
     requested: Option<browser::RecipeTransport>,
     allow_cdp_fallback: bool,
-    is_chatgpt: bool,
+    builtin_recipe: R,
 ) -> Result<Vec<browser::RecipeTransport>> {
+    let builtin_recipe = builtin_recipe.into_builtin_web_recipe();
     let Some(requested) = requested else {
         if allow_cdp_fallback {
             bail!("--allow-cdp-fallback is only valid with --transport chrome-extension-native");
@@ -1193,7 +1210,7 @@ fn recipe_transports_with_explicit_override(
         return Ok(transports);
     };
     if matches!(requested, browser::RecipeTransport::ChromeExtensionNative) {
-        if !is_chatgpt {
+        if builtin_recipe != Some(web_recipe::BuiltinWebRecipe::Chatgpt) {
             bail!("chrome-extension-native transport currently supports only the built-in `chatgpt` recipe");
         }
         let mut selected = vec![browser::RecipeTransport::ChromeExtensionNative];
@@ -1208,12 +1225,14 @@ fn recipe_transports_with_explicit_override(
     Ok(vec![requested])
 }
 
-fn recipe_effective_allow_cdp_fallback(
+fn recipe_effective_allow_cdp_fallback<R: IntoBuiltinWebRecipe>(
     allow_cdp_fallback: bool,
     recipe_vars: &BTreeMap<String, String>,
-    is_chatgpt: bool,
+    builtin_recipe: R,
 ) -> bool {
-    allow_cdp_fallback && !(is_chatgpt && recipe_uses_conversation_selector(recipe_vars))
+    let builtin_recipe = builtin_recipe.into_builtin_web_recipe();
+    allow_cdp_fallback
+        && !(builtin_recipe.is_some() && recipe_uses_conversation_selector(recipe_vars))
 }
 
 fn recipe_should_auto_discover_cdp_target(
@@ -1226,28 +1245,36 @@ fn recipe_should_auto_discover_cdp_target(
         && (!extension_native_will_route || (requested_extension_native && allow_cdp_fallback))
 }
 
-fn recipe_should_auto_select_extension_native(
+fn recipe_should_auto_select_extension_native<R: IntoBuiltinWebRecipe>(
     requested_transport: Option<browser::RecipeTransport>,
-    is_chatgpt: bool,
+    builtin_recipe: R,
     recipe_transports_pinned: bool,
     managed_profile_only: bool,
     explicit_browser_target: bool,
     extension_connected: bool,
 ) -> bool {
+    let builtin_recipe = builtin_recipe.into_builtin_web_recipe();
     requested_transport.is_none()
-        && is_chatgpt
+        && builtin_recipe == Some(web_recipe::BuiltinWebRecipe::Chatgpt)
         && !recipe_transports_pinned
         && !managed_profile_only
         && !explicit_browser_target
         && extension_connected
 }
 
-fn manual_browser_recipe_fallback(recipe_path: &Path, bundle: Option<&Path>) -> String {
+fn manual_browser_recipe_fallback(
+    recipe_path: &Path,
+    bundle: Option<&Path>,
+    builtin_recipe: Option<web_recipe::BuiltinWebRecipe>,
+) -> String {
     let bundle_hint = bundle
         .map(|path| format!(" Upload or paste `{}` manually.", path.display()))
         .unwrap_or_default();
+    let destination = builtin_recipe
+        .map(web_recipe::BuiltinWebRecipe::display_name)
+        .unwrap_or("the target site");
     format!(
-        "manual fallback for `{}`: open ChatGPT in the target Chrome profile and complete the web flow manually.{bundle_hint}",
+        "manual fallback for `{}`: open {destination} in the target Chrome profile and complete the web flow manually.{bundle_hint}",
         recipe_path.display()
     )
 }
@@ -1268,19 +1295,35 @@ fn recipe_transport_error_detail(err: &anyhow::Error) -> String {
 fn recipe_transport_error_detail_for_recipe(
     err: &anyhow::Error,
     recipe_vars: &BTreeMap<String, String>,
+    builtin_recipe: Option<web_recipe::BuiltinWebRecipe>,
 ) -> String {
     let mut detail = recipe_transport_error_detail(err);
-    if chatgpt_recipe::terminal_fallback_phase(err).is_some() {
+    if let Some((recipe, _phase)) = web_recipe::terminal_fallback_marker(err)
+        .or_else(|| {
+            chatgpt_recipe::terminal_fallback_phase(err)
+                .map(|phase| (web_recipe::BuiltinWebRecipe::Chatgpt, phase))
+        })
+        .filter(|(recipe, _)| builtin_recipe.is_none_or(|expected| expected == *recipe))
+    {
         if let Some(run_id) = recipe_vars
             .get("run_id")
             .map(String::as_str)
             .map(str::trim)
             .filter(|value| !value.is_empty())
         {
-            let marked_url = chatgpt_web::mark_chatgpt_url(run_id);
-            detail.push_str(&format!(
-                "\nManual recovery: continue in the yoetz-owned ChatGPT tab for run `{run_id}` ({marked_url}; CDP/dev-browser marker window.name `yoetz:{run_id}`; extension marker prefix `yoetz-chatgpt-native:{run_id}:`). The request may already be uploaded or sent; do not rerun automatically unless you intend a duplicate submission."
-            ));
+            let marked_url = match recipe {
+                web_recipe::BuiltinWebRecipe::Chatgpt => chatgpt_web::mark_chatgpt_url(run_id),
+                web_recipe::BuiltinWebRecipe::Claude => claude_web::mark_claude_url(run_id)
+                    .unwrap_or_else(|_| "https://claude.ai/new".to_string()),
+            };
+            match recipe {
+                web_recipe::BuiltinWebRecipe::Chatgpt => detail.push_str(&format!(
+                    "\nManual recovery: continue in the yoetz-owned ChatGPT tab for run `{run_id}` ({marked_url}; CDP/dev-browser marker window.name `yoetz:{run_id}`; extension marker prefix `yoetz-chatgpt-native:{run_id}:`). The request may already be uploaded or sent; do not rerun automatically unless you intend a duplicate submission."
+                )),
+                web_recipe::BuiltinWebRecipe::Claude => detail.push_str(&format!(
+                    "\nManual recovery: continue in the yoetz-owned Claude tab for run `{run_id}` ({marked_url}; CDP marker window.name `yoetz:{run_id}`). The request may already be uploaded or sent; do not rerun automatically unless you intend a duplicate submission."
+                )),
+            }
         }
     }
     detail
@@ -1308,7 +1351,9 @@ fn recipe_should_stop_live_transport_fallback(
     if browser::is_chrome_approval_wait_error(err) {
         return true;
     }
-    if chatgpt_recipe::terminal_fallback_phase(err).is_some() {
+    if web_recipe::terminal_fallback_marker(err).is_some()
+        || chatgpt_recipe::terminal_fallback_phase(err).is_some()
+    {
         return true;
     }
     if browser::is_chatgpt_auth_issue_error(err) {
@@ -1319,6 +1364,9 @@ fn recipe_should_stop_live_transport_fallback(
             return true;
         }
         return !is_live_cdp_only_transport(transport);
+    }
+    if is_claude_auth_issue_error(err) {
+        return true;
     }
     if browser::is_chatgpt_profile_selector_visibility_error(err) {
         if recipe_uses_exact_browser_context_selector(recipe_vars) {
@@ -1363,6 +1411,14 @@ fn is_live_cdp_only_transport(transport: browser::RecipeTransport) -> bool {
         transport,
         browser::RecipeTransport::ChromeDevtoolsMcp | browser::RecipeTransport::DevBrowser
     )
+}
+
+fn is_claude_auth_issue_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        let message = cause.to_string().to_ascii_lowercase();
+        message.contains("claude login is required")
+            || (message.contains("cloudflare challenge") && message.contains("claude.ai"))
+    })
 }
 
 /// When tier 1 (chrome-devtools-mcp) already determined Chrome is not
@@ -1418,12 +1474,13 @@ fn recipe_uses_chatgpt_browser_context_selector(
         || recipe_uses_profile_email_selector(recipe_vars)
 }
 
-fn constrain_chatgpt_transports_for_browser_context_selector(
+fn constrain_chatgpt_transports_for_browser_context_selector<R: IntoBuiltinWebRecipe>(
     transports: Vec<browser::RecipeTransport>,
     recipe_vars: &std::collections::BTreeMap<String, String>,
-    is_chatgpt: bool,
+    builtin_recipe: R,
 ) -> Vec<browser::RecipeTransport> {
-    if !is_chatgpt {
+    let builtin_recipe = builtin_recipe.into_builtin_web_recipe();
+    if builtin_recipe.is_none() {
         return transports;
     }
 
@@ -1457,12 +1514,13 @@ fn constrain_chatgpt_transports_for_browser_context_selector(
     transports
 }
 
-fn constrain_chatgpt_transports_for_conversation(
+fn constrain_chatgpt_transports_for_conversation<R: IntoBuiltinWebRecipe>(
     transports: Vec<browser::RecipeTransport>,
     recipe_vars: &std::collections::BTreeMap<String, String>,
-    is_chatgpt: bool,
+    builtin_recipe: R,
 ) -> Vec<browser::RecipeTransport> {
-    if !is_chatgpt || !recipe_uses_conversation_selector(recipe_vars) {
+    let builtin_recipe = builtin_recipe.into_builtin_web_recipe();
+    if builtin_recipe.is_none() || !recipe_uses_conversation_selector(recipe_vars) {
         return transports;
     }
     transports
@@ -1471,13 +1529,14 @@ fn constrain_chatgpt_transports_for_conversation(
         .collect()
 }
 
-fn ensure_chatgpt_transport_constraints_allow_any(
+fn ensure_chatgpt_transport_constraints_allow_any<R: IntoBuiltinWebRecipe>(
     transports: &[browser::RecipeTransport],
     requested: Option<browser::RecipeTransport>,
     recipe_vars: &std::collections::BTreeMap<String, String>,
-    is_chatgpt: bool,
+    builtin_recipe: R,
 ) -> Result<()> {
-    if !transports.is_empty() || !is_chatgpt {
+    let builtin_recipe = builtin_recipe.into_builtin_web_recipe();
+    if !transports.is_empty() || builtin_recipe.is_none() {
         return Ok(());
     }
 
@@ -1487,8 +1546,15 @@ fn ensure_chatgpt_transport_constraints_allow_any(
         .unwrap_or_else(|| "configured transports".to_string());
 
     if recipe_uses_conversation_selector(recipe_vars) {
+        let recipe = builtin_recipe.expect("checked above");
+        let setup = if recipe == web_recipe::BuiltinWebRecipe::Chatgpt {
+            "Install the Yoetz Chrome extension (`yoetz browser extension setup --chatgpt`) or pass --transport chrome-extension-native."
+        } else {
+            "Claude native-extension conversation support is not available in Wave 1; start a fresh Claude run without conversation/followup."
+        };
         bail!(
-            "conversation requires chrome-extension-native; {requested} is not compatible. Install the Yoetz Chrome extension (`yoetz browser extension setup --chatgpt`) or pass --transport chrome-extension-native."
+            "{} conversation requires chrome-extension-native; {requested} is not compatible. {setup}",
+            recipe.display_name()
         );
     }
 
@@ -2003,15 +2069,15 @@ async fn run_recipe_via_chrome_devtools_mcp(
     recipe_vars: &BTreeMap<String, String>,
     selected_cdp_target: Option<&browser::ResolvedCdpTarget>,
     format: OutputFormat,
-    is_chatgpt: bool,
+    builtin_recipe: Option<web_recipe::BuiltinWebRecipe>,
+    preflight_warnings: &[String],
     fallback_used: bool,
 ) -> Result<Value> {
-    if !is_chatgpt {
+    let Some(builtin_recipe) = builtin_recipe else {
         return Err(anyhow!(
-            "chrome-devtools-mcp transport currently supports only the built-in `chatgpt` recipe; \
-             claude and gemini ports will land after the chatgpt path is verified end-to-end"
+            "chrome-devtools-mcp transport supports only built-in web recipes"
         ));
-    }
+    };
     if recipe_args.profile.is_some() {
         return Err(anyhow!(
             "chrome-devtools-mcp transport does not support `--profile`; \
@@ -2030,6 +2096,18 @@ async fn run_recipe_via_chrome_devtools_mcp(
         return Err(anyhow!(
             "chrome-devtools-mcp transport requires `--bundle`; it does not support inline paste mode"
         ));
+    }
+    if builtin_recipe == web_recipe::BuiltinWebRecipe::Claude {
+        return run_claude_recipe_via_chrome_devtools_mcp(
+            ctx,
+            recipe_args,
+            recipe_vars,
+            selected_cdp_target,
+            format,
+            preflight_warnings,
+            fallback_used,
+        )
+        .await;
     }
     let started_at = Instant::now();
 
@@ -2120,6 +2198,67 @@ async fn run_recipe_via_chrome_devtools_mcp(
     Ok(payload)
 }
 
+async fn run_claude_recipe_via_chrome_devtools_mcp(
+    ctx: &AppContext,
+    recipe_args: &BrowserRecipeArgs,
+    recipe_vars: &BTreeMap<String, String>,
+    selected_cdp_target: Option<&browser::ResolvedCdpTarget>,
+    format: OutputFormat,
+    preflight_warnings: &[String],
+    fallback_used: bool,
+) -> Result<Value> {
+    let started_at = Instant::now();
+    let recipe_spec = build_claude_recipe_spec(recipe_args, recipe_vars, preflight_warnings)?;
+    let recipe_ctx = chrome_devtools_mcp::DevtoolsMcpRecipeContext {
+        cdp_endpoint: selected_cdp_target.map(|target| target.endpoint.clone()),
+        bundle_path: recipe_spec.bundle_path.clone(),
+        bundle_text: None,
+        model: claude_recipe::CLAUDE_FABLE_MAX_MODEL.to_string(),
+        prompt: recipe_spec.prompt.clone(),
+        browser_context_id: recipe_spec.browser_context_id.clone(),
+        profile_email: recipe_spec.profile_email.clone(),
+        run_id: recipe_spec.run_id.clone(),
+        response_timeout_ms: recipe_spec.wait_timeout_ms,
+        response_poll_interval_ms: recipe_spec.wait_interval_ms,
+        upload_timeout_ms: recipe_spec.upload_timeout_ms,
+        show_approval_guidance: matches!(format, OutputFormat::Text | OutputFormat::Markdown),
+    };
+    let response = chrome_devtools_mcp::claude::run(&recipe_ctx).await?;
+    let elapsed_ms = started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+    let output = claude_recipe::ClaudeRecipeOutput {
+        transport: "chrome-devtools-mcp".to_string(),
+        backend: "chrome-devtools-mcp".to_string(),
+        response: response.response,
+        model_used: response.model_used,
+        model_selection_status: response.model_selection_status,
+        warnings: recipe_spec.warnings,
+        fallback_used,
+        conversation_id: response.conversation_id,
+        conversation_url: response.conversation_url,
+        run_id: recipe_spec.run_id,
+        elapsed_ms,
+    };
+    let mut payload = output.to_value();
+    attach_browser_recipe_artifacts(&mut payload, recipe_args.bundle.as_deref())?;
+    maybe_write_output(ctx, &payload)?;
+    match format {
+        OutputFormat::Json => write_json(&payload)?,
+        OutputFormat::Jsonl => write_jsonl("browser.recipe", &output.to_recipe_complete_event())?,
+        OutputFormat::Text | OutputFormat::Markdown => {
+            println!("{}", payload["response"].as_str().unwrap_or_default());
+        }
+    }
+    maybe_notify_browser_recipe_completion(
+        ctx,
+        recipe_args.no_notify,
+        claude_recipe::CLAUDE_REPORTED_MODEL,
+        &payload,
+        elapsed_ms,
+        None,
+    );
+    Ok(payload)
+}
+
 fn build_chatgpt_recipe_spec(
     recipe_args: &BrowserRecipeArgs,
     recipe_vars: &BTreeMap<String, String>,
@@ -2174,6 +2313,78 @@ fn build_chatgpt_recipe_spec(
         upload_timeout_ms,
         send_timeout_ms,
     })
+}
+
+fn build_claude_recipe_spec(
+    recipe_args: &BrowserRecipeArgs,
+    recipe_vars: &BTreeMap<String, String>,
+    warnings: &[String],
+) -> Result<claude_recipe::ClaudeRecipeSpec> {
+    ensure_claude_fable_max_only(recipe_args, recipe_vars)?;
+    let poll_settings = dev_browser::resolve_chatgpt_poll_settings(recipe_vars)?;
+    let upload_timeout_ms =
+        dev_browser::resolve_chatgpt_upload_timeout_ms(recipe_vars, recipe_args.bundle.as_deref())?;
+    claude_web::validate_thread_mode(recipe_vars.get("thread").map(String::as_str))?;
+    Ok(claude_recipe::ClaudeRecipeSpec {
+        bundle_path: recipe_args.bundle.clone(),
+        prompt: recipe_vars
+            .get("prompt")
+            .cloned()
+            .unwrap_or_else(|| DEFAULT_CHATGPT_RECIPE_PROMPT.to_string()),
+        browser_context_id: recipe_vars
+            .get("browser_context_id")
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty()),
+        profile_email: recipe_vars
+            .get("profile_email")
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty()),
+        run_id: recipe_vars
+            .get("run_id")
+            .cloned()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(claude_web::generate_run_id),
+        wait_timeout_ms: poll_settings.timeout_ms,
+        wait_interval_ms: poll_settings.interval_ms,
+        upload_timeout_ms,
+        warnings: warnings.to_vec(),
+    })
+}
+
+fn ensure_claude_fable_max_only(
+    recipe_args: &BrowserRecipeArgs,
+    recipe_vars: &BTreeMap<String, String>,
+) -> Result<()> {
+    if recipe_args.model_strategy == chatgpt_recipe::ChatgptModelStrategy::Current {
+        bail!("Claude supports only Fable 5 with Max effort and Thinking on; --model-strategy current is not allowed");
+    }
+    let unsupported = ["model", "effort", "thinking"]
+        .into_iter()
+        .filter(|key| recipe_vars.contains_key(*key))
+        .collect::<Vec<_>>();
+    if !unsupported.is_empty() {
+        bail!(
+            "Claude supports only Fable 5 with Max effort and Thinking on; remove unsupported var(s): {}",
+            unsupported.join(", ")
+        );
+    }
+    Ok(())
+}
+
+fn claude_inline_warn_tokens(recipe_vars: &BTreeMap<String, String>) -> Result<usize> {
+    recipe_vars
+        .get("inline_warn_tokens")
+        .map(String::as_str)
+        .unwrap_or_else(|| {
+            const DEFAULT: &str = "150000";
+            debug_assert_eq!(
+                DEFAULT.parse::<usize>().ok(),
+                Some(claude_recipe::DEFAULT_INLINE_WARN_TOKENS)
+            );
+            DEFAULT
+        })
+        .parse::<usize>()
+        .context("inline_warn_tokens must be a non-negative integer")
 }
 
 fn ensure_chatgpt_sol_pro_only_vars(recipe_vars: &BTreeMap<String, String>) -> Result<()> {
@@ -2247,15 +2458,15 @@ fn bundle_prompt_for_recipe(bundle_path: Option<&Path>) -> Result<Option<String>
     Ok(Some(bundle.prompt))
 }
 
-fn run_recipe_via_chrome_extension_native(
+fn run_recipe_via_chrome_extension_native<R: IntoBuiltinWebRecipe>(
     ctx: &AppContext,
     recipe_args: &BrowserRecipeArgs,
     recipe_vars: &BTreeMap<String, String>,
     format: OutputFormat,
-    is_chatgpt: bool,
+    builtin_recipe: R,
     fallback_used: bool,
 ) -> Result<Value> {
-    if !is_chatgpt {
+    if builtin_recipe.into_builtin_web_recipe() != Some(web_recipe::BuiltinWebRecipe::Chatgpt) {
         return Err(anyhow!(
             "chrome-extension-native transport currently supports only the built-in `chatgpt` recipe"
         ));
@@ -2372,6 +2583,7 @@ fn maybe_write_followup_session_metadata(
     recipe_args: &BrowserRecipeArgs,
     current_prompt_hash: Option<&str>,
     payload: &Value,
+    recipe: web_recipe::BuiltinWebRecipe,
 ) {
     let Some(current_prompt_hash) = current_prompt_hash else {
         return;
@@ -2394,16 +2606,30 @@ fn maybe_write_followup_session_metadata(
         .and_then(|name| name.to_str())
         .unwrap_or("session")
         .to_string();
-    let Ok(conversation) = chatgpt_web::normalize_conversation(conversation_raw) else {
+    let conversation = match recipe {
+        web_recipe::BuiltinWebRecipe::Chatgpt => {
+            chatgpt_web::normalize_conversation(conversation_raw).map(|value| {
+                web_recipe::WebConversation {
+                    id: value.id,
+                    url: value.url,
+                }
+            })
+        }
+        web_recipe::BuiltinWebRecipe::Claude => {
+            claude_web::normalize_conversation(conversation_raw)
+        }
+    };
+    let Ok(conversation) = conversation else {
         eprintln!(
             "warning: could not normalize followup conversation for metadata {}",
             session_dir.join("followup.json").display()
         );
         return;
     };
-    if let Err(err) = followup::write_followup_metadata(
+    if let Err(err) = followup::write_followup_metadata_for_recipe(
         &session_dir,
         &session_id,
+        recipe,
         &conversation,
         current_prompt_hash,
     ) {
@@ -2440,16 +2666,16 @@ fn resolve_dev_browser_delivery_mode_for_platform(
     Ok((requested_paste_mode, bundle_text, false))
 }
 
-fn run_recipe_via_dev_browser(
+fn run_recipe_via_dev_browser<R: IntoBuiltinWebRecipe>(
     ctx: &AppContext,
     recipe_args: &BrowserRecipeArgs,
     recipe_vars: &BTreeMap<String, String>,
     cdp_endpoint: Option<&str>,
     format: OutputFormat,
-    is_chatgpt: bool,
+    builtin_recipe: R,
     fallback_used: bool,
 ) -> Result<Value> {
-    if !is_chatgpt {
+    if builtin_recipe.into_builtin_web_recipe() != Some(web_recipe::BuiltinWebRecipe::Chatgpt) {
         return Err(anyhow!(
             "dev-browser transport currently supports only the built-in `chatgpt` recipe"
         ));
@@ -2536,18 +2762,25 @@ fn run_recipe_via_dev_browser(
     Ok(payload)
 }
 
-fn run_recipe_via_agent_browser(
+fn run_recipe_via_agent_browser<R: IntoBuiltinWebRecipe>(
     ctx: &AppContext,
     recipe: browser::Recipe,
     recipe_args: &BrowserRecipeArgs,
     recipe_vars: BTreeMap<String, String>,
     profile_dir: PathBuf,
     format: OutputFormat,
-    is_chatgpt: bool,
+    builtin_recipe: R,
     fallback_used: bool,
     prefer_auto_connect: bool,
     selected_cdp_target: &mut Option<browser::ResolvedCdpTarget>,
 ) -> Result<Value> {
+    let builtin_recipe = builtin_recipe.into_builtin_web_recipe();
+    if builtin_recipe == Some(web_recipe::BuiltinWebRecipe::Claude) {
+        return Err(anyhow!(
+            "agent-browser transport for the built-in `claude` recipe is reserved for Wave 3; Wave 1 supports chrome-devtools-mcp"
+        ));
+    }
+    let is_chatgpt = builtin_recipe == Some(web_recipe::BuiltinWebRecipe::Chatgpt);
     let needs_auth = is_chatgpt;
     let live_connection = if needs_auth {
         if profile_forces_managed_browser(
@@ -3613,8 +3846,10 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 browser::build_recipe_vars(recipe.defaults.as_ref(), &recipe_args.vars)?;
             let profile_dir =
                 browser::resolve_profile_dir(&ctx.browser_defaults, recipe_args.profile.as_ref())?;
-            let is_chatgpt = is_chatgpt_recipe(&recipe, &recipe_path);
-            let current_prompt_hash = if is_chatgpt {
+            let builtin_recipe = builtin_web_recipe(&recipe, &recipe_path);
+            let is_chatgpt = builtin_recipe == Some(web_recipe::BuiltinWebRecipe::Chatgpt);
+            let is_claude = builtin_recipe == Some(web_recipe::BuiltinWebRecipe::Claude);
+            let current_prompt_hash = if let Some(recipe_kind) = builtin_recipe {
                 apply_chatgpt_prompt_default(&recipe_args, &mut recipe_vars)?;
                 let current_prompt_hash = followup::compute_prompt_hash(
                     recipe_vars
@@ -3628,9 +3863,22 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         Some(followup_raw),
                         recipe_vars.get("conversation").map(String::as_str),
                     )?;
-                    let resolved_followup = followup::resolve_followup_target(
+                    let resolved_followup = followup::resolve_followup_target_for_recipe(
                         followup_raw,
                         &yoetz_core::session::session_base_dir(),
+                        recipe_kind,
+                        |raw| match recipe_kind {
+                            web_recipe::BuiltinWebRecipe::Chatgpt => {
+                                let value = chatgpt_web::normalize_conversation(raw)?;
+                                Ok(web_recipe::WebConversation {
+                                    id: value.id,
+                                    url: value.url,
+                                })
+                            }
+                            web_recipe::BuiltinWebRecipe::Claude => {
+                                claude_web::normalize_conversation(raw)
+                            }
+                        },
                     )?;
                     followup::guard_duplicate_prompt(
                         &current_prompt_hash,
@@ -3662,7 +3910,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 recipe_args.cdp.is_some() || recipe_args.browser_id.is_some();
             let extension_auto_selection_eligible = recipe_should_auto_select_extension_native(
                 recipe_args.transport,
-                is_chatgpt,
+                builtin_recipe,
                 recipe_transports_pinned,
                 managed_profile_only,
                 explicit_browser_target,
@@ -3673,13 +3921,17 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             let effective_allow_cdp_fallback = recipe_effective_allow_cdp_fallback(
                 recipe_args.allow_cdp_fallback,
                 &recipe_vars,
-                is_chatgpt,
+                builtin_recipe,
             );
             if recipe_uses_extension_instance_selector(&recipe_vars) && !extension_native_will_route
             {
-                bail!(
-                    "extension_instance_id and extension_profile_id selectors require chrome-extension-native; install the Yoetz Chrome extension (`yoetz browser extension setup --chatgpt`) or pass --transport chrome-extension-native"
-                );
+                if is_claude {
+                    bail!("extension_instance_id and extension_profile_id require Claude chrome-extension-native support, which is not available in Wave 1")
+                } else {
+                    bail!(
+                        "extension_instance_id and extension_profile_id selectors require chrome-extension-native; install the Yoetz Chrome extension (`yoetz browser extension setup --chatgpt`) or pass --transport chrome-extension-native"
+                    );
+                }
             }
             if is_chatgpt {
                 chatgpt_web::validate_thread_mode(recipe_vars.get("thread").map(String::as_str))?;
@@ -3687,7 +3939,26 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                     .entry("run_id".to_string())
                     .or_insert_with(chatgpt_web::generate_run_id);
                 chatgpt_web::validate_run_id(run_id)?;
+            } else if is_claude {
+                ensure_claude_fable_max_only(&recipe_args, &recipe_vars)?;
+                claude_web::validate_thread_mode(recipe_vars.get("thread").map(String::as_str))?;
+                let run_id = recipe_vars
+                    .entry("run_id".to_string())
+                    .or_insert_with(claude_web::generate_run_id);
+                claude_web::mark_claude_url(run_id)?;
             }
+            let preflight_warnings = if is_claude {
+                let warnings = claude_recipe::inline_size_warnings(
+                    recipe_args.bundle.as_deref(),
+                    claude_inline_warn_tokens(&recipe_vars)?,
+                )?;
+                for warning in &warnings {
+                    eprintln!("warning: {warning}");
+                }
+                warnings
+            } else {
+                Vec::new()
+            };
             let mut resolved_cdp_target = browser::resolve_cdp_target_with_selector(
                 recipe_args.cdp.as_deref(),
                 recipe_args.browser_id.as_deref(),
@@ -3701,8 +3972,8 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             )?;
             maybe_print_auto_selected_cdp_target(resolved_cdp_target.as_ref(), format);
             let base_transports = browser::maybe_select_extension_native_for_chatgpt(
-                browser::recipe_transports(&recipe, is_chatgpt),
-                is_chatgpt,
+                browser::recipe_transports(&recipe, builtin_recipe),
+                builtin_recipe,
                 recipe_transports_pinned,
                 extension_auto_selection_eligible,
             );
@@ -3713,11 +3984,11 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 base_transports,
                 recipe_args.transport,
                 effective_allow_cdp_fallback,
-                is_chatgpt,
+                builtin_recipe,
             )?;
             let live_attach_owner_is_present =
                 live_attach_owner_present(&live_attach::inspect_daemon_sync());
-            let prefer_auto_connect = is_chatgpt
+            let prefer_auto_connect = builtin_recipe.is_some()
                 && !managed_profile_only
                 && !recipe_uses_exact_browser_context_selector(&recipe_vars)
                 && should_prefer_running_profile_auto_connect(
@@ -3732,23 +4003,29 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             let transports = constrain_chatgpt_transports_for_browser_context_selector(
                 transports,
                 &recipe_vars,
-                is_chatgpt,
+                builtin_recipe,
             );
-            let transports =
-                constrain_chatgpt_transports_for_conversation(transports, &recipe_vars, is_chatgpt);
+            let transports = constrain_chatgpt_transports_for_conversation(
+                transports,
+                &recipe_vars,
+                builtin_recipe,
+            );
             ensure_chatgpt_transport_constraints_allow_any(
                 &transports,
                 recipe_args.transport,
                 &recipe_vars,
-                is_chatgpt,
+                builtin_recipe,
             )?;
             maybe_print_auto_selected_extension_native_transport(
                 extension_native_auto_selected,
                 &transports,
                 format,
             );
-            let manual_fallback =
-                manual_browser_recipe_fallback(&recipe_path, recipe_args.bundle.as_deref());
+            let manual_fallback = manual_browser_recipe_fallback(
+                &recipe_path,
+                recipe_args.bundle.as_deref(),
+                builtin_recipe,
+            );
             let mut transport_errors = Vec::new();
 
             let mut skip_remaining_live_cdp = false;
@@ -3778,7 +4055,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         &recipe_vars,
                         cdp_endpoint.as_deref(),
                         format,
-                        is_chatgpt,
+                        builtin_recipe,
                         fallback_used,
                     ),
                     browser::RecipeTransport::AgentBrowser => run_recipe_via_agent_browser(
@@ -3788,7 +4065,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         recipe_vars.clone(),
                         profile_dir.clone(),
                         format,
-                        is_chatgpt,
+                        builtin_recipe,
                         fallback_used,
                         prefer_auto_connect,
                         &mut resolved_cdp_target,
@@ -3800,7 +4077,8 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                             &recipe_vars,
                             resolved_cdp_target.as_ref(),
                             format,
-                            is_chatgpt,
+                            builtin_recipe,
+                            &preflight_warnings,
                             fallback_used,
                         )
                         .await
@@ -3811,7 +4089,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                             &recipe_args,
                             &recipe_vars,
                             format,
-                            is_chatgpt,
+                            builtin_recipe,
                             fallback_used,
                         )
                     }
@@ -3828,11 +4106,12 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         ) {
                             maybe_remember_cdp_target(resolved_cdp_target.as_ref(), format);
                         }
-                        if is_chatgpt {
+                        if let Some(recipe_kind) = builtin_recipe {
                             maybe_write_followup_session_metadata(
                                 &recipe_args,
                                 current_prompt_hash.as_deref(),
                                 &_payload,
+                                recipe_kind,
                             );
                         }
                         return Ok(());
@@ -3856,7 +4135,11 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         ) {
                             transport_errors.push((
                                 transport,
-                                recipe_transport_error_detail_for_recipe(&err, &recipe_vars),
+                                recipe_transport_error_detail_for_recipe(
+                                    &err,
+                                    &recipe_vars,
+                                    builtin_recipe,
+                                ),
                             ));
                             if recipe_has_remaining_manual_fallback(&transports, index) {
                                 transport_errors.push((
@@ -3871,11 +4154,12 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         }
                         if matches!(transport, browser::RecipeTransport::ChromeExtensionNative)
                             && !effective_allow_cdp_fallback
+                            && web_recipe::terminal_fallback_marker(&err).is_none()
                             && chatgpt_recipe::terminal_fallback_phase(&err).is_none()
                             && matches!(format, OutputFormat::Text | OutputFormat::Markdown)
                         {
                             eprintln!(
-                                "info: chrome-extension-native failed before a terminal ChatGPT phase; rerun with --allow-cdp-fallback to explicitly use the existing CDP transport for this run"
+                                "info: chrome-extension-native failed before a terminal browser phase; rerun with --allow-cdp-fallback to explicitly use the existing CDP transport for this run"
                             );
                         }
                         if !matches!(transport, browser::RecipeTransport::Manual) {
@@ -3891,7 +4175,11 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         }
                         transport_errors.push((
                             transport,
-                            recipe_transport_error_detail_for_recipe(&err, &recipe_vars),
+                            recipe_transport_error_detail_for_recipe(
+                                &err,
+                                &recipe_vars,
+                                builtin_recipe,
+                            ),
                         ));
                     }
                 }
@@ -4778,6 +5066,30 @@ mod tests {
     }
 
     #[test]
+    fn recipe_should_stop_fallback_on_claude_auth_and_terminal_phases() {
+        let vars = BTreeMap::new();
+        let auth = anyhow!("Claude login is required in the attached Chrome profile");
+        assert!(recipe_should_stop_live_transport_fallback(
+            &auth,
+            None,
+            browser::RecipeTransport::ChromeDevtoolsMcp,
+            &vars,
+        ));
+
+        let terminal = web_recipe::mark_terminal_fallback_phase(
+            anyhow!("response poll failed"),
+            web_recipe::BuiltinWebRecipe::Claude,
+            web_recipe::WebRecipeTransportPhase::WaitResponse,
+        );
+        assert!(recipe_should_stop_live_transport_fallback(
+            &terminal,
+            None,
+            browser::RecipeTransport::ChromeDevtoolsMcp,
+            &vars,
+        ));
+    }
+
+    #[test]
     fn recipe_should_stop_live_transport_fallback_on_live_attach_daemon_timeout() {
         let err = anyhow!(
             "yoetz live-attach daemon at 127.0.0.1:45555 timed out after 75000ms waiting for a response"
@@ -4988,6 +5300,40 @@ mod tests {
         assert_eq!(
             recipe_transport_name(browser::RecipeTransport::ChromeExtensionNative),
             "chrome-extension-native"
+        );
+    }
+
+    #[test]
+    fn builtin_web_recipe_detects_exact_chatgpt_and_claude_recipes() {
+        let recipe = |name: &str| browser::Recipe {
+            name: Some(name.to_string()),
+            transports: None,
+            defaults: None,
+            steps: Vec::new(),
+        };
+
+        assert_eq!(
+            builtin_web_recipe(&recipe("chatgpt"), Path::new("recipes/custom.yaml")),
+            Some(web_recipe::BuiltinWebRecipe::Chatgpt)
+        );
+        assert_eq!(
+            builtin_web_recipe(&recipe("CLAUDE"), Path::new("recipes/custom.yaml")),
+            Some(web_recipe::BuiltinWebRecipe::Claude)
+        );
+        assert_eq!(
+            builtin_web_recipe(
+                &recipe("custom"),
+                Path::new("recipes/chatgpt-enterprise.yaml")
+            ),
+            Some(web_recipe::BuiltinWebRecipe::Chatgpt)
+        );
+        assert_eq!(
+            builtin_web_recipe(&recipe("custom"), Path::new("recipes/claude.yaml")),
+            Some(web_recipe::BuiltinWebRecipe::Claude)
+        );
+        assert_eq!(
+            builtin_web_recipe(&recipe("custom"), Path::new("recipes/not-claude.yaml")),
+            None
         );
     }
 
@@ -5726,10 +6072,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_recipe_via_chrome_devtools_mcp_rejects_non_chatgpt_recipes() {
-        // Until the claude/gemini ports land, non-chatgpt recipes through the
-        // chrome-devtools-mcp transport surface a clear guidance error rather
-        // than silently trying to drive the wrong DOM.
+    async fn run_recipe_via_chrome_devtools_mcp_rejects_non_builtin_recipes() {
         let recipe_args = BrowserRecipeArgs {
             recipe: PathBuf::from("recipes/claude.yaml"),
             transport: None,
@@ -5751,14 +6094,15 @@ mod tests {
             &recipe_vars,
             None,
             OutputFormat::Text,
-            /* is_chatgpt */ false,
+            None,
+            &[],
             /* fallback_used */ false,
         )
         .await
         .unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("chrome-devtools-mcp"));
-        assert!(msg.contains("chatgpt"));
+        assert!(msg.contains("built-in web recipes"));
     }
 
     #[tokio::test]
@@ -5787,7 +6131,8 @@ mod tests {
             &recipe_vars,
             None,
             OutputFormat::Text,
-            /* is_chatgpt */ true,
+            Some(web_recipe::BuiltinWebRecipe::Chatgpt),
+            &[],
             /* fallback_used */ false,
         )
         .await
@@ -5819,7 +6164,8 @@ mod tests {
             &recipe_vars,
             None,
             OutputFormat::Text,
-            /* is_chatgpt */ true,
+            Some(web_recipe::BuiltinWebRecipe::Chatgpt),
+            &[],
             /* fallback_used */ false,
         )
         .await
@@ -5852,7 +6198,8 @@ mod tests {
             &recipe_vars,
             None,
             OutputFormat::Text,
-            /* is_chatgpt */ true,
+            Some(web_recipe::BuiltinWebRecipe::Chatgpt),
+            &[],
             /* fallback_used */ false,
         )
         .await
@@ -5885,7 +6232,8 @@ mod tests {
             &recipe_vars,
             None,
             OutputFormat::Text,
-            /* is_chatgpt */ true,
+            Some(web_recipe::BuiltinWebRecipe::Chatgpt),
+            &[],
             /* fallback_used */ false,
         )
         .await
@@ -5918,7 +6266,8 @@ mod tests {
             &recipe_vars,
             None,
             OutputFormat::Text,
-            /* is_chatgpt */ true,
+            Some(web_recipe::BuiltinWebRecipe::Chatgpt),
+            &[],
             /* fallback_used */ false,
         )
         .await
@@ -6061,6 +6410,102 @@ mod tests {
         assert!(message.contains("only GPT-5.6 Sol + Pro intelligence"));
         assert!(message.contains("model"));
         assert!(message.contains("extended"));
+    }
+
+    #[test]
+    fn claude_inline_warning_uses_actual_bundle_contents_and_zero_disables_it() {
+        let dir = TempDir::new().unwrap();
+        let bundle = dir.path().join("arbitrary-name.md");
+        fs::write(&bundle, "a".repeat(80)).unwrap();
+
+        let warnings = claude_recipe::inline_size_warnings(Some(&bundle), 10).unwrap();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("estimated 20 tokens"));
+        assert!(warnings[0].contains("heuristic"));
+        assert!(claude_recipe::inline_size_warnings(Some(&bundle), 0)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn claude_recipe_output_serializes_standard_contract_with_run_metadata() {
+        let output = claude_recipe::ClaudeRecipeOutput {
+            transport: "chrome-devtools-mcp".to_string(),
+            backend: "chrome-devtools-mcp".to_string(),
+            response: "done".to_string(),
+            model_used: Some("Fable 5 Max".to_string()),
+            model_selection_status: web_recipe::WebModelSelectionStatus::Selected,
+            warnings: vec!["size warning".to_string()],
+            fallback_used: false,
+            conversation_id: None,
+            conversation_url: None,
+            run_id: "run-claude".to_string(),
+            elapsed_ms: 1234,
+        };
+
+        let payload = output.to_value();
+        assert_eq!(payload["status"], "ok");
+        assert_eq!(payload["model_strategy"], "select");
+        assert_eq!(payload["delivery_mode"], "file_upload");
+        assert_eq!(payload["run_id"], "run-claude");
+        assert_eq!(payload["elapsed_ms"], 1234);
+        assert_eq!(payload["warnings"], json!(["size warning"]));
+    }
+
+    #[test]
+    fn claude_exact_model_policy_rejects_current_and_override_vars() {
+        let mut args = BrowserRecipeArgs {
+            recipe: PathBuf::from("recipes/claude.yaml"),
+            transport: None,
+            allow_cdp_fallback: false,
+            bundle: Some(PathBuf::from("/tmp/bundle.md")),
+            profile: None,
+            cdp: None,
+            browser_id: None,
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Current,
+            vars: vec![],
+            followup: None,
+            allow_duplicate_prompt: false,
+            no_notify: false,
+        };
+        let err = ensure_claude_fable_max_only(&args, &BTreeMap::new()).unwrap_err();
+        assert!(err.to_string().contains("--model-strategy current"));
+
+        args.model_strategy = chatgpt_recipe::ChatgptModelStrategy::Select;
+        for key in ["model", "effort", "thinking"] {
+            let vars = BTreeMap::from([(key.to_string(), "override".to_string())]);
+            let err = ensure_claude_fable_max_only(&args, &vars).unwrap_err();
+            assert!(err.to_string().contains(key));
+        }
+    }
+
+    #[test]
+    fn claude_conversation_is_rejected_before_non_native_side_effects_in_wave_one() {
+        let vars = BTreeMap::from([(
+            "conversation".to_string(),
+            "123e4567-e89b-12d3-a456-426614174000".to_string(),
+        )]);
+        let transports = constrain_chatgpt_transports_for_conversation(
+            vec![
+                browser::RecipeTransport::ChromeDevtoolsMcp,
+                browser::RecipeTransport::DevBrowser,
+                browser::RecipeTransport::AgentBrowser,
+                browser::RecipeTransport::Manual,
+            ],
+            &vars,
+            Some(web_recipe::BuiltinWebRecipe::Claude),
+        );
+        assert!(transports.is_empty());
+        let err = ensure_chatgpt_transport_constraints_allow_any(
+            &transports,
+            None,
+            &vars,
+            Some(web_recipe::BuiltinWebRecipe::Claude),
+        )
+        .unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("Claude conversation requires chrome-extension-native"));
+        assert!(message.contains("not available in Wave 1"));
     }
 
     #[test]
@@ -6391,7 +6836,11 @@ mod tests {
         );
         let vars = BTreeMap::from([("run_id".to_string(), "run-123".to_string())]);
 
-        let detail = recipe_transport_error_detail_for_recipe(&err, &vars);
+        let detail = recipe_transport_error_detail_for_recipe(
+            &err,
+            &vars,
+            Some(web_recipe::BuiltinWebRecipe::Chatgpt),
+        );
 
         assert!(detail.contains("Manual recovery"));
         assert!(detail.contains("run `run-123`"));

--- a/crates/yoetz-cli/src/web_recipe.rs
+++ b/crates/yoetz-cli/src/web_recipe.rs
@@ -1,0 +1,183 @@
+use anyhow::Error as AnyhowError;
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::path::Path;
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BuiltinWebRecipe {
+    #[default]
+    Chatgpt,
+    Claude,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WebConversation {
+    pub id: String,
+    pub url: String,
+}
+
+impl BuiltinWebRecipe {
+    pub fn detect(name: Option<&str>, recipe_path: &Path) -> Option<Self> {
+        if let Some(recipe) = name.and_then(Self::from_exact_name) {
+            return Some(recipe);
+        }
+
+        let stem = recipe_path
+            .file_stem()
+            .and_then(|value| value.to_str())?
+            .to_ascii_lowercase();
+        if recipe_stem_matches(&stem, "chatgpt") {
+            Some(Self::Chatgpt)
+        } else if recipe_stem_matches(&stem, "claude") {
+            Some(Self::Claude)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Chatgpt => "chatgpt",
+            Self::Claude => "claude",
+        }
+    }
+
+    pub fn display_name(self) -> &'static str {
+        match self {
+            Self::Chatgpt => "ChatGPT",
+            Self::Claude => "Claude",
+        }
+    }
+
+    fn from_exact_name(value: &str) -> Option<Self> {
+        if value.eq_ignore_ascii_case("chatgpt") {
+            Some(Self::Chatgpt)
+        } else if value.eq_ignore_ascii_case("claude") {
+            Some(Self::Claude)
+        } else {
+            None
+        }
+    }
+}
+
+impl fmt::Display for BuiltinWebRecipe {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.display_name())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WebRecipeTransportPhase {
+    Upload,
+    Send,
+    WaitResponse,
+}
+
+impl fmt::Display for WebRecipeTransportPhase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Upload => "upload",
+            Self::Send => "send",
+            Self::WaitResponse => "wait_response",
+        })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "{recipe} {phase} phase failed after browser side effects; automatic transport fallback is disabled"
+)]
+pub struct WebRecipeTerminalFallbackError {
+    recipe: BuiltinWebRecipe,
+    phase: WebRecipeTransportPhase,
+}
+
+impl WebRecipeTerminalFallbackError {
+    pub fn recipe(&self) -> BuiltinWebRecipe {
+        self.recipe
+    }
+
+    pub fn phase(&self) -> WebRecipeTransportPhase {
+        self.phase
+    }
+}
+
+pub fn mark_terminal_fallback_phase(
+    err: AnyhowError,
+    recipe: BuiltinWebRecipe,
+    phase: WebRecipeTransportPhase,
+) -> AnyhowError {
+    err.context(WebRecipeTerminalFallbackError { recipe, phase })
+}
+
+pub fn terminal_fallback_marker(
+    err: &AnyhowError,
+) -> Option<(BuiltinWebRecipe, WebRecipeTransportPhase)> {
+    if let Some(marker) = err.downcast_ref::<WebRecipeTerminalFallbackError>() {
+        return Some((marker.recipe(), marker.phase()));
+    }
+    err.chain().find_map(|cause| {
+        cause
+            .downcast_ref::<WebRecipeTerminalFallbackError>()
+            .map(|marker| (marker.recipe(), marker.phase()))
+    })
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, ValueEnum)]
+#[serde(rename_all = "snake_case")]
+pub enum WebModelStrategy {
+    Select,
+    Current,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WebModelSelectionStatus {
+    Selected,
+    KeptCurrent,
+    Current,
+    Unavailable,
+    Mismatch,
+}
+
+fn recipe_stem_matches(stem: &str, recipe: &str) -> bool {
+    stem == recipe
+        || stem
+            .strip_prefix(recipe)
+            .is_some_and(|suffix| suffix.starts_with(['-', '_']))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::anyhow;
+
+    #[test]
+    fn terminal_fallback_marker_preserves_recipe_and_phase() {
+        let err = mark_terminal_fallback_phase(
+            anyhow!("send failed"),
+            BuiltinWebRecipe::Claude,
+            WebRecipeTransportPhase::Send,
+        );
+
+        assert_eq!(
+            terminal_fallback_marker(&err),
+            Some((BuiltinWebRecipe::Claude, WebRecipeTransportPhase::Send))
+        );
+        assert!(err.to_string().contains("Claude send phase failed"));
+    }
+
+    #[test]
+    fn shared_model_contract_serializes_like_the_existing_chatgpt_contract() {
+        assert_eq!(
+            serde_json::to_value(WebModelStrategy::Select).unwrap(),
+            serde_json::json!("select")
+        );
+        assert_eq!(
+            serde_json::to_value(WebModelSelectionStatus::KeptCurrent).unwrap(),
+            serde_json::json!("kept_current")
+        );
+    }
+}

--- a/crates/yoetz-cli/tests/cli.rs
+++ b/crates/yoetz-cli/tests/cli.rs
@@ -316,7 +316,7 @@ fn browser_recipe_help_shows_explicit_transport_flag() {
 }
 
 #[test]
-fn browser_extension_help_shows_chatgpt_lifecycle() {
+fn browser_extension_help_shows_multi_site_lifecycle() {
     yoetz()
         .args(["browser", "extension", "--help"])
         .assert()
@@ -339,7 +339,8 @@ fn browser_extension_setup_help_shows_open_chrome() {
         .assert()
         .success()
         .stdout(predicate::str::contains("--open-chrome"))
-        .stdout(predicate::str::contains("--chatgpt"));
+        .stdout(predicate::str::contains("--chatgpt"))
+        .stdout(predicate::str::contains("--claude"));
 }
 
 #[test]
@@ -348,6 +349,8 @@ fn browser_extension_maintenance_help_shows_instance_selectors() {
         .args(["browser", "extension", "doctor", "--help"])
         .assert()
         .success()
+        .stdout(predicate::str::contains("--chatgpt"))
+        .stdout(predicate::str::contains("--claude"))
         .stdout(predicate::str::contains("--profile-email"))
         .stdout(predicate::str::contains("--extension-instance-id"))
         .stdout(predicate::str::contains("--extension-profile-id"));
@@ -364,18 +367,30 @@ fn browser_extension_maintenance_help_shows_instance_selectors() {
         .args(["browser", "extension", "canary", "--help"])
         .assert()
         .success()
+        .stdout(predicate::str::contains("--chatgpt"))
+        .stdout(predicate::str::contains("--claude"))
+        .stdout(predicate::str::contains("--profile-email"))
+        .stdout(predicate::str::contains("--extension-instance-id"))
+        .stdout(predicate::str::contains("--extension-profile-id"));
+
+    yoetz()
+        .args(["browser", "extension", "inspect", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--chatgpt"))
+        .stdout(predicate::str::contains("--claude"))
         .stdout(predicate::str::contains("--profile-email"))
         .stdout(predicate::str::contains("--extension-instance-id"))
         .stdout(predicate::str::contains("--extension-profile-id"));
 }
 
 #[test]
-fn browser_extension_status_requires_chatgpt_scope() {
+fn browser_extension_status_requires_exactly_one_site_scope() {
     yoetz()
         .args(["browser", "extension", "status", "--format", "json"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("pass --chatgpt"));
+        .stderr(predicate::str::contains("--chatgpt or --claude"));
 }
 
 #[test]
@@ -406,17 +421,26 @@ fn browser_extension_status_text_is_copy_paste_friendly() {
     let dir = tempfile::tempdir().unwrap();
     let native_hosts = dir.path().join("native-hosts");
     let state = dir.path().join("state");
-    yoetz()
-        .env("YOETZ_CHROME_NATIVE_MESSAGING_DIR", &native_hosts)
-        .env("YOETZ_DIR", &state)
-        .args(["browser", "extension", "status", "--chatgpt"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains(
-            "Yoetz ChatGPT native extension: not_installed",
-        ))
-        .stdout(predicate::str::contains("extension_instance_id:"))
-        .stdout(predicate::str::contains("connected_instances: none"));
+    for (site_flag, display_name, site_scope) in [
+        ("--chatgpt", "ChatGPT", "chatgpt"),
+        ("--claude", "Claude", "claude"),
+    ] {
+        yoetz()
+            .env("YOETZ_CHROME_NATIVE_MESSAGING_DIR", &native_hosts)
+            .env("YOETZ_DIR", &state)
+            .args(["browser", "extension", "status", site_flag])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(format!(
+                "Yoetz native extension for {display_name}: not_installed"
+            )))
+            .stdout(predicate::str::contains(format!(
+                "site_scope: {site_scope}"
+            )))
+            .stdout(predicate::str::contains("site_ready: no"))
+            .stdout(predicate::str::contains("extension_instance_id:"))
+            .stdout(predicate::str::contains("connected_instances: none"));
+    }
 }
 
 #[test]

--- a/crates/yoetz-cli/tests/cli.rs
+++ b/crates/yoetz-cli/tests/cli.rs
@@ -293,7 +293,9 @@ fn browser_check_help_shows_cdp_flag() {
         .assert()
         .success()
         .stdout(predicate::str::contains("--cdp"))
-        .stdout(predicate::str::contains("--transport"));
+        .stdout(predicate::str::contains("--transport"))
+        .stdout(predicate::str::contains("--chatgpt"))
+        .stdout(predicate::str::contains("--claude"));
 }
 
 #[test]

--- a/extensions/chatgpt-native/manifest.json
+++ b/extensions/chatgpt-native/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "Yoetz ChatGPT Native Transport",
-  "short_name": "Yoetz ChatGPT",
-  "description": "Experimental Yoetz native transport for ChatGPT recipe jobs.",
+  "name": "Yoetz Native Transport",
+  "short_name": "Yoetz Transport",
+  "description": "Yoetz native transport for supported web recipe jobs.",
   "version": "0.5.33",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAujviQNA7EjHnfqpn3TM5IfgmHzOnvtu5pXg3Y1rS5koNJBT2PSG7FTGi9wD4oqNLVFehKm5h46vq1u1ACsMjAUrqMMUVvf7RUeqieUmfbtKRmx24N2blfz4b8KYpMlNUhf8IZ5TAFbvzy9NEO2KHAHCV6pP84E4lLBW2OQIDhqJd0FfS3Ecn91pbsH3tcsU6Gu+WiPEHLXZjPj85KcgQ+8qL0Xz83V5hEXIocMlCQ0RnMOfQIp5qUEIKgZ7qKqEjW2czNz48s5Fdgzbv95Lf09vat1NWiDHXZtDPWIa6TRjlKAAXIwsz5A/DJibzWiCgKiuOWmCgQPJgDidoyj/7RQIDAQAB",
   "icons": {
@@ -21,7 +21,8 @@
     "tabGroups"
   ],
   "host_permissions": [
-    "https://chatgpt.com/*"
+    "https://chatgpt.com/*",
+    "https://claude.ai/*"
   ],
   "background": {
     "service_worker": "src/service-worker.js",
@@ -30,7 +31,8 @@
   "content_scripts": [
     {
       "matches": [
-        "https://chatgpt.com/*"
+        "https://chatgpt.com/*",
+        "https://claude.ai/*"
       ],
       "js": [
         "src/content-script.js"
@@ -41,10 +43,13 @@
   "web_accessible_resources": [
     {
       "resources": [
-        "src/chatgpt-dom.js"
+        "src/chatgpt-dom.js",
+        "src/sites/chatgpt.js",
+        "src/sites/chatgpt-backend.js"
       ],
       "matches": [
-        "https://chatgpt.com/*"
+        "https://chatgpt.com/*",
+        "https://claude.ai/*"
       ]
     }
   ],
@@ -55,7 +60,7 @@
       "48": "icons/icon-48.png",
       "128": "icons/icon-128.png"
     },
-    "default_title": "Yoetz ChatGPT Native Transport",
+    "default_title": "Yoetz Native Transport",
     "default_popup": "popup.html"
   },
   "minimum_chrome_version": "120"

--- a/extensions/chatgpt-native/manifest.json
+++ b/extensions/chatgpt-native/manifest.json
@@ -44,8 +44,10 @@
     {
       "resources": [
         "src/chatgpt-dom.js",
+        "src/claude-dom.js",
         "src/sites/chatgpt.js",
-        "src/sites/chatgpt-backend.js"
+        "src/sites/chatgpt-backend.js",
+        "src/sites/claude.js"
       ],
       "matches": [
         "https://chatgpt.com/*",

--- a/extensions/chatgpt-native/native-host-manifest.template.json
+++ b/extensions/chatgpt-native/native-host-manifest.template.json
@@ -1,6 +1,6 @@
 {
   "name": "com.yoetz.chatgpt_native",
-  "description": "Yoetz ChatGPT native messaging host",
+  "description": "Yoetz native transport messaging host",
   "path": "{{YOETZ_BINARY}}",
   "type": "stdio",
   "allowed_origins": [

--- a/extensions/chatgpt-native/popup.html
+++ b/extensions/chatgpt-native/popup.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Yoetz ChatGPT Native Transport</title>
+    <title>Yoetz Native Transport</title>
     <style>
       body {
         min-width: 240px;

--- a/extensions/chatgpt-native/src/claude-dom.js
+++ b/extensions/chatgpt-native/src/claude-dom.js
@@ -8,6 +8,7 @@ const FILE_INPUT_SELECTOR = "input[data-testid='file-upload']";
 const ATTACHMENT_SELECTOR = "[data-testid='file-thumbnail']";
 const COPY_ACTION_SELECTOR = "[data-testid='action-bar-copy']";
 const ASSISTANT_SELECTOR = "[data-is-streaming]";
+const MODEL_MENU_SETTLE_MS = 300;
 
 export function ownedWindowName(job) {
   return `${YOETZ_WINDOW_PREFIX}${job.run_id}:${job.job_id}`;
@@ -209,7 +210,7 @@ export async function ensureConversationLoaded(root = document, conversationId, 
 export async function configureModelState(root, job = {}) {
   const timeoutMs = Number(job.model_selection_timeout_ms) || 10000;
   const modelButton = await waitFor(() => root.querySelector(MODEL_SELECTOR), 20000);
-  clickIfClosed(modelButton);
+  await openModelMenu(modelButton, timeoutMs);
   const fable = await waitForOptional(() => visibleElements(root, "[role='menuitemradio']")
     .find((element) => normalizeText(element.innerText || element.textContent).toLowerCase().startsWith("fable 5")), timeoutMs);
   if (!fable) {
@@ -224,33 +225,41 @@ export async function configureModelState(root, job = {}) {
       ...diagnostics
     };
   }
-  fable.click();
 
-  clickIfClosed(modelButton);
+  const alreadySelected = await verifyAlreadySelectedModel(root, modelButton, fable, timeoutMs);
+  if (alreadySelected) {
+    return alreadySelected;
+  }
+
+  fable.click();
+  await settleAfterMenuSelection(modelButton, timeoutMs);
+
+  await openModelMenu(modelButton, timeoutMs);
   let effortTrigger = await waitFor(() => root.querySelector("[data-testid='effort-menu-trigger']"), timeoutMs);
   dispatchHover(effortTrigger);
   const max = await waitFor(() => root.querySelector("[role='menuitemradio'][data-testid='effort-option-max']"), timeoutMs);
   max.click();
+  await settleAfterMenuSelection(modelButton, timeoutMs);
 
-  clickIfClosed(modelButton);
+  await openModelMenu(modelButton, timeoutMs);
   effortTrigger = await waitFor(() => root.querySelector("[data-testid='effort-menu-trigger']"), timeoutMs);
   dispatchHover(effortTrigger);
-  const thinking = await waitFor(() => visibleElements(root, "span[role='switch'][aria-checked]")
-    .find((element) => /Thinking/i.test(normalizeText(
-      element.getAttribute("aria-label")
-      || element.closest("[role='menuitem']")?.innerText
-      || element.parentElement?.innerText
-    ))), timeoutMs);
+  const thinking = await waitFor(() => findThinkingSwitch(root), timeoutMs);
   if (thinking.getAttribute("aria-checked") !== "true") {
     thinking.click();
   }
+  await sleep(MODEL_MENU_SETTLE_MS);
 
-  clickIfClosed(modelButton);
+  await closeModelMenu(root, modelButton);
+  await sleep(MODEL_MENU_SETTLE_MS);
+  await openModelMenu(modelButton, timeoutMs);
   const verificationEffort = await waitFor(() => root.querySelector("[data-testid='effort-menu-trigger']"), timeoutMs);
   dispatchHover(verificationEffort);
   await waitFor(() => root.querySelector("[role='menuitemradio'][data-testid='effort-option-max']"), timeoutMs);
+  await waitFor(() => findThinkingSwitch(root), timeoutMs);
   const diagnostics = modelSelectionDiagnostics(root);
   const menuClosed = await closeModelMenu(root, modelButton);
+  await sleep(MODEL_MENU_SETTLE_MS);
   return {
     status: diagnostics.modelVerified && diagnostics.maxVerified && diagnostics.thinkingChecked && menuClosed
       ? "selected"
@@ -379,12 +388,7 @@ export function modelSelectionDiagnostics(root = document) {
     && selectedModels.some((element) => normalizeText(element.innerText || element.textContent).toLowerCase().startsWith("fable 5"));
   const maxOption = root.querySelector("[role='menuitemradio'][data-testid='effort-option-max']");
   const maxVerified = maxOption?.getAttribute("aria-checked") === "true" && /\bMax\b/i.test(modelChip);
-  const switches = visibleElements(root, "span[role='switch'][aria-checked]");
-  const thinking = switches.find((element) => /Thinking/i.test(normalizeText(
-    element.getAttribute("aria-label")
-    || element.closest("[role='menuitem']")?.innerText
-    || element.parentElement?.innerText
-  )));
+  const thinking = findThinkingSwitch(root);
   const thinkingChecked = thinking?.getAttribute("aria-checked") === "true";
   const options = visibleElements(root, "[role='menuitem'], [role='menuitemradio'], button, [role='switch']")
     .map((element) => normalizeText(element.innerText || element.textContent))
@@ -434,10 +438,82 @@ function conversationIdFromLocation() {
   return match ? decodeURIComponent(match[1]) : null;
 }
 
-function clickIfClosed(button) {
-  if (button.getAttribute("aria-expanded") !== "true") {
-    button.click();
+async function openModelMenu(button, timeoutMs) {
+  if (button.getAttribute("aria-expanded") === "true") {
+    await sleep(MODEL_MENU_SETTLE_MS);
+    if (button.getAttribute("aria-expanded") === "true") {
+      return;
+    }
   }
+
+  const attemptTimeoutMs = Math.max(100, Math.min(timeoutMs, 1000));
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    button.click();
+    const opened = await waitForOptional(
+      () => button.getAttribute("aria-expanded") === "true",
+      attemptTimeoutMs
+    );
+    if (opened) {
+      await sleep(MODEL_MENU_SETTLE_MS);
+      if (button.getAttribute("aria-expanded") === "true") {
+        return;
+      }
+    }
+  }
+  throw new Error(`Claude model menu did not open within ${timeoutMs}ms`);
+}
+
+async function settleAfterMenuSelection(modelButton, timeoutMs) {
+  await waitFor(() => modelButton.getAttribute("aria-expanded") !== "true", timeoutMs);
+  await sleep(MODEL_MENU_SETTLE_MS);
+}
+
+async function verifyAlreadySelectedModel(root, modelButton, fable, timeoutMs) {
+  const modelChip = normalizeText(modelButton.innerText || modelButton.textContent);
+  if (fable.getAttribute("aria-checked") !== "true" || !/\bFable 5\b.*\bMax\b/i.test(modelChip)) {
+    return null;
+  }
+
+  const effortTrigger = root.querySelector("[data-testid='effort-menu-trigger']");
+  if (!effortTrigger) {
+    return null;
+  }
+  dispatchHover(effortTrigger);
+  const max = await waitForOptional(
+    () => root.querySelector("[role='menuitemradio'][data-testid='effort-option-max']"),
+    timeoutMs
+  );
+  if (!max) {
+    return null;
+  }
+  const thinking = await waitForOptional(() => findThinkingSwitch(root), timeoutMs);
+  if (!thinking) {
+    return null;
+  }
+
+  const diagnostics = modelSelectionDiagnostics(root);
+  if (!diagnostics.modelVerified || !diagnostics.maxVerified || !diagnostics.thinkingChecked) {
+    return null;
+  }
+  const menuClosed = await closeModelMenu(root, modelButton);
+  await sleep(MODEL_MENU_SETTLE_MS);
+  return {
+    status: menuClosed ? "selected" : "mismatch",
+    requested_model: "fable-5-max",
+    model_used: "Fable 5 Max",
+    menuClosed,
+    ...(menuClosed ? {} : { warning: "Claude model menu remained open after Escape; refusing to send" }),
+    ...diagnostics
+  };
+}
+
+function findThinkingSwitch(root) {
+  return visibleElements(root, "span[role='switch'][aria-checked]")
+    .find((element) => /Thinking/i.test(normalizeText(
+      element.getAttribute("aria-label")
+      || element.closest("[role='menuitem']")?.innerText
+      || element.parentElement?.innerText
+    )));
 }
 
 function dispatchHover(element) {
@@ -471,6 +547,14 @@ async function closeModelMenu(root, modelButton) {
     bubbles: true,
     cancelable: true
   }));
+  const escaped = await waitForOptional(
+    () => modelButton.getAttribute("aria-expanded") !== "true",
+    1000
+  );
+  if (escaped) {
+    return true;
+  }
+  modelButton.click();
   return Boolean(await waitForOptional(
     () => modelButton.getAttribute("aria-expanded") !== "true",
     2000

--- a/extensions/chatgpt-native/src/claude-dom.js
+++ b/extensions/chatgpt-native/src/claude-dom.js
@@ -119,7 +119,7 @@ export async function uploadFile(root, file, options = {}) {
   const input = await waitFor(() => findFileInput(root), Math.min(timeoutMs, 20000));
   const transfer = new DataTransfer();
   transfer.items.add(file);
-  Object.defineProperty(input, "files", { configurable: true, value: transfer.files });
+  input.files = transfer.files;
   input.dispatchEvent(new Event("change", { bubbles: true }));
   await waitFor(() => {
     const attachment = Array.from(root.querySelectorAll(ATTACHMENT_SELECTOR)).find((node) =>

--- a/extensions/chatgpt-native/src/claude-dom.js
+++ b/extensions/chatgpt-native/src/claude-dom.js
@@ -1,0 +1,544 @@
+export const YOETZ_WINDOW_PREFIX = "yoetz-claude-native:";
+export const OWNERSHIP_ATTR = "data-yoetz-claude-native-job";
+
+const CLAUDE_ORIGIN = "https://claude.ai";
+const COMPOSER_SELECTOR = "[data-testid='chat-input']";
+const MODEL_SELECTOR = "[data-testid='model-selector-dropdown']";
+const FILE_INPUT_SELECTOR = "input[data-testid='file-upload']";
+const ATTACHMENT_SELECTOR = "[data-testid='file-thumbnail']";
+const COPY_ACTION_SELECTOR = "[data-testid='action-bar-copy']";
+const ASSISTANT_SELECTOR = "[data-is-streaming]";
+
+export function ownedWindowName(job) {
+  return `${YOETZ_WINDOW_PREFIX}${job.run_id}:${job.job_id}`;
+}
+
+export function parseOwnedWindowName(value) {
+  if (typeof value !== "string" || !value.startsWith(YOETZ_WINDOW_PREFIX)) {
+    return null;
+  }
+  const rest = value.slice(YOETZ_WINDOW_PREFIX.length);
+  const separator = rest.lastIndexOf(":");
+  return separator > 0
+    ? { run_id: rest.slice(0, separator), job_id: rest.slice(separator + 1) }
+    : null;
+}
+
+export function claudeJobUrl(runId) {
+  const url = new URL("/new", CLAUDE_ORIGIN);
+  url.searchParams.set("_yoetz", runId);
+  return url.toString();
+}
+
+export function claudeConversationJobUrl(conversationId, runId) {
+  const url = new URL(`/chat/${encodeURIComponent(conversationId)}`, CLAUDE_ORIGIN);
+  url.searchParams.set("_yoetz", runId);
+  return url.toString();
+}
+
+export function classifyManualHandoff({ url = "", title = "", text = "" } = {}) {
+  const haystack = normalizeText(`${title} ${text} ${url}`).toLowerCase();
+  if (/cloudflare|checking your browser|attention required|security check|just a moment|verify you are human|cf-chl/.test(haystack)) {
+    return {
+      state: "challenge_required",
+      message: "Claude browser verification is required in this Chrome profile"
+    };
+  }
+  if (/\blog in\b|\blogin\b|\bsign in\b|\bsign up\b|continue with google|\/login|\/oauth/.test(haystack)) {
+    return {
+      state: "login_required",
+      message: "Claude login is required in this Chrome profile"
+    };
+  }
+  return null;
+}
+
+export function classifyWaitManualHandoff({ url = "", title = "" } = {}) {
+  return classifyManualHandoff({ url, title, text: "" });
+}
+
+export function findComposer(root = document) {
+  return root.querySelector(COMPOSER_SELECTOR);
+}
+
+export function findFileInput(root = document) {
+  return root.querySelector(FILE_INPUT_SELECTOR);
+}
+
+export function findSendButton(root = document) {
+  return root.querySelector("button[aria-label='Send message']");
+}
+
+export function getPageText(root = document) {
+  return normalizeText(root.body?.innerText ?? root.body?.textContent ?? "");
+}
+
+export function markOwnership(root, job) {
+  root.documentElement?.setAttribute(OWNERSHIP_ATTR, `${job.run_id}:${job.job_id}`);
+}
+
+export function assertOwnedPage(win, job) {
+  const parsed = parseOwnedWindowName(win.name);
+  if (parsed?.run_id !== job.run_id || parsed?.job_id !== job.job_id) {
+    throw new Error(`tab ownership marker mismatch for job ${job.job_id}`);
+  }
+}
+
+export async function insertPrompt(root, prompt, options = {}) {
+  const composer = await waitFor(() => findComposer(root), options.timeoutMs ?? 20000);
+  composer.focus();
+  const text = String(prompt ?? "");
+  if (composer.isContentEditable || composer.getAttribute("contenteditable") === "true") {
+    if (typeof root.execCommand !== "function") {
+      throw new Error("Claude ProseMirror composer does not expose document.execCommand");
+    }
+    const selection = root.getSelection?.();
+    const range = root.createRange?.();
+    if (selection && range) {
+      range.selectNodeContents(composer);
+      selection.removeAllRanges();
+      selection.addRange(range);
+    }
+    const inserted = root.execCommand("insertText", false, text);
+    if (inserted === false && normalizeText(composer.textContent) !== normalizeText(text)) {
+      throw new Error("Claude ProseMirror composer rejected insertText");
+    }
+  } else if ("value" in composer) {
+    composer.value = text;
+    composer.dispatchEvent(new Event("input", { bubbles: true }));
+  } else {
+    throw new Error("Claude composer is neither contenteditable nor a value control");
+  }
+  composer.dispatchEvent(new Event("change", { bubbles: true }));
+  return true;
+}
+
+export async function uploadFile(root, file, options = {}) {
+  const timeoutMs = options.timeoutMs ?? 120000;
+  const input = await waitFor(() => findFileInput(root), Math.min(timeoutMs, 20000));
+  const transfer = new DataTransfer();
+  transfer.items.add(file);
+  Object.defineProperty(input, "files", { configurable: true, value: transfer.files });
+  input.dispatchEvent(new Event("change", { bubbles: true }));
+  await waitFor(() => {
+    const attachment = Array.from(root.querySelectorAll(ATTACHMENT_SELECTOR)).find((node) =>
+      normalizeText(node.querySelector("h3")?.textContent) === file.name
+      && Boolean(node.querySelector("button[aria-label='Remove']"))
+    );
+    const send = findSendButton(root);
+    return attachment && send && !send.disabled && send.getAttribute("aria-disabled") !== "true";
+  }, timeoutMs);
+  return true;
+}
+
+export async function ensureFreshChat(root = document, job = {}, options = {}) {
+  await waitForReadyComposer(root, options.timeoutMs ?? 20000);
+  const pathname = globalThis.location?.pathname ?? "";
+  if (/^\/chat\//.test(pathname)) {
+    throw commandError(
+      "fresh_chat_lost",
+      `Claude fresh job ${job.job_id ?? "(unknown)"} opened an existing conversation`,
+      { phase: "upload", side_effect_started: false }
+    );
+  }
+  return { status: "fresh", pathname };
+}
+
+export async function ensureConversationLoaded(root = document, conversationId, options = {}) {
+  const timeoutMs = options.timeoutMs ?? 120000;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    const currentId = conversationIdFromLocation();
+    if (currentId && currentId !== conversationId) {
+      throw commandError(
+        "conversation_changed",
+        `Claude conversation changed from ${conversationId} to ${currentId}`,
+        {
+          phase: "upload",
+          side_effect_started: false,
+          requested_conversation_id: conversationId,
+          current_conversation_id: currentId,
+          current_url: globalThis.location?.href ?? ""
+        }
+      );
+    }
+    if (currentId === conversationId && findComposer(root)) {
+      return { status: "loaded", conversation_id: conversationId, pathname: globalThis.location?.pathname ?? "" };
+    }
+    const handoff = classifyManualHandoff({
+      url: globalThis.location?.href,
+      title: root.title,
+      text: getPageText(root).slice(0, 500)
+    });
+    if (handoff) {
+      throw commandError(handoff.state, handoff.message, {
+        phase: "upload",
+        side_effect_started: false,
+        requested_conversation_id: conversationId,
+        current_url: globalThis.location?.href ?? ""
+      });
+    }
+    const pageText = getPageText(root).toLowerCase();
+    if (/conversation (?:not found|unavailable)|unable to load|does not exist|you do not have access/.test(pageText)) {
+      throw commandError(
+        "conversation_unavailable",
+        `Claude conversation ${conversationId} is unavailable in this profile`,
+        {
+          phase: "upload",
+          side_effect_started: false,
+          requested_conversation_id: conversationId,
+          current_url: globalThis.location?.href ?? ""
+        }
+      );
+    }
+    await sleep(options.intervalMs ?? 200);
+  }
+  throw commandError(
+    "conversation_not_loaded",
+    `Claude conversation ${conversationId} did not load before timeout`,
+    {
+      phase: "upload",
+      side_effect_started: false,
+      requested_conversation_id: conversationId,
+      current_conversation_id: conversationIdFromLocation(),
+      current_url: globalThis.location?.href ?? ""
+    }
+  );
+}
+
+export async function configureModelState(root, job = {}) {
+  const timeoutMs = Number(job.model_selection_timeout_ms) || 10000;
+  const modelButton = await waitFor(() => root.querySelector(MODEL_SELECTOR), 20000);
+  clickIfClosed(modelButton);
+  const fable = await waitForOptional(() => visibleElements(root, "[role='menuitemradio']")
+    .find((element) => normalizeText(element.innerText || element.textContent).toLowerCase().startsWith("fable 5")), timeoutMs);
+  if (!fable) {
+    const diagnostics = modelSelectionDiagnostics(root);
+    const menuClosed = await closeModelMenu(root, modelButton);
+    return {
+      status: "unavailable",
+      requested_model: "fable-5-max",
+      model_used: diagnostics.modelChip || null,
+      warning: `Claude Fable 5 is unavailable; live options: ${diagnostics.options.join(", ") || "none"}${menuClosed ? "" : "; model menu remained open"}`,
+      menuClosed,
+      ...diagnostics
+    };
+  }
+  fable.click();
+
+  clickIfClosed(modelButton);
+  let effortTrigger = await waitFor(() => root.querySelector("[data-testid='effort-menu-trigger']"), timeoutMs);
+  dispatchHover(effortTrigger);
+  const max = await waitFor(() => root.querySelector("[role='menuitemradio'][data-testid='effort-option-max']"), timeoutMs);
+  max.click();
+
+  clickIfClosed(modelButton);
+  effortTrigger = await waitFor(() => root.querySelector("[data-testid='effort-menu-trigger']"), timeoutMs);
+  dispatchHover(effortTrigger);
+  const thinking = await waitFor(() => visibleElements(root, "span[role='switch'][aria-checked]")
+    .find((element) => /Thinking/i.test(normalizeText(
+      element.getAttribute("aria-label")
+      || element.closest("[role='menuitem']")?.innerText
+      || element.parentElement?.innerText
+    ))), timeoutMs);
+  if (thinking.getAttribute("aria-checked") !== "true") {
+    thinking.click();
+  }
+
+  clickIfClosed(modelButton);
+  const verificationEffort = await waitFor(() => root.querySelector("[data-testid='effort-menu-trigger']"), timeoutMs);
+  dispatchHover(verificationEffort);
+  await waitFor(() => root.querySelector("[role='menuitemradio'][data-testid='effort-option-max']"), timeoutMs);
+  const diagnostics = modelSelectionDiagnostics(root);
+  const menuClosed = await closeModelMenu(root, modelButton);
+  return {
+    status: diagnostics.modelVerified && diagnostics.maxVerified && diagnostics.thinkingChecked && menuClosed
+      ? "selected"
+      : "mismatch",
+    requested_model: "fable-5-max",
+    model_used: diagnostics.modelVerified && diagnostics.maxVerified ? "Fable 5 Max" : diagnostics.modelChip || null,
+    menuClosed,
+    ...(menuClosed ? {} : { warning: "Claude model menu remained open after Escape; refusing to send" }),
+    ...diagnostics
+  };
+}
+
+export async function clickSend(root, options = {}) {
+  const send = await waitFor(() => {
+    const candidate = findSendButton(root);
+    return candidate && !candidate.disabled && candidate.getAttribute("aria-disabled") !== "true"
+      ? candidate
+      : null;
+  }, options.timeoutMs ?? 120000);
+  send.click();
+  return true;
+}
+
+export function sendAcceptanceBaseline(root = document) {
+  return {
+    user_count: userTurnCount(root),
+    assistant_count: assistantRoots(root).length
+  };
+}
+
+export async function waitForSendAccepted(root, baseline = {}, options = {}) {
+  const timeoutMs = options.timeoutMs ?? 120000;
+  return waitFor(() => {
+    const userCount = userTurnCount(root);
+    const assistantCount = assistantRoots(root).length;
+    const generating = isResponseGenerating(root);
+    if (userCount > Number(baseline.user_count ?? 0)
+        || assistantCount > Number(baseline.assistant_count ?? 0)
+        || generating) {
+      return { accepted: true, user_count: userCount, assistant_count: assistantCount };
+    }
+    return null;
+  }, timeoutMs);
+}
+
+export function extractResponse(root = document) {
+  const assistants = assistantRoots(root);
+  const last = assistants.at(-1) ?? null;
+  const turn = last?.closest?.("[data-testid*='turn'], article") ?? last;
+  const body = last?.querySelector?.(".font-claude-response") ?? null;
+  const text = normalizeResponseText(body?.innerText || body?.textContent || "");
+  const globalCopyButtons = root.querySelectorAll(COPY_ACTION_SELECTOR).length;
+  const scopedCopyButtons = turn?.querySelectorAll?.(COPY_ACTION_SELECTOR)?.length ?? 0;
+  const isGenerating = isResponseGenerating(root);
+  const precedingUserCount = last ? precedingUserTurnCount(root, last) : 0;
+  const diagnostics = {
+    counts: {
+      assistant_turns: assistants.length,
+      copy_buttons: globalCopyButtons,
+      stop_controls: root.querySelectorAll("button[aria-label='Stop response']").length,
+      thinking_rows: root.querySelectorAll("button[class*='group/status']").length
+    },
+    assistant_turn_snippets: assistants.slice(-3).map((element) => elementSummary(element)),
+    page_text_chars: String(root.body?.innerText ?? "").length,
+    page_text_content_chars: String(root.body?.textContent ?? "").length
+  };
+  if (!last || !body || !text) {
+    return {
+      method: "none",
+      text: "",
+      is_generating: isGenerating,
+      assistant_count: assistants.length,
+      turn_index: assistants.length - 1,
+      preceding_user_count: precedingUserCount,
+      copy_button_count: globalCopyButtons,
+      has_copy_button: scopedCopyButtons > 0,
+      diagnostics
+    };
+  }
+  return {
+    method: "assistant_dom",
+    text,
+    is_generating: isGenerating,
+    assistant_count: assistants.length,
+    turn_index: assistants.length - 1,
+    preceding_user_count: precedingUserCount,
+    copy_button_count: globalCopyButtons,
+    has_copy_button: scopedCopyButtons > 0,
+    diagnostics
+  };
+}
+
+export function isResponseGenerating(root = document) {
+  const last = assistantRoots(root).at(-1);
+  return Boolean(
+    root.querySelector("button[aria-label='Stop response']")
+    || last?.getAttribute?.("data-is-streaming") === "true"
+  );
+}
+
+export function clickStopGenerating(root = document) {
+  const stop = root.querySelector("button[aria-label='Stop response']");
+  if (!stop) return false;
+  stop.click();
+  return true;
+}
+
+export async function confirmGenerationStopped(root = document, options = {}) {
+  const startedAt = Date.now();
+  const stopped = clickStopGenerating(root);
+  const timeoutMs = options.timeoutMs ?? 5000;
+  while (Date.now() - startedAt <= timeoutMs) {
+    if (!isResponseGenerating(root)) {
+      return { stopped, confirmed_idle: true, waited_ms: Date.now() - startedAt };
+    }
+    await sleep(100);
+  }
+  return { stopped, confirmed_idle: false, waited_ms: Date.now() - startedAt };
+}
+
+export function modelSelectionDiagnostics(root = document) {
+  const modelButton = root.querySelector(MODEL_SELECTOR);
+  const modelChip = normalizeText(modelButton?.innerText || modelButton?.textContent);
+  const selectedModels = Array.from(root.querySelectorAll("[role='menuitemradio'][aria-checked='true']"));
+  const modelVerified = /\bFable 5\b/i.test(modelChip)
+    && selectedModels.some((element) => normalizeText(element.innerText || element.textContent).toLowerCase().startsWith("fable 5"));
+  const maxOption = root.querySelector("[role='menuitemradio'][data-testid='effort-option-max']");
+  const maxVerified = maxOption?.getAttribute("aria-checked") === "true" && /\bMax\b/i.test(modelChip);
+  const switches = visibleElements(root, "span[role='switch'][aria-checked]");
+  const thinking = switches.find((element) => /Thinking/i.test(normalizeText(
+    element.getAttribute("aria-label")
+    || element.closest("[role='menuitem']")?.innerText
+    || element.parentElement?.innerText
+  )));
+  const thinkingChecked = thinking?.getAttribute("aria-checked") === "true";
+  const options = visibleElements(root, "[role='menuitem'], [role='menuitemradio'], button, [role='switch']")
+    .map((element) => normalizeText(element.innerText || element.textContent))
+    .filter(Boolean)
+    .slice(0, 50);
+  return {
+    modelVerified,
+    maxVerified,
+    thinkingChecked,
+    modelChip,
+    options,
+    thinkingAriaChecked: thinking?.getAttribute("aria-checked") ?? null
+  };
+}
+
+export function normalizeText(value) {
+  return String(value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function normalizeResponseText(value) {
+  return String(value ?? "")
+    .replace(/\r\n/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function assistantRoots(root) {
+  return Array.from(root.querySelectorAll(ASSISTANT_SELECTOR));
+}
+
+function userTurnCount(root) {
+  return root.querySelectorAll("[data-testid='user-message']").length;
+}
+
+function precedingUserTurnCount(root, target) {
+  const users = Array.from(root.querySelectorAll("[data-testid='user-message']"));
+  return users.filter((element) => {
+    const position = element.compareDocumentPosition?.(target) ?? 0;
+    const following = globalThis.Node?.DOCUMENT_POSITION_FOLLOWING ?? 4;
+    return Boolean(position & following);
+  }).length;
+}
+
+function conversationIdFromLocation() {
+  const match = String(globalThis.location?.pathname ?? "").match(/^\/chat\/([^/?#]+)$/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+function clickIfClosed(button) {
+  if (button.getAttribute("aria-expanded") !== "true") {
+    button.click();
+  }
+}
+
+function dispatchHover(element) {
+  const rect = element.getBoundingClientRect?.() ?? { left: 0, top: 0, width: 1, height: 1 };
+  const clientX = Number(rect.left ?? 0) + Math.max(1, Number(rect.width ?? 1) / 2);
+  const clientY = Number(rect.top ?? 0) + Math.max(1, Number(rect.height ?? 1) / 2);
+  for (const type of ["pointerover", "pointerenter", "pointermove", "mouseover", "mouseenter", "mousemove"]) {
+    const pointer = type.startsWith("pointer") && typeof PointerEvent !== "undefined";
+    const EventType = pointer ? PointerEvent : MouseEvent;
+    element.dispatchEvent(new EventType(type, {
+      bubbles: true,
+      cancelable: true,
+      view: globalThis.window,
+      clientX,
+      clientY,
+      ...(pointer ? { pointerType: "mouse", pointerId: 1, isPrimary: true } : {})
+    }));
+  }
+}
+
+async function closeModelMenu(root, modelButton) {
+  if (modelButton.getAttribute("aria-expanded") !== "true") return true;
+  const target = root.activeElement ?? modelButton;
+  const EventType = root.defaultView?.KeyboardEvent ?? globalThis.KeyboardEvent;
+  if (typeof EventType !== "function") {
+    return false;
+  }
+  target.dispatchEvent(new EventType("keydown", {
+    key: "Escape",
+    code: "Escape",
+    bubbles: true,
+    cancelable: true
+  }));
+  return Boolean(await waitForOptional(
+    () => modelButton.getAttribute("aria-expanded") !== "true",
+    2000
+  ));
+}
+
+function visibleElements(root, selector) {
+  return Array.from(root.querySelectorAll(selector)).filter((element) => element.getClientRects().length > 0);
+}
+
+function elementSummary(element) {
+  const innerText = String(element?.innerText ?? "");
+  const textContent = String(element?.textContent ?? "");
+  return {
+    text: normalizeResponseText(innerText || textContent).slice(-500),
+    inner_text_chars: innerText.length,
+    text_content_chars: textContent.length,
+    streaming: element?.getAttribute?.("data-is-streaming") ?? null
+  };
+}
+
+async function waitForReadyComposer(root, timeoutMs) {
+  try {
+    return await waitFor(() => findComposer(root), timeoutMs);
+  } catch (error) {
+    const handoff = classifyManualHandoff({
+      url: globalThis.location?.href,
+      title: root.title,
+      text: getPageText(root).slice(0, 500)
+    });
+    if (handoff) {
+      throw commandError(handoff.state, handoff.message, {
+        phase: "upload",
+        side_effect_started: false
+      });
+    }
+    throw error;
+  }
+}
+
+async function waitFor(read, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let value = read();
+  while (!value && Date.now() <= deadline) {
+    await sleep(100);
+    value = read();
+  }
+  if (!value) {
+    throw new Error(`Claude page did not reach the requested state within ${timeoutMs}ms`);
+  }
+  return value;
+}
+
+async function waitForOptional(read, timeoutMs) {
+  try {
+    return await waitFor(read, timeoutMs);
+  } catch {
+    return null;
+  }
+}
+
+function commandError(code, message, detail = {}) {
+  const error = new Error(message);
+  error.code = code;
+  Object.assign(error, detail);
+  return error;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/extensions/chatgpt-native/src/claude-dom.js
+++ b/extensions/chatgpt-native/src/claude-dom.js
@@ -310,7 +310,7 @@ export function extractResponse(root = document) {
   const last = assistants.at(-1) ?? null;
   const turn = last?.closest?.("[data-testid*='turn'], article") ?? last;
   const body = last?.querySelector?.(".font-claude-response") ?? null;
-  const text = normalizeResponseText(body?.innerText || body?.textContent || "");
+  const text = responseBodyText(body);
   const globalCopyButtons = root.querySelectorAll(COPY_ACTION_SELECTOR).length;
   const scopedCopyButtons = turn?.querySelectorAll?.(COPY_ACTION_SELECTOR)?.length ?? 0;
   const isGenerating = isResponseGenerating(root);
@@ -414,6 +414,18 @@ function normalizeResponseText(value) {
     .replace(/[ \t]+\n/g, "\n")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
+}
+
+function responseBodyText(body) {
+  if (!body) return "";
+  const sanitized = body.cloneNode?.(true);
+  if (!sanitized) {
+    return normalizeResponseText(body.innerText || body.textContent || "");
+  }
+  for (const statusRow of sanitized.querySelectorAll?.("button[class*='group/status']") ?? []) {
+    statusRow.remove();
+  }
+  return normalizeResponseText(sanitized.innerText || sanitized.textContent || "");
 }
 
 function assistantRoots(root) {

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -1,5 +1,8 @@
 const activeJobs = new Map();
-let domHelpersPromise = null;
+const siteAdapterPromises = new Map();
+const siteAdapterModules = Object.freeze({
+  chatgpt: "src/sites/chatgpt.js"
+});
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   handleMessage(message)
@@ -23,24 +26,25 @@ async function handleMessage(message) {
     case "yoetz_extract_response":
       return extractJobResponse(message.job);
     case "yoetz_fetch_conversation":
-      return fetchConversationAnswer(message.job, message.conversation_id);
+      return fetchSiteConversationAnswer(message.job, message.conversation_id);
     case "yoetz_cancel_send":
       return cancelSend(message.job);
     case "yoetz_inspect_page":
       return inspectPage(message.run_id, {
         conversation_id: message.conversation_id,
-        include_page_text: Boolean(message.include_page_text)
+        include_page_text: Boolean(message.include_page_text),
+        recipe: message.recipe
       });
     case "yoetz_auth_probe":
-      return authProbe();
+      return authProbe(message.recipe);
     case "yoetz_probe":
-      return probe();
+      return probe(message.recipe);
     default:
       throw new Error(`unknown content-script command ${message?.type}`);
   }
 }
 
-// Best-effort cancel: click ChatGPT's stop control, then WAIT for generation to
+// Best-effort cancel: click the site's stop control, then WAIT for generation to
 // actually go idle before returning so the service worker does not remove the
 // tab while the abort request to OpenAI is still in flight (closing the tab
 // early lets the server keep generating). Returns confirmed_idle so the worker
@@ -52,8 +56,8 @@ async function handleMessage(message) {
 // safe-tab-only operation; the service worker is already going to remove the
 // tab right after this regardless of outcome. confirmGenerationStopped never
 // throws, so cancel stays best-effort.
-async function cancelSend(_job) {
-  const { confirmGenerationStopped } = await domHelpers();
+async function cancelSend(job) {
+  const { confirmGenerationStopped } = await domHelpers(job);
   const result = await confirmGenerationStopped(document);
   return {
     stopped: Boolean(result?.stopped),
@@ -70,7 +74,7 @@ async function prepareJob(job) {
     getPageText,
     markOwnership,
     ownedWindowName
-  } = await domHelpers();
+  } = await domHelpers(job);
   activeJobs.delete(job.job_id);
   const handoff = classifyManualHandoff({
     url: location.href,
@@ -106,8 +110,9 @@ async function prepareJob(job) {
 }
 
 async function uploadJobFile(job, filePayload) {
-  const { parseOwnedWindowName, uploadFile } = await domHelpers();
-  assertJobOwnership(job, parseOwnedWindowName, ownershipOptionsForJob(job, "upload"));
+  const { parseOwnedWindowName, uploadFile } = await domHelpers(job);
+  const adapter = await siteAdapter(job);
+  assertJobOwnership(job, parseOwnedWindowName, ownershipOptionsForJob(job, "upload", adapter));
   const bytes = base64ToUint8Array(filePayload.bytes_base64);
   const file = new File([bytes], filePayload.filename || "yoetz-bundle.md", {
     type: filePayload.mime_type || "text/markdown"
@@ -117,23 +122,25 @@ async function uploadJobFile(job, filePayload) {
 }
 
 async function configureModel(job) {
-  const { configureModelState, parseOwnedWindowName } = await domHelpers();
-  assertJobOwnership(job, parseOwnedWindowName, ownershipOptionsForJob(job, "model_selection"));
+  const { configureModelState, parseOwnedWindowName } = await domHelpers(job);
+  const adapter = await siteAdapter(job);
+  assertJobOwnership(job, parseOwnedWindowName, ownershipOptionsForJob(job, "model_selection", adapter));
   return configureModelState(document, job);
 }
 
 async function sendPrompt(job, prompt) {
+  const adapter = await siteAdapter(job);
   const {
     clickSend,
     insertPrompt,
     parseOwnedWindowName,
     sendAcceptanceBaseline,
     waitForSendAccepted
-  } = await domHelpers();
-  assertJobOwnership(job, parseOwnedWindowName, ownershipOptionsForJob(job, "send"));
+  } = await domHelpers(job);
+  assertJobOwnership(job, parseOwnedWindowName, ownershipOptionsForJob(job, "send", adapter));
   const baseline = sendAcceptanceBaseline(document);
   await insertPrompt(document, prompt, { timeoutMs: 20000 });
-  assertJobOwnership(job, parseOwnedWindowName, ownershipOptionsForJob(job, "send"));
+  assertJobOwnership(job, parseOwnedWindowName, ownershipOptionsForJob(job, "send", adapter));
   const clickOptions = { timeoutMs: Number(job.send_timeout_ms) || 120000 };
   const expectedConversationId = expectedConversationIdForJob(job);
   if (expectedConversationId) {
@@ -148,7 +155,7 @@ async function sendPrompt(job, prompt) {
   } catch (error) {
     throw commandError(
       "send_acceptance_unknown",
-      `ChatGPT send click was committed, but Yoetz could not confirm ChatGPT accepted the prompt before timeout. If a response eventually appears, do not rerun automatically: ${String(error?.message ?? error)}`,
+      `${adapter.displayName} send click was committed, but Yoetz could not confirm ${adapter.displayName} accepted the prompt before timeout. If a response eventually appears, do not rerun automatically: ${String(error?.message ?? error)}`,
       {
         phase: "send",
         side_effect_started: true
@@ -160,25 +167,26 @@ async function sendPrompt(job, prompt) {
     sent: true,
     ...accepted,
     url: location.href,
-    conversation_id: conversationIdFromUrl(location.href),
+    conversation_id: adapter.conversationIdFromUrl(location.href),
     submitted_user_count: submitted.user_count,
     submitted_assistant_count: submitted.assistant_count
   };
 }
 
 async function extractJobResponse(job) {
+  const adapter = await siteAdapter(job);
   const {
     classifyWaitManualHandoff,
     extractResponse,
     parseOwnedWindowName
-  } = await domHelpers();
-  assertJobOwnership(job, parseOwnedWindowName);
-  const conversationId = conversationIdFromUrl(location.href);
+  } = await domHelpers(job);
+  assertJobOwnership(job, parseOwnedWindowName, { adapter });
+  const conversationId = adapter.conversationIdFromUrl(location.href);
   const expectedConversationId = expectedConversationIdForJob(job);
   if (expectedConversationId && conversationId !== expectedConversationId) {
     throw commandError(
       "conversation_changed",
-      `tab moved from ChatGPT conversation ${expectedConversationId} to ${conversationId ?? "(none)"}`,
+      `tab moved from ${adapter.displayName} conversation ${expectedConversationId} to ${conversationId ?? "(none)"}`,
       {
         phase: "wait_response",
         side_effect_started: true,
@@ -203,204 +211,28 @@ async function extractJobResponse(job) {
   };
 }
 
-// T1 freeze-proof answer source: read the FINAL assistant answer from ChatGPT's backend
-// conversation API instead of the rendered DOM. The owned tab live-streams the answer while
-// BACKGROUNDED, where Chromium suspends rAF rendering, so the DOM freezes at the first token
-// ("I"); but a same-origin JSON GET runs on a task source Chrome does NOT throttle in background
-// tabs, so it returns the complete server-side answer (live-proven: full answer in a hidden tab
-// while the DOM was clipped). Same-origin fetch from this ISOLATED content script authenticates
-// with the page's httpOnly session cookie; host_permissions already covers chatgpt.com, so this
-// is zero new permission. The service worker owns WHEN to call this (gated on DOM idle) and the
-// T1->T2(reload)->T3(DOM) fallback; this function only reads + resolves the answer node.
-async function fetchConversationAnswer(job, requestedConversationId) {
-  const { parseOwnedWindowName } = await domHelpers();
-  // Ownership marker (window.name run/job) must still match — never read for the wrong job/tab.
-  assertJobOwnership(job, parseOwnedWindowName);
-  const conversationId = String(requestedConversationId ?? "").trim()
-    || expectedConversationIdForJob(job)
-    || conversationIdFromUrl(location.href);
-  if (!conversationId) {
-    throw backendApiError("backend_api_unavailable", "no conversation id available for backend-api read");
-  }
-  // accessToken is fetched PER CALL — it expires and must never be cached.
-  const token = await fetchChatgptAccessToken();
-  if (!token) {
-    throw backendApiError("backend_api_unauthorized", "no ChatGPT access token (session expired or signed out)");
-  }
-  let res;
-  try {
-    res = await fetch(`/backend-api/conversation/${encodeURIComponent(conversationId)}`, {
-      method: "GET",
-      credentials: "include",
-      headers: { Authorization: `Bearer ${token}`, Accept: "application/json" }
-    });
-  } catch (error) {
-    throw backendApiError("backend_api_unavailable", `backend-api conversation fetch failed: ${String(error?.message ?? error)}`);
-  }
-  // 401/403 -> auth lane (SW falls back to reload-to-render / DOM); other non-2xx -> unavailable.
-  if (res.status === 401 || res.status === 403) {
-    throw backendApiError("backend_api_unauthorized", `backend-api conversation returned ${res.status}`);
-  }
-  if (!res.ok) {
-    throw backendApiError("backend_api_unavailable", `backend-api conversation returned ${res.status}`);
-  }
-  let data;
-  try {
-    data = await res.json();
-  } catch (error) {
-    throw backendApiError("backend_api_unavailable", `backend-api conversation returned non-JSON: ${String(error?.message ?? error)}`);
-  }
-  return resolveBackendAnswer(job, conversationId, data);
-}
-
-// Backend-api read failures are all wait_response-phase, side-effect-started (the prompt was already
-// sent). The SW maps backend_api_* codes to its T2 reload / T3 DOM fallback.
-function backendApiError(code, message) {
-  return commandError(code, message, { phase: "wait_response", side_effect_started: true });
-}
-
-async function fetchChatgptAccessToken() {
-  try {
-    const res = await fetch("/api/auth/session", {
-      method: "GET",
-      credentials: "include",
-      headers: { Accept: "application/json" }
-    });
-    if (!res.ok) {
-      return null;
-    }
-    const session = await res.json();
-    const token = session?.accessToken;
-    return typeof token === "string" && token.length > 0 ? token : null;
-  } catch {
-    return null;
-  }
-}
-
-// Resolve the FINAL assistant answer node from the conversation mapping. Returns an
-// extraction-shaped payload: node_fresh:true + is_generating:false when a NEW completed answer
-// exists; otherwise node_fresh:false + is_generating:true so the SW keeps waiting (never completes
-// on a stale/earlier turn). Never throws — a malformed/partial mapping is "not ready", not an
-// error.
-function resolveBackendAnswer(job, conversationId, data) {
-  const baseline = nonNegativeInt(job?.submitted_assistant_count ?? job?.response_baseline?.assistant_count ?? 0);
-  const notReady = (detail) => ({
-    method: "backend_api",
-    text: "",
-    is_generating: true,
-    conversation_id: conversationId,
-    node_fresh: false,
-    assistant_count: 0,
-    turn_index: -1,
-    has_copy_button: false,
-    copy_button_count: 0,
-    backend_api_detail: detail
+// Ask the selected adapter for a backend answer when its finality strategy supports one.
+// The worker owns when to call this fallback; the adapter owns site-specific API semantics.
+async function fetchSiteConversationAnswer(job, requestedConversationId) {
+  const adapter = await siteAdapter(job);
+  const { parseOwnedWindowName } = adapter.dom;
+  return adapter.fetchConversationAnswer({
+    job,
+    requestedConversationId,
+    parseOwnedWindowName,
+    assertJobOwnership,
+    expectedConversationId: expectedConversationIdForJob(job),
+    locationHref: location.href,
+    commandError
   });
-  const mapping = data && typeof data === "object" && data.mapping && typeof data.mapping === "object"
-    ? data.mapping
-    : null;
-  if (!mapping) {
-    return notReady("backend-api response had no conversation mapping");
-  }
-  // Freshness MUST be scoped to the ACTIVE current_node lineage, not the whole mapping. ChatGPT
-  // retains off-branch assistant answers (regenerations / abandoned / alternate branches) in the
-  // mapping; a global count could be inflated past the baseline by an off-branch node while the
-  // active lineage still points at a STALE earlier answer — returning that stale answer as fresh.
-  // So walk current_node -> root ONCE: the latest answer node on that path is THE answer, and the
-  // count of answer nodes on that path is what we compare against the pre-send baseline. current_node
-  // may be a tool/reasoning_recap node, so we cannot read it directly.
-  const { answerNode, count: lineageAnswerCount } = collectLineageAnswerNodes(mapping, data.current_node);
-  if (!answerNode) {
-    return notReady("no completed assistant answer node on the active lineage yet (still generating / tool-only)");
-  }
-  if (lineageAnswerCount <= baseline) {
-    return notReady(`assistant answer not fresh past baseline (active-lineage ${lineageAnswerCount} <= ${baseline})`);
-  }
-  const text = answerTextOf(answerNode.message);
-  if (!text) {
-    return notReady("latest active-lineage assistant answer node had no text parts");
-  }
-  return {
-    method: "backend_api",
-    text,
-    is_generating: false,
-    conversation_id: conversationId,
-    node_fresh: true,
-    assistant_count: lineageAnswerCount,
-    turn_index: Math.max(0, lineageAnswerCount - 1),
-    node_id: String(answerNode.id ?? answerNode.message?.id ?? ""),
-    has_copy_button: false,
-    copy_button_count: 0
-  };
-}
-
-// A node is a deliverable assistant answer ONLY if: assistant role, content_type 'text', addressed
-// to the user (recipient 'all'), end_turn true, and non-empty text. content_type+end_turn alone is
-// NOT sufficient — reasoning_recap nodes also carry end_turn:true (verified live), and tool turns
-// use non-'all' recipients.
-function isAssistantAnswerNode(message) {
-  if (!message || typeof message !== "object") {
-    return false;
-  }
-  if (message.author?.role !== "assistant") {
-    return false;
-  }
-  const content = message.content;
-  if (!content || content.content_type !== "text") {
-    return false;
-  }
-  if ((message.recipient ?? "all") !== "all") {
-    return false;
-  }
-  if (message.end_turn !== true) {
-    return false;
-  }
-  return answerTextOf(message).length > 0;
-}
-
-function answerTextOf(message) {
-  const parts = message?.content?.parts;
-  if (!Array.isArray(parts)) {
-    return "";
-  }
-  return parts.filter((part) => typeof part === "string").join("").trim();
-}
-
-// Walk current_node -> root once, collecting the COMPLETED assistant answer nodes that lie on the
-// ACTIVE lineage. Returns { answerNode: latest-on-lineage (closest to current_node), count }.
-// Off-branch answers (not on this path) are intentionally not seen here.
-function collectLineageAnswerNodes(mapping, currentNodeId) {
-  let id = currentNodeId;
-  let guard = 0;
-  let answerNode = null;
-  let count = 0;
-  while (id && guard < 2000) {
-    guard += 1;
-    const node = mapping[id];
-    if (!node) {
-      break;
-    }
-    if (isAssistantAnswerNode(node.message)) {
-      if (!answerNode) {
-        answerNode = node;
-      }
-      count += 1;
-    }
-    id = node.parent;
-  }
-  return { answerNode, count };
-}
-
-function nonNegativeInt(value) {
-  const n = Number(value);
-  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 0;
 }
 
 async function inspectPage(runId, options = {}) {
-  const { extractResponse, getPageText, modelSelectionDiagnostics, parseOwnedWindowName } = await domHelpers();
+  const adapter = await siteAdapter(options.recipe);
+  const { extractResponse, getPageText, modelSelectionDiagnostics, parseOwnedWindowName } = await domHelpers(options.recipe);
   const parsed = parseOwnedWindowName(window.name);
   const urlRunId = runIdFromUrl(location.href);
-  const conversationId = conversationIdFromUrl(location.href);
+  const conversationId = adapter.conversationIdFromUrl(location.href);
   const conversationTarget = String(options.conversation_id ?? "").trim();
   const runMatches = !runId || parsed?.run_id === runId || urlRunId === runId;
   const conversationMatches = Boolean(conversationTarget && conversationId === conversationTarget);
@@ -432,8 +264,9 @@ async function inspectPage(runId, options = {}) {
   return result;
 }
 
-async function authProbe() {
-  const { classifyManualHandoff, getPageText } = await domHelpers();
+async function authProbe(recipe) {
+  const adapter = await siteAdapter(recipe);
+  const { classifyManualHandoff, getPageText } = await domHelpers(recipe);
   const text = getPageText(document);
   const handoff = classifyManualHandoff({
     url: location.href,
@@ -446,7 +279,7 @@ async function authProbe() {
     authenticated,
     manual_handoff: handoff,
     message: authenticated
-      ? "ChatGPT authenticated in this Chrome profile"
+      ? `${adapter.displayName} authenticated in this Chrome profile`
       : handoff.message,
     url: location.href,
     title: document.title,
@@ -454,8 +287,8 @@ async function authProbe() {
   };
 }
 
-async function probe() {
-  const { getPageText } = await domHelpers();
+async function probe(recipe) {
+  const { getPageText } = await domHelpers(recipe);
   return {
     url: location.href,
     title: document.title,
@@ -464,7 +297,8 @@ async function probe() {
 }
 
 async function bindJob(job) {
-  const { markOwnership, parseOwnedWindowName } = await domHelpers();
+  const adapter = await siteAdapter(job);
+  const { markOwnership, parseOwnedWindowName } = await domHelpers(job);
   const parsed = parseOwnedWindowName(window.name);
   if (parsed?.job_id !== job.job_id || parsed?.run_id !== job.run_id) {
     throw commandError(
@@ -487,12 +321,12 @@ async function bindJob(job) {
       }
     );
   }
-  const conversationId = conversationIdFromUrl(location.href);
+  const conversationId = adapter.conversationIdFromUrl(location.href);
   const expectedConversationId = expectedConversationIdForJob(job);
   if (expectedConversationId && conversationId !== expectedConversationId) {
     throw commandError(
       "conversation_changed",
-      `tab moved from ChatGPT conversation ${expectedConversationId} to ${conversationId ?? "(none)"}`,
+      `tab moved from ${adapter.displayName} conversation ${expectedConversationId} to ${conversationId ?? "(none)"}`,
       {
         phase: "wait_response",
         side_effect_started: true,
@@ -521,14 +355,14 @@ function assertJobOwnership(job, parseOwnedWindowName, options = {}) {
     throw new Error(`tab ownership marker mismatch for job ${job.job_id}`);
   }
   if (options.requireConversation) {
-    const actualConversationId = conversationIdFromUrl(location.href);
+    const actualConversationId = options.adapter.conversationIdFromUrl(location.href);
     if (actualConversationId === options.requireConversation) {
       return;
     }
     const code = actualConversationId ? "conversation_changed" : "conversation_not_loaded";
     throw commandError(
       code,
-      `job ${job.job_id} expected ChatGPT conversation ${options.requireConversation}, current conversation is ${actualConversationId ?? "(none)"}`,
+      `job ${job.job_id} expected ${options.adapter.displayName} conversation ${options.requireConversation}, current conversation is ${actualConversationId ?? "(none)"}`,
       {
         phase: options.phase ?? "upload",
         side_effect_started: false,
@@ -537,19 +371,19 @@ function assertJobOwnership(job, parseOwnedWindowName, options = {}) {
       }
     );
   }
-  if (options.requireFresh && String(location.pathname ?? "").startsWith("/c/")) {
-    throw commandError("fresh_chat_lost", `job ${job.job_id} is no longer on a fresh ChatGPT page`, {
+  if (options.requireFresh && options.adapter.isConversationUrl(location.href)) {
+    throw commandError("fresh_chat_lost", `job ${job.job_id} is no longer on a fresh ${options.adapter.displayName} page`, {
       phase: "upload",
       side_effect_started: false
     });
   }
 }
 
-function ownershipOptionsForJob(job, phase) {
+function ownershipOptionsForJob(job, phase, adapter) {
   const conversationId = conversationIdForJob(job);
   return conversationId
-    ? { requireConversation: conversationId, phase }
-    : { requireFresh: true, phase };
+    ? { adapter, requireConversation: conversationId, phase }
+    : { adapter, requireFresh: true, phase };
 }
 
 function assertUrlRunMarker(job) {
@@ -583,11 +417,35 @@ function conversationLoadOptionsForJob(job) {
   return options;
 }
 
-async function domHelpers() {
-  if (!domHelpersPromise) {
-    domHelpersPromise = import(chrome.runtime.getURL("src/chatgpt-dom.js"));
+async function domHelpers(jobOrRecipe) {
+  return (await siteAdapter(jobOrRecipe)).dom;
+}
+
+async function siteAdapter(jobOrRecipe) {
+  const requested = typeof jobOrRecipe === "string"
+    ? jobOrRecipe
+    : jobOrRecipe?.recipe;
+  const recipe = requested == null ? "chatgpt" : requested;
+  const modulePath = typeof recipe === "string" ? siteAdapterModules[recipe] : null;
+  if (!modulePath) {
+    throw commandError(
+      "unsupported_recipe",
+      `recipe ${JSON.stringify(recipe)} is not available in this content-script build; rejected before side effects`,
+      { phase: "profile", side_effect_started: false }
+    );
   }
-  return domHelpersPromise;
+  if (!siteAdapterPromises.has(recipe)) {
+    siteAdapterPromises.set(recipe, import(chrome.runtime.getURL(modulePath)));
+  }
+  const module = await siteAdapterPromises.get(recipe);
+  if (!module?.siteAdapter) {
+    throw commandError(
+      "unsupported_recipe",
+      `recipe ${JSON.stringify(recipe)} did not expose a site adapter; rejected before side effects`,
+      { phase: "profile", side_effect_started: false }
+    );
+  }
+  return module.siteAdapter;
 }
 
 function base64ToUint8Array(value) {
@@ -636,16 +494,6 @@ function contentScriptBuild() {
 function runIdFromUrl(value) {
   try {
     return new URL(value).searchParams.get("_yoetz");
-  } catch {
-    return null;
-  }
-}
-
-function conversationIdFromUrl(value) {
-  try {
-    const pathname = new URL(value, location.href).pathname;
-    const match = pathname.match(/^\/c\/([^/?#]+)$/);
-    return match ? decodeURIComponent(match[1]) : null;
   } catch {
     return null;
   }

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -1,7 +1,8 @@
 const activeJobs = new Map();
 const siteAdapterPromises = new Map();
 const siteAdapterModules = Object.freeze({
-  chatgpt: "src/sites/chatgpt.js"
+  chatgpt: "src/sites/chatgpt.js",
+  claude: "src/sites/claude.js"
 });
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
@@ -288,8 +289,10 @@ async function authProbe(recipe) {
 }
 
 async function probe(recipe) {
-  const { getPageText } = await domHelpers(recipe);
+  const adapter = await siteAdapter(recipe);
+  const { getPageText } = adapter.dom;
   return {
+    recipe: adapter.recipe,
     url: location.href,
     title: document.title,
     text: getPageText(document).slice(0, 2000)

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -316,14 +316,20 @@ async function startJob(message) {
     return;
   }
   if (!adapter.isAcceptableModelSelection(modelSelection)) {
-    await failJob(job, "model_selection_failed", `Requested ${adapter.displayName} model was not selected: ${modelSelection.status ?? "unknown"}`, {
+    const diagnostics = modelSelectionFailureDiagnostics(modelSelection);
+    const diagnosticSummary = formatModelSelectionFailureDiagnostics(diagnostics);
+    await failJob(job, "model_selection_failed", [
+      `Requested ${adapter.displayName} model was not selected: ${modelSelection.status ?? "unknown"}`,
+      diagnosticSummary ? `diagnostics: ${diagnosticSummary}` : null
+    ].filter(Boolean).join(". "), {
       phase: "model_selection",
       side_effect_started: false,
       requested_model: job.model,
       model_strategy: job.model_strategy,
       model_used: job.model_used,
       model_selection_status: job.model_selection_status,
-      model_selection: modelSelection
+      model_selection: modelSelection,
+      ...(Object.keys(diagnostics).length > 0 ? { model_selection_diagnostics: diagnostics } : {})
     });
     return;
   }
@@ -335,6 +341,31 @@ async function startJob(message) {
   if (!postNative(progress(job, "ready_for_file", { tab_id: tab.id, message: `${adapter.displayName} tab is ready for bundle upload` }))) {
     await recordTerminalDeliveryLost(job, "upload");
   }
+}
+
+function modelSelectionFailureDiagnostics(selection) {
+  const diagnostics = {};
+  for (const key of [
+    "modelVerified",
+    "maxVerified",
+    "thinkingChecked",
+    "modelChip",
+    "thinkingAriaChecked"
+  ]) {
+    if (Object.prototype.hasOwnProperty.call(selection ?? {}, key)) {
+      diagnostics[key] = selection[key];
+    }
+  }
+  if (Array.isArray(selection?.options)) {
+    diagnostics.options = selection.options.slice(0, 50);
+  }
+  return diagnostics;
+}
+
+function formatModelSelectionFailureDiagnostics(diagnostics) {
+  return Object.entries(diagnostics)
+    .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
+    .join(", ");
 }
 
 async function acceptFileChunk(message) {

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -9,7 +9,7 @@ import {
   progress,
   validateEnvelope
 } from "./protocol.js";
-import { chatgptConversationJobUrl, chatgptJobUrl } from "./chatgpt-dom.js";
+import { advertisedRecipes, siteAdapterForRecipe } from "./sites/index.js";
 
 const DEFAULT_WAIT_TIMEOUT_MS = 90 * 60 * 1000;
 const JOB_TTL_MS = 3 * 60 * 60 * 1000;
@@ -17,6 +17,7 @@ const HEARTBEAT_ALARM = "yoetz-heartbeat";
 const RECONNECT_ALARM = "yoetz-reconnect";
 const TERMINAL_STATUSES = new Set(["complete", "cancelled", "failed", "manual_handoff", "state_lost", "terminal_delivery_lost"]);
 const EXTENSION_ID_STORAGE_KEY = "yoetz_extension_instance_id";
+const ADVERTISED_RECIPES = Object.freeze(advertisedRecipes());
 const MIN_STABLE_IDLE_MS = Number(globalThis.__YOETZ_MIN_STABLE_IDLE_MS ?? 90000);
 // Require multiple stable polls so final controls cannot win before late text hydration.
 const STABLE_IDLE_INTERVAL_MULTIPLIER = Number(globalThis.__YOETZ_STABLE_IDLE_INTERVAL_MULTIPLIER ?? 3);
@@ -42,7 +43,7 @@ const MAX_RENDER_REFRESH_ATTEMPTS = Math.max(
     ? Number(globalThis.__YOETZ_MAX_RENDER_REFRESH_ATTEMPTS)
     : 1
 );
-// Once ChatGPT has exposed a final assistant affordance (copy control) AND scoped
+// Once a site adapter has exposed its final assistant affordance AND scoped
 // text is extractable AND generation has stopped, the response is structurally
 // complete. Confirm it over a SHORT stable window at a FAST cadence instead of
 // waiting out the full MIN_STABLE_IDLE_MS late-hydration floor. The dual-candidate
@@ -232,7 +233,18 @@ async function startJob(message) {
     }));
     return;
   }
-  const job = normalizeJob(message);
+  let adapter;
+  try {
+    adapter = siteAdapterForRecipe(message.payload?.recipe);
+  } catch (error) {
+    postNative(errorEnvelope(messageJob(message), error?.code ?? "unsupported_recipe", String(error?.message ?? error), {
+      request_id: message.request_id,
+      phase: "profile",
+      side_effect_started: false
+    }));
+    return;
+  }
+  const job = normalizeJob(message, adapter);
   job.started_at = Date.now();
   job.updated_at = Date.now();
   job.connection_generation = connectionGeneration;
@@ -257,8 +269,8 @@ async function startJob(message) {
   await persistJob(job);
 
   const url = job.expected_conversation_id
-    ? chatgptConversationJobUrl(job.expected_conversation_id, job.run_id)
-    : chatgptJobUrl(job.run_id);
+    ? adapter.conversationJobUrl(job.expected_conversation_id, job.run_id)
+    : adapter.jobUrl(job.run_id);
   const tab = await chrome.tabs.create({ url, active: false });
   job.tab_id = tab.id;
   job.updated_at = Date.now();
@@ -268,14 +280,14 @@ async function startJob(message) {
     tab_id: tab.id,
     url,
     inspect_command: inspectCommand,
-    message: `opened yoetz-owned ChatGPT tab ${url}; inspect with: ${inspectCommand}`
+    message: `opened yoetz-owned ${adapter.displayName} tab ${url}; inspect with: ${inspectCommand}`
   }))) {
     await recordTerminalDeliveryLost(job, "upload");
     return;
   }
 
-  await waitForChatgptTab(tab.id);
-  await waitForContentScript(tab.id);
+  await waitForSiteTab(tab.id, adapter);
+  await waitForContentScript(tab.id, adapter);
   const prepared = await sendToTab(tab.id, { type: "yoetz_prepare_job", job });
   if (prepared.manual_handoff) {
     postNative(progress(job, "manual_handoff", prepared.manual_handoff));
@@ -298,8 +310,8 @@ async function startJob(message) {
     await recordTerminalDeliveryLost(job, "model_selection");
     return;
   }
-  if (!isAcceptableModelSelection(modelSelection)) {
-    await failJob(job, "model_selection_failed", `Requested ChatGPT model was not selected: ${modelSelection.status ?? "unknown"}`, {
+  if (!adapter.isAcceptableModelSelection(modelSelection)) {
+    await failJob(job, "model_selection_failed", `Requested ${adapter.displayName} model was not selected: ${modelSelection.status ?? "unknown"}`, {
       phase: "model_selection",
       side_effect_started: false,
       requested_model: job.model,
@@ -315,7 +327,7 @@ async function startJob(message) {
   job.status = "waiting_for_file";
   job.updated_at = Date.now();
   await persistJob(job);
-  if (!postNative(progress(job, "ready_for_file", { tab_id: tab.id, message: "ChatGPT tab is ready for bundle upload" }))) {
+  if (!postNative(progress(job, "ready_for_file", { tab_id: tab.id, message: `${adapter.displayName} tab is ready for bundle upload` }))) {
     await recordTerminalDeliveryLost(job, "upload");
   }
 }
@@ -428,11 +440,11 @@ async function runJobWithFile(job, file) {
     if (!postNative(progress(job, "prompt_sent", {
       timeout_ms: responseWaitTimeoutMs(job),
       inspect_command: inspectCommand,
-      yoetz_url: chatgptJobUrl(job.run_id),
+      yoetz_url: adapterForJob(job).jobUrl(job.run_id),
       submitted_url: job.submitted_url,
       conversation_id: conversationIdForJob(job),
-      conversation_url: conversationUrlForId(conversationIdForJob(job)),
-      message: `prompt sent; waiting for ChatGPT response (timeout ${formatDurationForMessage(responseWaitTimeoutMs(job))}); inspect with: ${inspectCommand}`
+      conversation_url: conversationUrlForJob(job, conversationIdForJob(job)),
+      message: `prompt sent; waiting for ${adapterForJob(job).displayName} response (timeout ${formatDurationForMessage(responseWaitTimeoutMs(job))}); inspect with: ${inspectCommand}`
     }))) {
       await recordTerminalDeliveryLost(job, "send");
       return;
@@ -478,24 +490,25 @@ async function completeJobWithExtraction(job, extraction) {
       assistant_turn_count: extraction.assistant_turn_count ?? extraction.assistant_count ?? 0,
       copy_button_count: extraction.copy_button_count ?? 0,
       conversation_id: conversationId,
-      conversation_url: conversationUrlForId(conversationId),
+      conversation_url: conversationUrlForJob(job, conversationId),
       model_strategy: job.model_strategy ?? "select",
       model_used: job.model_used ?? null,
       model_selection_status: job.model_selection_status ?? "unavailable",
       warnings: [
         ...(job.warnings ?? []),
-        ...(extraction.text ? [] : ["empty ChatGPT response extracted"]),
+        ...(extraction.text ? [] : [adapterForJob(job).completion.emptyResponseWarning]),
         ...(extraction.warning ? [extraction.warning] : [])
       ]
     }
   });
   const completeBytes = nativeEnvelopeByteLength(completeEnvelope);
   if (completeBytes > MAX_NATIVE_OUTBOUND_BYTES) {
+    const adapter = adapterForJob(job);
     const inspectCommand = inspectCommandForJob(job);
     await failJob(
       job,
       "response_too_large",
-      `ChatGPT response is too large to deliver through chrome-extension-native (${completeBytes} bytes > ${MAX_NATIVE_OUTBOUND_BYTES}); inspect the owned tab with: ${inspectCommand}`,
+      `${adapter.displayName} response is too large to deliver through chrome-extension-native (${completeBytes} bytes > ${MAX_NATIVE_OUTBOUND_BYTES}); inspect the owned tab with: ${inspectCommand}`,
       {
         phase: "wait_response",
         side_effect_started: true,
@@ -526,17 +539,15 @@ function conversationIdForJob(job, extraction = null) {
   return job?.submitted_conversation_id ?? extraction?.conversation_id ?? job?.conversation_id ?? null;
 }
 
-function conversationUrlForId(conversationId) {
-  if (!conversationId) {
-    return null;
-  }
-  return `https://chatgpt.com/c/${encodeURIComponent(conversationId)}`;
+function conversationUrlForJob(job, conversationId) {
+  return adapterForJob(job).conversationUrl(conversationId);
 }
 
 async function resumeWaitingResponseJob(job) {
   try {
-    await waitForChatgptTab(job.tab_id);
-    await waitForContentScript(job.tab_id);
+    const adapter = adapterForJob(job);
+    await waitForSiteTab(job.tab_id, adapter);
+    await waitForContentScript(job.tab_id, adapter);
     const rebound = await sendToTab(job.tab_id, { type: "yoetz_bind_job", job });
     postNative(progress(job, "content_script_recovered", {
       restored: true,
@@ -569,9 +580,9 @@ async function cancelJob(message) {
   chunks.discard(job.job_id);
   await persistJob(job);
 
-  // Best-effort: tell the content script to click ChatGPT's stop control AND
+  // Best-effort: tell the content script to click the site's stop control AND
   // wait for generation to actually go idle before we tear the tab down — a bare
-  // stop click only initiates ChatGPT's abort to OpenAI, and removing the tab
+  // a stop click only initiates the site's abort, and removing the tab
   // microseconds later races/drops that request so the server keeps generating.
   // We await cancelSend so chrome.tabs.remove below runs only AFTER the stop is
   // confirmed (or its bounded ~5s idle-wait elapses). The content script's
@@ -693,28 +704,29 @@ async function handleReconnect(message) {
 }
 
 async function handleDoctorAuthProbe(message) {
+  const adapter = siteAdapterForRecipe(message.payload?.recipe);
   postNative(makeEnvelope("job_complete", {
     request_id: message.request_id,
     job_id: message.job_id,
     run_id: message.run_id,
     workspace_id: message.workspace_id,
-    payload: await probeChatgptAuthentication()
+    payload: await probeSiteAuthentication(adapter)
   }));
 }
 
-async function probeChatgptAuthentication() {
-  const tabs = await chrome.tabs.query({ url: "https://chatgpt.com/*" });
-  const selected = selectChatgptAuthProbeTab(tabs);
+async function probeSiteAuthentication(adapter) {
+  const tabs = await chrome.tabs.query({ url: adapter.tabQueryPattern });
+  const selected = selectSiteAuthProbeTab(tabs, adapter);
   if (!selected) {
     return {
-      status: "no_chatgpt_tab",
+      status: adapter.auth.noTabStatus,
       authenticated: false,
-      message: "No ChatGPT tab is open in this Chrome profile; open https://chatgpt.com/ and rerun doctor",
+      message: `No ${adapter.displayName} tab is open in this Chrome profile; open ${adapter.homeUrl} and rerun doctor`,
       inspected_tabs: 0
     };
   }
   try {
-    const probe = await sendToTab(selected.tab.id, { type: "yoetz_auth_probe" });
+    const probe = await sendToTab(selected.tab.id, { type: "yoetz_auth_probe", recipe: adapter.recipe });
     return {
       ...probe,
       tab_id: selected.tab.id,
@@ -727,7 +739,7 @@ async function probeChatgptAuthentication() {
     return {
       status: "content_script_unavailable",
       authenticated: false,
-      message: `Yoetz content script is not ready in selected ChatGPT tab: ${String(error?.message ?? error)}`,
+      message: `Yoetz content script is not ready in selected ${adapter.displayName} tab: ${String(error?.message ?? error)}`,
       tab_id: selected.tab.id,
       tab_url: selected.tab.url ?? null,
       tab_title: selected.tab.title ?? null,
@@ -737,9 +749,9 @@ async function probeChatgptAuthentication() {
   }
 }
 
-function selectChatgptAuthProbeTab(tabs) {
+function selectSiteAuthProbeTab(tabs, adapter) {
   const candidates = (tabs ?? [])
-    .filter((tab) => tab?.id && String(tab.url ?? "").startsWith("https://chatgpt.com/"))
+    .filter((tab) => tab?.id && adapter.isAllowedTabUrl(tab.url))
     .map((tab) => ({
       tab,
       yoetzOwned: new URL(tab.url).searchParams.has("_yoetz")
@@ -754,25 +766,13 @@ function selectChatgptAuthProbeTab(tabs) {
     ?? candidates[0];
   return {
     tab: candidate.tab,
-    selection: chatgptAuthProbeSelection(candidate),
+    selection: adapter.auth.selection(candidate),
     total: candidates.length
   };
 }
 
-function chatgptAuthProbeSelection(candidate) {
-  if (candidate.tab.active && !candidate.yoetzOwned) {
-    return "active_non_yoetz_chatgpt_tab";
-  }
-  if (!candidate.yoetzOwned) {
-    return "non_yoetz_chatgpt_tab";
-  }
-  if (candidate.tab.active) {
-    return "active_yoetz_job_tab";
-  }
-  return "yoetz_job_tab";
-}
-
 async function handleInspectRun(message) {
+  const adapter = siteAdapterForRecipe(message.payload?.recipe);
   const runId = String(message.payload?.run_id ?? "").trim();
   if (!runId) {
     postNative(errorEnvelope(messageJob(message), "missing_run_id", "inspect_run requires payload.run_id", {
@@ -780,7 +780,7 @@ async function handleInspectRun(message) {
     }));
     return;
   }
-  const tabs = await chrome.tabs.query({ url: "https://chatgpt.com/*" });
+  const tabs = await chrome.tabs.query({ url: adapter.tabQueryPattern });
   const matches = [];
   const errors = [];
   for (const tab of tabs) {
@@ -791,16 +791,15 @@ async function handleInspectRun(message) {
       const inspection = sanitizeInspection(await sendToTab(tab.id, {
         type: "yoetz_inspect_page",
         run_id: runId,
-        conversation_id: runId
+        conversation_id: runId,
+        recipe: adapter.recipe
       }));
       const responseInProgress = Boolean(inspection?.extraction?.is_generating);
       matches.push({
         tab_id: tab.id,
         url: tab.url ?? inspection?.url ?? null,
         title: tab.title ?? inspection?.title ?? null,
-        // Non-final marker for inspect read mid-stream. ChatGPT Pro streams several interim
-        // turns before the answer; while generating, inspection.extraction.text is a partial/interim
-        // turn's body (observed live as a single "I"), NOT the verdict. Wait for generation to stop.
+        // Non-final marker for an inspect read while the site still reports generation.
         response_in_progress: responseInProgress,
         note: responseInProgress
           ? "response still generating; extraction.text is a partial/interim assistant turn, not the final answer"
@@ -820,7 +819,7 @@ async function handleInspectRun(message) {
     }
   }
   if (matches.length === 0) {
-    postNative(errorEnvelope(messageJob(message), "run_not_found", `no Yoetz ChatGPT tab found for run ${runId}`, {
+    postNative(errorEnvelope(messageJob(message), "run_not_found", `no Yoetz ${adapter.displayName} tab found for run ${runId}`, {
       request_id: message.request_id,
       run_id: runId,
       inspected_tabs: errors
@@ -988,7 +987,7 @@ async function restoreJobsFromStorage({ emitLostState = false } = {}) {
       postNative(progress(job, "ready_for_file", {
         tab_id: job.tab_id,
         restored: true,
-        message: "ChatGPT tab is ready for bundle upload"
+        message: `${adapterForJob(job).displayName} tab is ready for bundle upload`
       }));
       continue;
     }
@@ -1008,7 +1007,7 @@ async function restoreJobsFromStorage({ emitLostState = false } = {}) {
         tab_id: job.tab_id,
         restored: true,
         inspect_command: inspectCommandForJob(job),
-        message: "restored ChatGPT response wait after service-worker restart"
+        message: `restored ${adapterForJob(job).displayName} response wait after service-worker restart`
       }))) {
         await recordTerminalDeliveryLost(job, "wait_response");
         continue;
@@ -1037,23 +1036,24 @@ function canResumeJobAfterWorkerRestart(job) {
 }
 
 function canResumeWaitingResponseAfterWorkerRestart(job) {
-  // The prompt has already been accepted by ChatGPT and the only remaining
+  // The prompt has already been accepted by the site and the only remaining
   // mutable state is the DOM polling loop. Rebind the content script to the
   // persisted owned tab and continue structural-finality polling.
   return job.status === "waiting_response" && Boolean(job.tab_id);
 }
 
-function normalizeJob(message) {
+function normalizeJob(message, adapter) {
   const payload = message.payload ?? {};
-  const conversation = normalizeConversationId(payload.conversation_id);
+  const conversation = adapter.normalizeConversationId(payload.conversation_id);
   return {
     job_id: message.job_id,
     run_id: message.run_id,
     workspace_id: message.workspace_id,
     capability_token: message.capability_token,
     request_id: message.request_id,
+    recipe: adapter.recipe,
     prompt: payload.prompt ?? "",
-    model: payload.model_strategy === "current" ? "current" : "gpt-5-6-sol-pro",
+    model: payload.model_strategy === "current" ? "current" : adapter.defaultModel,
     model_strategy: payload.model_strategy ?? "select",
     wait_timeout_ms: payload.wait_timeout_ms ?? DEFAULT_WAIT_TIMEOUT_MS,
     wait_interval_ms: payload.wait_interval_ms ?? 30000,
@@ -1074,24 +1074,8 @@ function normalizeJob(message) {
   };
 }
 
-function normalizeConversationId(value) {
-  if (value == null) {
-    return { ok: true, id: null };
-  }
-  if (typeof value !== "string") {
-    return { ok: false, message: "invalid `conversation_id`: expected a string ChatGPT conversation id" };
-  }
-  const id = value.trim();
-  if (!id || id === "." || id === "..") {
-    return { ok: false, message: "invalid `conversation_id`: expected a non-empty ChatGPT conversation id" };
-  }
-  if (id.length > 256) {
-    return { ok: false, message: "invalid `conversation_id`: expected at most 256 characters" };
-  }
-  if (!/^[A-Za-z0-9_.-]+$/.test(id)) {
-    return { ok: false, message: "invalid `conversation_id`: expected ASCII letters, digits, `_`, `.`, or `-`" };
-  }
-  return { ok: true, id };
+function adapterForJob(job) {
+  return siteAdapterForRecipe(job?.recipe);
 }
 
 function requireJob(jobId) {
@@ -1159,7 +1143,8 @@ function postHello() {
         protocol_version: PROTOCOL_VERSION,
         extension_instance_id: identity.extension_instance_id,
         profile_email: identity.profile_email || null,
-        profile_id: identity.profile_id || null
+        profile_id: identity.profile_id || null,
+        recipes: [...ADVERTISED_RECIPES]
       }
     }));
   }).catch(async (error) => {
@@ -1180,7 +1165,8 @@ function postHello() {
         protocol_version: PROTOCOL_VERSION,
         extension_instance_id: extensionInstanceId,
         profile_email: null,
-        profile_id: null
+        profile_id: null,
+        recipes: [...ADVERTISED_RECIPES]
       }
     }));
   });
@@ -1332,18 +1318,18 @@ function cryptoRandomId() {
   return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
-async function waitForChatgptTab(tabId) {
+async function waitForSiteTab(tabId, adapter) {
   for (let attempt = 0; attempt < 60; attempt += 1) {
     const tab = await chrome.tabs.get(tabId);
-    if (tab.status === "complete" && tab.url?.startsWith("https://chatgpt.com/")) {
+    if (tab.status === "complete" && adapter.isAllowedTabUrl(tab.url)) {
       return;
     }
     await sleep(500);
   }
-  throw new Error(`ChatGPT tab ${tabId} did not load`);
+  throw new Error(`${adapter.displayName} tab ${tabId} did not load`);
 }
 
-async function waitForContentScript(tabId) {
+async function waitForContentScript(tabId, adapter) {
   for (let attempt = 0; attempt < 40; attempt += 1) {
     try {
       await sendToTab(tabId, { type: "yoetz_probe" });
@@ -1352,7 +1338,7 @@ async function waitForContentScript(tabId) {
       await sleep(500);
     }
   }
-  throw new Error(`Yoetz content script did not become ready in ChatGPT tab ${tabId}`);
+  throw new Error(`Yoetz content script did not become ready in ${adapter.displayName} tab ${tabId}`);
 }
 
 async function sendToTab(tabId, message) {
@@ -1404,6 +1390,7 @@ async function maybeGroupTab(tabId, job) {
 }
 
 async function waitForResponse(job) {
+  const completion = adapterForJob(job).completion;
   const startedAt = Number(job.response_wait_started_at) || Date.now();
   job.response_wait_started_at = startedAt;
   const interval = Math.max(500, Math.min(Number(job.wait_interval_ms) || 30000, 30000));
@@ -1461,8 +1448,8 @@ async function waitForResponse(job) {
       && extractionIdle
       && extraction?.method !== "page_text_fallback"
     );
-    const backendApiFinal = Boolean(scopedExtractionCandidate && isFreshBackendApiExtraction(extraction));
-    const finalAffordance = Boolean(scopedExtractionCandidate && hasFinalAssistantAffordance(extraction));
+    const backendApiFinal = Boolean(scopedExtractionCandidate && completion.isFreshBackendApiExtraction(extraction));
+    const finalAffordance = Boolean(scopedExtractionCandidate && completion.hasFinalAssistantAffordance(extraction));
     const finalStructuralResponse = finalAffordance || backendApiFinal;
     // Broad page text is diagnostic only; final controls without scoped text
     // means extraction failed, not that page chrome is safe to return.
@@ -1470,33 +1457,42 @@ async function waitForResponse(job) {
       postSendAssistantActivity
       && extraction?.method === "page_text_fallback"
       && !extraction?.is_generating
-      && hasFinalAssistantAffordance(extraction)
+      && completion.hasFinalAssistantAffordance(extraction)
     );
     const stableIdleUnscopedCopy = Boolean(
       scopedExtractionCandidate
       && !finalStructuralResponse
-      && hasStableIdleUnscopedCopyAffordance(job, extraction)
+      && completion.hasStableIdleUnscopedCopyAffordance(
+        job,
+        extraction,
+        MIN_UNSCOPED_COPY_STABLE_TEXT_CHARS
+      )
     );
-    const renderRefreshCandidateEligible = isRenderFreezeRefreshCandidate(
+    const renderRefreshCandidateEligible = completion.isRenderFreezeRefreshCandidate(
       job,
       extraction,
       scopedExtractionCandidate,
-      finalStructuralResponse
+      finalStructuralResponse,
+      {
+        conversationId: conversationIdForJob(job, extraction),
+        shortResponseMaxChars: RENDER_FREEZE_SHORT_RESPONSE_MAX_CHARS,
+        maxRefreshAttempts: MAX_RENDER_REFRESH_ATTEMPTS
+      }
     );
     let stableForMs = 0;
     let unscopedCopyStableForMs = 0;
     let renderRefreshStableForMs = 0;
     if (backendApiFinal) {
-      return completedExtraction(extraction, "backend_api", 0);
+      return completion.completedExtraction(extraction, "backend_api", 0);
     }
     if (finalStructuralResponse) {
-      // Once ChatGPT exposes final assistant controls, scope and turn checks
+      // Once the adapter exposes final assistant controls, scope and turn checks
       // have already ruled out pre-send content. From here we track the best
       // scoped candidate by text growth so late page chrome cannot replace a
       // completed response, and transient generating blips cannot forget it.
-      const bestSelection = selectFinalAffordanceCandidate(bestFinalAffordanceCandidate, extraction);
+      const bestSelection = completion.selectFinalAffordanceCandidate(bestFinalAffordanceCandidate, extraction);
       bestFinalAffordanceCandidate = bestSelection.candidate;
-      const candidateSelection = selectFinalAffordanceCandidate(
+      const candidateSelection = completion.selectFinalAffordanceCandidate(
         finalAffordanceCandidate ?? bestFinalAffordanceCandidate,
         extraction
       );
@@ -1515,7 +1511,7 @@ async function waitForResponse(job) {
       // for the short confirm window, the response is settled — emit instead of
       // burning the full idle floor.
       if (stableForMs >= affordanceConfirmMs) {
-        return completedExtraction(finalAffordanceCandidate, "copy_button", stableForMs);
+        return completion.completedExtraction(finalAffordanceCandidate, "copy_button", stableForMs);
       }
       unscopedCopyCandidate = null;
       bestUnscopedCopyCandidate = null;
@@ -1536,9 +1532,9 @@ async function waitForResponse(job) {
       renderRefreshCandidateSinceMs = 0;
     }
     if (stableIdleUnscopedCopy) {
-      const bestSelection = selectFinalAffordanceCandidate(bestUnscopedCopyCandidate, extraction);
+      const bestSelection = completion.selectFinalAffordanceCandidate(bestUnscopedCopyCandidate, extraction);
       bestUnscopedCopyCandidate = bestSelection.candidate;
-      const candidateSelection = selectFinalAffordanceCandidate(
+      const candidateSelection = completion.selectFinalAffordanceCandidate(
         unscopedCopyCandidate ?? bestUnscopedCopyCandidate,
         extraction
       );
@@ -1552,7 +1548,11 @@ async function waitForResponse(job) {
       }
       unscopedCopyStableForMs = Date.now() - unscopedCopyCandidateSinceMs;
       if (unscopedCopyStableForMs >= finalAffordanceIdleMs) {
-        return completedExtraction(unscopedCopyCandidate, "stable_idle_unscoped_copy_button", unscopedCopyStableForMs);
+        return completion.completedExtraction(
+          unscopedCopyCandidate,
+          "stable_idle_unscoped_copy_button",
+          unscopedCopyStableForMs
+        );
       }
     } else if (!finalStructuralResponse) {
       unscopedCopyCandidate = null;
@@ -1562,14 +1562,15 @@ async function waitForResponse(job) {
       }
     }
     if (renderRefreshCandidateEligible) {
-      if (!sameRenderRefreshCandidate(renderRefreshCandidate, extraction)) {
+      if (!completion.sameRenderRefreshCandidate(renderRefreshCandidate, extraction)) {
         renderRefreshCandidate = extraction;
         renderRefreshCandidateSinceMs = Date.now();
       } else if (!renderRefreshCandidateSinceMs) {
         renderRefreshCandidateSinceMs = Date.now();
       }
       renderRefreshStableForMs = Date.now() - renderRefreshCandidateSinceMs;
-      if (renderRefreshStableForMs >= MIN_RENDER_FREEZE_IDLE_MS && canRefreshFrozenRender(job)) {
+      if (renderRefreshStableForMs >= MIN_RENDER_FREEZE_IDLE_MS
+          && completion.canRefreshFrozenRender(job, MAX_RENDER_REFRESH_ATTEMPTS)) {
         await refreshFrozenRender(job, extraction, renderRefreshStableForMs);
         renderRefreshCandidate = null;
         renderRefreshCandidateSinceMs = 0;
@@ -1590,7 +1591,16 @@ async function waitForResponse(job) {
       }
       const extractionFailureStableForMs = Date.now() - extractionFailureSinceMs;
       if (extractionFailureStableForMs >= finalAffordanceIdleMs) {
-        await failJob(job, "response_extraction_failed", finalAffordanceExtractionFailureMessage(job, extraction, extractionFailureStableForMs), {
+        await failJob(
+          job,
+          "response_extraction_failed",
+          completion.finalAffordanceExtractionFailureMessage(
+            job,
+            extraction,
+            extractionFailureStableForMs,
+            inspectCommandForJob(job)
+          ),
+          {
           phase: "wait_response",
           side_effect_started: true,
           completion_reason: "final_affordance_without_scoped_text",
@@ -1601,7 +1611,8 @@ async function waitForResponse(job) {
           turn_index: extraction.turn_index ?? -1,
           copy_button_count: extraction.copy_button_count ?? 0,
           diagnostics: diagnosticPayload(extraction.diagnostics)
-        });
+          }
+        );
         return null;
       }
     } else {
@@ -1638,7 +1649,8 @@ async function waitForResponse(job) {
     await sleep(nextDelay);
   }
   const inspectCommand = inspectCommandForJob(job);
-  const timeoutSummary = `ChatGPT response did not reach stable completion before timeout (baseline_assistant_count=${job.response_baseline?.assistant_count ?? 0}, best_method=${best.method}, best_text_chars=${best.text?.length ?? 0}, best_assistant_count=${best.assistant_count ?? 0}, best_turn_index=${best.turn_index ?? -1}, best_copy_button_count=${best.copy_button_count ?? 0}, best_is_generating=${Boolean(best.is_generating)}, last_method=${last.method}, last_text_chars=${last.text?.length ?? 0}, last_assistant_count=${last.assistant_count ?? 0}, last_turn_index=${last.turn_index ?? -1}, last_copy_button_count=${last.copy_button_count ?? 0}, last_is_generating=${Boolean(last.is_generating)}, last_diagnostics=${diagnosticSummary(last.diagnostics)}). The owned ChatGPT tab is left open; if it finishes later, recover with: ${inspectCommand}`;
+  const adapter = adapterForJob(job);
+  const timeoutSummary = `${adapter.displayName} response did not reach stable completion before timeout (baseline_assistant_count=${job.response_baseline?.assistant_count ?? 0}, best_method=${best.method}, best_text_chars=${best.text?.length ?? 0}, best_assistant_count=${best.assistant_count ?? 0}, best_turn_index=${best.turn_index ?? -1}, best_copy_button_count=${best.copy_button_count ?? 0}, best_is_generating=${Boolean(best.is_generating)}, last_method=${last.method}, last_text_chars=${last.text?.length ?? 0}, last_assistant_count=${last.assistant_count ?? 0}, last_turn_index=${last.turn_index ?? -1}, last_copy_button_count=${last.copy_button_count ?? 0}, last_is_generating=${Boolean(last.is_generating)}, last_diagnostics=${diagnosticSummary(last.diagnostics)}). The owned ${adapter.displayName} tab is left open; if it finishes later, recover with: ${inspectCommand}`;
   await failJob(job, "response_timeout", timeoutSummary, {
     phase: "wait_response",
     side_effect_started: true,
@@ -1715,6 +1727,7 @@ function postResponseProgress(job, extraction) {
 }
 
 function postWaitingResponseProgress(job, extraction, detail = {}) {
+  const adapter = adapterForJob(job);
   const elapsedMs = Number(detail.elapsed_ms ?? 0);
   const timeoutMs = Number(detail.timeout_ms ?? responseWaitTimeoutMs(job));
   const finalityStatus = detail.awaiting_final_affordance ? ", waiting for final assistant controls" : "";
@@ -1724,7 +1737,7 @@ function postWaitingResponseProgress(job, extraction, detail = {}) {
   postNative(progress(job, "waiting_response", {
     ...detail,
     inspect_command: detail.inspect_command ?? inspectCommandForJob(job),
-    message: `waiting for ChatGPT response (${formatDurationForMessage(elapsedMs)} elapsed of ${formatDurationForMessage(timeoutMs)} timeout; method=${extraction?.method ?? "none"}, assistant_count=${extraction?.assistant_count ?? 0}, copy_buttons=${extraction?.copy_button_count ?? 0}${scopedCopyStatus}${generating ? ", generating" : ""}${interimStatus}${finalityStatus})`,
+    message: `waiting for ${adapter.displayName} response (${formatDurationForMessage(elapsedMs)} elapsed of ${formatDurationForMessage(timeoutMs)} timeout; method=${extraction?.method ?? "none"}, assistant_count=${extraction?.assistant_count ?? 0}, copy_buttons=${extraction?.copy_button_count ?? 0}${scopedCopyStatus}${generating ? ", generating" : ""}${interimStatus}${finalityStatus})`,
     extraction_method: extraction?.method ?? "none",
     response_in_progress: generating,
     interim_assistant_turn: interimAssistantTurn,
@@ -1744,7 +1757,7 @@ function responseWaitTimeoutMs(job) {
 
 function inspectCommandForJob(job) {
   const selector = job.extension_instance_id ? ` --extension-instance-id ${job.extension_instance_id}` : "";
-  return `yoetz browser extension inspect --chatgpt --run-id ${job.run_id}${selector}`;
+  return `yoetz browser extension inspect ${adapterForJob(job).inspectScope} --run-id ${job.run_id}${selector}`;
 }
 
 function formatDurationForMessage(ms) {
@@ -1804,6 +1817,7 @@ async function extractDomResponseForJob(job) {
 }
 
 async function maybeBackendApiExtractionForJob(job, domExtraction) {
+  const completion = adapterForJob(job).completion;
   if (!shouldFetchBackendApi(job, domExtraction)) {
     return null;
   }
@@ -1818,9 +1832,9 @@ async function maybeBackendApiExtractionForJob(job, domExtraction) {
       conversation_id: conversationId
     });
     const normalized = normalizeBackendApiExtraction(backendExtraction, domExtraction, conversationId);
-    return isFreshBackendApiExtraction(normalized) ? normalized : null;
+    return completion.isFreshBackendApiExtraction(normalized) ? normalized : null;
   } catch (error) {
-    if (!isBackendApiFallbackError(error)) {
+    if (!completion.isBackendApiFallbackError(error)) {
       throw error;
     }
     job.backend_api_disabled = true;
@@ -1832,7 +1846,7 @@ async function maybeBackendApiExtractionForJob(job, domExtraction) {
 }
 
 function shouldFetchBackendApi(job, domExtraction) {
-  if (job?.backend_api_disabled) {
+  if (!adapterForJob(job).completion.supportsBackendApiFallback || job?.backend_api_disabled) {
     return false;
   }
   if (!domExtraction || domExtraction.manual_handoff || domExtraction.is_generating) {
@@ -1865,15 +1879,6 @@ function normalizeBackendApiExtraction(backendExtraction, domExtraction, convers
   };
 }
 
-function isBackendApiFallbackError(error) {
-  const code = String(error?.code ?? "");
-  if (code.startsWith("backend_api_")) {
-    return true;
-  }
-  const message = String(error?.message ?? error);
-  return /unknown content-script command yoetz_fetch_conversation|unexpected tab message yoetz_fetch_conversation|401|unauthorized|conversation api|backend api/i.test(message);
-}
-
 async function recoverContentScriptJob(job, error) {
   job.content_script_recovery_attempted = true;
   job.updated_at = Date.now();
@@ -1881,7 +1886,7 @@ async function recoverContentScriptJob(job, error) {
   postNative(progress(job, "content_script_recovering", {
     reason: String(error?.message ?? error)
   }));
-  await waitForContentScript(job.tab_id);
+  await waitForContentScript(job.tab_id, adapterForJob(job));
   const rebound = await sendToTab(job.tab_id, { type: "yoetz_bind_job", job });
   postNative(progress(job, "content_script_recovered", {
     url: rebound?.url ?? null,
@@ -1898,7 +1903,7 @@ function isPostSendExtraction(job, extraction) {
   if (!extraction || extraction.method === "page_text_fallback") {
     return false;
   }
-  if (isFreshBackendApiExtraction(extraction)) {
+  if (adapterForJob(job).completion.isFreshBackendApiExtraction(extraction)) {
     return true;
   }
   return isPostSendAssistantActivity(job, extraction);
@@ -1908,7 +1913,7 @@ function isPostSendAssistantActivity(job, extraction, allowUnknownTurnIndex = fa
   if (!extraction) {
     return false;
   }
-  if (isFreshBackendApiExtraction(extraction)) {
+  if (adapterForJob(job).completion.isFreshBackendApiExtraction(extraction)) {
     return true;
   }
   const submittedUserCount = nonNegativeFiniteNumber(job.submitted_user_count);
@@ -1930,103 +1935,15 @@ function isPostSendAssistantActivity(job, extraction, allowUnknownTurnIndex = fa
   return baselineCount === 0 && currentCount > 0;
 }
 
-function isFreshBackendApiExtraction(extraction) {
-  return extraction?.method === "backend_api"
-    && extraction.node_fresh === true
-    && !extraction.is_generating
-    && Boolean(normalizedResponseText(extraction.text));
-}
-
 function nonNegativeFiniteNumber(value) {
   const number = Number(value);
   return Number.isFinite(number) && number >= 0 ? number : null;
 }
 
-function isAcceptableModelSelection(selection) {
-  if (selection?.status === "current") {
-    return selection?.requested_model === "current"
-      && selection?.family_status === "skipped"
-      && selection?.effort_status === "skipped";
-  }
-  return selection?.status === "selected"
-    && selection?.requested_model === "gpt-5-6-sol-pro"
-    && selection?.family_status === "verified"
-    && selection?.effort_status === "verified"
-    && modelUsedLooksLikeSolPro(selection?.model_used);
-}
-
-function modelUsedLooksLikeSolPro(value) {
-  const folded = String(value ?? "").toLowerCase();
-  return /\bsol\b/.test(folded) && /\bpro\b/.test(folded);
-}
-
-function hasFinalAssistantAffordance(extraction) {
-  // ChatGPT shows assistant copy controls when a turn is externally complete.
-  // Pair this with the scoped extraction and !is_generating checks above.
-  return Boolean(!extraction?.is_generating && extraction?.has_copy_button);
-}
-
-function hasStableIdleUnscopedCopyAffordance(job, extraction) {
-  if (hasFinalAssistantAffordance(extraction)) {
-    return false;
-  }
-  if (!hasNoVisibleStopControls(extraction)) {
-    return false;
-  }
-  if (normalizedResponseText(extraction?.text).length < MIN_UNSCOPED_COPY_STABLE_TEXT_CHARS) {
-    return false;
-  }
-  const baselineCopyButtonCount = nonNegativeFiniteNumber(job.response_baseline?.copy_button_count);
-  const copyButtonCount = nonNegativeFiniteNumber(extraction?.copy_button_count);
-  return baselineCopyButtonCount !== null
-    && copyButtonCount !== null
-    && copyButtonCount > baselineCopyButtonCount;
-}
-
-function hasNoVisibleStopControls(extraction) {
-  const stopControlCount = nonNegativeFiniteNumber(extraction?.diagnostics?.counts?.stop_controls);
-  return stopControlCount === null || stopControlCount === 0;
-}
-
-function isRenderFreezeRefreshCandidate(job, extraction, scopedExtractionCandidate, finalAffordance) {
-  if (!scopedExtractionCandidate || finalAffordance) {
-    return false;
-  }
-  if (!canRefreshFrozenRender(job)) {
-    return false;
-  }
-  if (!hasExplicitlyNoVisibleStopControls(extraction)) {
-    return false;
-  }
-  const text = normalizedResponseText(extraction?.text);
-  if (!text || text.length > RENDER_FREEZE_SHORT_RESPONSE_MAX_CHARS) {
-    return false;
-  }
-  const conversationId = conversationIdForJob(job, extraction);
-  return Boolean(conversationId);
-}
-
-function hasExplicitlyNoVisibleStopControls(extraction) {
-  const stopControlCount = nonNegativeFiniteNumber(extraction?.diagnostics?.counts?.stop_controls);
-  return stopControlCount === 0;
-}
-
-function canRefreshFrozenRender(job) {
-  return Number(job?.render_refresh_attempts ?? 0) < MAX_RENDER_REFRESH_ATTEMPTS;
-}
-
-function sameRenderRefreshCandidate(candidate, extraction) {
-  if (!candidate || !extraction) {
-    return false;
-  }
-  return normalizedResponseText(candidate.text) === normalizedResponseText(extraction.text)
-    && Number(candidate.assistant_count ?? 0) === Number(extraction.assistant_count ?? 0)
-    && Number(candidate.turn_index ?? -1) === Number(extraction.turn_index ?? -1);
-}
-
 async function refreshFrozenRender(job, extraction, stableForMs) {
   const conversationId = conversationIdForJob(job, extraction);
-  const url = chatgptConversationJobUrl(conversationId, job.run_id);
+  const adapter = adapterForJob(job);
+  const url = adapter.conversationJobUrl(conversationId, job.run_id);
   job.render_refresh_attempts = Number(job.render_refresh_attempts ?? 0) + 1;
   job.updated_at = Date.now();
   await persistJob(job);
@@ -2039,11 +1956,11 @@ async function refreshFrozenRender(job, extraction, stableForMs) {
     stable_for_ms: stableForMs,
     response_length: extraction?.text?.length ?? 0,
     extraction_method: extraction?.method ?? "none",
-    message: `refreshing owned ChatGPT conversation render after idle short response stayed frozen for ${formatDurationForMessage(stableForMs)}`
+    message: `refreshing owned ${adapter.displayName} conversation render after idle short response stayed frozen for ${formatDurationForMessage(stableForMs)}`
   }));
   await chrome.tabs.update(job.tab_id, { url, active: false });
-  await waitForChatgptTab(job.tab_id);
-  await waitForContentScript(job.tab_id);
+  await waitForSiteTab(job.tab_id, adapter);
+  await waitForContentScript(job.tab_id, adapter);
   const rebound = await sendToTab(job.tab_id, { type: "yoetz_bind_job", job });
   postNative(progress(job, "render_refreshed", {
     tab_id: job.tab_id,
@@ -2052,7 +1969,7 @@ async function refreshFrozenRender(job, extraction, stableForMs) {
     attempt: job.render_refresh_attempts,
     url: rebound?.url ?? null,
     title: rebound?.title ?? null,
-    message: "owned ChatGPT conversation render refreshed; continuing final-response polling"
+    message: `owned ${adapter.displayName} conversation render refreshed; continuing final-response polling`
   }));
 }
 
@@ -2064,55 +1981,12 @@ function responseStableIdleThresholdMs(intervalMs) {
   );
 }
 
-function selectFinalAffordanceCandidate(candidate, extraction) {
-  const candidateText = normalizedResponseText(candidate?.text);
-  const nextText = normalizedResponseText(extraction?.text);
-  if (!candidate && extraction) {
-    return { candidate: extraction, resetTimer: true };
-  }
-  if (!nextText) {
-    return { candidate, resetTimer: false };
-  }
-  if (!candidateText) {
-    return { candidate: extraction, resetTimer: true };
-  }
-  if (nextText.length < candidateText.length) {
-    return { candidate, resetTimer: false };
-  }
-  if (nextText === candidateText) {
-    return { candidate, resetTimer: false };
-  }
-  return { candidate: extraction, resetTimer: nextText.length > candidateText.length };
-}
-
-function normalizedResponseText(value) {
-  return String(value ?? "")
-    .replace(/\r\n/g, "\n")
-    .replace(/[ \t]+\n/g, "\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-}
-
 function nativeEnvelopeByteLength(message) {
   const json = JSON.stringify(message);
   if (typeof TextEncoder !== "undefined") {
     return new TextEncoder().encode(json).byteLength;
   }
   return json.length;
-}
-
-function finalAffordanceExtractionFailureMessage(job, extraction, stableForMs) {
-  return `ChatGPT rendered a final assistant affordance but Yoetz could not extract scoped assistant text (method=${extraction?.method ?? "none"}, assistant_count=${extraction?.assistant_count ?? 0}, turn_index=${extraction?.turn_index ?? -1}, copy_button_count=${extraction?.copy_button_count ?? 0}, stable_for_ms=${stableForMs}). Inspect the owned tab with \`yoetz browser extension inspect --chatgpt --run-id ${job.run_id}\` before rerunning.`;
-}
-
-function completedExtraction(extraction, completionReason, stableForMs) {
-  return {
-    ...extraction,
-    completion_reason: completionReason,
-    stable_for_ms: stableForMs,
-    assistant_turn_count: Number(extraction.assistant_count ?? 0),
-    copy_button_count: Number(extraction.copy_button_count ?? 0)
-  };
 }
 
 function enforceMessageCapability(message) {
@@ -2153,7 +2027,7 @@ function assertSubmittedConversationCurrent(job, sendResult) {
   }
   throw commandError(
     "conversation_changed",
-    `job ${job.job_id} sent in ChatGPT conversation ${currentConversationId ?? "(none)"} instead of ${expectedConversationId}`,
+    `job ${job.job_id} sent in ${adapterForJob(job).displayName} conversation ${currentConversationId ?? "(none)"} instead of ${expectedConversationId}`,
     {
       phase: "send",
       side_effect_started: true,
@@ -2175,7 +2049,7 @@ function assertJobConversationCurrent(job, extraction) {
   }
   throw commandError(
     "conversation_changed",
-    `job ${job.job_id} moved from ChatGPT conversation ${expectedConversationId} to ${currentConversationId ?? "(none)"}`,
+    `job ${job.job_id} moved from ${adapterForJob(job).displayName} conversation ${expectedConversationId} to ${currentConversationId ?? "(none)"}`,
     {
       phase: "wait_response",
       side_effect_started: true,

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -270,6 +270,8 @@ async function startJob(message) {
   const tabActivation = await createJobTab(url, adapter);
   const tab = tabActivation.tab;
   job.tab_id = tab.id;
+  job.previous_active_tab_id = tabActivation.previousTabId;
+  job.restore_previous_after = tabActivation.restorePreviousAfter;
   job.updated_at = Date.now();
   await persistJob(job);
   const inspectCommand = inspectCommandForJob(job);
@@ -283,28 +285,23 @@ async function startJob(message) {
     return;
   }
 
-  let modelSelection;
-  try {
-    await waitForSiteTab(tab.id, adapter);
-    await waitForContentScript(tab.id, adapter);
-    const prepared = await sendToTab(tab.id, { type: "yoetz_prepare_job", job });
-    if (prepared.manual_handoff) {
-      postNative(progress(job, "manual_handoff", prepared.manual_handoff));
-      await failJob(job, "manual_handoff", prepared.manual_handoff.message, {
-        state: prepared.manual_handoff.state,
-        phase: "upload",
-        side_effect_started: true,
-        terminal_status: "manual_handoff"
-      });
-      return;
-    }
-    job.status = "selecting_model";
-    job.updated_at = Date.now();
-    await persistJob(job);
-    modelSelection = await sendToTab(tab.id, { type: "yoetz_configure_model", job });
-  } finally {
-    await restorePreviousTab(tabActivation);
+  await waitForSiteTab(tab.id, adapter);
+  await waitForContentScript(tab.id, adapter);
+  const prepared = await sendToTab(tab.id, { type: "yoetz_prepare_job", job });
+  if (prepared.manual_handoff) {
+    postNative(progress(job, "manual_handoff", prepared.manual_handoff));
+    await failJob(job, "manual_handoff", prepared.manual_handoff.message, {
+      state: prepared.manual_handoff.state,
+      phase: "upload",
+      side_effect_started: true,
+      terminal_status: "manual_handoff"
+    });
+    return;
   }
+  job.status = "selecting_model";
+  job.updated_at = Date.now();
+  await persistJob(job);
+  const modelSelection = await sendToTab(tab.id, { type: "yoetz_configure_model", job });
   job.model_used = modelSelection.model_used ?? null;
   job.model_selection_status = modelSelection.status ?? "unavailable";
   job.warnings = [
@@ -472,6 +469,7 @@ async function runJobWithFile(job, file) {
     assertSubmittedConversationCurrent(job, sendResult);
     assertJobConnectionCurrent(job);
     if (job.cancelled) return;
+    await restorePreviousTabForJob(job, "send");
     const inspectCommand = inspectCommandForJob(job);
     if (!postNative(progress(job, "prompt_sent", {
       timeout_ms: responseWaitTimeoutMs(job),
@@ -1368,8 +1366,11 @@ async function waitForSiteTab(tabId, adapter) {
 async function createJobTab(url, adapter) {
   const policy = adapter.tabActivation ?? {};
   const activateOnCreate = policy.activateOnCreate === true;
+  const restorePreviousAfter = typeof policy.restorePreviousAfter === "string"
+    ? policy.restorePreviousAfter
+    : null;
   let previousTabId = null;
-  if (activateOnCreate && policy.restorePreviousAfterModelSelection === true) {
+  if (activateOnCreate && restorePreviousAfter) {
     try {
       const [previousTab] = await chrome.tabs.query({ active: true, currentWindow: true });
       previousTabId = previousTab?.id ?? null;
@@ -1378,7 +1379,21 @@ async function createJobTab(url, adapter) {
     }
   }
   const tab = await chrome.tabs.create({ url, active: activateOnCreate });
-  return { tab, previousTabId };
+  return { tab, previousTabId, restorePreviousAfter };
+}
+
+async function restorePreviousTabForJob(job, phase) {
+  if (job.restore_previous_after !== phase) {
+    return;
+  }
+  await restorePreviousTab({
+    tab: { id: job.tab_id },
+    previousTabId: job.previous_active_tab_id
+  });
+  job.previous_active_tab_id = null;
+  job.restore_previous_after = null;
+  job.updated_at = Date.now();
+  await persistJob(job);
 }
 
 async function restorePreviousTab({ tab, previousTabId }) {

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -267,7 +267,8 @@ async function startJob(message) {
   const url = job.expected_conversation_id
     ? adapter.conversationJobUrl(job.expected_conversation_id, job.run_id)
     : adapter.jobUrl(job.run_id);
-  const tab = await chrome.tabs.create({ url, active: false });
+  const tabActivation = await createJobTab(url, adapter);
+  const tab = tabActivation.tab;
   job.tab_id = tab.id;
   job.updated_at = Date.now();
   await persistJob(job);
@@ -282,20 +283,28 @@ async function startJob(message) {
     return;
   }
 
-  await waitForSiteTab(tab.id, adapter);
-  await waitForContentScript(tab.id, adapter);
-  const prepared = await sendToTab(tab.id, { type: "yoetz_prepare_job", job });
-  if (prepared.manual_handoff) {
-    postNative(progress(job, "manual_handoff", prepared.manual_handoff));
-    await failJob(job, "manual_handoff", prepared.manual_handoff.message, {
-      state: prepared.manual_handoff.state,
-      phase: "upload",
-      side_effect_started: true,
-      terminal_status: "manual_handoff"
-    });
-    return;
+  let modelSelection;
+  try {
+    await waitForSiteTab(tab.id, adapter);
+    await waitForContentScript(tab.id, adapter);
+    const prepared = await sendToTab(tab.id, { type: "yoetz_prepare_job", job });
+    if (prepared.manual_handoff) {
+      postNative(progress(job, "manual_handoff", prepared.manual_handoff));
+      await failJob(job, "manual_handoff", prepared.manual_handoff.message, {
+        state: prepared.manual_handoff.state,
+        phase: "upload",
+        side_effect_started: true,
+        terminal_status: "manual_handoff"
+      });
+      return;
+    }
+    job.status = "selecting_model";
+    job.updated_at = Date.now();
+    await persistJob(job);
+    modelSelection = await sendToTab(tab.id, { type: "yoetz_configure_model", job });
+  } finally {
+    await restorePreviousTab(tabActivation);
   }
-  const modelSelection = await sendToTab(tab.id, { type: "yoetz_configure_model", job });
   job.model_used = modelSelection.model_used ?? null;
   job.model_selection_status = modelSelection.status ?? "unavailable";
   job.warnings = [
@@ -1325,6 +1334,33 @@ async function waitForSiteTab(tabId, adapter) {
   throw new Error(`${adapter.displayName} tab ${tabId} did not load`);
 }
 
+async function createJobTab(url, adapter) {
+  const policy = adapter.tabActivation ?? {};
+  const activateOnCreate = policy.activateOnCreate === true;
+  let previousTabId = null;
+  if (activateOnCreate && policy.restorePreviousAfterModelSelection === true) {
+    try {
+      const [previousTab] = await chrome.tabs.query({ active: true, currentWindow: true });
+      previousTabId = previousTab?.id ?? null;
+    } catch {
+      // Capturing focus is best effort; mounting the site is the correctness gate.
+    }
+  }
+  const tab = await chrome.tabs.create({ url, active: activateOnCreate });
+  return { tab, previousTabId };
+}
+
+async function restorePreviousTab({ tab, previousTabId }) {
+  if (previousTabId == null || previousTabId === tab?.id) {
+    return;
+  }
+  try {
+    await chrome.tabs.update(previousTabId, { active: true });
+  } catch {
+    // The user may have closed or moved the prior tab while the site mounted.
+  }
+}
+
 async function waitForContentScript(tabId, adapter) {
   for (let attempt = 0; attempt < 40; attempt += 1) {
     try {
@@ -2237,6 +2273,7 @@ function phaseForStatus(status) {
   const phaseByStatus = {
     starting: "upload",
     opening_tab: "upload",
+    selecting_model: "model_selection",
     waiting_for_file: "upload",
     receiving_file: "upload",
     file_received: "upload",

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -43,15 +43,11 @@ const MAX_RENDER_REFRESH_ATTEMPTS = Math.max(
     ? Number(globalThis.__YOETZ_MAX_RENDER_REFRESH_ATTEMPTS)
     : 1
 );
-// Once a site adapter has exposed its final assistant affordance AND scoped
-// text is extractable AND generation has stopped, the response is structurally
-// complete. Confirm it over a SHORT stable window at a FAST cadence instead of
-// waiting out the full MIN_STABLE_IDLE_MS late-hydration floor. The dual-candidate
-// latch still re-arms this window on any text growth (selectFinalAffordanceCandidate
-// -> resetTimer), so a still-hydrating response cannot complete early; this only
-// removes the dead wall-clock wait after the text has genuinely settled. This is the
-// post-affordance confirm window and is always clamped to the slower idle floor so it
-// can only ever shorten the wait, never lengthen it.
+// Once a site adapter exposes its final structural signal with scoped text and
+// generation stopped, the candidate is sampled at a fast cadence. Adapters with
+// a durable final affordance may use the short confirmation window; adapters
+// whose signal is idle DOM state require the full stable-idle window. In both
+// cases text growth re-arms the candidate timer, so late hydration cannot win.
 const MIN_AFFORDANCE_CONFIRM_MS = Math.max(
   0,
   Number(globalThis.__YOETZ_MIN_AFFORDANCE_CONFIRM_MS ?? 8000)
@@ -1332,7 +1328,7 @@ async function waitForSiteTab(tabId, adapter) {
 async function waitForContentScript(tabId, adapter) {
   for (let attempt = 0; attempt < 40; attempt += 1) {
     try {
-      await sendToTab(tabId, { type: "yoetz_probe" });
+      await sendToTab(tabId, { type: "yoetz_probe", recipe: adapter.recipe });
       return;
     } catch {
       await sleep(500);
@@ -1400,6 +1396,9 @@ async function waitForResponse(job) {
   // ceiling (and so test envs that drive MIN_STABLE_IDLE_MS below the confirm default
   // still complete promptly).
   const affordanceConfirmMs = Math.min(MIN_AFFORDANCE_CONFIRM_MS, finalAffordanceIdleMs);
+  const finalStructuralConfirmMs = completion.finalAffordanceRequiresStableIdle
+    ? finalAffordanceIdleMs
+    : affordanceConfirmMs;
   let best = { method: "none", text: "", is_generating: true };
   let last = { method: "none", text: "", is_generating: true };
   let finalAffordanceCandidate = null;
@@ -1486,8 +1485,8 @@ async function waitForResponse(job) {
       return completion.completedExtraction(extraction, "backend_api", 0);
     }
     if (finalStructuralResponse) {
-      // Once the adapter exposes final assistant controls, scope and turn checks
-      // have already ruled out pre-send content. From here we track the best
+      // Once the adapter exposes its final structural signal, scope and turn
+      // checks have already ruled out pre-send content. From here we track the best
       // scoped candidate by text growth so late page chrome cannot replace a
       // completed response, and transient generating blips cannot forget it.
       const bestSelection = completion.selectFinalAffordanceCandidate(bestFinalAffordanceCandidate, extraction);
@@ -1510,8 +1509,11 @@ async function waitForResponse(job) {
       // stableForMs is "time since the scoped text last grew". Once that has held
       // for the short confirm window, the response is settled — emit instead of
       // burning the full idle floor.
-      if (stableForMs >= affordanceConfirmMs) {
-        return completion.completedExtraction(finalAffordanceCandidate, "copy_button", stableForMs);
+      if (stableForMs >= finalStructuralConfirmMs) {
+        const completionReason = finalAffordanceCandidate?.has_copy_button
+          ? "copy_button"
+          : "stable_idle";
+        return completion.completedExtraction(finalAffordanceCandidate, completionReason, stableForMs);
       }
       unscopedCopyCandidate = null;
       bestUnscopedCopyCandidate = null;

--- a/extensions/chatgpt-native/src/sites/chatgpt-backend.js
+++ b/extensions/chatgpt-native/src/sites/chatgpt-backend.js
@@ -1,0 +1,167 @@
+// ChatGPT-only freeze-proof extraction via the same-origin conversation API.
+// The worker decides when to use this fallback; this adapter owns the endpoint,
+// authentication, active-lineage freshness, and answer-node semantics.
+export async function fetchConversationAnswer({
+  job,
+  requestedConversationId,
+  parseOwnedWindowName,
+  assertJobOwnership,
+  expectedConversationId,
+  locationHref,
+  commandError
+}) {
+  assertJobOwnership(job, parseOwnedWindowName);
+  const conversationId = String(requestedConversationId ?? "").trim()
+    || expectedConversationId
+    || conversationIdFromUrl(locationHref);
+  if (!conversationId) {
+    throw backendApiError(commandError, "backend_api_unavailable", "no conversation id available for backend-api read");
+  }
+  const token = await fetchChatgptAccessToken();
+  if (!token) {
+    throw backendApiError(commandError, "backend_api_unauthorized", "no ChatGPT access token (session expired or signed out)");
+  }
+  let response;
+  try {
+    response = await fetch(`/backend-api/conversation/${encodeURIComponent(conversationId)}`, {
+      method: "GET",
+      credentials: "include",
+      headers: { Authorization: `Bearer ${token}`, Accept: "application/json" }
+    });
+  } catch (error) {
+    throw backendApiError(commandError, "backend_api_unavailable", `backend-api conversation fetch failed: ${String(error?.message ?? error)}`);
+  }
+  if (response.status === 401 || response.status === 403) {
+    throw backendApiError(commandError, "backend_api_unauthorized", `backend-api conversation returned ${response.status}`);
+  }
+  if (!response.ok) {
+    throw backendApiError(commandError, "backend_api_unavailable", `backend-api conversation returned ${response.status}`);
+  }
+  let data;
+  try {
+    data = await response.json();
+  } catch (error) {
+    throw backendApiError(commandError, "backend_api_unavailable", `backend-api conversation returned non-JSON: ${String(error?.message ?? error)}`);
+  }
+  return resolveBackendAnswer(job, conversationId, data);
+}
+
+function backendApiError(commandError, code, message) {
+  return commandError(code, message, { phase: "wait_response", side_effect_started: true });
+}
+
+async function fetchChatgptAccessToken() {
+  try {
+    const response = await fetch("/api/auth/session", {
+      method: "GET",
+      credentials: "include",
+      headers: { Accept: "application/json" }
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const session = await response.json();
+    const token = session?.accessToken;
+    return typeof token === "string" && token.length > 0 ? token : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveBackendAnswer(job, conversationId, data) {
+  const baseline = nonNegativeInt(job?.submitted_assistant_count ?? job?.response_baseline?.assistant_count ?? 0);
+  const notReady = (detail) => ({
+    method: "backend_api",
+    text: "",
+    is_generating: true,
+    conversation_id: conversationId,
+    node_fresh: false,
+    assistant_count: 0,
+    turn_index: -1,
+    has_copy_button: false,
+    copy_button_count: 0,
+    backend_api_detail: detail
+  });
+  const mapping = data && typeof data === "object" && data.mapping && typeof data.mapping === "object"
+    ? data.mapping
+    : null;
+  if (!mapping) {
+    return notReady("backend-api response had no conversation mapping");
+  }
+  const { answerNode, count: lineageAnswerCount } = collectLineageAnswerNodes(mapping, data.current_node);
+  if (!answerNode) {
+    return notReady("no completed assistant answer node on the active lineage yet (still generating / tool-only)");
+  }
+  if (lineageAnswerCount <= baseline) {
+    return notReady(`assistant answer not fresh past baseline (active-lineage ${lineageAnswerCount} <= ${baseline})`);
+  }
+  const text = answerTextOf(answerNode.message);
+  if (!text) {
+    return notReady("latest active-lineage assistant answer node had no text parts");
+  }
+  return {
+    method: "backend_api",
+    text,
+    is_generating: false,
+    conversation_id: conversationId,
+    node_fresh: true,
+    assistant_count: lineageAnswerCount,
+    turn_index: Math.max(0, lineageAnswerCount - 1),
+    node_id: String(answerNode.id ?? answerNode.message?.id ?? ""),
+    has_copy_button: false,
+    copy_button_count: 0
+  };
+}
+
+function isAssistantAnswerNode(message) {
+  if (!message || typeof message !== "object" || message.author?.role !== "assistant") {
+    return false;
+  }
+  const content = message.content;
+  return Boolean(
+    content
+    && content.content_type === "text"
+    && (message.recipient ?? "all") === "all"
+    && message.end_turn === true
+    && answerTextOf(message).length > 0
+  );
+}
+
+function answerTextOf(message) {
+  const parts = message?.content?.parts;
+  return Array.isArray(parts)
+    ? parts.filter((part) => typeof part === "string").join("").trim()
+    : "";
+}
+
+function collectLineageAnswerNodes(mapping, currentNodeId) {
+  let id = currentNodeId;
+  let guard = 0;
+  let answerNode = null;
+  let count = 0;
+  while (id && guard < 2000) {
+    guard += 1;
+    const node = mapping[id];
+    if (!node) break;
+    if (isAssistantAnswerNode(node.message)) {
+      answerNode ??= node;
+      count += 1;
+    }
+    id = node.parent;
+  }
+  return { answerNode, count };
+}
+
+function nonNegativeInt(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? Math.floor(number) : 0;
+}
+
+function conversationIdFromUrl(value) {
+  try {
+    const match = new URL(String(value ?? "")).pathname.match(/^\/c\/([^/?#]+)$/);
+    return match ? decodeURIComponent(match[1]) : null;
+  } catch {
+    return null;
+  }
+}

--- a/extensions/chatgpt-native/src/sites/chatgpt.js
+++ b/extensions/chatgpt-native/src/sites/chatgpt.js
@@ -200,7 +200,7 @@ export const chatgptSiteAdapter = Object.freeze({
   fetchConversationAnswer,
   tabActivation: Object.freeze({
     activateOnCreate: false,
-    restorePreviousAfterModelSelection: false
+    restorePreviousAfter: null
   }),
   auth: Object.freeze({
     noTabStatus: "no_chatgpt_tab",

--- a/extensions/chatgpt-native/src/sites/chatgpt.js
+++ b/extensions/chatgpt-native/src/sites/chatgpt.js
@@ -1,0 +1,227 @@
+import * as dom from "../chatgpt-dom.js";
+import { fetchConversationAnswer } from "./chatgpt-backend.js";
+export * from "../chatgpt-dom.js";
+export { fetchConversationAnswer } from "./chatgpt-backend.js";
+
+const CHATGPT_MODEL = "gpt-5-6-sol-pro";
+const CHATGPT_ORIGIN = "https://chatgpt.com";
+
+function conversationIdFromUrl(value) {
+  try {
+    const pathname = new URL(String(value ?? ""), CHATGPT_ORIGIN).pathname;
+    const match = pathname.match(/^\/c\/([^/?#]+)$/);
+    return match ? decodeURIComponent(match[1]) : null;
+  } catch {
+    return null;
+  }
+}
+
+function conversationUrl(conversationId) {
+  if (!conversationId) return null;
+  return `${CHATGPT_ORIGIN}/c/${encodeURIComponent(conversationId)}`;
+}
+
+function normalizeConversationId(value) {
+  if (value == null) {
+    return { ok: true, id: null };
+  }
+  if (typeof value !== "string") {
+    return { ok: false, message: "invalid `conversation_id`: expected a string ChatGPT conversation id" };
+  }
+  const id = value.trim();
+  if (!id || id === "." || id === "..") {
+    return { ok: false, message: "invalid `conversation_id`: expected a non-empty ChatGPT conversation id" };
+  }
+  if (id.length > 256) {
+    return { ok: false, message: "invalid `conversation_id`: expected at most 256 characters" };
+  }
+  if (!/^[A-Za-z0-9_.-]+$/.test(id)) {
+    return { ok: false, message: "invalid `conversation_id`: expected ASCII letters, digits, `_`, `.`, or `-`" };
+  }
+  return { ok: true, id };
+}
+
+function modelUsedLooksLikeSolPro(value) {
+  const folded = String(value ?? "").toLowerCase();
+  return /\bsol\b/.test(folded) && /\bpro\b/.test(folded);
+}
+
+function isAcceptableModelSelection(selection) {
+  if (selection?.status === "current") {
+    return selection?.requested_model === "current"
+      && selection?.family_status === "skipped"
+      && selection?.effort_status === "skipped";
+  }
+  return selection?.status === "selected"
+    && selection?.requested_model === CHATGPT_MODEL
+    && selection?.family_status === "verified"
+    && selection?.effort_status === "verified"
+    && modelUsedLooksLikeSolPro(selection?.model_used);
+}
+
+function normalizedResponseText(value) {
+  return String(value ?? "")
+    .replace(/\r\n/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function nonNegativeFiniteNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 0 ? number : null;
+}
+
+function isFreshBackendApiExtraction(extraction) {
+  return extraction?.method === "backend_api"
+    && extraction.node_fresh === true
+    && !extraction.is_generating
+    && Boolean(normalizedResponseText(extraction.text));
+}
+
+function hasFinalAssistantAffordance(extraction) {
+  return Boolean(!extraction?.is_generating && extraction?.has_copy_button);
+}
+
+function hasNoVisibleStopControls(extraction) {
+  const stopControlCount = nonNegativeFiniteNumber(extraction?.diagnostics?.counts?.stop_controls);
+  return stopControlCount === null || stopControlCount === 0;
+}
+
+function hasStableIdleUnscopedCopyAffordance(job, extraction, minTextChars) {
+  if (hasFinalAssistantAffordance(extraction)
+      || !hasNoVisibleStopControls(extraction)
+      || normalizedResponseText(extraction?.text).length < minTextChars) {
+    return false;
+  }
+  const baseline = nonNegativeFiniteNumber(job.response_baseline?.copy_button_count);
+  const current = nonNegativeFiniteNumber(extraction?.copy_button_count);
+  return baseline !== null && current !== null && current > baseline;
+}
+
+function hasExplicitlyNoVisibleStopControls(extraction) {
+  const stopControlCount = nonNegativeFiniteNumber(extraction?.diagnostics?.counts?.stop_controls);
+  return stopControlCount === 0;
+}
+
+function isRenderFreezeRefreshCandidate(
+  job,
+  extraction,
+  scopedExtractionCandidate,
+  finalAffordance,
+  { conversationId, shortResponseMaxChars, maxRefreshAttempts }
+) {
+  if (!scopedExtractionCandidate
+      || finalAffordance
+      || extraction?.method === "backend_api"
+      || !hasExplicitlyNoVisibleStopControls(extraction)) {
+    return false;
+  }
+  const text = normalizedResponseText(extraction?.text);
+  return Boolean(
+    text
+    && text.length <= shortResponseMaxChars
+    && conversationId
+    && Number(job.render_refresh_attempts ?? 0) < maxRefreshAttempts
+  );
+}
+
+function canRefreshFrozenRender(job, maxRefreshAttempts) {
+  return Number(job?.render_refresh_attempts ?? 0) < maxRefreshAttempts;
+}
+
+function sameRenderRefreshCandidate(candidate, extraction) {
+  return Boolean(candidate && extraction)
+    && normalizedResponseText(candidate.text) === normalizedResponseText(extraction.text)
+    && Number(candidate.assistant_count ?? 0) === Number(extraction.assistant_count ?? 0)
+    && Number(candidate.turn_index ?? -1) === Number(extraction.turn_index ?? -1);
+}
+
+function selectFinalAffordanceCandidate(candidate, extraction) {
+  const candidateText = normalizedResponseText(candidate?.text);
+  const nextText = normalizedResponseText(extraction?.text);
+  if (!candidate && extraction) {
+    return { candidate: extraction, resetTimer: true };
+  }
+  if (!nextText) {
+    return { candidate, resetTimer: false };
+  }
+  if (!candidateText) {
+    return { candidate: extraction, resetTimer: true };
+  }
+  if (nextText.length < candidateText.length) {
+    return { candidate, resetTimer: false };
+  }
+  if (nextText === candidateText) {
+    return { candidate, resetTimer: false };
+  }
+  return { candidate: extraction, resetTimer: nextText.length > candidateText.length };
+}
+
+function finalAffordanceExtractionFailureMessage(job, extraction, stableForMs, inspectCommand) {
+  return `ChatGPT rendered a final assistant affordance but Yoetz could not extract scoped assistant text (method=${extraction?.method ?? "none"}, assistant_count=${extraction?.assistant_count ?? 0}, turn_index=${extraction?.turn_index ?? -1}, copy_button_count=${extraction?.copy_button_count ?? 0}, stable_for_ms=${stableForMs}). Inspect the owned tab with \`${inspectCommand}\` before rerunning.`;
+}
+
+function completedExtraction(extraction, completionReason, stableForMs) {
+  return {
+    ...extraction,
+    completion_reason: completionReason,
+    stable_for_ms: stableForMs,
+    assistant_turn_count: Number(extraction.assistant_count ?? 0),
+    copy_button_count: Number(extraction.copy_button_count ?? 0)
+  };
+}
+
+function isBackendApiFallbackError(error) {
+  const code = String(error?.code ?? "");
+  if (code.startsWith("backend_api_")) {
+    return true;
+  }
+  const message = String(error?.message ?? error);
+  return /unknown content-script command yoetz_fetch_conversation|unexpected tab message yoetz_fetch_conversation|401|unauthorized|conversation api|backend api/i.test(message);
+}
+
+export const chatgptSiteAdapter = Object.freeze({
+  recipe: "chatgpt",
+  displayName: "ChatGPT",
+  homeUrl: `${CHATGPT_ORIGIN}/`,
+  tabQueryPattern: `${CHATGPT_ORIGIN}/*`,
+  defaultModel: CHATGPT_MODEL,
+  inspectScope: "--chatgpt",
+  dom,
+  jobUrl: dom.chatgptJobUrl,
+  conversationJobUrl: dom.chatgptConversationJobUrl,
+  conversationUrl,
+  conversationIdFromUrl,
+  isConversationUrl: (url) => Boolean(conversationIdFromUrl(url)),
+  normalizeConversationId,
+  isAllowedTabUrl: (url) => String(url ?? "").startsWith(`${CHATGPT_ORIGIN}/`),
+  isAcceptableModelSelection,
+  fetchConversationAnswer,
+  auth: Object.freeze({
+    noTabStatus: "no_chatgpt_tab",
+    selection(candidate) {
+      if (candidate.tab.active && !candidate.yoetzOwned) return "active_non_yoetz_chatgpt_tab";
+      if (!candidate.yoetzOwned) return "non_yoetz_chatgpt_tab";
+      if (candidate.tab.active) return "active_yoetz_job_tab";
+      return "yoetz_job_tab";
+    }
+  }),
+  completion: Object.freeze({
+    supportsBackendApiFallback: true,
+    renderRefreshMode: "reload_conversation",
+    emptyResponseWarning: "empty ChatGPT response extracted",
+    isFreshBackendApiExtraction,
+    hasFinalAssistantAffordance,
+    hasStableIdleUnscopedCopyAffordance,
+    isRenderFreezeRefreshCandidate,
+    canRefreshFrozenRender,
+    sameRenderRefreshCandidate,
+    selectFinalAffordanceCandidate,
+    finalAffordanceExtractionFailureMessage,
+    completedExtraction,
+    isBackendApiFallbackError
+  })
+});
+
+export { chatgptSiteAdapter as siteAdapter };

--- a/extensions/chatgpt-native/src/sites/chatgpt.js
+++ b/extensions/chatgpt-native/src/sites/chatgpt.js
@@ -198,6 +198,10 @@ export const chatgptSiteAdapter = Object.freeze({
   isAllowedTabUrl: (url) => String(url ?? "").startsWith(`${CHATGPT_ORIGIN}/`),
   isAcceptableModelSelection,
   fetchConversationAnswer,
+  tabActivation: Object.freeze({
+    activateOnCreate: false,
+    restorePreviousAfterModelSelection: false
+  }),
   auth: Object.freeze({
     noTabStatus: "no_chatgpt_tab",
     selection(candidate) {

--- a/extensions/chatgpt-native/src/sites/claude.js
+++ b/extensions/chatgpt-native/src/sites/claude.js
@@ -96,7 +96,7 @@ export const claudeSiteAdapter = Object.freeze({
   isAcceptableModelSelection,
   tabActivation: Object.freeze({
     activateOnCreate: true,
-    restorePreviousAfterModelSelection: true
+    restorePreviousAfter: "send"
   }),
   auth: Object.freeze({
     noTabStatus: "no_claude_tab",

--- a/extensions/chatgpt-native/src/sites/claude.js
+++ b/extensions/chatgpt-native/src/sites/claude.js
@@ -94,6 +94,10 @@ export const claudeSiteAdapter = Object.freeze({
   normalizeConversationId,
   isAllowedTabUrl: (url) => String(url ?? "").startsWith(`${CLAUDE_ORIGIN}/`),
   isAcceptableModelSelection,
+  tabActivation: Object.freeze({
+    activateOnCreate: true,
+    restorePreviousAfterModelSelection: true
+  }),
   auth: Object.freeze({
     noTabStatus: "no_claude_tab",
     selection(candidate) {

--- a/extensions/chatgpt-native/src/sites/claude.js
+++ b/extensions/chatgpt-native/src/sites/claude.js
@@ -1,0 +1,126 @@
+import * as dom from "../claude-dom.js";
+export * from "../claude-dom.js";
+
+const CLAUDE_MODEL = "fable-5-max";
+const CLAUDE_ORIGIN = "https://claude.ai";
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function conversationIdFromUrl(value) {
+  try {
+    const pathname = new URL(String(value ?? ""), CLAUDE_ORIGIN).pathname;
+    const match = pathname.match(/^\/chat\/([^/?#]+)$/);
+    const id = match ? decodeURIComponent(match[1]) : null;
+    return id && UUID.test(id) ? id : null;
+  } catch {
+    return null;
+  }
+}
+
+function conversationUrl(conversationId) {
+  return conversationId ? `${CLAUDE_ORIGIN}/chat/${encodeURIComponent(conversationId)}` : null;
+}
+
+function normalizeConversationId(value) {
+  if (value == null) return { ok: true, id: null };
+  if (typeof value !== "string") {
+    return { ok: false, message: "invalid `conversation_id`: expected a Claude conversation UUID" };
+  }
+  const id = conversationIdFromUrl(value.trim()) ?? value.trim();
+  return UUID.test(id)
+    ? { ok: true, id }
+    : { ok: false, message: "invalid `conversation_id`: expected a Claude conversation UUID" };
+}
+
+function isAcceptableModelSelection(selection) {
+  return selection?.status === "selected"
+    && selection?.requested_model === CLAUDE_MODEL
+    && selection?.modelVerified === true
+    && selection?.maxVerified === true
+    && selection?.thinkingChecked === true
+    && selection?.model_used === "Fable 5 Max";
+}
+
+function normalizedResponseText(value) {
+  return String(value ?? "")
+    .replace(/\r\n/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function hasFinalAssistantAffordance(extraction) {
+  return Boolean(
+    !extraction?.is_generating
+    && extraction?.method === "assistant_dom"
+    && normalizedResponseText(extraction?.text)
+  );
+}
+
+function selectFinalAffordanceCandidate(candidate, extraction) {
+  const candidateText = normalizedResponseText(candidate?.text);
+  const nextText = normalizedResponseText(extraction?.text);
+  if (!candidate && extraction) return { candidate: extraction, resetTimer: true };
+  if (!nextText) return { candidate, resetTimer: false };
+  if (!candidateText) return { candidate: extraction, resetTimer: true };
+  if (nextText.length < candidateText.length || nextText === candidateText) {
+    return { candidate, resetTimer: false };
+  }
+  return { candidate: extraction, resetTimer: nextText.length > candidateText.length };
+}
+
+function completedExtraction(extraction, completionReason, stableForMs) {
+  return {
+    ...extraction,
+    completion_reason: completionReason,
+    stable_for_ms: stableForMs,
+    assistant_turn_count: Number(extraction.assistant_count ?? 0),
+    copy_button_count: Number(extraction.copy_button_count ?? 0)
+  };
+}
+
+export const claudeSiteAdapter = Object.freeze({
+  recipe: "claude",
+  displayName: "Claude",
+  homeUrl: `${CLAUDE_ORIGIN}/new`,
+  tabQueryPattern: `${CLAUDE_ORIGIN}/*`,
+  defaultModel: CLAUDE_MODEL,
+  inspectScope: "--claude",
+  dom,
+  jobUrl: dom.claudeJobUrl,
+  conversationJobUrl: dom.claudeConversationJobUrl,
+  conversationUrl,
+  conversationIdFromUrl,
+  isConversationUrl: (url) => Boolean(conversationIdFromUrl(url)),
+  normalizeConversationId,
+  isAllowedTabUrl: (url) => String(url ?? "").startsWith(`${CLAUDE_ORIGIN}/`),
+  isAcceptableModelSelection,
+  auth: Object.freeze({
+    noTabStatus: "no_claude_tab",
+    selection(candidate) {
+      if (candidate.tab.active && !candidate.yoetzOwned) return "active_non_yoetz_claude_tab";
+      if (!candidate.yoetzOwned) return "non_yoetz_claude_tab";
+      if (candidate.tab.active) return "active_yoetz_job_tab";
+      return "yoetz_job_tab";
+    }
+  }),
+  completion: Object.freeze({
+    supportsBackendApiFallback: false,
+    renderRefreshMode: "none",
+    finalAffordanceRequiresStableIdle: true,
+    emptyResponseWarning: "empty Claude response extracted",
+    isFreshBackendApiExtraction: () => false,
+    hasFinalAssistantAffordance,
+    hasStableIdleUnscopedCopyAffordance: () => false,
+    isRenderFreezeRefreshCandidate: () => false,
+    canRefreshFrozenRender: () => false,
+    sameRenderRefreshCandidate: () => false,
+    selectFinalAffordanceCandidate,
+    finalAffordanceExtractionFailureMessage(_job, extraction, stableForMs, inspectCommand) {
+      return `Claude rendered final assistant controls but Yoetz could not extract scoped assistant text (method=${extraction?.method ?? "none"}, assistant_count=${extraction?.assistant_count ?? 0}, copy_button_count=${extraction?.copy_button_count ?? 0}, stable_for_ms=${stableForMs}). Inspect the owned tab with \`${inspectCommand}\` before rerunning.`;
+    },
+    completedExtraction,
+    isBackendApiFallbackError: () => false
+  })
+});
+
+export { claudeSiteAdapter as siteAdapter };

--- a/extensions/chatgpt-native/src/sites/index.js
+++ b/extensions/chatgpt-native/src/sites/index.js
@@ -1,0 +1,20 @@
+import { chatgptSiteAdapter } from "./chatgpt.js";
+
+const adapters = new Map([
+  [chatgptSiteAdapter.recipe, chatgptSiteAdapter]
+]);
+
+export function advertisedRecipes() {
+  return [...adapters.keys()];
+}
+
+export function siteAdapterForRecipe(value) {
+  const recipe = value == null ? "chatgpt" : value;
+  const adapter = typeof recipe === "string" ? adapters.get(recipe) : null;
+  if (adapter) {
+    return adapter;
+  }
+  const error = new Error(`recipe ${JSON.stringify(recipe)} is not available in this extension build; rejected before side effects`);
+  error.code = "unsupported_recipe";
+  throw error;
+}

--- a/extensions/chatgpt-native/src/sites/index.js
+++ b/extensions/chatgpt-native/src/sites/index.js
@@ -1,7 +1,9 @@
 import { chatgptSiteAdapter } from "./chatgpt.js";
+import { claudeSiteAdapter } from "./claude.js";
 
 const adapters = new Map([
-  [chatgptSiteAdapter.recipe, chatgptSiteAdapter]
+  [chatgptSiteAdapter.recipe, chatgptSiteAdapter],
+  [claudeSiteAdapter.recipe, claudeSiteAdapter]
 ]);
 
 export function advertisedRecipes() {

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -194,7 +194,7 @@ test("content script rejects an unavailable site adapter before DOM side effects
   try {
     const response = await send({
       type: "yoetz_prepare_job",
-      job: { ...resumeJob(), recipe: "claude" }
+      job: { ...resumeJob(), recipe: "unknown" }
     });
 
     assert.equal(response.ok, false);

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { uint8ArrayToBase64 } from "../src/chunks.js";
 
-const helperModule = `const hooks = globalThis.__contentScriptTestHooks;
+const chatgptBackendModuleUrl = new URL("../src/sites/chatgpt-backend.js", import.meta.url).href;
+const helperModule = `import { fetchConversationAnswer } from ${JSON.stringify(chatgptBackendModuleUrl)};
+export { fetchConversationAnswer };
+const hooks = globalThis.__contentScriptTestHooks;
 
 export function ownedWindowName(job) {
   return \`yoetz-chatgpt-native:\${job.run_id}:\${job.job_id}\`;
@@ -106,7 +109,44 @@ export function modelSelectionDiagnostics() {
 function conversationIdFromLocation() {
   const match = String(globalThis.location.pathname ?? "").match(/^\\/c\\/([^/?#]+)$/);
   return match ? decodeURIComponent(match[1]) : null;
-}`;
+}
+
+const dom = {
+  ownedWindowName,
+  parseOwnedWindowName,
+  getPageText,
+  classifyManualHandoff,
+  classifyWaitManualHandoff,
+  ensureFreshChat,
+  ensureConversationLoaded,
+  markOwnership,
+  uploadFile,
+  configureModelState,
+  sendAcceptanceBaseline,
+  insertPrompt,
+  clickSend,
+  waitForSendAccepted,
+  extractResponse,
+  modelSelectionDiagnostics
+};
+
+export const siteAdapter = {
+  recipe: "chatgpt",
+  displayName: "ChatGPT",
+  dom,
+  fetchConversationAnswer,
+  conversationIdFromUrl(value) {
+    try {
+      const match = new URL(value).pathname.match(/^\\/c\\/([^/?#]+)$/);
+      return match ? decodeURIComponent(match[1]) : null;
+    } catch {
+      return null;
+    }
+  },
+  isConversationUrl(value) {
+    return Boolean(this.conversationIdFromUrl(value));
+  }
+};`;
 
 test("content script resume path skips fresh enforcement and completes on requested conversation", async () => {
   const { send, hooks, restore } = await loadContentScript("resume_happy", "https://chatgpt.com/c/conv-123?_yoetz=run_resume");
@@ -144,6 +184,26 @@ test("content script resume path skips fresh enforcement and completes on reques
     const extracted = await send({ type: "yoetz_extract_response", job });
     assert.equal(extracted.ok, true);
     assert.equal(extracted.payload.conversation_id, "conv-123");
+  } finally {
+    restore();
+  }
+});
+
+test("content script rejects an unavailable site adapter before DOM side effects", async () => {
+  const { send, hooks, restore } = await loadContentScript("unsupported_recipe", "https://chatgpt.com/");
+  try {
+    const response = await send({
+      type: "yoetz_prepare_job",
+      job: { ...resumeJob(), recipe: "claude" }
+    });
+
+    assert.equal(response.ok, false);
+    assert.equal(response.code, "unsupported_recipe");
+    assert.equal(response.phase, "profile");
+    assert.equal(response.side_effect_started, false);
+    assert.deepEqual(hooks.ensureFreshChatCalls, []);
+    assert.deepEqual(hooks.ensureConversationLoadedCalls, []);
+    assert.deepEqual(hooks.markOwnershipCalls, []);
   } finally {
     restore();
   }

--- a/extensions/chatgpt-native/tests/fake-claude.test.js
+++ b/extensions/chatgpt-native/tests/fake-claude.test.js
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 import {
   configureModelState,
@@ -9,6 +10,16 @@ import {
   uploadFile
 } from "../src/claude-dom.js";
 import { claudeSiteAdapter } from "../src/sites/claude.js";
+
+const claudeDomSource = await readFile(new URL("../src/claude-dom.js", import.meta.url), "utf8");
+
+test("Claude upload uses the native files setter for page-world visibility", () => {
+  assert.doesNotMatch(
+    claudeDomSource,
+    /Object\.defineProperty\(\s*input\s*,\s*["']files["']/
+  );
+  assert.match(claudeDomSource, /\binput\.files\s*=\s*transfer\.files\b/);
+});
 
 test("fake Claude background turn returns the complete scoped response only after final controls", () => {
   const terminalMarker = "YOETZ TERMINAL MARKER";

--- a/extensions/chatgpt-native/tests/fake-claude.test.js
+++ b/extensions/chatgpt-native/tests/fake-claude.test.js
@@ -276,6 +276,37 @@ test("fake Claude Thinking row keeps the response non-final until tool use and s
   assert.equal(claudeSiteAdapter.completion.hasFinalAssistantAffordance(complete), true);
 });
 
+test("fake Claude extraction excludes collapsed thinking status text from the answer", () => {
+  const answer = "Final answer without thinking chrome.";
+  const contaminated = [
+    "Thinking about concerns with this request",
+    "Thinking about concerns with this request",
+    "⌄",
+    answer
+  ].join("\n");
+  const page = fakeClaudePage({ text: contaminated, streaming: false, copy: true });
+  page.body.cloneNode = () => {
+    let text = contaminated;
+    return {
+      get innerText() {
+        return text;
+      },
+      get textContent() {
+        return text;
+      },
+      querySelectorAll(selector) {
+        return selector === "button[class*='group/status']"
+          ? [{ remove: () => { text = answer; } }]
+          : [];
+      }
+    };
+  };
+
+  const extraction = extractResponse(page.root);
+
+  assert.equal(extraction.text, answer);
+});
+
 test("fake Claude extraction fails closed when final controls are not scoped to the answer", () => {
   const page = fakeClaudePage({ text: "", streaming: false, copy: false });
   page.root.body.innerText = "possibly clipped page text";

--- a/extensions/chatgpt-native/tests/fake-claude.test.js
+++ b/extensions/chatgpt-native/tests/fake-claude.test.js
@@ -1,0 +1,458 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  configureModelState,
+  ensureConversationLoaded,
+  extractResponse,
+  insertPrompt,
+  isResponseGenerating,
+  uploadFile
+} from "../src/claude-dom.js";
+import { claudeSiteAdapter } from "../src/sites/claude.js";
+
+test("fake Claude background turn returns the complete scoped response only after final controls", () => {
+  const terminalMarker = "YOETZ TERMINAL MARKER";
+  const text = `${"A complete long response. ".repeat(300)}${terminalMarker}`;
+  const page = fakeClaudePage({ text, streaming: false, copy: true });
+
+  const extraction = extractResponse(page.root);
+
+  assert.equal(extraction.method, "assistant_dom");
+  assert.equal(extraction.text.endsWith(terminalMarker), true);
+  assert.equal(extraction.is_generating, false);
+  assert.equal(extraction.has_copy_button, true);
+  assert.equal(claudeSiteAdapter.completion.hasFinalAssistantAffordance(extraction), true);
+});
+
+test("fake Claude ProseMirror composer inserts through execCommand", async () => {
+  const commands = [];
+  const events = [];
+  const composer = {
+    isContentEditable: true,
+    textContent: "",
+    getAttribute: (name) => name === "contenteditable" ? "true" : null,
+    focus() {
+      root.activeElement = this;
+    },
+    dispatchEvent(event) {
+      events.push(event.type);
+      return true;
+    }
+  };
+  const root = {
+    activeElement: null,
+    querySelector: (selector) => selector === "[data-testid='chat-input']" ? composer : null,
+    execCommand(command, _showUi, value) {
+      commands.push({ command, value });
+      assert.equal(root.activeElement, composer);
+      composer.textContent = value;
+      return true;
+    }
+  };
+
+  await insertPrompt(root, "Review this bundle");
+
+  assert.deepEqual(commands, [{ command: "insertText", value: "Review this bundle" }]);
+  assert.equal(composer.textContent, "Review this bundle");
+  assert.deepEqual(events, ["change"]);
+});
+
+test("fake Claude upload waits for the committed chip and re-enabled send", async () => {
+  const previousDataTransfer = globalThis.DataTransfer;
+  globalThis.DataTransfer = FakeDataTransfer;
+  try {
+    let attachment = null;
+    let committedAt = null;
+    const send = {
+      disabled: true,
+      getAttribute: () => null
+    };
+    const input = {
+      files: null,
+      dispatchEvent(event) {
+        assert.equal(event.type, "change");
+        const name = this.files[0].name;
+        attachment = {
+          querySelector(selector) {
+            if (selector === "h3") return { textContent: name };
+            if (selector === "button[aria-label='Remove']") return {};
+            return null;
+          }
+        };
+        setTimeout(() => {
+          send.disabled = false;
+          committedAt = Date.now();
+        }, 25);
+        return true;
+      }
+    };
+    const root = {
+      querySelector(selector) {
+        if (selector === "input[data-testid='file-upload']") return input;
+        if (selector === "button[aria-label='Send message']") return send;
+        return null;
+      },
+      querySelectorAll(selector) {
+        return selector === "[data-testid='file-thumbnail']" && attachment ? [attachment] : [];
+      }
+    };
+    const file = new File(["bundle"], "fixture.md", { type: "text/markdown" });
+
+    await uploadFile(root, file, { timeoutMs: 1000 });
+
+    assert.equal(input.files[0].name, "fixture.md");
+    assert.equal(send.disabled, false);
+    assert.ok(committedAt !== null && Date.now() >= committedAt);
+  } finally {
+    globalThis.DataTransfer = previousDataTransfer;
+  }
+});
+
+test("fake Claude model picker drives hover-only Max and Thinking then closes", async () => {
+  const fixture = makeClaudeModelFixture();
+  const previousPointerEvent = globalThis.PointerEvent;
+  const previousMouseEvent = globalThis.MouseEvent;
+  const previousKeyboardEvent = globalThis.KeyboardEvent;
+  globalThis.PointerEvent = FakePointerEvent;
+  globalThis.MouseEvent = FakeMouseEvent;
+  globalThis.KeyboardEvent = FakeKeyboardEvent;
+  try {
+    const result = await configureModelState(fixture.root, { model_selection_timeout_ms: 250 });
+
+    assert.equal(result.status, "selected");
+    assert.equal(result.model_used, "Fable 5 Max");
+    assert.equal(result.thinkingChecked, true);
+    assert.equal(fixture.thinking.getAttribute("aria-checked"), "true");
+    assert.ok(fixture.hoverEvents >= 3, "effort submenu must be re-hovered for Max, Thinking, and verification");
+    assert.equal(fixture.sawMousePointer, true);
+    assert.equal(fixture.modelButton.getAttribute("aria-expanded"), "false");
+  } finally {
+    globalThis.PointerEvent = previousPointerEvent;
+    globalThis.MouseEvent = previousMouseEvent;
+    globalThis.KeyboardEvent = previousKeyboardEvent;
+  }
+});
+
+test("fake Claude missing Fable returns unavailable with live options", async () => {
+  const fixture = makeClaudeModelFixture({ includeFable: false });
+  const previousPointerEvent = globalThis.PointerEvent;
+  const previousMouseEvent = globalThis.MouseEvent;
+  const previousKeyboardEvent = globalThis.KeyboardEvent;
+  globalThis.PointerEvent = FakePointerEvent;
+  globalThis.MouseEvent = FakeMouseEvent;
+  globalThis.KeyboardEvent = FakeKeyboardEvent;
+  try {
+    const result = await configureModelState(fixture.root, { model_selection_timeout_ms: 1 });
+
+    assert.equal(result.status, "unavailable");
+    assert.ok(result.options.includes("Sonnet 5"));
+    assert.match(result.warning, /live options: Sonnet 5/);
+    assert.equal(fixture.modelButton.getAttribute("aria-expanded"), "false");
+  } finally {
+    globalThis.PointerEvent = previousPointerEvent;
+    globalThis.MouseEvent = previousMouseEvent;
+    globalThis.KeyboardEvent = previousKeyboardEvent;
+  }
+});
+
+test("fake Claude Thinking row keeps the response non-final until tool use and streaming stop", () => {
+  const page = fakeClaudePage({
+    text: "Searching the attached marker file",
+    streaming: true,
+    copy: true,
+    thinking: true
+  });
+
+  const interim = extractResponse(page.root);
+  assert.equal(interim.is_generating, true);
+  assert.equal(claudeSiteAdapter.completion.hasFinalAssistantAffordance(interim), false);
+
+  page.assistant.streaming = false;
+  page.assistant.thinking = false;
+  page.body.textContent = "Found marker FILE-42. Final answer complete.";
+  page.body.innerText = page.body.textContent;
+  const complete = extractResponse(page.root);
+  assert.equal(complete.is_generating, false);
+  assert.equal(complete.text, "Found marker FILE-42. Final answer complete.");
+  assert.equal(claudeSiteAdapter.completion.hasFinalAssistantAffordance(complete), true);
+});
+
+test("fake Claude extraction fails closed when final controls are not scoped to the answer", () => {
+  const page = fakeClaudePage({ text: "", streaming: false, copy: false });
+  page.root.body.innerText = "possibly clipped page text";
+  page.root.body.textContent = page.root.body.innerText;
+  page.globalCopy = [{}];
+
+  const extraction = extractResponse(page.root);
+
+  assert.equal(extraction.method, "none");
+  assert.equal(extraction.text, "");
+  assert.equal(extraction.copy_button_count, 1);
+  assert.equal(extraction.has_copy_button, false);
+  assert.equal(claudeSiteAdapter.completion.hasFinalAssistantAffordance(extraction), false);
+});
+
+test("fake Claude completed scoped answer does not require a hover-only copy button", () => {
+  const page = fakeClaudePage({ text: "complete without hover", streaming: false, copy: false });
+
+  const extraction = extractResponse(page.root);
+
+  assert.equal(extraction.method, "assistant_dom");
+  assert.equal(extraction.has_copy_button, false);
+  assert.equal(claudeSiteAdapter.completion.hasFinalAssistantAffordance(extraction), true);
+  assert.equal(claudeSiteAdapter.completion.finalAffordanceRequiresStableIdle, true);
+});
+
+test("fake Claude conversation loader preserves changed and unavailable taxonomy", async () => {
+  const originalLocation = globalThis.location;
+  const requested = "123e4567-e89b-12d3-a456-426614174000";
+  const different = "123e4567-e89b-12d3-a456-426614174001";
+  try {
+    globalThis.location = {
+      pathname: `/chat/${different}`,
+      href: `https://claude.ai/chat/${different}`
+    };
+    await assert.rejects(
+      ensureConversationLoaded(fakeConversationRoot(""), requested, { timeoutMs: 1 }),
+      (error) => error?.code === "conversation_changed"
+        && error?.requested_conversation_id === requested
+        && error?.current_conversation_id === different
+    );
+
+    globalThis.location = {
+      pathname: `/chat/${requested}`,
+      href: `https://claude.ai/chat/${requested}`
+    };
+    await assert.rejects(
+      ensureConversationLoaded(
+        fakeConversationRoot("This conversation is unavailable. You do not have access."),
+        requested,
+        { timeoutMs: 1 }
+      ),
+      (error) => error?.code === "conversation_unavailable"
+        && error?.requested_conversation_id === requested
+    );
+  } finally {
+    globalThis.location = originalLocation;
+  }
+});
+
+test("fake Claude model acceptance requires Fable 5, Max, and Thinking together", () => {
+  const selected = {
+    status: "selected",
+    requested_model: "fable-5-max",
+    model_used: "Fable 5 Max",
+    modelVerified: true,
+    maxVerified: true,
+    thinkingChecked: true
+  };
+  assert.equal(claudeSiteAdapter.isAcceptableModelSelection(selected), true);
+  for (const field of ["modelVerified", "maxVerified", "thinkingChecked"]) {
+    assert.equal(
+      claudeSiteAdapter.isAcceptableModelSelection({ ...selected, [field]: false }),
+      false,
+      field
+    );
+  }
+});
+
+function fakeClaudePage({ text, streaming, copy, thinking = false }) {
+  const body = { innerText: text, textContent: text };
+  const copyButton = {};
+  const page = {
+    globalCopy: copy ? [copyButton] : []
+  };
+  const assistant = {
+    streaming,
+    thinking,
+    getAttribute(name) {
+      return name === "data-is-streaming" ? String(this.streaming) : null;
+    },
+    querySelector(selector) {
+      if (selector === ".font-claude-response") return body;
+      if (selector === "button[class*='group/status']") return this.thinking ? {} : null;
+      return null;
+    },
+    closest() {
+      return turn;
+    }
+  };
+  const turn = {
+    querySelectorAll(selector) {
+      return selector === "[data-testid='action-bar-copy']" && copy ? [copyButton] : [];
+    }
+  };
+  const user = {
+    compareDocumentPosition() {
+      return 4;
+    }
+  };
+  const root = {
+    body: { innerText: text, textContent: text },
+    querySelector(selector) {
+      if (selector === "button[aria-label='Stop response']") return null;
+      return null;
+    },
+    querySelectorAll(selector) {
+      if (selector === "[data-is-streaming]") return [assistant];
+      if (selector === "[data-testid='action-bar-copy']") return page.globalCopy;
+      if (selector === "button[aria-label='Stop response']") return [];
+      if (selector === "button[class*='group/status']") return thinking ? [{}] : [];
+      if (selector === "[data-testid='user-message']") return [user];
+      return [];
+    }
+  };
+  page.root = root;
+  page.assistant = assistant;
+  page.body = body;
+  return page;
+}
+
+class FakeDataTransfer {
+  constructor() {
+    this.files = [];
+    this.items = { add: (file) => this.files.push(file) };
+  }
+}
+
+class FakePointerEvent extends Event {
+  constructor(type, init = {}) {
+    super(type, init);
+    this.pointerType = init.pointerType;
+    this.pointerId = init.pointerId;
+    this.clientX = init.clientX;
+    this.clientY = init.clientY;
+  }
+}
+
+class FakeMouseEvent extends Event {
+  constructor(type, init = {}) {
+    super(type, init);
+    this.clientX = init.clientX;
+    this.clientY = init.clientY;
+  }
+}
+
+class FakeKeyboardEvent extends Event {
+  constructor(type, init = {}) {
+    super(type, init);
+    this.key = init.key;
+    this.code = init.code;
+  }
+}
+
+function makeClaudeModelFixture({ includeFable = true } = {}) {
+  let menuOpen = false;
+  let effortHovered = false;
+  let hoverEvents = 0;
+  let sawMousePointer = false;
+
+  const control = (attrs, text, onClick = () => {}) => ({
+    attrs: { ...attrs },
+    innerText: text,
+    textContent: text,
+    parentElement: null,
+    getAttribute(name) {
+      return this.attrs[name] ?? null;
+    },
+    setAttribute(name, value) {
+      this.attrs[name] = String(value);
+    },
+    getClientRects() {
+      return [{}];
+    },
+    getBoundingClientRect() {
+      return { left: 10, top: 20, width: 40, height: 20 };
+    },
+    closest() {
+      return null;
+    },
+    click() {
+      onClick(this);
+    },
+    dispatchEvent(event) {
+      if (event.type.startsWith("pointer")) {
+        hoverEvents += 1;
+        if (event.pointerType === "mouse" && event.pointerId === 1 && event.clientX > 0 && event.clientY > 0) {
+          sawMousePointer = true;
+          effortHovered = true;
+        }
+      }
+      if (event.type === "keydown" && event.key === "Escape") {
+        menuOpen = false;
+        modelButton.setAttribute("aria-expanded", "false");
+      }
+      return true;
+    }
+  });
+
+  const modelButton = control({ "data-testid": "model-selector-dropdown", "aria-expanded": "false" }, "Sonnet 5 High", () => {
+    menuOpen = true;
+    effortHovered = false;
+    modelButton.setAttribute("aria-expanded", "true");
+  });
+  const fable = control({ role: "menuitemradio", "aria-checked": "false" }, "Fable 5", (element) => {
+    element.setAttribute("aria-checked", "true");
+    modelButton.innerText = "Fable 5 High";
+    modelButton.textContent = modelButton.innerText;
+    menuOpen = false;
+    modelButton.setAttribute("aria-expanded", "false");
+  });
+  const sonnet = control({ role: "menuitemradio", "aria-checked": includeFable ? "false" : "true" }, "Sonnet 5");
+  const effort = control({ "data-testid": "effort-menu-trigger" }, "Effort");
+  const max = control({ role: "menuitemradio", "data-testid": "effort-option-max", "aria-checked": "false" }, "Max", (element) => {
+    element.setAttribute("aria-checked", "true");
+    modelButton.innerText = "Fable 5 Max";
+    modelButton.textContent = modelButton.innerText;
+    menuOpen = false;
+    effortHovered = false;
+    modelButton.setAttribute("aria-expanded", "false");
+  });
+  const thinking = control({ role: "switch", "aria-label": "Thinking", "aria-checked": "false" }, "Thinking", (element) => {
+    element.setAttribute("aria-checked", "true");
+  });
+  const root = {
+    activeElement: modelButton,
+    defaultView: { KeyboardEvent: FakeKeyboardEvent },
+    querySelector(selector) {
+      if (selector === "[data-testid='model-selector-dropdown']") return modelButton;
+      if (selector === "[data-testid='effort-menu-trigger']") return menuOpen ? effort : null;
+      if (selector === "[role='menuitemradio'][data-testid='effort-option-max']") {
+        return menuOpen && effortHovered ? max : null;
+      }
+      return null;
+    },
+    querySelectorAll(selector) {
+      if (!menuOpen) return [];
+      if (selector === "[role='menuitemradio']") {
+        return includeFable ? [fable, sonnet] : [sonnet];
+      }
+      if (selector === "[role='menuitemradio'][aria-checked='true']") {
+        return [fable, sonnet, max].filter((element) => element.getAttribute("aria-checked") === "true");
+      }
+      if (selector === "span[role='switch'][aria-checked]") {
+        return effortHovered ? [thinking] : [];
+      }
+      if (selector === "[role='menuitem'], [role='menuitemradio'], button, [role='switch']") {
+        return [includeFable ? fable : null, sonnet, effort, effortHovered ? max : null, effortHovered ? thinking : null].filter(Boolean);
+      }
+      return [];
+    }
+  };
+
+  Object.defineProperties(root, {
+    hoverEvents: { get: () => hoverEvents },
+    sawMousePointer: { get: () => sawMousePointer }
+  });
+  return { root, modelButton, thinking, get hoverEvents() { return hoverEvents; }, get sawMousePointer() { return sawMousePointer; } };
+}
+
+function fakeConversationRoot(text) {
+  return {
+    title: "Claude",
+    body: { innerText: text, textContent: text },
+    querySelector() {
+      return null;
+    }
+  };
+}

--- a/extensions/chatgpt-native/tests/fake-claude.test.js
+++ b/extensions/chatgpt-native/tests/fake-claude.test.js
@@ -133,6 +133,94 @@ test("fake Claude model picker drives hover-only Max and Thinking then closes", 
   }
 });
 
+test("fake Claude model picker waits for a delayed menu close before reopening", async () => {
+  const fixture = makeClaudeModelFixture({ delayedSelectionClose: true });
+  const previousPointerEvent = globalThis.PointerEvent;
+  const previousMouseEvent = globalThis.MouseEvent;
+  const previousKeyboardEvent = globalThis.KeyboardEvent;
+  globalThis.PointerEvent = FakePointerEvent;
+  globalThis.MouseEvent = FakeMouseEvent;
+  globalThis.KeyboardEvent = FakeKeyboardEvent;
+  try {
+    const result = await configureModelState(fixture.root, { model_selection_timeout_ms: 250 });
+
+    assert.equal(result.status, "selected");
+    assert.equal(result.model_used, "Fable 5 Max");
+    assert.equal(fixture.modelButton.getAttribute("aria-expanded"), "false");
+  } finally {
+    globalThis.PointerEvent = previousPointerEvent;
+    globalThis.MouseEvent = previousMouseEvent;
+    globalThis.KeyboardEvent = previousKeyboardEvent;
+  }
+});
+
+test("fake Claude model picker waits for Thinking to render before verification", async () => {
+  const fixture = makeClaudeModelFixture({ delayedThinkingRender: true });
+  const previousPointerEvent = globalThis.PointerEvent;
+  const previousMouseEvent = globalThis.MouseEvent;
+  const previousKeyboardEvent = globalThis.KeyboardEvent;
+  globalThis.PointerEvent = FakePointerEvent;
+  globalThis.MouseEvent = FakeMouseEvent;
+  globalThis.KeyboardEvent = FakeKeyboardEvent;
+  try {
+    const result = await configureModelState(fixture.root, { model_selection_timeout_ms: 250 });
+
+    assert.equal(result.status, "selected");
+    assert.equal(result.thinkingChecked, true);
+  } finally {
+    globalThis.PointerEvent = previousPointerEvent;
+    globalThis.MouseEvent = previousMouseEvent;
+    globalThis.KeyboardEvent = previousKeyboardEvent;
+  }
+});
+
+test("fake Claude model picker preserves an already exact selection without clicking options", async () => {
+  const fixture = makeClaudeModelFixture({ initiallyConfigured: true, delayedThinkingRender: true });
+  const previousPointerEvent = globalThis.PointerEvent;
+  const previousMouseEvent = globalThis.MouseEvent;
+  const previousKeyboardEvent = globalThis.KeyboardEvent;
+  globalThis.PointerEvent = FakePointerEvent;
+  globalThis.MouseEvent = FakeMouseEvent;
+  globalThis.KeyboardEvent = FakeKeyboardEvent;
+  try {
+    const result = await configureModelState(fixture.root, { model_selection_timeout_ms: 250 });
+
+    assert.equal(result.status, "selected");
+    assert.equal(result.model_used, "Fable 5 Max");
+    assert.equal(fixture.fableClicks, 0);
+    assert.equal(fixture.maxClicks, 0);
+    assert.equal(fixture.thinkingClicks, 0);
+    assert.equal(fixture.modelButton.getAttribute("aria-expanded"), "false");
+  } finally {
+    globalThis.PointerEvent = previousPointerEvent;
+    globalThis.MouseEvent = previousMouseEvent;
+    globalThis.KeyboardEvent = previousKeyboardEvent;
+  }
+});
+
+test("fake Claude full and already-exact paths both return adapter-acceptable results", async () => {
+  const fullSelection = makeClaudeModelFixture();
+  const alreadyExact = makeClaudeModelFixture({ initiallyConfigured: true, ignoreEscape: true });
+  const previousPointerEvent = globalThis.PointerEvent;
+  const previousMouseEvent = globalThis.MouseEvent;
+  const previousKeyboardEvent = globalThis.KeyboardEvent;
+  globalThis.PointerEvent = FakePointerEvent;
+  globalThis.MouseEvent = FakeMouseEvent;
+  globalThis.KeyboardEvent = FakeKeyboardEvent;
+  try {
+    const fullResult = await configureModelState(fullSelection.root, { model_selection_timeout_ms: 250 });
+    const exactResult = await configureModelState(alreadyExact.root, { model_selection_timeout_ms: 250 });
+
+    assert.equal(claudeSiteAdapter.isAcceptableModelSelection(fullResult), true);
+    assert.equal(claudeSiteAdapter.isAcceptableModelSelection(exactResult), true);
+    assert.deepEqual(Object.keys(exactResult).sort(), Object.keys(fullResult).sort());
+  } finally {
+    globalThis.PointerEvent = previousPointerEvent;
+    globalThis.MouseEvent = previousMouseEvent;
+    globalThis.KeyboardEvent = previousKeyboardEvent;
+  }
+});
+
 test("fake Claude missing Fable returns unavailable with live options", async () => {
   const fixture = makeClaudeModelFixture({ includeFable: false });
   const previousPointerEvent = globalThis.PointerEvent;
@@ -341,11 +429,21 @@ class FakeKeyboardEvent extends Event {
   }
 }
 
-function makeClaudeModelFixture({ includeFable = true } = {}) {
+function makeClaudeModelFixture({
+  includeFable = true,
+  delayedSelectionClose = false,
+  delayedThinkingRender = false,
+  ignoreEscape = false,
+  initiallyConfigured = false
+} = {}) {
   let menuOpen = false;
   let effortHovered = false;
+  let thinkingVisible = false;
   let hoverEvents = 0;
   let sawMousePointer = false;
+  let fableClicks = 0;
+  let maxClicks = 0;
+  let thinkingClicks = 0;
 
   const control = (attrs, text, onClick = () => {}) => ({
     attrs: { ...attrs },
@@ -376,9 +474,14 @@ function makeClaudeModelFixture({ includeFable = true } = {}) {
         if (event.pointerType === "mouse" && event.pointerId === 1 && event.clientX > 0 && event.clientY > 0) {
           sawMousePointer = true;
           effortHovered = true;
+          if (delayedThinkingRender) {
+            setTimeout(() => { thinkingVisible = true; }, 10);
+          } else {
+            thinkingVisible = true;
+          }
         }
       }
-      if (event.type === "keydown" && event.key === "Escape") {
+      if (event.type === "keydown" && event.key === "Escape" && !ignoreEscape) {
         menuOpen = false;
         modelButton.setAttribute("aria-expanded", "false");
       }
@@ -386,29 +489,52 @@ function makeClaudeModelFixture({ includeFable = true } = {}) {
     }
   });
 
-  const modelButton = control({ "data-testid": "model-selector-dropdown", "aria-expanded": "false" }, "Sonnet 5 High", () => {
-    menuOpen = true;
-    effortHovered = false;
-    modelButton.setAttribute("aria-expanded", "true");
-  });
-  const fable = control({ role: "menuitemradio", "aria-checked": "false" }, "Fable 5", (element) => {
+  const modelButton = control(
+    { "data-testid": "model-selector-dropdown", "aria-expanded": "false" },
+    initiallyConfigured ? "Fable 5 Max" : "Sonnet 5 High",
+    () => {
+      if (modelButton.getAttribute("aria-expanded") === "true") {
+        menuOpen = false;
+        effortHovered = false;
+        thinkingVisible = false;
+        modelButton.setAttribute("aria-expanded", "false");
+        return;
+      }
+      menuOpen = true;
+      effortHovered = false;
+      thinkingVisible = false;
+      modelButton.setAttribute("aria-expanded", "true");
+    }
+  );
+  const closeAfterSelection = () => {
+    menuOpen = false;
+    const markClosed = () => modelButton.setAttribute("aria-expanded", "false");
+    if (delayedSelectionClose) {
+      setTimeout(markClosed, 10);
+    } else {
+      markClosed();
+    }
+  };
+  const fable = control({ role: "menuitemradio", "aria-checked": initiallyConfigured ? "true" : "false" }, "Fable 5", (element) => {
+    fableClicks += 1;
     element.setAttribute("aria-checked", "true");
     modelButton.innerText = "Fable 5 High";
     modelButton.textContent = modelButton.innerText;
-    menuOpen = false;
-    modelButton.setAttribute("aria-expanded", "false");
+    closeAfterSelection();
   });
   const sonnet = control({ role: "menuitemradio", "aria-checked": includeFable ? "false" : "true" }, "Sonnet 5");
   const effort = control({ "data-testid": "effort-menu-trigger" }, "Effort");
-  const max = control({ role: "menuitemradio", "data-testid": "effort-option-max", "aria-checked": "false" }, "Max", (element) => {
+  const max = control({ role: "menuitemradio", "data-testid": "effort-option-max", "aria-checked": initiallyConfigured ? "true" : "false" }, "Max", (element) => {
+    maxClicks += 1;
     element.setAttribute("aria-checked", "true");
     modelButton.innerText = "Fable 5 Max";
     modelButton.textContent = modelButton.innerText;
-    menuOpen = false;
     effortHovered = false;
-    modelButton.setAttribute("aria-expanded", "false");
+    thinkingVisible = false;
+    closeAfterSelection();
   });
-  const thinking = control({ role: "switch", "aria-label": "Thinking", "aria-checked": "false" }, "Thinking", (element) => {
+  const thinking = control({ role: "switch", "aria-label": "Thinking", "aria-checked": initiallyConfigured ? "true" : "false" }, "Thinking", (element) => {
+    thinkingClicks += 1;
     element.setAttribute("aria-checked", "true");
   });
   const root = {
@@ -431,10 +557,16 @@ function makeClaudeModelFixture({ includeFable = true } = {}) {
         return [fable, sonnet, max].filter((element) => element.getAttribute("aria-checked") === "true");
       }
       if (selector === "span[role='switch'][aria-checked]") {
-        return effortHovered ? [thinking] : [];
+        return effortHovered && thinkingVisible ? [thinking] : [];
       }
       if (selector === "[role='menuitem'], [role='menuitemradio'], button, [role='switch']") {
-        return [includeFable ? fable : null, sonnet, effort, effortHovered ? max : null, effortHovered ? thinking : null].filter(Boolean);
+        return [
+          includeFable ? fable : null,
+          sonnet,
+          effort,
+          effortHovered ? max : null,
+          effortHovered && thinkingVisible ? thinking : null
+        ].filter(Boolean);
       }
       return [];
     }
@@ -444,7 +576,16 @@ function makeClaudeModelFixture({ includeFable = true } = {}) {
     hoverEvents: { get: () => hoverEvents },
     sawMousePointer: { get: () => sawMousePointer }
   });
-  return { root, modelButton, thinking, get hoverEvents() { return hoverEvents; }, get sawMousePointer() { return sawMousePointer; } };
+  return {
+    root,
+    modelButton,
+    thinking,
+    get fableClicks() { return fableClicks; },
+    get maxClicks() { return maxClicks; },
+    get thinkingClicks() { return thinkingClicks; },
+    get hoverEvents() { return hoverEvents; },
+    get sawMousePointer() { return sawMousePointer; }
+  };
 }
 
 function fakeConversationRoot(text) {

--- a/extensions/chatgpt-native/tests/manifest.test.js
+++ b/extensions/chatgpt-native/tests/manifest.test.js
@@ -7,11 +7,20 @@ import { EXTENSION_ID } from "../src/protocol.js";
 const manifest = JSON.parse(await readFile(new URL("../manifest.json", import.meta.url), "utf8"));
 const nativeHostManifest = JSON.parse(await readFile(new URL("../native-host-manifest.template.json", import.meta.url), "utf8"));
 
-test("manifest is MV3 and scoped only to ChatGPT", () => {
+test("manifest is one multi-site transport package", () => {
   assert.equal(manifest.manifest_version, 3);
   assert.equal(manifest.minimum_chrome_version, "120");
-  assert.deepEqual(manifest.host_permissions, ["https://chatgpt.com/*"]);
-  assert.deepEqual(manifest.content_scripts[0].matches, ["https://chatgpt.com/*"]);
+  assert.equal(manifest.name, "Yoetz Native Transport");
+  assert.deepEqual(manifest.host_permissions, ["https://chatgpt.com/*", "https://claude.ai/*"]);
+  assert.deepEqual(manifest.content_scripts[0].matches, ["https://chatgpt.com/*", "https://claude.ai/*"]);
+  assert.deepEqual(
+    manifest.web_accessible_resources[0].matches,
+    ["https://chatgpt.com/*", "https://claude.ai/*"]
+  );
+  assert.deepEqual(
+    new Set(manifest.web_accessible_resources[0].resources),
+    new Set(["src/chatgpt-dom.js", "src/sites/chatgpt.js", "src/sites/chatgpt-backend.js"])
+  );
 });
 
 test("manifest declares the required narrow permission set", () => {

--- a/extensions/chatgpt-native/tests/manifest.test.js
+++ b/extensions/chatgpt-native/tests/manifest.test.js
@@ -19,7 +19,13 @@ test("manifest is one multi-site transport package", () => {
   );
   assert.deepEqual(
     new Set(manifest.web_accessible_resources[0].resources),
-    new Set(["src/chatgpt-dom.js", "src/sites/chatgpt.js", "src/sites/chatgpt-backend.js"])
+    new Set([
+      "src/chatgpt-dom.js",
+      "src/claude-dom.js",
+      "src/sites/chatgpt.js",
+      "src/sites/chatgpt-backend.js",
+      "src/sites/claude.js"
+    ])
   );
 });
 

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -150,18 +150,27 @@ test("service worker runs a Claude job through its adapter and probes the select
   const originalChrome = globalThis.chrome;
   const port = makePort();
   const sentToTabs = [];
+  const updatedTabs = [];
   let sent = false;
   const conversationId = "123e4567-e89b-12d3-a456-426614174000";
 
   globalThis.chrome = chromeStub({
     port,
     tabs: {
+      query: async (query) => {
+        assert.deepEqual(query, { active: true, currentWindow: true });
+        return [{ id: 17, active: true }];
+      },
       create: async ({ url, active }) => {
         assert.equal(url, "https://claude.ai/new?_yoetz=run_job_claude");
-        assert.equal(active, false);
+        assert.equal(active, true);
         return { id: 71 };
       },
       get: async (id) => ({ id, status: "complete", url: "https://claude.ai/new?_yoetz=run_job_claude" }),
+      update: async (id, options) => {
+        updatedTabs.push({ id, options });
+        return { id, ...options };
+      },
       sendMessage: async (id, message) => {
         sentToTabs.push({ id, message });
         switch (message.type) {
@@ -245,6 +254,7 @@ test("service worker runs a Claude job through its adapter and probes the select
       sentToTabs.find((item) => item.message.type === "yoetz_probe")?.message.recipe,
       "claude"
     );
+    assert.deepEqual(updatedTabs, [{ id: 17, options: { active: true } }]);
 
     port.emit(envelope("job_file_chunk", "job_claude", {
       sequence: 0,
@@ -265,6 +275,56 @@ test("service worker runs a Claude job through its adapter and probes the select
     assert.equal(complete.payload.completion_reason, "stable_idle");
     assert.equal(complete.payload.conversation_id, conversationId);
     assert.equal(complete.payload.conversation_url, `https://claude.ai/chat/${conversationId}`);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker reports a generic Claude model timeout as model_selection", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      query: async () => [{ id: 17, active: true }],
+      create: async (options) => ({ id: 71, ...options }),
+      get: async (id) => ({ id, status: "complete", url: "https://claude.ai/new?_yoetz=run_job_claude_model_timeout" }),
+      update: async (id, options) => ({ id, ...options }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: { recipe: "claude" } };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: false, error: "Claude page did not reach the requested state within 10000ms" };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?claude_model_timeout_phase=${Date.now()}`);
+    await eventually(() => port.messages.some((message) => message.type === "hello"));
+    port.messages.length = 0;
+
+    port.emit(envelope("job_start", "job_claude_model_timeout", {
+      recipe: "claude",
+      prompt: "review"
+    }));
+
+    await eventually(() => port.messages.some((message) =>
+      message.type === "job_error" && message.job_id === "job_claude_model_timeout"
+    ));
+    const error = port.messages.find((message) =>
+      message.type === "job_error" && message.job_id === "job_claude_model_timeout"
+    );
+    assert.equal(error.payload.code, "extension_error");
+    assert.equal(error.payload.phase, "model_selection");
+    assert.equal(error.payload.side_effect_started, true);
   } finally {
     globalThis.chrome = originalChrome;
   }

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -87,6 +87,7 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
     assert.equal(port.messages[0].payload.profile_email, "work@example.com");
     assert.equal(port.messages[0].payload.profile_id, "gaia-work");
     assert.match(port.messages[0].payload.extension_instance_id, /^ext_/);
+    assert.deepEqual(port.messages[0].payload.recipes, ["chatgpt"]);
 
     port.emit(envelope("reconnect", "job_reconnect"));
     await eventually(() => port.messages.some((message) => message.type === "reconnect" && message.job_id === "job_reconnect"));
@@ -386,6 +387,41 @@ test("service worker rejects invalid conversation ids before opening a tab", asy
       const error = port.messages.find((message) => message.type === "job_error");
       assert.equal(error.payload.code, "invalid_conversation");
       assert.equal(error.payload.phase, "upload");
+      assert.equal(error.payload.side_effect_started, false);
+      assert.deepEqual(createdTabs, []);
+    } finally {
+      globalThis.chrome = originalChrome;
+    }
+  }
+});
+
+test("service worker rejects unavailable recipes before opening a tab", async () => {
+  for (const recipe of ["claude", "unknown"]) {
+    const originalChrome = globalThis.chrome;
+    const port = makePort();
+    const createdTabs = [];
+    globalThis.chrome = chromeStub({
+      port,
+      tabs: {
+        create: async (opts) => {
+          createdTabs.push(opts);
+          return { id: createdTabs.length, ...opts };
+        },
+        get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+        sendMessage: async () => {
+          throw new Error("unsupported recipes must fail before tab messaging");
+        }
+      }
+    });
+
+    try {
+      await import(`../src/service-worker.js?unsupported_recipe=${recipe}_${Date.now()}`);
+      port.emit(envelope("job_start", `job_${recipe}`, { recipe, prompt: "review" }));
+
+      await eventually(() => port.messages.some((message) => message.type === "job_error"));
+      const error = port.messages.find((message) => message.type === "job_error");
+      assert.equal(error.payload.code, "unsupported_recipe");
+      assert.equal(error.payload.phase, "profile");
       assert.equal(error.payload.side_effect_started, false);
       assert.deepEqual(createdTabs, []);
     } finally {
@@ -1521,6 +1557,7 @@ test("service worker hello falls back with instance id when profile identity fai
     assert.match(hello.payload.extension_instance_id, /^ext_/);
     assert.equal(hello.payload.profile_email, null);
     assert.equal(hello.payload.profile_id, null);
+    assert.deepEqual(hello.payload.recipes, ["chatgpt"]);
   } finally {
     globalThis.chrome = originalChrome;
   }

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -330,6 +330,77 @@ test("service worker reports a generic Claude model timeout as model_selection",
   }
 });
 
+test("service worker surfaces Claude model mismatch legs in the job error", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      query: async () => [{ id: 17, active: true }],
+      create: async (options) => ({ id: 71, ...options }),
+      get: async (id) => ({ id, status: "complete", url: "https://claude.ai/new?_yoetz=run_job_claude_mismatch" }),
+      update: async (id, options) => ({ id, ...options }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: { recipe: "claude" } };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return {
+              ok: true,
+              payload: {
+                status: "mismatch",
+                requested_model: "fable-5-max",
+                model_used: "Fable 5 Max",
+                modelVerified: true,
+                maxVerified: true,
+                thinkingChecked: false,
+                modelChip: "Fable 5 Max",
+                thinkingAriaChecked: null,
+                options: ["Fable 5", "Max", "Thinking"]
+              }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?claude_model_mismatch_detail=${Date.now()}`);
+    await eventually(() => port.messages.some((message) => message.type === "hello"));
+    port.messages.length = 0;
+
+    port.emit(envelope("job_start", "job_claude_mismatch", {
+      recipe: "claude",
+      prompt: "review"
+    }));
+
+    await eventually(() => port.messages.some((message) =>
+      message.type === "job_error" && message.job_id === "job_claude_mismatch"
+    ));
+    const error = port.messages.find((message) =>
+      message.type === "job_error" && message.job_id === "job_claude_mismatch"
+    );
+    assert.match(error.payload.message, /modelVerified=true/);
+    assert.match(error.payload.message, /maxVerified=true/);
+    assert.match(error.payload.message, /thinkingChecked=false/);
+    assert.deepEqual(error.payload.model_selection_diagnostics, {
+      modelVerified: true,
+      maxVerified: true,
+      thinkingChecked: false,
+      modelChip: "Fable 5 Max",
+      thinkingAriaChecked: null,
+      options: ["Fable 5", "Max", "Thinking"]
+    });
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker doctor auth probe prefers active non-owned ChatGPT tab and surfaces login", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -87,7 +87,7 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
     assert.equal(port.messages[0].payload.profile_email, "work@example.com");
     assert.equal(port.messages[0].payload.profile_id, "gaia-work");
     assert.match(port.messages[0].payload.extension_instance_id, /^ext_/);
-    assert.deepEqual(port.messages[0].payload.recipes, ["chatgpt"]);
+    assert.deepEqual(port.messages[0].payload.recipes, ["chatgpt", "claude"]);
 
     port.emit(envelope("reconnect", "job_reconnect"));
     await eventually(() => port.messages.some((message) => message.type === "reconnect" && message.job_id === "job_reconnect"));
@@ -143,6 +143,130 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
     globalThis.chrome = originalChrome;
     globalThis.setInterval = originalSetInterval;
     globalThis.clearInterval = originalClearInterval;
+  }
+});
+
+test("service worker runs a Claude job through its adapter and probes the selected recipe", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const sentToTabs = [];
+  let sent = false;
+  const conversationId = "123e4567-e89b-12d3-a456-426614174000";
+
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async ({ url, active }) => {
+        assert.equal(url, "https://claude.ai/new?_yoetz=run_job_claude");
+        assert.equal(active, false);
+        return { id: 71 };
+      },
+      get: async (id) => ({ id, status: "complete", url: "https://claude.ai/new?_yoetz=run_job_claude" }),
+      sendMessage: async (id, message) => {
+        sentToTabs.push({ id, message });
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: { recipe: "claude", url: "https://claude.ai/new" } };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return {
+              ok: true,
+              payload: {
+                status: "selected",
+                requested_model: "fable-5-max",
+                modelVerified: true,
+                maxVerified: true,
+                thinkingChecked: true,
+                model_used: "Fable 5 Max"
+              }
+            };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return {
+              ok: true,
+              payload: {
+                sent: true,
+                conversation_id: conversationId,
+                submitted_user_count: 1,
+                submitted_assistant_count: 0
+              }
+            };
+          case "yoetz_extract_response":
+            return {
+              ok: true,
+              payload: sent
+                ? {
+                    method: "assistant_dom",
+                    text: "Claude answer",
+                    is_generating: false,
+                    assistant_count: 1,
+                    copy_button_count: 0,
+                    has_copy_button: false,
+                    turn_index: 0,
+                    conversation_id: conversationId
+                  }
+                : { method: "none", text: "", is_generating: false, assistant_count: 0, turn_index: -1 }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      },
+      group: async () => 1
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?claude_job=${Date.now()}`);
+    await eventually(() => port.messages.some((message) => message.type === "hello"));
+    assert.deepEqual(
+      port.messages.find((message) => message.type === "hello")?.payload.recipes,
+      ["chatgpt", "claude"]
+    );
+    port.messages.length = 0;
+
+    port.emit(envelope("job_start", "job_claude", {
+      recipe: "claude",
+      prompt: "review",
+      wait_interval_ms: 500,
+      wait_timeout_ms: 2500
+    }));
+    await eventually(() => port.messages.some((message) =>
+      message.job_id === "job_claude"
+      && (message.type === "job_error" || message.payload?.phase === "ready_for_file")
+    ));
+    const startError = port.messages.find((message) =>
+      message.type === "job_error" && message.job_id === "job_claude"
+    );
+    assert.equal(startError, undefined, JSON.stringify(startError?.payload));
+    assert.equal(
+      sentToTabs.find((item) => item.message.type === "yoetz_probe")?.message.recipe,
+      "claude"
+    );
+
+    port.emit(envelope("job_file_chunk", "job_claude", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "bundle.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+    await eventually(() => port.messages.some((message) =>
+      message.type === "job_complete" && message.job_id === "job_claude"
+    ));
+    const complete = port.messages.find((message) =>
+      message.type === "job_complete" && message.job_id === "job_claude"
+    );
+    assert.equal(complete.payload.response, "Claude answer");
+    assert.equal(complete.payload.model_used, "Fable 5 Max");
+    assert.equal(complete.payload.completion_reason, "stable_idle");
+    assert.equal(complete.payload.conversation_id, conversationId);
+    assert.equal(complete.payload.conversation_url, `https://claude.ai/chat/${conversationId}`);
+  } finally {
+    globalThis.chrome = originalChrome;
   }
 });
 
@@ -396,7 +520,7 @@ test("service worker rejects invalid conversation ids before opening a tab", asy
 });
 
 test("service worker rejects unavailable recipes before opening a tab", async () => {
-  for (const recipe of ["claude", "unknown"]) {
+  for (const recipe of ["unknown"]) {
     const originalChrome = globalThis.chrome;
     const port = makePort();
     const createdTabs = [];
@@ -1557,7 +1681,7 @@ test("service worker hello falls back with instance id when profile identity fai
     assert.match(hello.payload.extension_instance_id, /^ext_/);
     assert.equal(hello.payload.profile_email, null);
     assert.equal(hello.payload.profile_id, null);
-    assert.deepEqual(hello.payload.recipes, ["chatgpt"]);
+    assert.deepEqual(hello.payload.recipes, ["chatgpt", "claude"]);
   } finally {
     globalThis.chrome = originalChrome;
   }

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -191,8 +191,10 @@ test("service worker runs a Claude job through its adapter and probes the select
               }
             };
           case "yoetz_upload_file":
+            assert.deepEqual(updatedTabs, []);
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
+            assert.deepEqual(updatedTabs, []);
             sent = true;
             return {
               ok: true,
@@ -204,6 +206,10 @@ test("service worker runs a Claude job through its adapter and probes the select
               }
             };
           case "yoetz_extract_response":
+            assert.deepEqual(
+              updatedTabs,
+              sent ? [{ id: 17, options: { active: true } }] : []
+            );
             return {
               ok: true,
               payload: sent
@@ -254,7 +260,7 @@ test("service worker runs a Claude job through its adapter and probes the select
       sentToTabs.find((item) => item.message.type === "yoetz_probe")?.message.recipe,
       "claude"
     );
-    assert.deepEqual(updatedTabs, [{ id: 17, options: { active: true } }]);
+    assert.deepEqual(updatedTabs, []);
 
     port.emit(envelope("job_file_chunk", "job_claude", {
       sequence: 0,
@@ -275,6 +281,7 @@ test("service worker runs a Claude job through its adapter and probes the select
     assert.equal(complete.payload.completion_reason, "stable_idle");
     assert.equal(complete.payload.conversation_id, conversationId);
     assert.equal(complete.payload.conversation_url, `https://claude.ai/chat/${conversationId}`);
+    assert.deepEqual(updatedTabs, [{ id: 17, options: { active: true } }]);
   } finally {
     globalThis.chrome = originalChrome;
   }

--- a/extensions/chatgpt-native/tests/sites.test.js
+++ b/extensions/chatgpt-native/tests/sites.test.js
@@ -41,6 +41,10 @@ test("Claude adapter owns UUID conversations, exact model policy, and DOM-only f
   assert.equal(adapter.normalizeConversationId("conv-123").ok, false);
   assert.equal(adapter.isAllowedTabUrl(`https://claude.ai/chat/${conversationId}`), true);
   assert.equal(adapter.isAllowedTabUrl("https://chatgpt.com/"), false);
+  assert.deepEqual(adapter.tabActivation, {
+    activateOnCreate: true,
+    restorePreviousAfter: "send"
+  });
   assert.equal(adapter.isAcceptableModelSelection({
     status: "selected",
     requested_model: "fable-5-max",
@@ -77,6 +81,10 @@ test("Claude adapter owns UUID conversations, exact model policy, and DOM-only f
 
 test("ChatGPT adapter owns conversation and model policy", () => {
   const adapter = siteAdapterForRecipe("chatgpt");
+  assert.deepEqual(adapter.tabActivation, {
+    activateOnCreate: false,
+    restorePreviousAfter: null
+  });
   assert.deepEqual(adapter.normalizeConversationId(" conv-123 "), { ok: true, id: "conv-123" });
   assert.equal(adapter.conversationUrl("conv-123"), "https://chatgpt.com/c/conv-123");
   assert.equal(adapter.isAcceptableModelSelection({

--- a/extensions/chatgpt-native/tests/sites.test.js
+++ b/extensions/chatgpt-native/tests/sites.test.js
@@ -5,8 +5,8 @@ import {
   siteAdapterForRecipe
 } from "../src/sites/index.js";
 
-test("Wave 2A advertises only the ChatGPT recipe", () => {
-  assert.deepEqual(advertisedRecipes(), ["chatgpt"]);
+test("Wave 2B advertises ChatGPT and Claude atomically", () => {
+  assert.deepEqual(advertisedRecipes(), ["chatgpt", "claude"]);
 });
 
 test("site adapter defaults a missing legacy recipe to ChatGPT", () => {
@@ -21,12 +21,58 @@ test("site adapter defaults a missing legacy recipe to ChatGPT", () => {
 });
 
 test("site adapter rejects unavailable and unknown recipes", () => {
-  for (const recipe of ["claude", "unknown", "", 42]) {
+  for (const recipe of ["unknown", "", 42]) {
     assert.throws(
       () => siteAdapterForRecipe(recipe),
       (error) => error?.code === "unsupported_recipe" && /before side effects/.test(error.message)
     );
   }
+});
+
+test("Claude adapter owns UUID conversations, exact model policy, and DOM-only finality", () => {
+  const adapter = siteAdapterForRecipe("claude");
+  const conversationId = "123e4567-e89b-12d3-a456-426614174000";
+
+  assert.equal(adapter.recipe, "claude");
+  assert.equal(adapter.displayName, "Claude");
+  assert.equal(adapter.jobUrl("run 1"), "https://claude.ai/new?_yoetz=run+1");
+  assert.equal(adapter.conversationJobUrl(conversationId, "run 1"), `https://claude.ai/chat/${conversationId}?_yoetz=run+1`);
+  assert.deepEqual(adapter.normalizeConversationId(conversationId), { ok: true, id: conversationId });
+  assert.equal(adapter.normalizeConversationId("conv-123").ok, false);
+  assert.equal(adapter.isAllowedTabUrl(`https://claude.ai/chat/${conversationId}`), true);
+  assert.equal(adapter.isAllowedTabUrl("https://chatgpt.com/"), false);
+  assert.equal(adapter.isAcceptableModelSelection({
+    status: "selected",
+    requested_model: "fable-5-max",
+    modelVerified: true,
+    maxVerified: true,
+    thinkingChecked: true,
+    model_used: "Fable 5 Max"
+  }), true);
+  assert.equal(adapter.isAcceptableModelSelection({
+    status: "selected",
+    requested_model: "fable-5-max",
+    modelVerified: true,
+    maxVerified: false,
+    thinkingChecked: true,
+    model_used: "Fable 5 High"
+  }), false);
+  assert.equal(adapter.completion.supportsBackendApiFallback, false);
+  assert.equal(adapter.completion.renderRefreshMode, "none");
+  assert.equal(adapter.completion.finalAffordanceRequiresStableIdle, true);
+  assert.equal(adapter.completion.hasFinalAssistantAffordance({
+    is_generating: false,
+    method: "assistant_dom",
+    text: "complete answer",
+    has_copy_button: false
+  }), true);
+  assert.equal(adapter.completion.hasFinalAssistantAffordance({
+    is_generating: true,
+    method: "assistant_dom",
+    text: "still streaming",
+    has_copy_button: true
+  }), false);
+  assert.equal(typeof adapter.dom.extractResponse, "function");
 });
 
 test("ChatGPT adapter owns conversation and model policy", () => {

--- a/extensions/chatgpt-native/tests/sites.test.js
+++ b/extensions/chatgpt-native/tests/sites.test.js
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  advertisedRecipes,
+  siteAdapterForRecipe
+} from "../src/sites/index.js";
+
+test("Wave 2A advertises only the ChatGPT recipe", () => {
+  assert.deepEqual(advertisedRecipes(), ["chatgpt"]);
+});
+
+test("site adapter defaults a missing legacy recipe to ChatGPT", () => {
+  const adapter = siteAdapterForRecipe(undefined);
+  assert.equal(adapter.recipe, "chatgpt");
+  assert.equal(adapter.displayName, "ChatGPT");
+  assert.equal(adapter.jobUrl("run 1"), "https://chatgpt.com/?_yoetz=run+1");
+  assert.equal(adapter.isAllowedTabUrl("https://chatgpt.com/c/conv-1"), true);
+  assert.equal(adapter.isAllowedTabUrl("https://claude.ai/chat/conv-1"), false);
+  assert.equal(typeof adapter.dom.extractResponse, "function");
+  assert.equal(typeof adapter.fetchConversationAnswer, "function");
+});
+
+test("site adapter rejects unavailable and unknown recipes", () => {
+  for (const recipe of ["claude", "unknown", "", 42]) {
+    assert.throws(
+      () => siteAdapterForRecipe(recipe),
+      (error) => error?.code === "unsupported_recipe" && /before side effects/.test(error.message)
+    );
+  }
+});
+
+test("ChatGPT adapter owns conversation and model policy", () => {
+  const adapter = siteAdapterForRecipe("chatgpt");
+  assert.deepEqual(adapter.normalizeConversationId(" conv-123 "), { ok: true, id: "conv-123" });
+  assert.equal(adapter.conversationUrl("conv-123"), "https://chatgpt.com/c/conv-123");
+  assert.equal(adapter.isAcceptableModelSelection({
+    status: "selected",
+    requested_model: "gpt-5-6-sol-pro",
+    family_status: "verified",
+    effort_status: "verified",
+    model_used: "GPT-5.6 Sol Pro"
+  }), true);
+  assert.equal(adapter.isAcceptableModelSelection({
+    status: "selected",
+    requested_model: "gpt-5-6-sol-pro",
+    family_status: "verified",
+    effort_status: "verified",
+    model_used: "GPT-5.6 Instant"
+  }), false);
+  assert.equal(adapter.completion.supportsBackendApiFallback, true);
+  assert.equal(adapter.completion.renderRefreshMode, "reload_conversation");
+  assert.equal(adapter.completion.hasFinalAssistantAffordance({
+    is_generating: false,
+    has_copy_button: true
+  }), true);
+  assert.equal(adapter.completion.hasFinalAssistantAffordance({
+    is_generating: true,
+    has_copy_button: true
+  }), false);
+  assert.equal(typeof adapter.completion.selectFinalAffordanceCandidate, "function");
+  assert.equal(typeof adapter.completion.finalAffordanceExtractionFailureMessage, "function");
+});

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -4,6 +4,8 @@ name: chatgpt
 # `crates/yoetz-cli/src/chatgpt_recipe.rs`. This YAML still defines the
 # generic agent-browser action sequence, but MCP/dev-browser consume the same
 # typed Rust contract even when they do not execute these steps literally.
+# The native extension is the same pinned multi-site "Yoetz Native Transport"
+# package used by the Claude recipe; this recipe selects its ChatGPT adapter.
 # Transport order when the native extension is missing or unhealthy:
 #   1. chrome-devtools-mcp — direct CDP client against running Chrome 147+
 #      (uses vendored `headless_chrome`; NOT a bridge to the chrome-devtools-mcp

--- a/recipes/claude.yaml
+++ b/recipes/claude.yaml
@@ -1,16 +1,59 @@
 name: claude
+# Authoritative typed contract: crates/yoetz-cli/src/claude_recipe.rs.
+#
+# Default extension-free transport order:
+#   chrome-devtools-mcp -> dev-browser -> agent-browser -> manual.
+# Wave 1 implements the CDP vertical slice. The literal claude_* actions below
+# reserve the same contract for the fallback transports delivered in Wave 3.
+#
+# Exact model policy: Fable 5, Effort=Max, Thinking=on. Selection is
+# fail-closed. `--model-strategy current` and vars model/effort/thinking are
+# rejected. The picker diagnostics list the live options when Fable is absent.
+#
+# Conversation/followup: `conversation=<uuid|https://claude.ai/chat/<uuid>>`
+# and `--followup` are native-extension-only. Wave 1 rejects them before CDP or
+# other fallback side effects; omitting them creates a fresh marked `/new` tab.
+#
+# inline_warn_tokens is a heuristic quality guard, not a documented Claude
+# cutoff. Above it, claude.ai may use retrieval-backed file access. Set 0 to
+# disable. Existing bundle byte caps are unchanged.
+
+defaults:
+  prompt: Review the attached file and provide your analysis.
+  thread: "fresh"
+  upload_timeout_ms: "120000"
+  upload_interval_ms: "2000"
+  send_timeout_ms: "120000"
+  wait_timeout_ms: "5400000"
+  wait_interval_ms: "30000"
+  inline_warn_tokens: "150000"
+
 steps:
   - action: open
-    args: ["https://claude.ai/new"]
-  - action: wait
-    args: ["--load", "domcontentloaded"]
+    args: ["https://claude.ai/new?_yoetz={{run_id}}"]
+  - sleep_ms: 4000
+
+  - action: eval
+    args:
+      - |
+        (() => {
+          window.name = "yoetz:{{run_id}}";
+          return "marked yoetz-owned claude tab";
+        })()
+  - sleep_ms: 500
+
+  - action: claude_select_model
+  - action: claude_open_attachment_ui
+  - action: claude_upload_bundle
+  - action: claude_wait_upload
+    args: ["--interval-ms", "{{upload_interval_ms}}", "--timeout-ms", "{{upload_timeout_ms}}"]
+
+  - action: type
+    args: ["[data-testid='chat-input']", "{{prompt}}"]
+  - action: claude_send
+  - action: claude_wait_response
+    args: ["--interval-ms", "{{wait_interval_ms}}", "--timeout-ms", "{{wait_timeout_ms}}"]
+    timeout_ms: 10000
+
   - action: snapshot
-    args: ["-i", "-c", "--json"]
-  - action: find
-    args: ["placeholder", "Message", "fill", "{{bundle_text}}"]
-  - action: find
-    args: ["role", "button", "click", "--name", "Send"]
-  - action: wait
-    args: ["--load", "networkidle"]
-  - action: snapshot
-    args: ["-i", "-c", "--json"]
+    args: ["-c", "--json"]

--- a/recipes/claude.yaml
+++ b/recipes/claude.yaml
@@ -6,15 +6,28 @@ name: claude
 # The typed CDP/dev-browser paths and the literal claude_* agent-browser actions
 # below implement the same fail-closed contract. dev-browser uses a macOS
 # clipboard fallback because its QuickJS runner cannot drive file inputs;
-# non-macOS dev-browser delivery degrades to inline text with a warning.
+# non-macOS dev-browser delivery degrades to inline text with a warning. Result
+# metadata always reports the actual delivery_mode and auto_paste_fallback.
+# When extension status --claude is connected, the built-in recipe promotes the
+# shared multi-site "Yoetz Native Transport" as its native-only default.
 #
 # Exact model policy: Fable 5, Effort=Max, Thinking=on. Selection is
 # fail-closed. `--model-strategy current` and vars model/effort/thinking are
-# rejected. The picker diagnostics list the live options when Fable is absent.
+# rejected. Picker opens are state-verified and paced; Max and Thinking are
+# re-read as visible aria-checked controls. Diagnostics expose every failed leg.
+# Claude tabs stay active through upload and accepted send because the SPA may
+# not mount or commit uploads in a never-focused tab; prior focus is restored
+# before the response wait.
 #
 # Conversation/followup: `conversation=<uuid|https://claude.ai/chat/<uuid>>`
 # and `--followup` are native-extension-only. Fallback transports reject them
 # before browser side effects; omitting them creates a fresh marked `/new` tab.
+#
+# Native uploads resolve the exact hidden input[data-testid='file-upload'] and
+# assign through the native input.files setter so page-world handlers see files
+# from the extension isolated world. Finality requires a non-streaming last
+# assistant turn and no Stop response control; cloned group/status thinking rows
+# are excluded from answer text without mutating the live DOM.
 #
 # inline_warn_tokens is a heuristic quality guard, not a documented Claude
 # cutoff. Above it, claude.ai may use retrieval-backed file access. Set 0 to

--- a/recipes/claude.yaml
+++ b/recipes/claude.yaml
@@ -3,16 +3,18 @@ name: claude
 #
 # Default extension-free transport order:
 #   chrome-devtools-mcp -> dev-browser -> agent-browser -> manual.
-# Wave 1 implements the CDP vertical slice. The literal claude_* actions below
-# reserve the same contract for the fallback transports delivered in Wave 3.
+# The typed CDP/dev-browser paths and the literal claude_* agent-browser actions
+# below implement the same fail-closed contract. dev-browser uses a macOS
+# clipboard fallback because its QuickJS runner cannot drive file inputs;
+# non-macOS dev-browser delivery degrades to inline text with a warning.
 #
 # Exact model policy: Fable 5, Effort=Max, Thinking=on. Selection is
 # fail-closed. `--model-strategy current` and vars model/effort/thinking are
 # rejected. The picker diagnostics list the live options when Fable is absent.
 #
 # Conversation/followup: `conversation=<uuid|https://claude.ai/chat/<uuid>>`
-# and `--followup` are native-extension-only. Wave 1 rejects them before CDP or
-# other fallback side effects; omitting them creates a fresh marked `/new` tab.
+# and `--followup` are native-extension-only. Fallback transports reject them
+# before browser side effects; omitting them creates a fresh marked `/new` tab.
 #
 # inline_warn_tokens is a heuristic quality guard, not a documented Claude
 # cutoff. Above it, claude.ai may use retrieval-backed file access. Set 0 to

--- a/scripts/build-chatgpt-native-extension.sh
+++ b/scripts/build-chatgpt-native-extension.sh
@@ -163,12 +163,14 @@ required = {
     "icons/icon-48.png",
     "icons/icon-128.png",
     "src/chatgpt-dom.js",
+    "src/claude-dom.js",
     "src/chunks.js",
     "src/content-script.js",
     "src/protocol.js",
     "src/service-worker.js",
     "src/sites/chatgpt-backend.js",
     "src/sites/chatgpt.js",
+    "src/sites/claude.js",
     "src/sites/index.js",
 }
 with zipfile.ZipFile(zip_path) as archive:

--- a/scripts/build-chatgpt-native-extension.sh
+++ b/scripts/build-chatgpt-native-extension.sh
@@ -61,8 +61,9 @@ for (const permission of requiredPermissions) {
     throw new Error(`missing required permission: ${permission}`);
   }
 }
-if (JSON.stringify(hostPermissions) !== JSON.stringify(["https://chatgpt.com/*"])) {
-  throw new Error(`host_permissions must be exactly ["https://chatgpt.com/*"], got ${JSON.stringify(hostPermissions)}`);
+const expectedHostPermissions = ["https://chatgpt.com/*", "https://claude.ai/*"];
+if (JSON.stringify(hostPermissions) !== JSON.stringify(expectedHostPermissions)) {
+  throw new Error(`host_permissions must be exactly ${JSON.stringify(expectedHostPermissions)}, got ${JSON.stringify(hostPermissions)}`);
 }
 if (
   optionalPermissions.length !== expectedOptionalPermissions.size
@@ -166,6 +167,9 @@ required = {
     "src/content-script.js",
     "src/protocol.js",
     "src/service-worker.js",
+    "src/sites/chatgpt-backend.js",
+    "src/sites/chatgpt.js",
+    "src/sites/index.js",
 }
 with zipfile.ZipFile(zip_path) as archive:
     names = archive.namelist()


### PR DESCRIPTION
## Summary

- Add a built-in `claude.ai` browser recipe for Fable 5 Max with fail-closed model and Thinking verification.
- Support Chrome DevTools MCP, agent-browser, the multi-site native extension, and inline fallback transports.
- Add Claude follow-ups, same-conversation resume, upload finality, token warnings, and status-row-safe response extraction.
- Document installation, managed-extension versioning, profile loading, and the machine-global single-writer constraint.

## Verification

- Final branch CI: https://github.com/avivsinai/yoetz/actions/runs/29682945802
- Live Claude smoke: Fable 5 Max selected; file uploaded; conversation echoed; terminal response completed in 129.6 seconds.
- Long-stream probe: 15,061 characters over 337 seconds with the terminal marker intact.
- Thinking/tool-use retrieval: all three markers recovered from an 8 MB file; no wait wedge; inline warning shown for 2.09M estimated tokens above the 150k threshold.
- Same-conversation resume recalled the prior token.
- Native ChatGPT canary returned exact `OK`.
- 16 MB fixture was rejected before side effects at the 10 MiB upload cap.
- Legacy fail-closed and agent-browser parity paths passed.
- Local release gates passed: `cargo fmt --all -- --check`, workspace clippy with warnings denied, workspace tests, and the extension test suite.

## Operations

- The managed extension remains one multi-site package with stamped version checks and migration guidance.
- Native-host and managed-extension installation is machine-global and must be treated as a single-writer operation.
