### PR TITLE
fix(extension): restore short-answer finality liveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- Prevented short ChatGPT answers from timing out when refreshed reasoning
+  chrome leaves the DOM generation signal stuck. Active-lineage backend
+  finality now polls independently, uses the pre-send answer baseline, and
+  tolerates two consecutive transient backend failures while remaining
+  fail-closed.
 
 ## [0.5.37] - 2026-07-20
 ### Fixed

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -70,6 +70,7 @@ const BACKEND_API_FETCH_COOLDOWN_MS = Math.max(
     ? Number(globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS)
     : 60000
 );
+const MAX_BACKEND_API_CONSECUTIVE_FAILURES = 3;
 const CHATGPT_DOM_ONLY_FINALITY_WARNING = "ChatGPT finality_anchor=dom_only: backend API positive-finality proof was unavailable; response relied on DOM-only completion";
 const JOBS_KEY_PREFIX = "jobs.";
 const LEGACY_JOBS_KEY = "jobs";
@@ -1928,11 +1929,10 @@ async function maybeBackendApiExtractionForJob(job, domExtraction) {
   if (!domExtraction || domExtraction.manual_handoff || !conversationId) {
     return null;
   }
-  if (domExtraction.is_generating) {
-    return job.backend_api_pending
-      ? backendApiPendingExtraction(domExtraction, null)
-      : null;
-  }
+  // DOM generation state is a useful rendering hint, not an authority boundary.
+  // A settled reasoning-recap widget can be misclassified as still generating
+  // after a render refresh. Keep polling the active-lineage backend anchor so it
+  // can prove completion (or keep us pending) in either DOM state.
   const lastFetchAt = Number(job.backend_api_last_fetch_at ?? 0);
   if (Date.now() - lastFetchAt < BACKEND_API_FETCH_COOLDOWN_MS) {
     return job.backend_api_pending
@@ -1950,6 +1950,7 @@ async function maybeBackendApiExtractionForJob(job, domExtraction) {
     });
     const normalized = normalizeBackendApiExtraction(backendExtraction, domExtraction, conversationId);
     const fresh = completion.isFreshBackendApiExtraction(normalized);
+    job.backend_api_consecutive_failures = 0;
     job.backend_api_pending = !fresh;
     job.updated_at = Date.now();
     await persistJob(job);
@@ -1960,12 +1961,20 @@ async function maybeBackendApiExtractionForJob(job, domExtraction) {
     }
     if (job.backend_api_pending) {
       // Do not silently downgrade to DOM finality after the backend has already
-      // proved that the active lineage is unfinished. Losing that positive
-      // anchor mid-run is an explicit failure; otherwise the same transient
-      // caption that armed the backend check can win on the next DOM poll.
+      // proved that the active lineage is unfinished. Transient fetch failures
+      // keep the DOM barred and retry on the normal cooldown; only a sustained
+      // loss of the positive anchor terminates the job.
+      job.backend_api_consecutive_failures = Math.max(
+        0,
+        Number(job.backend_api_consecutive_failures ?? 0) || 0
+      ) + 1;
+      job.updated_at = Date.now();
+      if (job.backend_api_consecutive_failures < MAX_BACKEND_API_CONSECUTIVE_FAILURES) {
+        await persistJob(job);
+        return backendApiPendingExtraction(domExtraction, null);
+      }
       job.backend_api_disabled = true;
       job.backend_api_disabled_reason = error?.code ?? String(error?.message ?? error);
-      job.updated_at = Date.now();
       await persistJob(job);
       throw error;
     }

--- a/extensions/chatgpt-native/src/sites/chatgpt-backend.js
+++ b/extensions/chatgpt-native/src/sites/chatgpt-backend.js
@@ -69,7 +69,10 @@ async function fetchChatgptAccessToken() {
 }
 
 function resolveBackendAnswer(job, conversationId, data) {
-  const baseline = nonNegativeInt(job?.submitted_assistant_count ?? job?.response_baseline?.assistant_count ?? 0);
+  // Freshness is relative to the assistant turns that existed before this send.
+  // The post-send DOM count can already include the newly-created in-progress
+  // turn, and is not comparable to completed answer nodes in the backend mapping.
+  const baseline = nonNegativeInt(job?.response_baseline?.assistant_count ?? 0);
   const notReady = (detail) => ({
     method: "backend_api",
     text: "",

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -486,13 +486,14 @@ function resumeJob() {
 
 // ---- T1 backend-api read (yoetz_fetch_conversation) ----
 
-function fetchJob(submittedAssistantCount = 0) {
+function fetchJob(preSendAssistantCount = 0) {
   return {
     job_id: "job_fetch",
     run_id: "run_fetch",
     conversation_id: "conv-123",
     expected_conversation_id: "conv-123",
-    submitted_assistant_count: submittedAssistantCount,
+    response_baseline: { assistant_count: preSendAssistantCount },
+    submitted_assistant_count: preSendAssistantCount,
     upload_timeout_ms: 1000,
     send_timeout_ms: 1000
   };
@@ -564,6 +565,35 @@ test("backend-api read returns the fresh final answer from the conversation mapp
     assert.equal(res.payload.conversation_id, "conv-123");
     assert.equal(res.payload.assistant_count, 2);
     assert.equal(res.payload.node_id, "a_final");
+  } finally {
+    restoreFetch();
+    restore();
+  }
+});
+
+test("backend-api freshness uses the pre-send answer baseline, not the post-send DOM turn count", async () => {
+  const { send, hooks, restore } = await loadContentScript("backend_post_send_dom_turn", "https://chatgpt.com/c/conv-123?_yoetz=run_fetch");
+  const restoreFetch = installBackendFetch({ conv: {
+    current_node: "a_final",
+    mapping: {
+      u1: { id: "u1", parent: null, children: ["a_final"], message: { author: { role: "user" }, content: { content_type: "text", parts: ["Return only 7"] }, end_turn: null } },
+      a_final: asstTextNode("a_final", "u1", "7")
+    }
+  }});
+  try {
+    const job = {
+      ...fetchJob(),
+      response_baseline: { assistant_count: 0 },
+      // Send acceptance can observe the newly-created in-progress DOM turn.
+      // That count is not comparable to completed backend answer nodes.
+      submitted_assistant_count: 1
+    };
+    await prepareFetchJob(send, hooks, job);
+    const res = await send({ type: "yoetz_fetch_conversation", job, conversation_id: "conv-123" });
+    assert.equal(res.ok, true, JSON.stringify(res));
+    assert.equal(res.payload.node_fresh, true);
+    assert.equal(res.payload.text, "7");
+    assert.equal(res.payload.assistant_count, 1);
   } finally {
     restoreFetch();
     restore();

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -3706,6 +3706,110 @@ test("service worker completes with backend-api text when the DOM answer turn ne
   }
 });
 
+test("service worker accepts fresh backend finality when the DOM generating heuristic stays stuck", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  let tabId = 0;
+  let sent = false;
+  let backendFetchCount = 0;
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/c/conv-stuck-generating?_yoetz=run_job_stuck_generating" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: verifiedSolProSelection() };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true, conversation_id: "conv-stuck-generating", submitted_assistant_count: 1 } };
+          case "yoetz_fetch_conversation":
+            backendFetchCount += 1;
+            return {
+              ok: true,
+              payload: {
+                method: "backend_api",
+                text: "7",
+                is_generating: false,
+                node_fresh: true,
+                conversation_id: "conv-stuck-generating",
+                assistant_count: 1,
+                turn_index: 0,
+                copy_button_count: 0,
+                has_copy_button: false
+              }
+            };
+          case "yoetz_extract_response":
+            return {
+              ok: true,
+              payload: sent
+                ? {
+                    method: "copy_scope_dom_fallback",
+                    text: "7",
+                    is_generating: true,
+                    assistant_count: 1,
+                    user_count: 1,
+                    preceding_user_count: 1,
+                    copy_button_count: 2,
+                    has_copy_button: true,
+                    turn_index: 0,
+                    conversation_id: "conv-stuck-generating",
+                    diagnostics: { counts: { stop_controls: 0, copy_buttons: 2 } }
+                  }
+                : {
+                    method: "none",
+                    text: "",
+                    is_generating: false,
+                    assistant_count: 0,
+                    user_count: 0,
+                    copy_button_count: 0,
+                    has_copy_button: false,
+                    turn_index: -1
+                  }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?backend_api_stuck_generating=${Date.now()}`);
+    port.emit(envelope("job_start", "job_stuck_generating", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 1000
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_stuck_generating", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_stuck_generating.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_complete"), 3000);
+    const complete = port.messages.find((message) => message.type === "job_complete");
+    assert.ok(backendFetchCount >= 1, "backend API must be consulted even while the DOM says generating");
+    assert.equal(complete.payload.response, "7");
+    assert.equal(complete.payload.extraction_method, "backend_api");
+    assert.equal(complete.payload.finality_anchor, "backend_api");
+    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker treats a stale backend-api node as still generating until a fresh node appears", async () => {
   const originalChrome = globalThis.chrome;
   const previousCooldown = globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS;
@@ -3735,6 +3839,11 @@ test("service worker treats a stale backend-api node as still generating until a
             return { ok: true, payload: { sent: true, conversation_id: "conv-stale", submitted_assistant_count: 1 } };
           case "yoetz_fetch_conversation":
             fetchCount += 1;
+            if (fetchCount === 2 || fetchCount === 3) {
+              throw Object.assign(new Error("transient backend-api conversation fetch failed"), {
+                code: "backend_api_unavailable"
+              });
+            }
             return {
               ok: true,
               payload: fetchCount === 1
@@ -3814,7 +3923,7 @@ test("service worker treats a stale backend-api node as still generating until a
 
     await eventually(() => port.messages.some((message) => message.type === "job_complete"), 6000);
     const complete = port.messages.find((message) => message.type === "job_complete");
-    assert.ok(fetchCount >= 2, "backend API should be retried after a stale current_node result");
+    assert.ok(fetchCount >= 4, "pending backend finality should survive two transient errors and retry to fresh");
     assert.equal(complete.payload.response, FINAL);
     assert.equal(complete.payload.extraction_method, "backend_api");
     assert.equal(complete.payload.completion_reason, "backend_api");
@@ -4057,7 +4166,7 @@ test("service worker fails closed if the backend positive-finality anchor disapp
 
     await eventually(() => port.messages.some((message) => message.type === "job_complete" || message.type === "job_error"), 6000);
     const error = port.messages.find((message) => message.type === "job_error");
-    assert.ok(fetchCount >= 2, "backend API should be retried before the anchor is declared lost");
+    assert.ok(fetchCount >= 4, "the anchor should be declared lost only after three consecutive errors");
     assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
     assert.equal(error?.payload.code, "backend_api_unavailable");
   } finally {


### PR DESCRIPTION
## Summary

- poll ChatGPT active-lineage backend finality independently of the DOM generating heuristic
- compare backend answer freshness against the pre-send assistant baseline
- keep DOM completion barred while tolerating two consecutive transient backend failures; fail closed on the third
- add live-shape regressions for stuck DOM generation, short one-character answers, freshness races, and backend retry/loss

## Verification

- `npm test` in `extensions/chatgpt-native`: 246 passed
- `cargo test --locked -p yoetz browser_extension_native::`: 50 passed
- `git diff --check`
- independent peer review: PASS

## Operational behavior

Backend-reachable ChatGPT completions may be delivered up to the 60-second backend polling cooldown after true completion. This is intentional: backend `end_turn` is authoritative when DOM generation state is stale.

Known fail-closed limitations: prior non-text answers can make DOM and backend answer-count baselines incomparable on follow-ups, and non-text final answers do not satisfy the backend text-answer classifier. Those shapes can time out rather than return unproven content.