### PR TITLE
fix: reconcile ChatGPT conversation assignment

### DIFF
--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -184,7 +184,9 @@ async function extractJobResponse(job) {
   assertJobOwnership(job, parseOwnedWindowName, { adapter });
   const conversationId = adapter.conversationIdFromUrl(location.href);
   const expectedConversationId = expectedConversationIdForJob(job);
-  if (expectedConversationId && conversationId !== expectedConversationId) {
+  if (expectedConversationId
+      && conversationId !== expectedConversationId
+      && !isExpectedConversationIdAssignment(job, adapter, expectedConversationId, conversationId)) {
     throw commandError(
       "conversation_changed",
       `tab moved from ${adapter.displayName} conversation ${expectedConversationId} to ${conversationId ?? "(none)"}`,
@@ -326,7 +328,9 @@ async function bindJob(job) {
   }
   const conversationId = adapter.conversationIdFromUrl(location.href);
   const expectedConversationId = expectedConversationIdForJob(job);
-  if (expectedConversationId && conversationId !== expectedConversationId) {
+  if (expectedConversationId
+      && conversationId !== expectedConversationId
+      && !isExpectedConversationIdAssignment(job, adapter, expectedConversationId, conversationId)) {
     throw commandError(
       "conversation_changed",
       `tab moved from ${adapter.displayName} conversation ${expectedConversationId} to ${conversationId ?? "(none)"}`,
@@ -405,6 +409,14 @@ function conversationIdForJob(job) {
 
 function expectedConversationIdForJob(job) {
   return String(job?.expected_conversation_id ?? job?.submitted_conversation_id ?? job?.conversation_id ?? "").trim() || null;
+}
+
+function isExpectedConversationIdAssignment(job, adapter, expectedConversationId, currentConversationId) {
+  return Boolean(adapter.isExpectedConversationIdAssignment?.(
+    job,
+    expectedConversationId,
+    currentConversationId
+  ));
 }
 
 function conversationLoadOptionsForJob(job) {

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -1515,7 +1515,9 @@ async function waitForResponse(job) {
     }
     const extraction = await extractResponseForJob(job);
     assertJobConnectionCurrent(job);
-    assertJobConversationCurrent(job, extraction);
+    if (reconcileJobConversationCurrent(job, extraction)) {
+      await persistJob(job);
+    }
     if (extraction?.manual_handoff) {
       postNative(progress(job, "manual_handoff", extraction.manual_handoff));
       await failJob(job, "manual_handoff", extraction.manual_handoff.message, {
@@ -2220,14 +2222,25 @@ function assertSubmittedConversationCurrent(job, sendResult) {
   );
 }
 
-function assertJobConversationCurrent(job, extraction) {
+function reconcileJobConversationCurrent(job, extraction) {
   const expectedConversationId = job.expected_conversation_id ?? job.submitted_conversation_id ?? job.conversation_id;
   if (!expectedConversationId) {
-    return;
+    return false;
   }
   const currentConversationId = extraction?.conversation_id ?? null;
   if (expectedConversationId === currentConversationId) {
-    return;
+    return false;
+  }
+  const currentUrl = extraction?.url ?? null;
+  if (adapterForJob(job).isExpectedConversationIdAssignment?.(
+    job,
+    expectedConversationId,
+    currentConversationId
+  )) {
+    job.submitted_conversation_id = currentConversationId;
+    job.submitted_url = currentUrl;
+    job.updated_at = Date.now();
+    return true;
   }
   throw commandError(
     "conversation_changed",

--- a/extensions/chatgpt-native/src/sites/chatgpt.js
+++ b/extensions/chatgpt-native/src/sites/chatgpt.js
@@ -41,6 +41,17 @@ function normalizeConversationId(value) {
   return { ok: true, id };
 }
 
+function isExpectedConversationIdAssignment(job, expectedConversationId, currentConversationId) {
+  const requestedConversationId = String(job?.conversation_id ?? "").trim();
+  const submittedConversationId = String(job?.submitted_conversation_id ?? "").trim();
+  const expected = String(expectedConversationId ?? "").trim();
+  const current = String(currentConversationId ?? "").trim();
+  return !requestedConversationId
+    && submittedConversationId === expected
+    && expected.startsWith("WEB:")
+    && normalizeConversationId(current).ok;
+}
+
 function modelUsedLooksLikeSolPro(value) {
   const folded = String(value ?? "").toLowerCase();
   return /\bsol\b/.test(folded) && /\bpro\b/.test(folded);
@@ -193,6 +204,7 @@ export const chatgptSiteAdapter = Object.freeze({
   conversationJobUrl: dom.chatgptConversationJobUrl,
   conversationUrl,
   conversationIdFromUrl,
+  isExpectedConversationIdAssignment,
   isConversationUrl: (url) => Boolean(conversationIdFromUrl(url)),
   normalizeConversationId,
   isAllowedTabUrl: (url) => String(url ?? "").startsWith(`${CHATGPT_ORIGIN}/`),

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -95,6 +95,7 @@ export async function clickSend(_document, options) {
 }
 
 export async function waitForSendAccepted() {
+  hooks.afterWaitForSendAccepted?.();
   return hooks.sendAccepted ?? { accepted: true };
 }
 
@@ -142,6 +143,9 @@ export const siteAdapter = {
     } catch {
       return null;
     }
+  },
+  isExpectedConversationIdAssignment() {
+    return Boolean(hooks.allowConversationAssignment);
   },
   isConversationUrl(value) {
     return Boolean(this.conversationIdFromUrl(value));
@@ -409,6 +413,76 @@ test("content script fresh path still requires a fresh page after prepare", asyn
 
     assert.equal(response.ok, false);
     assert.equal(response.code, "fresh_chat_lost");
+  } finally {
+    restore();
+  }
+});
+
+test("content script accepts ChatGPT replacing a submitted WEB conversation id on the owned tab", async () => {
+  const { send, hooks, restore, location } = await loadContentScript("fresh_web_assignment", "https://chatgpt.com/?_yoetz=run_fresh_assignment");
+  try {
+    hooks.allowConversationAssignment = true;
+    const job = {
+      job_id: "job_fresh_assignment",
+      run_id: "run_fresh_assignment",
+      upload_timeout_ms: 1000,
+      send_timeout_ms: 1000
+    };
+    const prepared = await send({ type: "yoetz_prepare_job", job });
+    assert.equal(prepared.ok, true);
+
+    globalThis.__contentScriptTestHooks.afterWaitForSendAccepted = () => {
+      location.href = "https://chatgpt.com/c/WEB:ca5209ac-2836-440d-b674-ffc54ee5dd2d?_yoetz=run_fresh_assignment";
+      location.pathname = "/c/WEB:ca5209ac-2836-440d-b674-ffc54ee5dd2d";
+    };
+    const sent = await send({ type: "yoetz_send_prompt", job, prompt: "review" });
+    assert.equal(sent.ok, true);
+    assert.equal(sent.payload.conversation_id, "WEB:ca5209ac-2836-440d-b674-ffc54ee5dd2d");
+
+    const waitingJob = {
+      ...job,
+      submitted_conversation_id: sent.payload.conversation_id
+    };
+    location.href = "https://chatgpt.com/c/6a5f60dc-8174-8329-949a-1f282d1dccbd";
+    location.pathname = "/c/6a5f60dc-8174-8329-949a-1f282d1dccbd";
+    const rebound = await send({ type: "yoetz_bind_job", job: waitingJob });
+    assert.equal(rebound.ok, true, JSON.stringify(rebound));
+    const extracted = await send({ type: "yoetz_extract_response", job: waitingJob });
+
+    assert.equal(extracted.ok, true, JSON.stringify(extracted));
+    assert.equal(extracted.payload.conversation_id, "6a5f60dc-8174-8329-949a-1f282d1dccbd");
+  } finally {
+    restore();
+  }
+});
+
+test("content script requires the surviving window.name marker for conversation assignment", async () => {
+  const { send, hooks, restore, location } = await loadContentScript(
+    "fresh_web_assignment_wrong_owner",
+    "https://chatgpt.com/?_yoetz=run_fresh_assignment"
+  );
+  try {
+    hooks.allowConversationAssignment = true;
+    const job = {
+      job_id: "job_fresh_assignment",
+      run_id: "run_fresh_assignment",
+      upload_timeout_ms: 1000,
+      send_timeout_ms: 1000
+    };
+    const prepared = await send({ type: "yoetz_prepare_job", job });
+    assert.equal(prepared.ok, true);
+
+    const waitingJob = {
+      ...job,
+      submitted_conversation_id: "WEB:ca5209ac-2836-440d-b674-ffc54ee5dd2d"
+    };
+    location.href = "https://chatgpt.com/c/6a5f60dc-8174-8329-949a-1f282d1dccbd";
+    location.pathname = "/c/6a5f60dc-8174-8329-949a-1f282d1dccbd";
+    globalThis.window.name = "yoetz-chatgpt-native:other_run:other_job";
+    const extracted = await send({ type: "yoetz_extract_response", job: waitingJob });
+
+    assert.equal(extracted.ok, false);
+    assert.match(extracted.error, /ownership marker mismatch/);
   } finally {
     restore();
   }

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -182,6 +182,107 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
   }
 });
 
+test("service worker reconciles ChatGPT conversation assignment after the URL marker is dropped", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const submittedConversationId = "WEB:ca5209ac-2836-440d-b674-ffc54ee5dd2d";
+  const assignedConversationId = "6a5f60dc-8174-8329-949a-1f282d1dccbd";
+  const sentJobs = new Set();
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async () => ({ id: 71 }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/?_yoetz=run_job_web_assignment" }),
+      sendMessage: async (id, message) => {
+        assert.equal(id, 71);
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: { url: "https://chatgpt.com/", title: "ChatGPT", text: "" } };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: verifiedSolProSelection() };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sentJobs.add(message.job.job_id);
+            return {
+              ok: true,
+              payload: {
+                sent: true,
+                conversation_id: submittedConversationId,
+                submitted_user_count: 1,
+                submitted_assistant_count: 0
+              }
+            };
+          case "yoetz_extract_response":
+            return {
+              ok: true,
+              payload: sentJobs.has(message.job.job_id) ? {
+                method: "assistant_dom_fallback",
+                text: "answer",
+                is_generating: false,
+                assistant_count: 1,
+                copy_button_count: 1,
+                has_copy_button: true,
+                turn_index: 0,
+                conversation_id: assignedConversationId,
+                url: `https://chatgpt.com/c/${assignedConversationId}`
+              } : {
+                method: "none",
+                text: "",
+                is_generating: false,
+                assistant_count: 0,
+                turn_index: -1
+              }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      },
+      group: async () => 1
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?web_assignment=${Date.now()}`);
+    await eventually(() => port.messages.some((message) => message.type === "hello"));
+    const runAssignmentJob = async (jobId) => {
+      port.messages.length = 0;
+      port.emit(envelope("job_start", jobId, {
+        prompt: "review",
+        wait_interval_ms: 10,
+        wait_timeout_ms: 1000
+      }));
+      await eventually(() => port.messages.some((message) =>
+        message.type === "job_progress" && message.payload?.phase === "ready_for_file"
+      ));
+      port.emit(envelope("job_file_chunk", jobId, {
+        sequence: 0,
+        total_chunks: 1,
+        total_bytes: 4,
+        filename: "bundle.md",
+        mime_type: "text/markdown",
+        bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+      }));
+      await eventually(() => port.messages.some((message) =>
+        message.type === "job_complete" || message.type === "job_error"
+      ));
+      return port.messages.find((message) =>
+        message.type === "job_complete" || message.type === "job_error"
+      );
+    };
+
+    const terminal = await runAssignmentJob("job_web_assignment");
+    assert.equal(terminal.type, "job_complete", JSON.stringify(terminal));
+    assert.equal(terminal.payload.conversation_id, assignedConversationId);
+    assert.equal(terminal.payload.conversation_url, `https://chatgpt.com/c/${assignedConversationId}`);
+
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker runs a Claude job through its adapter and probes the selected recipe", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();

--- a/extensions/chatgpt-native/tests/sites.test.js
+++ b/extensions/chatgpt-native/tests/sites.test.js
@@ -81,12 +81,34 @@ test("Claude adapter owns UUID conversations, exact model policy, and DOM-only f
 
 test("ChatGPT adapter owns conversation and model policy", () => {
   const adapter = siteAdapterForRecipe("chatgpt");
+  const provisionalConversationId = "WEB:ca5209ac-2836-440d-b674-ffc54ee5dd2d";
+  const assignedConversationId = "6a5f60dc-8174-8329-949a-1f282d1dccbd";
   assert.deepEqual(adapter.tabActivation, {
     activateOnCreate: false,
     restorePreviousAfter: null
   });
   assert.deepEqual(adapter.normalizeConversationId(" conv-123 "), { ok: true, id: "conv-123" });
   assert.equal(adapter.conversationUrl("conv-123"), "https://chatgpt.com/c/conv-123");
+  assert.equal(adapter.isExpectedConversationIdAssignment({
+    conversation_id: null,
+    submitted_conversation_id: provisionalConversationId
+  }, provisionalConversationId, assignedConversationId), true);
+  assert.equal(adapter.isExpectedConversationIdAssignment({
+    conversation_id: null,
+    submitted_conversation_id: provisionalConversationId
+  }, provisionalConversationId, null), false);
+  assert.equal(adapter.isExpectedConversationIdAssignment({
+    conversation_id: null,
+    submitted_conversation_id: provisionalConversationId
+  }, provisionalConversationId, "WEB:different"), false);
+  assert.equal(adapter.isExpectedConversationIdAssignment({
+    conversation_id: "conv-requested",
+    submitted_conversation_id: provisionalConversationId
+  }, provisionalConversationId, assignedConversationId), false);
+  assert.equal(adapter.isExpectedConversationIdAssignment({
+    conversation_id: null,
+    submitted_conversation_id: "WEB:different"
+  }, provisionalConversationId, assignedConversationId), false);
   assert.equal(adapter.isAcceptableModelSelection({
     status: "selected",
     requested_model: "gpt-5-6-sol-pro",


### PR DESCRIPTION
## Summary

- reconcile the ChatGPT fresh-conversation transition from a temporary WEB: id to the canonical /c/<id>
- keep resume jobs and unrelated conversation drift fail-closed
- persist the canonical conversation id and URL after assignment
- lock the real no-query canonical URL behavior with content-script, service-worker, and adapter regressions

## Impact

On released 0.5.39, fresh ChatGPT extension-transport runs fail during wait_response with conversation_changed after ChatGPT assigns the canonical conversation id. This is a user-facing outage for that path until the fix ships.

## Validation

- npm test: 250/250
- extension build parity check: PASS
- exact-SHA CI: https://github.com/avivsinai/yoetz/actions/runs/29835537786
- live Personal Pro run 20260721T135545Z_b3d451: EXIT=0, temporary WEB: id reconciled to 6a5f7a6c-e238-8326-bf2e-f60141b8855a, full 2595-character response returned
- managed extension restored to released 0.5.39 content after validation

## Coverage

Live coverage is Personal Pro only. Enterprise and workspace account behavior remains untested; the policy is gated on fresh jobs with the WEB: prefix and remains fail-closed otherwise.