### PR TITLE
fix(extension): require positive ChatGPT finality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- Kept native ChatGPT runs in progress when the backend active lineage is not
+  yet final, preventing transient reasoning captions from winning the DOM
+  finality race. DOM-only fallback completions now emit explicit finality
+  provenance and a warning.
 
 ## [0.5.36] - 2026-07-19
 ### Fixed

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -70,6 +70,7 @@ const BACKEND_API_FETCH_COOLDOWN_MS = Math.max(
     ? Number(globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS)
     : 60000
 );
+const CHATGPT_DOM_ONLY_FINALITY_WARNING = "ChatGPT finality_anchor=dom_only: backend API positive-finality proof was unavailable; response relied on DOM-only completion";
 const JOBS_KEY_PREFIX = "jobs.";
 const LEGACY_JOBS_KEY = "jobs";
 // Cap for the tail of last_response_progress_text persisted to chrome.storage.session.
@@ -506,6 +507,10 @@ async function runJobWithFile(job, file) {
 
 async function completeJobWithExtraction(job, extraction) {
   const conversationId = conversationIdForJob(job, extraction);
+  const adapter = adapterForJob(job);
+  const finalityAnchor = adapter.recipe === "chatgpt"
+    ? (extraction.method === "backend_api" ? "backend_api" : "dom_only")
+    : null;
   const completeEnvelope = makeEnvelope("job_complete", {
     job_id: job.job_id,
     run_id: job.run_id,
@@ -520,6 +525,7 @@ async function completeJobWithExtraction(job, extraction) {
       response: extraction.text,
       extraction_method: extraction.method,
       completion_reason: extraction.completion_reason,
+      finality_anchor: finalityAnchor,
       stable_for_ms: extraction.stable_for_ms,
       assistant_turn_count: extraction.assistant_turn_count ?? extraction.assistant_count ?? 0,
       copy_button_count: extraction.copy_button_count ?? 0,
@@ -530,8 +536,9 @@ async function completeJobWithExtraction(job, extraction) {
       model_selection_status: job.model_selection_status ?? "unavailable",
       warnings: [
         ...(job.warnings ?? []),
-        ...(extraction.text ? [] : [adapterForJob(job).completion.emptyResponseWarning]),
-        ...(extraction.warning ? [extraction.warning] : [])
+        ...(extraction.text ? [] : [adapter.completion.emptyResponseWarning]),
+        ...(extraction.warning ? [extraction.warning] : []),
+        ...(finalityAnchor === "dom_only" ? [CHATGPT_DOM_ONLY_FINALITY_WARNING] : [])
       ]
     }
   });
@@ -1524,11 +1531,19 @@ async function waitForResponse(job) {
       assertJobConnectionCurrent(job);
     }
     const extractionIdle = !extraction?.is_generating;
-    const scopedExtractionCandidate = Boolean(
+    const backendApiPending = Boolean(extraction?.backend_api_pending);
+    const scopedDomExtractionCandidate = Boolean(
       postSend
       && extractionIdle
       && extraction?.method !== "page_text_fallback"
     );
+    // Once the ChatGPT conversation API has answered but says the active
+    // lineage has no completed end_turn yet, DOM affordances are not proof of
+    // finality. Reasoning captions can temporarily render as copyable assistant
+    // content while stop/Answer-now controls disappear. Keep the DOM sample for
+    // render-refresh diagnostics, but require the backend positive anchor before
+    // allowing it to complete the job.
+    const scopedExtractionCandidate = scopedDomExtractionCandidate && !backendApiPending;
     const backendApiFinal = Boolean(scopedExtractionCandidate && completion.isFreshBackendApiExtraction(extraction));
     const finalAffordance = Boolean(scopedExtractionCandidate && completion.hasFinalAssistantAffordance(extraction));
     const finalStructuralResponse = finalAffordance || backendApiFinal;
@@ -1538,6 +1553,7 @@ async function waitForResponse(job) {
       postSendAssistantActivity
       && extraction?.method === "page_text_fallback"
       && !extraction?.is_generating
+      && !backendApiPending
       && completion.hasFinalAssistantAffordance(extraction)
     );
     const stableIdleUnscopedCopy = Boolean(
@@ -1552,7 +1568,7 @@ async function waitForResponse(job) {
     const renderRefreshCandidateEligible = completion.isRenderFreezeRefreshCandidate(
       job,
       extraction,
-      scopedExtractionCandidate,
+      scopedDomExtractionCandidate,
       finalStructuralResponse,
       {
         conversationId: conversationIdForJob(job, extraction),
@@ -1600,7 +1616,7 @@ async function waitForResponse(job) {
       unscopedCopyCandidate = null;
       bestUnscopedCopyCandidate = null;
       unscopedCopyCandidateSinceMs = 0;
-    } else if (extraction?.is_generating) {
+    } else if (extraction?.is_generating || backendApiPending) {
       finalAffordanceCandidate = null;
       finalAffordanceCandidateSinceMs = 0;
       unscopedCopyCandidate = null;
@@ -1668,7 +1684,7 @@ async function waitForResponse(job) {
       renderRefreshCandidate = null;
       renderRefreshCandidateSinceMs = 0;
     }
-    const awaitingFinalAffordance = Boolean(scopedExtractionCandidate && !finalStructuralResponse);
+    const awaitingFinalAffordance = Boolean(scopedDomExtractionCandidate && !finalStructuralResponse);
     if (finalAffordanceWithoutScopedText) {
       if (!extractionFailureSinceMs) {
         extractionFailureSinceMs = Date.now();
@@ -1721,7 +1737,8 @@ async function waitForResponse(job) {
         backend_api_final: backendApiFinal,
         stable_idle_unscoped_copy_candidate: stableIdleUnscopedCopy,
         extraction_failure_candidate: finalAffordanceWithoutScopedText,
-        render_refresh_candidate: renderRefreshCandidateEligible
+        render_refresh_candidate: renderRefreshCandidateEligible,
+        backend_api_pending: backendApiPending
       };
       if (awaitingFinalAffordance) {
         waitingDetail.awaiting_final_affordance = true;
@@ -1777,7 +1794,7 @@ function assistantTurnsSinceSend(job, extraction) {
 // A second-or-later assistant turn appearing while generation is still active proves the earlier
 // turn(s) were interim status posts ("I'll review...", "I've narrowed..."), not the final answer.
 function interimTurnState(job, extraction) {
-  const generating = Boolean(extraction?.is_generating);
+  const generating = Boolean(extraction?.is_generating || extraction?.backend_api_pending);
   const turnsSinceSend = assistantTurnsSinceSend(job, extraction);
   return { generating, turnsSinceSend, interimAssistantTurn: generating && turnsSinceSend > 1 };
 }
@@ -1803,6 +1820,7 @@ function postResponseProgress(job, extraction) {
     response_tail: text.slice(-500),
     extraction_method: extraction.method,
     is_generating: generating,
+    backend_api_pending: Boolean(extraction.backend_api_pending),
     assistant_count: extraction.assistant_count ?? 0,
     turn_index: extraction.turn_index ?? -1,
     copy_button_count: extraction.copy_button_count ?? 0,
@@ -1827,6 +1845,7 @@ function postWaitingResponseProgress(job, extraction, detail = {}) {
     interim_assistant_turn: interimAssistantTurn,
     assistant_turns_since_send: turnsSinceSend,
     is_generating: generating,
+    backend_api_pending: Boolean(extraction?.backend_api_pending),
     assistant_count: extraction?.assistant_count ?? 0,
     turn_index: extraction?.turn_index ?? -1,
     copy_button_count: extraction?.copy_button_count ?? 0,
@@ -1902,10 +1921,24 @@ async function extractDomResponseForJob(job) {
 
 async function maybeBackendApiExtractionForJob(job, domExtraction) {
   const completion = adapterForJob(job).completion;
-  if (!shouldFetchBackendApi(job, domExtraction)) {
+  if (!completion.supportsBackendApiFallback || job?.backend_api_disabled) {
     return null;
   }
   const conversationId = conversationIdForJob(job, domExtraction);
+  if (!domExtraction || domExtraction.manual_handoff || !conversationId) {
+    return null;
+  }
+  if (domExtraction.is_generating) {
+    return job.backend_api_pending
+      ? backendApiPendingExtraction(domExtraction, null)
+      : null;
+  }
+  const lastFetchAt = Number(job.backend_api_last_fetch_at ?? 0);
+  if (Date.now() - lastFetchAt < BACKEND_API_FETCH_COOLDOWN_MS) {
+    return job.backend_api_pending
+      ? backendApiPendingExtraction(domExtraction, null)
+      : null;
+  }
   job.backend_api_last_fetch_at = Date.now();
   job.updated_at = Date.now();
   await persistJob(job);
@@ -1916,31 +1949,41 @@ async function maybeBackendApiExtractionForJob(job, domExtraction) {
       conversation_id: conversationId
     });
     const normalized = normalizeBackendApiExtraction(backendExtraction, domExtraction, conversationId);
-    return completion.isFreshBackendApiExtraction(normalized) ? normalized : null;
+    const fresh = completion.isFreshBackendApiExtraction(normalized);
+    job.backend_api_pending = !fresh;
+    job.updated_at = Date.now();
+    await persistJob(job);
+    return fresh ? normalized : backendApiPendingExtraction(domExtraction, normalized);
   } catch (error) {
     if (!completion.isBackendApiFallbackError(error)) {
       throw error;
     }
+    if (job.backend_api_pending) {
+      // Do not silently downgrade to DOM finality after the backend has already
+      // proved that the active lineage is unfinished. Losing that positive
+      // anchor mid-run is an explicit failure; otherwise the same transient
+      // caption that armed the backend check can win on the next DOM poll.
+      job.backend_api_disabled = true;
+      job.backend_api_disabled_reason = error?.code ?? String(error?.message ?? error);
+      job.updated_at = Date.now();
+      await persistJob(job);
+      throw error;
+    }
     job.backend_api_disabled = true;
     job.backend_api_disabled_reason = error?.code ?? String(error?.message ?? error);
+    job.backend_api_pending = false;
     job.updated_at = Date.now();
     await persistJob(job);
     return null;
   }
 }
 
-function shouldFetchBackendApi(job, domExtraction) {
-  if (!adapterForJob(job).completion.supportsBackendApiFallback || job?.backend_api_disabled) {
-    return false;
-  }
-  if (!domExtraction || domExtraction.manual_handoff || domExtraction.is_generating) {
-    return false;
-  }
-  if (!conversationIdForJob(job, domExtraction)) {
-    return false;
-  }
-  const lastFetchAt = Number(job.backend_api_last_fetch_at ?? 0);
-  return Date.now() - lastFetchAt >= BACKEND_API_FETCH_COOLDOWN_MS;
+function backendApiPendingExtraction(domExtraction, backendExtraction) {
+  return {
+    ...domExtraction,
+    backend_api_pending: true,
+    backend_api_detail: backendExtraction?.backend_api_detail ?? null
+  };
 }
 
 function normalizeBackendApiExtraction(backendExtraction, domExtraction, conversationId) {

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -1332,7 +1332,10 @@ test("service worker keeps the current-model warning to one final payload entry"
     await eventually(() => port.messages.some((message) => message.type === "job_complete" && message.job_id === "job_current_warning"));
     const complete = port.messages.find((message) => message.type === "job_complete" && message.job_id === "job_current_warning");
     assert.equal(complete.payload.model_selection_status, "current");
-    assert.deepEqual(complete.payload.warnings, ["model pinning bypassed — answer may come from any model"]);
+    assert.deepEqual(complete.payload.warnings, [
+      "model pinning bypassed — answer may come from any model",
+      "ChatGPT finality_anchor=dom_only: backend API positive-finality proof was unavailable; response relied on DOM-only completion"
+    ]);
   } finally {
     globalThis.chrome = originalChrome;
   }
@@ -2789,6 +2792,8 @@ test("service worker completion is structural and does not classify response tex
     const complete = port.messages.find((message) => message.type === "job_complete");
     assert.equal(complete.payload.response, "Thought for 9m 55s\nThought for 9m 55s");
     assert.equal(complete.payload.completion_reason, "copy_button");
+    assert.equal(complete.payload.finality_anchor, "dom_only");
+    assert.match(complete.payload.warnings.at(-1), /finality_anchor=dom_only/);
   } finally {
     globalThis.chrome = originalChrome;
   }
@@ -3813,6 +3818,8 @@ test("service worker treats a stale backend-api node as still generating until a
     assert.equal(complete.payload.response, FINAL);
     assert.equal(complete.payload.extraction_method, "backend_api");
     assert.equal(complete.payload.completion_reason, "backend_api");
+    assert.equal(complete.payload.finality_anchor, "backend_api");
+    assert.deepEqual(complete.payload.warnings, []);
     assert.equal(port.messages.some((message) => message.type === "job_error"), false);
   } finally {
     globalThis.chrome = originalChrome;
@@ -3824,7 +3831,246 @@ test("service worker treats a stale backend-api node as still generating until a
   }
 });
 
-test("service worker still refreshes a frozen render while backend-api reads are stale", async () => {
+test("service worker does not return a longer transient caption before a shorter backend final answer", async () => {
+  const originalChrome = globalThis.chrome;
+  const previousCooldown = globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS;
+  globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS = 2000;
+  const port = makePort();
+  let tabId = 0;
+  let sent = false;
+  let fetchCount = 0;
+  const CAPTION = "The checksum and nine-file scope match. I am checking edge-state coexistence, canonicalization, resend enforcement, and delivery claim/rollback invariants.";
+  const FINAL = "PASS - no release-blocking findings in this exact patch.";
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/c/conv-caption?_yoetz=run_job_backend_caption_then_final" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: verifiedSolProSelection() };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true, conversation_id: "conv-caption", submitted_assistant_count: 1 } };
+          case "yoetz_fetch_conversation":
+            fetchCount += 1;
+            return {
+              ok: true,
+              payload: fetchCount === 1
+                ? {
+                    method: "backend_api",
+                    text: "",
+                    is_generating: true,
+                    node_fresh: false,
+                    conversation_id: "conv-caption",
+                    assistant_count: 1,
+                    turn_index: 0
+                  }
+                : {
+                    method: "backend_api",
+                    text: FINAL,
+                    is_generating: false,
+                    node_fresh: true,
+                    conversation_id: "conv-caption",
+                    assistant_count: 2,
+                    turn_index: 1,
+                    copy_button_count: 0,
+                    has_copy_button: false
+                  }
+            };
+          case "yoetz_extract_response":
+            return {
+              ok: true,
+              payload: sent
+                ? {
+                    method: "copy_scope_dom_fallback",
+                    text: CAPTION,
+                    is_generating: false,
+                    assistant_count: 2,
+                    user_count: 1,
+                    preceding_user_count: 1,
+                    copy_button_count: 2,
+                    has_copy_button: true,
+                    turn_index: 1,
+                    conversation_id: "conv-caption",
+                    diagnostics: { counts: { stop_controls: 0, copy_buttons: 2 } }
+                  }
+                : {
+                    method: "copy_scope_dom_fallback",
+                    text: "previous answer",
+                    is_generating: false,
+                    assistant_count: 1,
+                    user_count: 0,
+                    copy_button_count: 1,
+                    has_copy_button: true,
+                    turn_index: 0,
+                    conversation_id: "conv-caption"
+                  }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?backend_caption_then_final=${Date.now()}`);
+    port.emit(envelope("job_start", "job_backend_caption_then_final", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 6000
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_backend_caption_then_final", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_backend_caption_then_final.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_complete"), 8000);
+    const complete = port.messages.find((message) => message.type === "job_complete");
+    assert.ok(fetchCount >= 2, "backend API should prove the active-lineage answer is final");
+    assert.ok(CAPTION.length > FINAL.length, "regression must not be catchable by a length heuristic");
+    assert.equal(complete.payload.response, FINAL);
+    assert.equal(complete.payload.extraction_method, "backend_api");
+    assert.equal(complete.payload.completion_reason, "backend_api");
+    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+    if (previousCooldown === undefined) {
+      delete globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS;
+    } else {
+      globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS = previousCooldown;
+    }
+  }
+});
+
+test("service worker fails closed if the backend positive-finality anchor disappears after pending", async () => {
+  const originalChrome = globalThis.chrome;
+  const previousCooldown = globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS;
+  globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS = 100;
+  const port = makePort();
+  let tabId = 0;
+  let sent = false;
+  let fetchCount = 0;
+  const CAPTION = "I am still checking rollback invariants before returning the verdict.";
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/c/conv-anchor-lost?_yoetz=run_job_backend_anchor_lost" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: verifiedSolProSelection() };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true, conversation_id: "conv-anchor-lost", submitted_assistant_count: 1 } };
+          case "yoetz_fetch_conversation":
+            fetchCount += 1;
+            if (fetchCount > 1) {
+              throw Object.assign(new Error("backend-api conversation fetch failed"), {
+                code: "backend_api_unavailable"
+              });
+            }
+            return {
+              ok: true,
+              payload: {
+                method: "backend_api",
+                text: "",
+                is_generating: true,
+                node_fresh: false,
+                conversation_id: "conv-anchor-lost",
+                assistant_count: 1,
+                turn_index: 0
+              }
+            };
+          case "yoetz_extract_response":
+            return {
+              ok: true,
+              payload: sent
+                ? {
+                    method: "copy_scope_dom_fallback",
+                    text: CAPTION,
+                    is_generating: false,
+                    assistant_count: 2,
+                    user_count: 1,
+                    preceding_user_count: 1,
+                    copy_button_count: 2,
+                    has_copy_button: true,
+                    turn_index: 1,
+                    conversation_id: "conv-anchor-lost",
+                    diagnostics: { counts: { stop_controls: 0, copy_buttons: 2 } }
+                  }
+                : {
+                    method: "copy_scope_dom_fallback",
+                    text: "previous answer",
+                    is_generating: false,
+                    assistant_count: 1,
+                    user_count: 0,
+                    copy_button_count: 1,
+                    has_copy_button: true,
+                    turn_index: 0,
+                    conversation_id: "conv-anchor-lost"
+                  }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?backend_anchor_lost=${Date.now()}`);
+    port.emit(envelope("job_start", "job_backend_anchor_lost", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 4000
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_backend_anchor_lost", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_backend_anchor_lost.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_complete" || message.type === "job_error"), 6000);
+    const error = port.messages.find((message) => message.type === "job_error");
+    assert.ok(fetchCount >= 2, "backend API should be retried before the anchor is declared lost");
+    assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
+    assert.equal(error?.payload.code, "backend_api_unavailable");
+  } finally {
+    globalThis.chrome = originalChrome;
+    if (previousCooldown === undefined) {
+      delete globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS;
+    } else {
+      globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS = previousCooldown;
+    }
+  }
+});
+
+test("service worker refreshes a frozen render while backend finality is pending", async () => {
   const originalChrome = globalThis.chrome;
   const previousCooldown = globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS;
   globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS = 30;
@@ -3872,15 +4118,27 @@ test("service worker still refreshes a frozen render while backend-api reads are
             fetchCount += 1;
             return {
               ok: true,
-              payload: {
-                method: "backend_api",
-                text: "",
-                is_generating: true,
-                node_fresh: false,
-                conversation_id: "conv-stale-refresh",
-                assistant_count: 1,
-                turn_index: 0
-              }
+              payload: reloaded
+                ? {
+                    method: "backend_api",
+                    text: FINAL,
+                    is_generating: false,
+                    node_fresh: true,
+                    conversation_id: "conv-stale-refresh",
+                    assistant_count: 1,
+                    turn_index: 0,
+                    copy_button_count: 0,
+                    has_copy_button: false
+                  }
+                : {
+                    method: "backend_api",
+                    text: "",
+                    is_generating: true,
+                    node_fresh: false,
+                    conversation_id: "conv-stale-refresh",
+                    assistant_count: 1,
+                    turn_index: 0
+                  }
             };
           case "yoetz_bind_job":
             bindCount += 1;
@@ -3950,7 +4208,8 @@ test("service worker still refreshes a frozen render while backend-api reads are
     assert.deepEqual(updates[0], { id: 1, opts: { url: conversationUrl, active: false } });
     assert.equal(bindCount, 1);
     assert.equal(complete.payload.response, FINAL);
-    assert.equal(complete.payload.completion_reason, "copy_button");
+    assert.equal(complete.payload.extraction_method, "backend_api");
+    assert.equal(complete.payload.completion_reason, "backend_api");
     assert.equal(port.messages.some((message) => message.type === "job_error"), false);
   } finally {
     globalThis.chrome = originalChrome;


### PR DESCRIPTION
Closes #318.

ChatGPT backend active-lineage results with node_fresh=false now latch the run in progress until a fresh end-turn answer is observed. DOM copy affordances remain available for render-refresh diagnostics but cannot complete while that latch is active. If the backend anchor disappears after becoming pending, the run fails closed. DOM-only fallback completions emit an explicit caller-visible warning.

Tests:
- node --test --test-reporter=dot tests/*.test.js (244 passed)
- cargo test -p yoetz browser_extension_native (52 passed)
- git diff --check