### PR TITLE
test: prove native extension parallel job isolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,8 +118,13 @@ recipe flows, treat `dev-browser` as a QuickJS/WASM runner, not Node.js:
   or unstamped loads. Never hand-patch the managed directory.
 - The native host and managed extension directory are machine-global,
   single-writer state shared by every agent lane. Serialize setup/update/reload
-  operations; concurrent lanes may run recipes only against one frozen loaded
-  artifact.
+  operations; recipe lanes may run only against one frozen loaded artifact.
+- Independent ChatGPT recipes may run concurrently through one connected
+  extension profile: each job owns a separate background tab. Profile selectors
+  route among loaded profiles; they are not required for ChatGPT parallelism.
+  Claude is asymmetric because its tab must stay active through upload and
+  accepted send. Until per-profile activation coordination is implemented,
+  serialize Claude recipes within one loaded Chrome profile.
 - ChatGPT and Claude conversation resume use
   `--var conversation=<site-specific-id|url>` or `--followup`
   (native-extension only, no automatic context management); callers own the

--- a/README.md
+++ b/README.md
@@ -301,8 +301,14 @@ yoetz browser recipe --recipe claude --transport chrome-extension-native --bundl
 Load the managed `$YOETZ_DIR/chatgpt-native-extension` directory unpacked in
 the Chrome profile that hosts the target AI sessions; do not load a repo
 checkout. Setup, update, and reload share machine-global native-host and managed
-extension state, so serialize those operations across agent lanes. Recipe runs
-may proceed concurrently only against one frozen loaded artifact.
+extension state, so serialize those operations across agent lanes.
+
+Independent ChatGPT recipe runs may share one connected extension profile: each
+job owns a separate background tab, and profile selectors are routing controls,
+not a prerequisite for parallelism. Claude is asymmetric because each job must
+keep its tab active through upload and accepted send. Until per-profile Claude
+activation coordination lands, serialize Claude recipe runs within one loaded
+Chrome profile. Both sites may run only against one frozen loaded artifact.
 
 Upgrade the installed CLI before another lane runs extension auto-heal after a
 release. An older CLI can overwrite the newer stamped managed copy.

--- a/crates/yoetz-cli/tests/native_extension_host.rs
+++ b/crates/yoetz-cli/tests/native_extension_host.rs
@@ -1,0 +1,346 @@
+#![cfg(unix)]
+
+use serde_json::{json, Value};
+use std::collections::VecDeque;
+use std::fs;
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+
+const FRAME_TIMEOUT: Duration = Duration::from_secs(5);
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
+const CHUNK_BYTES: usize = 192 * 1024;
+
+#[test]
+fn native_host_multiplexes_clients_and_isolates_disconnect_cancellation() {
+    let mut host = NativeHost::start();
+    let token = wait_for_token(&host.token_path);
+
+    let bundle_a = write_bundle(host.temp.path(), "a.md", CHUNK_BYTES + 11, b'a');
+    let bundle_b = write_bundle(host.temp.path(), "b.md", CHUNK_BYTES + 17, b'b');
+    let client_a = LocalClient::connect(&host.socket_path, "job_a", &bundle_a, &token);
+    let client_b = LocalClient::connect(&host.socket_path, "job_b", &bundle_b, &token);
+
+    host.output.take("job_start", "job_a");
+    host.output.take("job_start", "job_b");
+
+    host.send(extension_frame(
+        "job_progress",
+        "job_a",
+        json!({"phase": "ready_for_file"}),
+    ));
+    client_a.take("job_progress");
+    assert_chunk(&host.output.take("job_file_chunk", "job_a"), 0, 2);
+
+    host.send(extension_frame(
+        "job_progress",
+        "job_b",
+        json!({"phase": "ready_for_file"}),
+    ));
+    client_b.take("job_progress");
+    assert_chunk(&host.output.take("job_file_chunk", "job_b"), 0, 2);
+
+    host.send(extension_frame(
+        "job_file_chunk_ack",
+        "job_a",
+        json!({"sequence": 0, "complete": false}),
+    ));
+    client_a.take("job_file_chunk_ack");
+    assert_chunk(&host.output.take("job_file_chunk", "job_a"), 1, 2);
+
+    host.send(extension_frame(
+        "job_file_chunk_ack",
+        "job_b",
+        json!({"sequence": 0, "complete": false}),
+    ));
+    client_b.take("job_file_chunk_ack");
+    assert_chunk(&host.output.take("job_file_chunk", "job_b"), 1, 2);
+
+    host.send(extension_frame(
+        "job_file_chunk_ack",
+        "job_b",
+        json!({"sequence": 1, "complete": true}),
+    ));
+    client_b.take("job_file_chunk_ack");
+    host.send(extension_frame(
+        "job_complete",
+        "job_b",
+        json!({"response": "B finished first"}),
+    ));
+    assert_eq!(
+        client_b.take("job_complete")["payload"]["response"],
+        "B finished first"
+    );
+
+    host.send(extension_frame(
+        "job_file_chunk_ack",
+        "job_a",
+        json!({"sequence": 1, "complete": true}),
+    ));
+    client_a.take("job_file_chunk_ack");
+    host.send(extension_frame(
+        "job_complete",
+        "job_a",
+        json!({"response": "A finished second"}),
+    ));
+    assert_eq!(
+        client_a.take("job_complete")["payload"]["response"],
+        "A finished second"
+    );
+
+    let bundle_c = write_bundle(host.temp.path(), "c.md", 4, b'c');
+    let bundle_d = write_bundle(host.temp.path(), "d.md", 4, b'd');
+    let client_c = LocalClient::connect(&host.socket_path, "job_c", &bundle_c, &token);
+    let client_d = LocalClient::connect(&host.socket_path, "job_d", &bundle_d, &token);
+    host.output.take("job_start", "job_c");
+    host.output.take("job_start", "job_d");
+
+    host.send(extension_frame(
+        "job_progress",
+        "job_c",
+        json!({"phase": "ready_for_file"}),
+    ));
+    assert_eq!(client_c.take("job_progress")["job_id"], "job_c");
+    assert_chunk(&host.output.take("job_file_chunk", "job_c"), 0, 1);
+    host.send(extension_frame(
+        "job_progress",
+        "job_d",
+        json!({"phase": "ready_for_file"}),
+    ));
+    client_d.take("job_progress");
+    assert_chunk(&host.output.take("job_file_chunk", "job_d"), 0, 1);
+
+    drop(client_c);
+    host.send(extension_frame(
+        "job_file_chunk_ack",
+        "job_d",
+        json!({"sequence": 0, "complete": true}),
+    ));
+    client_d.take("job_file_chunk_ack");
+    host.send(extension_frame(
+        "job_complete",
+        "job_d",
+        json!({"response": "D survived C disconnect"}),
+    ));
+    assert_eq!(
+        client_d.take("job_complete")["payload"]["response"],
+        "D survived C disconnect"
+    );
+
+    let cancel = host.output.take("job_cancel", "job_c");
+    assert_eq!(cancel["payload"]["reason"], "local_client_disconnected");
+}
+
+struct NativeHost {
+    child: Child,
+    stdin: ChildStdin,
+    output: FrameInbox,
+    temp: TempDir,
+    socket_path: PathBuf,
+    token_path: PathBuf,
+}
+
+impl NativeHost {
+    fn start() -> Self {
+        let temp = tempfile::tempdir().unwrap();
+        let state_dir = temp.path().join("state");
+        let socket_path = temp.path().join("native.sock");
+        let token_path = state_dir
+            .join("chrome-extension-native")
+            .join("chatgpt-native.token");
+        let mut child = Command::new(env!("CARGO_BIN_EXE_yoetz"))
+            .args(["browser", "chrome-native-host", "--chatgpt"])
+            .env("YOETZ_DIR", &state_dir)
+            .env("YOETZ_CHROME_EXTENSION_NATIVE_SOCKET", &socket_path)
+            .env(
+                "YOETZ_CHROME_NATIVE_MESSAGING_DIR",
+                temp.path().join("native-hosts"),
+            )
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .unwrap();
+        let stdin = child.stdin.take().unwrap();
+        let stdout = child.stdout.take().unwrap();
+        let output = FrameInbox::from_reader(stdout);
+        wait_for_path(&socket_path);
+        Self {
+            child,
+            stdin,
+            output,
+            temp,
+            socket_path,
+            token_path,
+        }
+    }
+
+    fn send(&mut self, frame: Value) {
+        write_frame(&mut self.stdin, &frame);
+    }
+}
+
+impl Drop for NativeHost {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+struct LocalClient {
+    stream: UnixStream,
+    job_id: String,
+}
+
+impl LocalClient {
+    fn connect(socket_path: &Path, job_id: &str, bundle_path: &Path, token: &str) -> Self {
+        let mut stream = UnixStream::connect(socket_path).unwrap();
+        stream.set_read_timeout(Some(FRAME_TIMEOUT)).unwrap();
+        let bundle_size = fs::metadata(bundle_path).unwrap().len();
+        write_frame(
+            &mut stream,
+            &json!({
+                "protocol_version": 1,
+                "transport": "chrome-extension-native",
+                "request_id": format!("req_start_{job_id}"),
+                "job_id": job_id,
+                "run_id": format!("run_{job_id}"),
+                "workspace_id": "workspace_test",
+                "capability_token": token,
+                "type": "job_start",
+                "payload": {
+                    "recipe": "chatgpt",
+                    "bundle_path": bundle_path,
+                    "bundle_size": bundle_size,
+                    "prompt": format!("prompt {job_id}"),
+                    "wait_timeout_ms": 5000
+                }
+            }),
+        );
+        Self {
+            stream,
+            job_id: job_id.to_string(),
+        }
+    }
+
+    fn take(&self, kind: &str) -> Value {
+        let frame = read_frame(&mut &self.stream);
+        assert_eq!(
+            frame["job_id"], self.job_id,
+            "client received another job's frame"
+        );
+        assert_eq!(frame["type"], kind, "client received an unexpected frame");
+        frame
+    }
+}
+
+struct FrameInbox {
+    receiver: Receiver<Value>,
+    pending: VecDeque<Value>,
+}
+
+impl FrameInbox {
+    fn from_reader(mut reader: impl Read + Send + 'static) -> Self {
+        let (sender, receiver) = mpsc::channel();
+        thread::spawn(move || {
+            while let Ok(frame) = try_read_frame(&mut reader) {
+                if sender.send(frame).is_err() {
+                    break;
+                }
+            }
+        });
+        Self {
+            receiver,
+            pending: VecDeque::new(),
+        }
+    }
+
+    fn take(&mut self, kind: &str, job_id: &str) -> Value {
+        if let Some(index) = self
+            .pending
+            .iter()
+            .position(|frame| frame["type"] == kind && frame["job_id"] == job_id)
+        {
+            return self.pending.remove(index).unwrap();
+        }
+        let deadline = Instant::now() + FRAME_TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let frame = self
+                .receiver
+                .recv_timeout(remaining)
+                .unwrap_or_else(|err| panic!("timed out waiting for {kind} for {job_id}: {err}"));
+            if frame["type"] == kind && frame["job_id"] == job_id {
+                return frame;
+            }
+            self.pending.push_back(frame);
+        }
+    }
+}
+
+fn extension_frame(kind: &str, job_id: &str, payload: Value) -> Value {
+    json!({
+        "protocol_version": 1,
+        "transport": "chrome-extension-native",
+        "request_id": format!("req_{kind}_{job_id}"),
+        "job_id": job_id,
+        "run_id": format!("run_{job_id}"),
+        "workspace_id": "workspace_test",
+        "type": kind,
+        "payload": payload
+    })
+}
+
+fn assert_chunk(frame: &Value, sequence: u64, total_chunks: u64) {
+    assert_eq!(frame["payload"]["sequence"], sequence);
+    assert_eq!(frame["payload"]["total_chunks"], total_chunks);
+}
+
+fn write_bundle(dir: &Path, name: &str, size: usize, byte: u8) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, vec![byte; size]).unwrap();
+    path
+}
+
+fn wait_for_token(path: &Path) -> String {
+    wait_for_path(path);
+    fs::read_to_string(path).unwrap().trim().to_string()
+}
+
+fn wait_for_path(path: &Path) {
+    let deadline = Instant::now() + STARTUP_TIMEOUT;
+    while !path.exists() {
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {}",
+            path.display()
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn write_frame(writer: &mut impl Write, frame: &Value) {
+    let bytes = serde_json::to_vec(frame).unwrap();
+    writer
+        .write_all(&(bytes.len() as u32).to_ne_bytes())
+        .unwrap();
+    writer.write_all(&bytes).unwrap();
+    writer.flush().unwrap();
+}
+
+fn read_frame(reader: &mut impl Read) -> Value {
+    try_read_frame(reader).unwrap()
+}
+
+fn try_read_frame(reader: &mut impl Read) -> std::io::Result<Value> {
+    let mut len = [0_u8; 4];
+    reader.read_exact(&mut len)?;
+    let mut bytes = vec![0_u8; u32::from_ne_bytes(len) as usize];
+    reader.read_exact(&mut bytes)?;
+    serde_json::from_slice(&bytes).map_err(std::io::Error::other)
+}

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -12,7 +12,11 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
   const originalClearInterval = globalThis.clearInterval;
   const port = makePort();
   const sentToTabs = [];
+  const createdTabs = [];
+  const jobTabs = new Map();
   const sentJobs = new Set();
+  const extractedJobs = new Set();
+  const releasableJobs = new Set();
   let tabId = 0;
 
   globalThis.setInterval = () => 1;
@@ -42,7 +46,11 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
       clear: () => {}
     },
     tabs: {
-      create: async () => ({ id: ++tabId }),
+      create: async (options) => {
+        const tab = { id: ++tabId, ...options };
+        createdTabs.push(tab);
+        return tab;
+      },
       get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
       sendMessage: async (id, message) => {
         sentToTabs.push({ id, message });
@@ -50,6 +58,7 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
           case "yoetz_probe":
             return { ok: true, payload: { url: "https://chatgpt.com/", title: "ChatGPT", text: "" } };
           case "yoetz_prepare_job":
+            jobTabs.set(message.job.job_id, id);
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
             return { ok: true, payload: verifiedSolProSelection() };
@@ -65,11 +74,14 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
               }
             };
           case "yoetz_extract_response":
+            extractedJobs.add(message.job.job_id);
             return {
               ok: true,
-              payload: sentJobs.has(message.job.job_id)
+              payload: sentJobs.has(message.job.job_id) && releasableJobs.has(message.job.job_id)
                 ? { method: "assistant_dom_fallback", text: `answer ${message.job.job_id}`, is_generating: false, assistant_count: 1, copy_button_count: 1, has_copy_button: true, turn_index: 0, conversation_id: `conv-${message.job.job_id}` }
-                : { method: "none", text: "", is_generating: false, assistant_count: 0, turn_index: -1 }
+                : sentJobs.has(message.job.job_id)
+                  ? { method: "assistant_dom_fallback", text: `partial ${message.job.job_id}`, is_generating: true, assistant_count: 1, copy_button_count: 0, has_copy_button: false, turn_index: 0, conversation_id: `conv-${message.job.job_id}` }
+                  : { method: "none", text: "", is_generating: false, assistant_count: 0, turn_index: -1 }
             };
           default:
             throw new Error(`unexpected tab message ${message.type}`);
@@ -98,8 +110,8 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
     for (const jobId of jobs) {
       port.emit(envelope("job_start", jobId, {
         prompt: `prompt ${jobId}`,
-        wait_interval_ms: 500,
-        wait_timeout_ms: 2500
+        wait_interval_ms: 50,
+        wait_timeout_ms: 5000
       }));
     }
     await eventually(() => port.messages.filter((message) => message.type === "job_progress" && message.payload.phase === "ready_for_file").length === 2);
@@ -114,6 +126,21 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
         bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
       }));
     }
+    await eventually(() => sentJobs.size === 2 && extractedJobs.size === 2);
+    assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
+    assert.notEqual(jobTabs.get("job_a"), jobTabs.get("job_b"));
+    assert.deepEqual(createdTabs.map((tab) => tab.active), [false, false]);
+
+    releasableJobs.add("job_b");
+    await eventually(() => port.messages.some((message) =>
+      message.job_id === "job_b" && ["job_complete", "job_error"].includes(message.type)
+    ));
+    assert.equal(
+      port.messages.find((message) => message.type === "job_error" && message.job_id === "job_b"),
+      undefined
+    );
+    assert.equal(port.messages.some((message) => message.type === "job_complete" && message.job_id === "job_a"), false);
+    releasableJobs.add("job_a");
     await eventually(() => port.messages.filter((message) => message.type === "job_complete").length === 2);
     assert.deepEqual(
       port.messages.filter((message) => message.type === "job_file_chunk_ack").map((message) => message.job_id).sort(),
@@ -136,6 +163,14 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
       "https://chatgpt.com/c/conv-job_a"
     );
     assert.equal(sentToTabs.filter((item) => item.message.type === "yoetz_upload_file").length, 2);
+    for (const jobId of jobs) {
+      const ownedTabIds = new Set(
+        sentToTabs
+          .filter((item) => item.message.job?.job_id === jobId)
+          .map((item) => item.id)
+      );
+      assert.deepEqual([...ownedTabIds], [jobTabs.get(jobId)], `${jobId} must remain on its own tab`);
+    }
     assert.equal(
       sentToTabs.find((item) => item.message.type === "yoetz_configure_model" && item.message.job.job_id === "job_b")?.message.job.model,
       "gpt-5-6-sol-pro"
@@ -5594,13 +5629,15 @@ test("service worker preserves terminal_delivery_lost jobs on restore", async ()
   }
 });
 
-test("service worker cancelJob clicks stop, removes tab, and evicts the in-memory job", async () => {
+test("service worker cancelJob isolates one of two active ChatGPT jobs", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
   const sentToTabs = [];
   const removedTabs = [];
+  const jobTabs = new Map();
+  const sentJobs = new Set();
   let createdTabId = 0;
-  let sent = false;
+  let survivorCanComplete = false;
   globalThis.chrome = chromeStub({
     port,
     tabs: {
@@ -5615,21 +5652,22 @@ test("service worker cancelJob clicks stop, removes tab, and evicts the in-memor
           case "yoetz_probe":
             return { ok: true, payload: {} };
           case "yoetz_prepare_job":
+            jobTabs.set(message.job.job_id, id);
             return { ok: true, payload: { manual_handoff: null } };
           case "yoetz_configure_model":
             return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
-            sent = true;
+            sentJobs.add(message.job.job_id);
             return { ok: true, payload: { sent: true } };
           case "yoetz_extract_response":
-            // Keep the response perpetually "still generating" so the worker
-            // remains in waitForResponse until cancel arrives.
             return {
               ok: true,
-              payload: sent
-                ? { method: "assistant_dom_fallback", text: "partial...", is_generating: true, assistant_count: 1, copy_button_count: 0, has_copy_button: false, turn_index: 0 }
+              payload: sentJobs.has(message.job.job_id)
+                ? survivorCanComplete && message.job.job_id === "job_survivor_b"
+                  ? { method: "assistant_dom_fallback", text: "survivor complete", is_generating: false, assistant_count: 1, copy_button_count: 1, has_copy_button: true, turn_index: 0 }
+                  : { method: "assistant_dom_fallback", text: `partial ${message.job.job_id}`, is_generating: true, assistant_count: 1, copy_button_count: 0, has_copy_button: false, turn_index: 0 }
                 : { method: "none", text: "", is_generating: false, assistant_count: 0, turn_index: -1 }
             };
           case "yoetz_cancel_send":
@@ -5645,26 +5683,28 @@ test("service worker cancelJob clicks stop, removes tab, and evicts the in-memor
     await import(`../src/service-worker.js?cancel_kills_tab=${Date.now()}`);
     await eventually(() => port.messages.some((m) => m.type === "hello"));
 
-    port.emit(envelope("job_start", "job_cancel_a", {
-      prompt: "prompt",
-      wait_interval_ms: 50,
-      wait_timeout_ms: 60000
-    }));
-    await eventually(() => port.messages.some((m) => m.payload?.phase === "ready_for_file"));
+    const jobs = ["job_cancel_a", "job_survivor_b"];
+    for (const jobId of jobs) {
+      port.emit(envelope("job_start", jobId, {
+        prompt: `prompt ${jobId}`,
+        wait_interval_ms: 50,
+        wait_timeout_ms: 60000
+      }));
+    }
+    await eventually(() => port.messages.filter((m) => m.payload?.phase === "ready_for_file").length === 2);
 
-    port.emit(envelope("job_file_chunk", "job_cancel_a", {
-      sequence: 0,
-      total_chunks: 1,
-      total_bytes: 4,
-      filename: "job_cancel_a.md",
-      mime_type: "text/markdown",
-      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
-    }));
-    // Wait for the prompt to be sent so the job is mid-response when we cancel.
-    await eventually(() => sent);
-    // Wait for at least one extract_response cycle so the job is firmly inside
-    // waitForResponse before cancel arrives.
-    await eventually(() => sentToTabs.some((m) => m.type === "yoetz_extract_response"));
+    for (const jobId of jobs) {
+      port.emit(envelope("job_file_chunk", jobId, {
+        sequence: 0,
+        total_chunks: 1,
+        total_bytes: 4,
+        filename: `${jobId}.md`,
+        mime_type: "text/markdown",
+        bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+      }));
+    }
+    await eventually(() => sentJobs.size === 2);
+    await eventually(() => jobs.every((jobId) => sentToTabs.some((m) => m.type === "yoetz_extract_response" && m.jobId === jobId)));
 
     port.emit(envelope("job_cancel", "job_cancel_a"));
 
@@ -5675,11 +5715,19 @@ test("service worker cancelJob clicks stop, removes tab, and evicts the in-memor
       sentToTabs.some((m) => m.type === "yoetz_cancel_send" && m.jobId === "job_cancel_a"),
       "expected service worker to forward yoetz_cancel_send to the content script"
     );
-    assert.deepEqual(removedTabs, [createdTabId],
-      "expected service worker to remove the ChatGPT tab on cancel");
+    assert.deepEqual(removedTabs, [jobTabs.get("job_cancel_a")],
+      "expected service worker to remove only the cancelled ChatGPT tab");
+    assert.equal(sentToTabs.some((m) => m.type === "yoetz_cancel_send" && m.jobId === "job_survivor_b"), false);
+    assert.equal(port.messages.some((m) => m.type === "job_cancel" && m.job_id === "job_survivor_b"), false);
     const cancelEnvelope = port.messages.find((m) => m.type === "job_cancel" && m.job_id === "job_cancel_a");
     assert.equal(cancelEnvelope.payload.cancelled, true);
     assert.equal(cancelEnvelope.payload.stop_clicked, true);
+
+    survivorCanComplete = true;
+    await eventually(() => port.messages.some((m) => m.type === "job_complete" && m.job_id === "job_survivor_b"));
+    const survivor = port.messages.find((m) => m.type === "job_complete" && m.job_id === "job_survivor_b");
+    assert.equal(survivor.payload.response, "survivor complete");
+    assert.notEqual(jobTabs.get("job_cancel_a"), jobTabs.get("job_survivor_b"));
 
     // Subsequent extract_response for the cancelled job_id must surface
     // "unknown job" — the in-memory map can no longer carry a cancelled entry.

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -359,9 +359,10 @@ yoetz browser extension inspect --chatgpt --run-id <run-id>
 yoetz browser extension grant-identity --chatgpt
 ```
 
-The extension transport is ChatGPT-only, native-host backed, and currently
-macOS/Linux-only. Do not use it as a general browser interpreter, and do not
-silently fall back to CDP after browser-side side effects have started.
+The extension transport supports ChatGPT and Claude, is native-host backed, and
+is currently macOS/Linux-only. Do not use it as a general browser interpreter,
+and do not silently fall back to CDP after browser-side side effects have
+started.
 For extension-native workflows, plain `yoetz browser check --format json`
 auto-selects `chrome-extension-native` when the extension reports connected,
 returns `auto_selected: true`, and avoids Chrome's remote-debugging approval
@@ -432,6 +433,14 @@ confirmation for local extensions.
 When multiple Chrome profiles have the extension loaded, pass
 `--var profile_email=<email>` if Chrome exposes one, or the stable
 `--var extension_instance_id=<id>` shown by `status --chatgpt`.
+
+Independent ChatGPT recipes may run concurrently through one connected profile:
+each job owns a separate background tab. Profile selectors only choose among
+loaded profiles and are not required for ChatGPT parallelism. Claude is
+asymmetric because each job must keep its tab active through upload and accepted
+send; serialize Claude recipes within one loaded profile until per-profile
+activation coordination is available. Setup, update, and reload remain
+machine-global single-writer operations for both sites.
 
 ### Cookie sync (legacy fallback)
 


### PR DESCRIPTION
## Why

Working assumption was that the native extension transport only supported parallelism across separate Chrome profiles. That premise was wrong, and the docs were what made it ambiguous.

The broker is already `job_id`-multiplexed (`browser_extension_native.rs:3070`) and the service worker already shards storage per job (`service-worker.js:2308`) — both deliberate. Profile selectors (`profile_email` / `extension_instance_id`) choose an *endpoint*; they were never what enabled concurrency.

The real constraint is a ChatGPT/Claude asymmetry:

| Site | Tab policy | Parallel today |
|---|---|---|
| ChatGPT | background (`sites/chatgpt.js:202`) | yes |
| Claude | active through accepted send (`sites/claude.js:98`) | no — jobs steal focus from each other |
| Mixed | — | yes |

## What this changes

Tests and docs only. **Zero production/runtime changes** — the `crates/` diff is one new test file, and it drives the real `browser chrome-native-host` entrypoint through pre-existing env hooks rather than any new test-only seam.

- `crates/yoetz-cli/tests/native_extension_host.rs` (new): process-level broker proof. Two real Unix clients over one spawned native host — interleaved chunk acks, out-of-order completion (B before A), and disconnect isolation (drop C, D still completes, only C is cancelled). Every client asserts it never receives another job's frame.
- `service-worker.test.js`: the two-job test now asserts distinct tabs per job, both created `active: false`, and staged completion so overlap is proven rather than assumed. The cancel test now cancels one of two active jobs and asserts the survivor completes with only the cancelled tab removed.
- `README.md`, `CLAUDE.md`, `skills/yoetz/SKILL.md`: state the asymmetry explicitly instead of the previous ambiguous "recipe runs may proceed concurrently". Also corrects a stale "extension transport is ChatGPT-only" claim in SKILL.md.

Claude activation coordination is deliberately **not** in this PR — it's a separate wave.

## Verification

- `native_extension_host`: 6/6 runs, no flake
- `cargo test --workspace --bins`: 587 passed, 0 failed, 2 ignored
- `cargo test --workspace --lib`: 58 passed
- extension `npm test`: 247/247
- clippy `-D warnings`, `cargo fmt --check`, `build-chatgpt-native-extension.sh --check`: pass

## Known issues found, not fixed here (pre-existing, out of scope)

- `discover_running_chrome_targets_skips_unhealthy_active_port_files` (`client.rs:4021`) mutates process-global `HOME` via `unsafe std::env::set_var` with no `#[serial]`, so it races sibling tests in the same binary. Observed once as `targets.len()==0`; passes in isolation and passed in the run above.
- The `cli.rs` integration binary can leave a `live-attach-daemon` running and wedge the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)