### PR TITLE
fix(extension): require terminal backend answer lineage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- Required ChatGPT backend finality to be the conversation's current answer
+  node with no messages still in progress, then confirm the same answer node
+  on a follow-up read, preventing completed interim captions from ending
+  long-running reasoning jobs.
 
 ## [0.5.38] - 2026-07-20
 ### Fixed

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -70,6 +70,12 @@ const BACKEND_API_FETCH_COOLDOWN_MS = Math.max(
     ? Number(globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS)
     : 60000
 );
+const BACKEND_API_CONFIRMATION_MS = Math.max(
+  0,
+  Number.isFinite(Number(globalThis.__YOETZ_BACKEND_API_CONFIRMATION_MS))
+    ? Number(globalThis.__YOETZ_BACKEND_API_CONFIRMATION_MS)
+    : 5000
+);
 const MAX_BACKEND_API_CONSECUTIVE_FAILURES = 3;
 const CHATGPT_DOM_ONLY_FINALITY_WARNING = "ChatGPT finality_anchor=dom_only: backend API positive-finality proof was unavailable; response relied on DOM-only completion";
 const JOBS_KEY_PREFIX = "jobs.";
@@ -1719,7 +1725,9 @@ async function waitForResponse(job) {
     } else {
       extractionFailureSinceMs = 0;
     }
-    const nextDelay = finalAffordance
+    const nextDelay = job.backend_api_confirmation
+      ? Math.min(interval, Math.max(50, BACKEND_API_CONFIRMATION_MS))
+      : finalAffordance
       // Poll fast while confirming a latched final affordance so the short confirm
       // window is sampled across several ticks rather than overshot by a coarse poll.
       ? Math.min(interval, AFFORDANCE_CONFIRM_POLL_MS)
@@ -1933,14 +1941,21 @@ async function maybeBackendApiExtractionForJob(job, domExtraction) {
   // A settled reasoning-recap widget can be misclassified as still generating
   // after a render refresh. Keep polling the active-lineage backend anchor so it
   // can prove completion (or keep us pending) in either DOM state.
+  const now = Date.now();
   const lastFetchAt = Number(job.backend_api_last_fetch_at ?? 0);
-  if (Date.now() - lastFetchAt < BACKEND_API_FETCH_COOLDOWN_MS) {
+  const confirmation = job.backend_api_confirmation;
+  const confirmationDue = Boolean(
+    confirmation
+    && now - Number(confirmation.observed_at ?? 0) >= BACKEND_API_CONFIRMATION_MS
+  );
+  if ((confirmation && !confirmationDue)
+      || (!confirmation && now - lastFetchAt < BACKEND_API_FETCH_COOLDOWN_MS)) {
     return job.backend_api_pending
       ? backendApiPendingExtraction(domExtraction, null)
       : null;
   }
-  job.backend_api_last_fetch_at = Date.now();
-  job.updated_at = Date.now();
+  job.backend_api_last_fetch_at = now;
+  job.updated_at = now;
   await persistJob(job);
   try {
     const backendExtraction = await sendToTab(job.tab_id, {
@@ -1951,10 +1966,39 @@ async function maybeBackendApiExtractionForJob(job, domExtraction) {
     const normalized = normalizeBackendApiExtraction(backendExtraction, domExtraction, conversationId);
     const fresh = completion.isFreshBackendApiExtraction(normalized);
     job.backend_api_consecutive_failures = 0;
-    job.backend_api_pending = !fresh;
+    if (!fresh) {
+      job.backend_api_confirmation = null;
+      job.backend_api_pending = true;
+      job.updated_at = Date.now();
+      await persistJob(job);
+      return backendApiPendingExtraction(domExtraction, normalized);
+    }
+    const nodeId = String(normalized.node_id ?? "").trim();
+    if (!nodeId) {
+      job.backend_api_confirmation = null;
+      job.backend_api_pending = true;
+      job.updated_at = Date.now();
+      await persistJob(job);
+      return backendApiPendingExtraction(domExtraction, {
+        ...normalized,
+        backend_api_detail: "fresh backend answer omitted node_id required for confirmation"
+      });
+    }
+    if (!confirmation || String(confirmation.node_id ?? "") !== nodeId) {
+      job.backend_api_confirmation = { node_id: nodeId, observed_at: Date.now() };
+      job.backend_api_pending = true;
+      job.updated_at = Date.now();
+      await persistJob(job);
+      return backendApiPendingExtraction(domExtraction, {
+        ...normalized,
+        backend_api_detail: `awaiting confirmation of backend answer node ${nodeId}`
+      });
+    }
+    job.backend_api_confirmation = null;
+    job.backend_api_pending = false;
     job.updated_at = Date.now();
     await persistJob(job);
-    return fresh ? normalized : backendApiPendingExtraction(domExtraction, normalized);
+    return normalized;
   } catch (error) {
     if (!completion.isBackendApiFallbackError(error)) {
       throw error;
@@ -1968,6 +2012,7 @@ async function maybeBackendApiExtractionForJob(job, domExtraction) {
         0,
         Number(job.backend_api_consecutive_failures ?? 0) || 0
       ) + 1;
+      job.backend_api_confirmation = null;
       job.updated_at = Date.now();
       if (job.backend_api_consecutive_failures < MAX_BACKEND_API_CONSECUTIVE_FAILURES) {
         await persistJob(job);
@@ -1981,6 +2026,7 @@ async function maybeBackendApiExtractionForJob(job, domExtraction) {
     job.backend_api_disabled = true;
     job.backend_api_disabled_reason = error?.code ?? String(error?.message ?? error);
     job.backend_api_pending = false;
+    job.backend_api_confirmation = null;
     job.updated_at = Date.now();
     await persistJob(job);
     return null;

--- a/extensions/chatgpt-native/src/sites/chatgpt-backend.js
+++ b/extensions/chatgpt-native/src/sites/chatgpt-backend.js
@@ -95,6 +95,13 @@ function resolveBackendAnswer(job, conversationId, data) {
   if (!answerNode) {
     return notReady("no completed assistant answer node on the active lineage yet (still generating / tool-only)");
   }
+  const currentNode = mapping[data.current_node];
+  if (currentNode !== answerNode) {
+    return notReady("latest assistant answer is not the conversation current_node (later reasoning / tool work is still active)");
+  }
+  if (hasInProgressMessage(mapping)) {
+    return notReady("conversation mapping still contains a status=in_progress message");
+  }
   if (lineageAnswerCount <= baseline) {
     return notReady(`assistant answer not fresh past baseline (active-lineage ${lineageAnswerCount} <= ${baseline})`);
   }
@@ -153,6 +160,12 @@ function collectLineageAnswerNodes(mapping, currentNodeId) {
     id = node.parent;
   }
   return { answerNode, count };
+}
+
+function hasInProgressMessage(mapping) {
+  return Object.values(mapping).some((node) =>
+    String(node?.message?.status ?? "").toLowerCase() === "in_progress"
+  );
 }
 
 function nonNegativeInt(value) {

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -600,18 +600,17 @@ test("backend-api freshness uses the pre-send answer baseline, not the post-send
   }
 });
 
-test("backend-api read walks past reasoning_recap and tool nodes to the real assistant answer", async () => {
-  const { send, hooks, restore } = await loadContentScript("backend_walk", "https://chatgpt.com/c/conv-123?_yoetz=run_fetch");
-  const FINAL = "I reviewed the bundle end to end; the consumer guard is correct and the producer invariants hold.";
+test("backend-api read does not accept an answer buried below a later current node", async () => {
+  const { send, hooks, restore } = await loadContentScript("backend_buried_answer", "https://chatgpt.com/c/conv-123?_yoetz=run_fetch");
+  const CAPTION = "I'll review the bundle end to end, then report whether the producer and consumer invariants hold.";
   const restoreFetch = installBackendFetch({ conv: {
-    // current_node is a reasoning_recap with end_turn:true (the live trap) whose parent chain leads to the text answer
+    // A backend caption can itself look like a completed answer. Once later
+    // work exists above it, the caption must not be treated as turn-final.
     current_node: "recap",
     mapping: {
-      u1: { id: "u1", parent: null, children: ["a_final"], message: { author: { role: "user" }, content: { content_type: "text", parts: ["review"] }, end_turn: null } },
-      a_final: asstTextNode("a_final", "u1", FINAL),
-      // a tool turn (recipient not 'all') must NOT count or be selected
-      tool1: { id: "tool1", parent: "a_final", children: ["recap"], message: { author: { role: "assistant" }, content: { content_type: "text", parts: ["{search}"] }, end_turn: true, recipient: "file_search.msearch" } },
-      // reasoning_recap with end_turn:true must NOT be selected
+      u1: { id: "u1", parent: null, children: ["a_caption"], message: { author: { role: "user" }, content: { content_type: "text", parts: ["review"] }, end_turn: null } },
+      a_caption: asstTextNode("a_caption", "u1", CAPTION),
+      tool1: { id: "tool1", parent: "a_caption", children: ["recap"], message: { author: { role: "assistant" }, content: { content_type: "text", parts: ["{search}"] }, end_turn: true, recipient: "file_search.msearch", status: "finished_successfully" } },
       recap: { id: "recap", parent: "tool1", children: [], message: { author: { role: "assistant" }, content: { content_type: "reasoning_recap", parts: ["recapped"] }, end_turn: true, recipient: "all" } }
     }
   }});
@@ -620,10 +619,45 @@ test("backend-api read walks past reasoning_recap and tool nodes to the real ass
     await prepareFetchJob(send, hooks, job);
     const res = await send({ type: "yoetz_fetch_conversation", job, conversation_id: "conv-123" });
     assert.equal(res.ok, true, JSON.stringify(res));
-    assert.equal(res.payload.node_fresh, true);
-    assert.equal(res.payload.text, FINAL);
-    assert.equal(res.payload.node_id, "a_final");
-    assert.equal(res.payload.assistant_count, 1, "recap + tool nodes must not count as answer turns");
+    assert.equal(res.payload.node_fresh, false);
+    assert.equal(res.payload.is_generating, true);
+    assert.equal(res.payload.text, "");
+    assert.match(res.payload.backend_api_detail, /current_node/i);
+  } finally {
+    restoreFetch();
+    restore();
+  }
+});
+
+test("backend-api read rejects an end_turn caption while any mapping message is in progress", async () => {
+  const { send, hooks, restore } = await loadContentScript("backend_in_progress_caption", "https://chatgpt.com/c/conv-123?_yoetz=run_fetch");
+  const CAPTION = "I'll compare both mechanisms across failure recovery, takeover safety, and implementation guardrails.";
+  const restoreFetch = installBackendFetch({ conv: {
+    current_node: "a_caption",
+    mapping: {
+      u1: { id: "u1", parent: null, children: ["a_caption"], message: { author: { role: "user" }, content: { content_type: "text", parts: ["compare"] }, end_turn: null } },
+      a_caption: asstTextNode("a_caption", "u1", CAPTION),
+      tool_in_flight: {
+        id: "tool_in_flight",
+        parent: "a_caption",
+        children: [],
+        message: {
+          author: { role: "tool" },
+          content: { content_type: "text", parts: [""] },
+          status: "in_progress"
+        }
+      }
+    }
+  }});
+  try {
+    const job = fetchJob(0);
+    await prepareFetchJob(send, hooks, job);
+    const res = await send({ type: "yoetz_fetch_conversation", job, conversation_id: "conv-123" });
+    assert.equal(res.ok, true, JSON.stringify(res));
+    assert.equal(res.payload.node_fresh, false);
+    assert.equal(res.payload.is_generating, true);
+    assert.equal(res.payload.text, "");
+    assert.match(res.payload.backend_api_detail, /in.progress/i);
   } finally {
     restoreFetch();
     restore();

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -4,6 +4,7 @@ import { uint8ArrayToBase64 } from "../src/chunks.js";
 
 globalThis.__YOETZ_MIN_STABLE_IDLE_MS = 100;
 globalThis.__YOETZ_STABLE_IDLE_INTERVAL_MULTIPLIER = 0;
+globalThis.__YOETZ_BACKEND_API_CONFIRMATION_MS = 50;
 
 test("service worker routes reconnect and multiplexes two native jobs", async () => {
   const originalChrome = globalThis.chrome;
@@ -3605,6 +3606,7 @@ test("service worker completes with backend-api text when the DOM answer turn ne
   let tabId = 0;
   let sent = false;
   let backendFetch = null;
+  let backendFetchCount = 0;
   const FINAL = "Backend API captured the full Pro review even though the DOM stayed frozen.";
   globalThis.chrome = chromeStub({
     port,
@@ -3626,6 +3628,7 @@ test("service worker completes with backend-api text when the DOM answer turn ne
             return { ok: true, payload: { sent: true, conversation_id: "conv-api", submitted_assistant_count: 1 } };
           case "yoetz_fetch_conversation":
             backendFetch = message;
+            backendFetchCount += 1;
             return {
               ok: true,
               payload: {
@@ -3633,6 +3636,7 @@ test("service worker completes with backend-api text when the DOM answer turn ne
                 text: FINAL,
                 is_generating: false,
                 node_fresh: true,
+                node_id: "answer-api",
                 conversation_id: "conv-api",
                 assistant_count: 1,
                 turn_index: 0,
@@ -3696,6 +3700,7 @@ test("service worker completes with backend-api text when the DOM answer turn ne
     await eventually(() => port.messages.some((message) => message.type === "job_complete"), 5000);
     const complete = port.messages.find((message) => message.type === "job_complete");
     assert.equal(backendFetch?.conversation_id, "conv-api");
+    assert.ok(backendFetchCount >= 2, "backend finality must survive a second fetch of the same current answer node");
     assert.equal(complete.payload.response, FINAL);
     assert.equal(complete.payload.extraction_method, "backend_api");
     assert.equal(complete.payload.completion_reason, "backend_api");
@@ -3739,6 +3744,7 @@ test("service worker accepts fresh backend finality when the DOM generating heur
                 text: "7",
                 is_generating: false,
                 node_fresh: true,
+                node_id: "answer-stuck-generating",
                 conversation_id: "conv-stuck-generating",
                 assistant_count: 1,
                 turn_index: 0,
@@ -3800,7 +3806,7 @@ test("service worker accepts fresh backend finality when the DOM generating heur
 
     await eventually(() => port.messages.some((message) => message.type === "job_complete"), 3000);
     const complete = port.messages.find((message) => message.type === "job_complete");
-    assert.ok(backendFetchCount >= 1, "backend API must be consulted even while the DOM says generating");
+    assert.ok(backendFetchCount >= 2, "backend API must confirm finality even while the DOM says generating");
     assert.equal(complete.payload.response, "7");
     assert.equal(complete.payload.extraction_method, "backend_api");
     assert.equal(complete.payload.finality_anchor, "backend_api");
@@ -3861,6 +3867,7 @@ test("service worker treats a stale backend-api node as still generating until a
                     text: FINAL,
                     is_generating: false,
                     node_fresh: true,
+                    node_id: "answer-stale-final",
                     conversation_id: "conv-stale",
                     assistant_count: 1,
                     turn_index: 0,
@@ -3975,6 +3982,19 @@ test("service worker does not return a longer transient caption before a shorter
               payload: fetchCount === 1
                 ? {
                     method: "backend_api",
+                    text: CAPTION,
+                    is_generating: false,
+                    node_fresh: true,
+                    node_id: "answer-caption-interim",
+                    conversation_id: "conv-caption",
+                    assistant_count: 2,
+                    turn_index: 1,
+                    copy_button_count: 0,
+                    has_copy_button: false
+                  }
+                : fetchCount === 2
+                ? {
+                    method: "backend_api",
                     text: "",
                     is_generating: true,
                     node_fresh: false,
@@ -3987,6 +4007,7 @@ test("service worker does not return a longer transient caption before a shorter
                     text: FINAL,
                     is_generating: false,
                     node_fresh: true,
+                    node_id: "answer-caption-final",
                     conversation_id: "conv-caption",
                     assistant_count: 2,
                     turn_index: 1,
@@ -4049,7 +4070,7 @@ test("service worker does not return a longer transient caption before a shorter
 
     await eventually(() => port.messages.some((message) => message.type === "job_complete"), 8000);
     const complete = port.messages.find((message) => message.type === "job_complete");
-    assert.ok(fetchCount >= 2, "backend API should prove the active-lineage answer is final");
+    assert.ok(fetchCount >= 4, "a transient fresh caption must fail confirmation before the final node is confirmed");
     assert.ok(CAPTION.length > FINAL.length, "regression must not be catchable by a length heuristic");
     assert.equal(complete.payload.response, FINAL);
     assert.equal(complete.payload.extraction_method, "backend_api");
@@ -4233,6 +4254,7 @@ test("service worker refreshes a frozen render while backend finality is pending
                     text: FINAL,
                     is_generating: false,
                     node_fresh: true,
+                    node_id: "answer-refresh-final",
                     conversation_id: "conv-stale-refresh",
                     assistant_count: 1,
                     turn_index: 0,


### PR DESCRIPTION
## Summary

- accept a ChatGPT backend answer only when it is the conversation current node and no mapping message remains in progress
- make the first fresh backend answer provisional and confirm the same node again after 5 seconds before completing
- add adapter and service-worker regressions for repeated end-turn captions, buried answers, in-progress work, and a caption that fails confirmation before the real final node lands

## Live evidence

Conversation `6a5e2526` supplied the full truth table across a single 25-minute GPT-5.6 Sol Pro run:

- mid-generation caption 1: current node was thoughts with an in-progress tool -> rejected
- mid-generation caption 2: current node was a tool with an in-progress message -> rejected
- terminal: current node was the 37,380-character final assistant answer, zero in-progress messages -> accepted; same-node follow-up read confirms it

This closes the v0.5.38 silent-corruption path where an interim assistant text message had `end_turn=true` and `finished_successfully`.

## Verification

- native extension suite: 247/247 passing, independently rerun by Claude
- `git diff --check`
- peer review PASS on the classifier and confirmation-state delta

## Known limitation

The mapping-wide in-progress scan can fail closed on a resumed conversation if an abandoned dead branch retains stale in-progress state. This is intentionally not relaxed without live follow-up lineage evidence; a private follow-up draft records the edge.