### PR TITLE
Fix Claude native thinking-caption extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevented collapsed claude.ai thinking captions from leaking into extracted
+  response text.
+
 ## [0.5.34] - 2026-07-19
 ### Added
 

--- a/extensions/chatgpt-native/src/claude-dom.js
+++ b/extensions/chatgpt-native/src/claude-dom.js
@@ -422,10 +422,21 @@ function responseBodyText(body) {
   if (!sanitized) {
     return normalizeResponseText(body.innerText || body.textContent || "");
   }
+  const statusCaptions = [];
   for (const statusRow of sanitized.querySelectorAll?.("button[class*='group/status']") ?? []) {
+    const caption = normalizeResponseText(statusRow.innerText || statusRow.textContent || "");
+    if (caption) statusCaptions.push(caption);
     statusRow.remove();
   }
-  return normalizeResponseText(sanitized.innerText || sanitized.textContent || "");
+  let text = normalizeResponseText(sanitized.innerText || sanitized.textContent || "");
+  for (const caption of statusCaptions) {
+    // Completed thinking can leave a hidden copy of the collapsed caption before the answer.
+    // Strip only an exact leading copy anchored to a status row observed in this response body.
+    if (text.startsWith(caption)) {
+      text = normalizeResponseText(text.slice(caption.length));
+    }
+  }
+  return text;
 }
 
 function assistantRoots(root) {

--- a/extensions/chatgpt-native/tests/fake-claude.test.js
+++ b/extensions/chatgpt-native/tests/fake-claude.test.js
@@ -307,6 +307,37 @@ test("fake Claude extraction excludes collapsed thinking status text from the an
   assert.equal(extraction.text, answer);
 });
 
+test("fake Claude extraction strips a duplicated collapsed thinking caption prefix", () => {
+  const caption = "Scrutinizing verification request authenticity and token protocol";
+  const answer = "YOETZ-EXT-VERIFY-20260719-QOPHET";
+  const contaminated = `${caption}${answer}`;
+  const page = fakeClaudePage({ text: contaminated, streaming: false, copy: true });
+  page.body.cloneNode = () => {
+    let text = `${caption}\n${caption}\n${answer}`;
+    return {
+      get innerText() {
+        return text;
+      },
+      get textContent() {
+        return text;
+      },
+      querySelectorAll(selector) {
+        return selector === "button[class*='group/status']"
+          ? [{
+              innerText: caption,
+              textContent: caption,
+              remove: () => { text = contaminated; }
+            }]
+          : [];
+      }
+    };
+  };
+
+  const extraction = extractResponse(page.root);
+
+  assert.equal(extraction.text, answer);
+});
+
 test("fake Claude extraction fails closed when final controls are not scoped to the answer", () => {
   const page = fakeClaudePage({ text: "", streaming: false, copy: false });
   page.root.body.innerText = "possibly clipped page text";


### PR DESCRIPTION
## Summary
- strip a hidden duplicate collapsed Claude thinking caption only when the same caption was observed in the response status row
- cover the reproduced concatenated caption-plus-answer shape from run 20260719T155057Z_49db4f
- document the fix under Unreleased

## Verification
- npm test: 241 passed
- cargo test -p yoetz browser_extension_native: 50 passed
- git diff --check

## Live verification
Deferred until the frozen managed extension is released and updated after the sales-lane all-clear; Claude owns that post-release stamped-artifact confirmation.