### PR TITLE
Fix ChatGPT Pro reasoning finality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- Kept ChatGPT Pro reasoning turns in progress while the `Answer now`
+  affordance is visible, including transitions where the Stop control is
+  temporarily disabled, instead of returning interim review text as final.
 
 ## [0.5.35] - 2026-07-19
 ### Fixed

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -1323,11 +1323,22 @@ function isThoughtStatusLine(line) {
 }
 
 export function isResponseGenerating(root = document) {
-  return Boolean(firstVisible(root, [
+  if (firstVisible(root, [
     'button[data-testid*="stop"]',
     'button[aria-label*="Stop generating" i]',
     'button[aria-label*="Stop streaming" i]'
-  ]));
+  ])) {
+    return true;
+  }
+
+  // ChatGPT Pro can disable its composer Stop button while continuing a
+  // same-turn reasoning pass. During that transition the assistant turn keeps
+  // an exact "Answer now" control visible; treating the disabled Stop button as
+  // idle otherwise lets the waiter return the preceding interim markdown.
+  const latestAssistantTurn = findAssistantTurns(root).at(-1);
+  return Boolean(latestAssistantTurn && Array.from(latestAssistantTurn.querySelectorAll("button"))
+    .some((button) => normalizeText(textOf(button)) === "Answer now"
+      && isVisible(button, { allowDisabled: true, allowNoLayout: true })));
 }
 
 // Best-effort: click ChatGPT's visible stop-streaming/stop-generating control if

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -413,6 +413,33 @@ test("extractResponse treats Thinking page text as complete without a stop contr
   assert.equal(extraction.is_generating, false);
 });
 
+test("extractResponse keeps an Answer now reasoning turn in progress while the stop control is transitional", () => {
+  const user = new FakeElement("article", { "data-message-author-role": "user" }, "Review the attached bundle");
+  const assistant = new FakeElement("div", { class: "agent-turn" }, [
+    "I’ll verify the artifact identity, then run the adversarial review.",
+    "Answer now",
+    "Verified patch hash and extracted patch data",
+    "Checked repository state"
+  ].join("\n\n"))
+    .append(
+      new FakeElement("div", { class: "markdown prose" }, "I’ll verify the artifact identity, then run the adversarial review."),
+      new FakeElement("button", {}, "Answer now"),
+      new FakeElement("div", { class: "markdown prose" }, "Verified patch hash and extracted patch data")
+    );
+  const conversation = new FakeElement("main", { role: "main" }, "Review the attached bundle").append(user, assistant);
+  const stop = new FakeElement("button", {
+    "aria-label": "Stop answering",
+    "aria-disabled": "true",
+    "data-testid": "stop-button"
+  }, "");
+  const doc = new FakeDocument(new FakeElement("body", {}, "Review the attached bundle").append(conversation, stop));
+
+  const extraction = extractResponse(doc);
+
+  assert.equal(extraction.method, "assistant_dom_fallback");
+  assert.equal(extraction.is_generating, true);
+});
+
 test("extractResponse prefers the newest assistant turn over an older copy button", () => {
   const oldCopy = new FakeElement("button", { "aria-label": "Copy" }, "Copy");
   const oldAssistant = new FakeElement("article", { "data-message-author-role": "assistant" }, "Old answer")
@@ -2247,6 +2274,9 @@ function matchesSimpleSelector(element, selector) {
   }
   if (selector.includes('[data-testid*="attachment"]')) {
     return String(attr("data-testid") ?? "").includes("attachment");
+  }
+  if (selector.includes('[data-testid*="stop"]')) {
+    return tag === "button" && String(attr("data-testid") ?? "").includes("stop");
   }
   if (selector.includes('[class*="code"]')) {
     return String(attr("class") ?? "").includes("code");


### PR DESCRIPTION
## Problem

ChatGPT Pro can keep reasoning within one assistant turn while rendering an exact Answer now control and a transitional disabled Stop answering button. The native extension rejected that Stop control as non-visible, reported is_generating=false, and could return interim review text as final.

Captured repro: sales run 20260719T173936Z_dc39d5.

## Fix

- Treat an exact visible Answer now button in only the latest assistant turn as ongoing generation when no active Stop control is visible.
- Leave cancellation clicking and service-worker candidate-latch semantics unchanged.
- Add the captured transitional-stop + interim-markdown regression fixture.

## Verification

- npm test in extensions/chatgpt-native: 242 passed
- cargo test -p yoetz browser_extension_native: 50 passed
- git diff --check: clean
- Claude peer review: PASS, no required changes

## Live gate

A real ChatGPT Pro reasoning run is still required after the updated extension is rolled out; sales v25 can serve as that live confirmation.