### PR TITLE
fix: guard native extension lifecycle state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,11 +117,15 @@ recipe flows, treat `dev-browser` as a QuickJS/WASM runner, not Node.js:
   it, and verifies the loaded version. `status` and `doctor` fail on wrong-path
   or unstamped loads. Never hand-patch the managed directory.
 - The native host and managed extension directory are machine-global,
-  single-writer state shared by every agent lane. Serialize setup/update/reload
-  operations; recipe lanes may run only against one frozen loaded artifact.
+  single-writer state shared by every agent lane. Recipe runs hold the shared
+  side of the lifecycle lock; setup/update/reload/auto-heal require the
+  exclusive side and fail closed if a recipe is active. Recipe lanes may run
+  only against one frozen loaded artifact.
 - Independent ChatGPT recipes may run concurrently through one connected
   extension profile: each job owns a separate background tab. Profile selectors
   route among loaded profiles; they are not required for ChatGPT parallelism.
+  Every parallel recipe must use a distinct Yoetz bundle session directory;
+  reusing one managed `bundle.md` fails with `session_busy` before browser work.
   Claude is asymmetric because its tab must stay active through upload and
   accepted send. Until per-profile activation coordination is implemented,
   serialize Claude recipes within one loaded Chrome profile.

--- a/README.md
+++ b/README.md
@@ -301,7 +301,9 @@ yoetz browser recipe --recipe claude --transport chrome-extension-native --bundl
 Load the managed `$YOETZ_DIR/chatgpt-native-extension` directory unpacked in
 the Chrome profile that hosts the target AI sessions; do not load a repo
 checkout. Setup, update, and reload share machine-global native-host and managed
-extension state, so serialize those operations across agent lanes.
+extension state. Recipe runs hold a shared lifecycle lock; setup, update,
+reload, and auto-heal require its exclusive side and fail with
+`extension_lifecycle_busy` instead of changing the loaded artifact mid-run.
 
 Independent ChatGPT recipe runs may share one connected extension profile: each
 job owns a separate background tab, and profile selectors are routing controls,
@@ -309,6 +311,9 @@ not a prerequisite for parallelism. Claude is asymmetric because each job must
 keep its tab active through upload and accepted send. Until per-profile Claude
 activation coordination lands, serialize Claude recipe runs within one loaded
 Chrome profile. Both sites may run only against one frozen loaded artifact.
+Give each parallel recipe its own Yoetz bundle session directory; reusing one
+managed `bundle.md` fails with `session_busy` rather than overwriting that
+session's `response.json` or `followup.json`.
 
 Upgrade the installed CLI before another lane runs extension auto-heal after a
 release. An older CLI can overwrite the newer stamped managed copy.

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -228,7 +228,15 @@ fn open_extension_lifecycle_lock() -> Result<(File, PathBuf)> {
     let parent = path
         .parent()
         .context("extension lifecycle lock must have a parent directory")?;
+    #[cfg(unix)]
     ensure_private_dir(parent)?;
+    #[cfg(not(unix))]
+    fs::create_dir_all(parent).with_context(|| {
+        format!(
+            "create extension lifecycle lock directory {}",
+            parent.display()
+        )
+    })?;
     let file = OpenOptions::new()
         .create(true)
         .read(true)

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -166,6 +166,12 @@ struct ExtensionLifecycleLock {
     _file: File,
 }
 
+impl Drop for ExtensionLifecycleLock {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self._file);
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ProtocolEnvelope {
     pub protocol_version: u32,
@@ -4920,6 +4926,20 @@ mod tests {
         assert!(manifest_dir
             .join(format!("{NATIVE_HOST_NAME}.json"))
             .exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    #[serial]
+    fn lifecycle_lock_guard_releases_a_fork_inherited_descriptor() {
+        let dir = TempDir::new().unwrap();
+        let _state_guard = EnvGuard::set("YOETZ_DIR", &dir.path().join("state"));
+        let recipe = acquire_extension_lifecycle_shared("fork inheritance test").unwrap();
+        let _child = crate::test_support::ForkChild::sleep_for(Duration::from_secs(5));
+
+        drop(recipe);
+
+        acquire_extension_lifecycle_exclusive("verify guard release").unwrap();
     }
 
     #[test]

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -1,10 +1,11 @@
 use anyhow::{anyhow, bail, Context, Result};
 use base64::Engine as _;
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::env;
-use std::fs::{self, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 #[cfg(unix)]
@@ -34,6 +35,7 @@ pub const TOKEN_FILENAME: &str = "chatgpt-native.token";
 pub const STATUS_FILENAME: &str = "chatgpt-native-status.json";
 pub const WRAPPER_FILENAME: &str = "yoetz-chrome-native-host";
 pub const INSTANCES_DIRNAME: &str = "instances";
+const EXTENSION_LIFECYCLE_LOCK_FILENAME: &str = "extension-lifecycle.lock";
 pub const CHROME_EXTENSIONS_URL: &str = "chrome://extensions/";
 pub const CHATGPT_EXTENSION_DIR_ENV: &str = "YOETZ_CHATGPT_NATIVE_EXTENSION_DIR";
 pub const MAX_CHROME_NATIVE_EXTENSION_MESSAGE_BYTES: usize = 64 * 1024 * 1024;
@@ -159,6 +161,11 @@ pub struct ManagedExtensionUpdateResult {
     pub copied_files: usize,
 }
 
+#[derive(Debug)]
+struct ExtensionLifecycleLock {
+    _file: File,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ProtocolEnvelope {
     pub protocol_version: u32,
@@ -204,7 +211,60 @@ impl ProtocolEnvelope {
     }
 }
 
+fn extension_lifecycle_lock_path() -> Result<PathBuf> {
+    Ok(extension_paths()?
+        .state_dir
+        .join(EXTENSION_LIFECYCLE_LOCK_FILENAME))
+}
+
+fn open_extension_lifecycle_lock() -> Result<(File, PathBuf)> {
+    let path = extension_lifecycle_lock_path()?;
+    let parent = path
+        .parent()
+        .context("extension lifecycle lock must have a parent directory")?;
+    ensure_private_dir(parent)?;
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&path)
+        .with_context(|| format!("open extension lifecycle lock {}", path.display()))?;
+    Ok((file, path))
+}
+
+fn acquire_extension_lifecycle_shared(action: &str) -> Result<ExtensionLifecycleLock> {
+    let (file, path) = open_extension_lifecycle_lock()?;
+    match FileExt::try_lock_shared(&file) {
+        Ok(()) => Ok(ExtensionLifecycleLock { _file: file }),
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => bail!(
+            "extension_lifecycle_busy: cannot start {action} while extension setup, update, reload, or auto-heal is in progress ({})",
+            path.display()
+        ),
+        Err(err) => Err(err)
+            .with_context(|| format!("lock extension lifecycle shared {}", path.display())),
+    }
+}
+
+fn acquire_extension_lifecycle_exclusive(action: &str) -> Result<ExtensionLifecycleLock> {
+    let (file, path) = open_extension_lifecycle_lock()?;
+    match FileExt::try_lock_exclusive(&file) {
+        Ok(()) => Ok(ExtensionLifecycleLock { _file: file }),
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => bail!(
+            "extension_lifecycle_busy: cannot {action} while native extension recipes or another lifecycle mutation are active ({})",
+            path.display()
+        ),
+        Err(err) => Err(err)
+            .with_context(|| format!("lock extension lifecycle exclusive {}", path.display())),
+    }
+}
+
 pub fn install_host() -> Result<InstallHostResult> {
+    let _lifecycle_lock = acquire_extension_lifecycle_exclusive("install native host")?;
+    install_host_unlocked()
+}
+
+fn install_host_unlocked() -> Result<InstallHostResult> {
     #[cfg(unix)]
     {
         let paths = extension_paths()?;
@@ -244,6 +304,14 @@ pub fn install_host() -> Result<InstallHostResult> {
     {
         bail!("chrome-extension-native install-host is currently supported on macOS/Linux only")
     }
+}
+
+pub fn setup_extension() -> Result<(InstallHostResult, ManagedExtensionUpdateResult)> {
+    let _lifecycle_lock = acquire_extension_lifecycle_exclusive("set up native extension")?;
+    Ok((
+        install_host_unlocked()?,
+        prepare_managed_chatgpt_extension_unlocked()?,
+    ))
 }
 
 pub fn chatgpt_extension_source_dir() -> Option<PathBuf> {
@@ -310,7 +378,7 @@ fn legacy_loaded_chatgpt_extension_dir() -> Result<PathBuf> {
         .join("unpacked"))
 }
 
-pub fn prepare_managed_chatgpt_extension() -> Result<ManagedExtensionUpdateResult> {
+fn prepare_managed_chatgpt_extension_unlocked() -> Result<ManagedExtensionUpdateResult> {
     let source_dir = chatgpt_extension_source_dir().with_context(|| {
         format!("could not find ChatGPT native extension source; set {CHATGPT_EXTENSION_DIR_ENV}")
     })?;
@@ -1300,6 +1368,11 @@ pub fn reconnect(selector: ExtensionInstanceSelector<'_>) -> Result<Value> {
 }
 
 pub fn reload_extension(selector: ExtensionInstanceSelector<'_>) -> Result<Value> {
+    let _lifecycle_lock = acquire_extension_lifecycle_exclusive("reload native extension")?;
+    reload_extension_unlocked(selector)
+}
+
+fn reload_extension_unlocked(selector: ExtensionInstanceSelector<'_>) -> Result<Value> {
     let response = send_control_job(
         "reconnect",
         json!({ "intent": "reload_extension" }),
@@ -1323,15 +1396,16 @@ pub fn update_extension(
     selector: ExtensionInstanceSelector<'_>,
     recipe: BuiltinWebRecipe,
 ) -> Result<Value> {
+    let _lifecycle_lock = acquire_extension_lifecycle_exclusive("update native extension")?;
     let paths = extension_paths()?;
     let previous_instance = select_extension_instance(&paths, selector)?;
-    let update = prepare_managed_chatgpt_extension()?;
+    let update = prepare_managed_chatgpt_extension_unlocked()?;
     let expected_version = update
         .manifest_version
         .as_deref()
         .context("managed extension copy has no stamped manifest version")?;
     ensure_reload_can_reach_managed_copy(&previous_instance, &update)?;
-    let reload = reload_extension(selector)?;
+    let reload = reload_extension_unlocked(selector)?;
     let instance = wait_for_extension_update(
         &paths,
         selector,
@@ -1498,6 +1572,32 @@ pub fn grant_identity_permission(selector: ExtensionInstanceSelector<'_>) -> Res
     }))
 }
 
+fn select_recipe_instance_with_lifecycle_lock(
+    paths: &ExtensionPaths,
+    selector: ExtensionInstanceSelector<'_>,
+    recipe_flag: &str,
+    action: &str,
+) -> Result<(ExtensionLifecycleLock, ExtensionInstanceStatus)> {
+    let mut lifecycle_lock = acquire_extension_lifecycle_shared(action)?;
+    let mut instance = select_extension_instance(paths, selector)?;
+    if let Some(message) =
+        extension_version_skew_message(instance.extension_version.as_deref(), Some(recipe_flag))
+    {
+        eprintln!("warning: {message}");
+        drop(lifecycle_lock);
+        match auto_heal_extension_version_skew(paths, selector) {
+            Ok(Some(_)) => eprintln!(
+                "info: refreshed and reloaded chrome-extension-native extension from packaged source"
+            ),
+            Ok(None) => {}
+            Err(err) => eprintln!("warning: automatic extension update failed: {err:#}"),
+        }
+        lifecycle_lock = acquire_extension_lifecycle_shared(action)?;
+        instance = select_extension_instance(paths, selector)?;
+    }
+    Ok((lifecycle_lock, instance))
+}
+
 pub fn run_chatgpt_recipe(
     spec: &ChatgptRecipeSpec,
     format: OutputFormat,
@@ -1508,34 +1608,17 @@ pub fn run_chatgpt_recipe(
         .context("chrome-extension-native transport requires `--bundle`")?;
     let bundle = validate_bundle_path(bundle_path)?;
     let paths = extension_paths()?;
-    let mut instance = select_extension_instance(
+    let selector = ExtensionInstanceSelector {
+        profile_email: spec.profile_email.as_deref(),
+        extension_instance_id: spec.extension_instance_id.as_deref(),
+        extension_profile_id: spec.extension_profile_id.as_deref(),
+    };
+    let (_lifecycle_lock, instance) = select_recipe_instance_with_lifecycle_lock(
         &paths,
-        ExtensionInstanceSelector {
-            profile_email: spec.profile_email.as_deref(),
-            extension_instance_id: spec.extension_instance_id.as_deref(),
-            extension_profile_id: spec.extension_profile_id.as_deref(),
-        },
+        selector,
+        "--chatgpt",
+        "ChatGPT native extension recipe",
     )?;
-    if let Some(message) =
-        extension_version_skew_message(instance.extension_version.as_deref(), Some("--chatgpt"))
-    {
-        eprintln!("warning: {message}");
-        let selector = ExtensionInstanceSelector {
-            profile_email: spec.profile_email.as_deref(),
-            extension_instance_id: spec.extension_instance_id.as_deref(),
-            extension_profile_id: spec.extension_profile_id.as_deref(),
-        };
-        match auto_heal_extension_version_skew(&paths, selector) {
-            Ok(Some(healed_instance)) => {
-                eprintln!(
-                    "info: refreshed and reloaded chrome-extension-native extension from packaged source"
-                );
-                instance = healed_instance;
-            }
-            Ok(None) => {}
-            Err(err) => eprintln!("warning: automatic extension update failed: {err:#}"),
-        }
-    }
     ensure_instance_matches_managed_copy(&instance)?;
     let token = read_capability_token(&paths.token_path)?;
     let mut stream = connect_socket(&instance.socket_path).with_context(|| {
@@ -1589,22 +1672,12 @@ pub fn run_claude_recipe(
         extension_instance_id: spec.extension_instance_id.as_deref(),
         extension_profile_id: spec.extension_profile_id.as_deref(),
     };
-    let mut instance = select_extension_instance(&paths, selector)?;
-    if let Some(message) =
-        extension_version_skew_message(instance.extension_version.as_deref(), Some("--claude"))
-    {
-        eprintln!("warning: {message}");
-        match auto_heal_extension_version_skew(&paths, selector) {
-            Ok(Some(healed_instance)) => {
-                eprintln!(
-                    "info: refreshed and reloaded chrome-extension-native extension from packaged source"
-                );
-                instance = healed_instance;
-            }
-            Ok(None) => {}
-            Err(err) => eprintln!("warning: automatic extension update failed: {err:#}"),
-        }
-    }
+    let (_lifecycle_lock, instance) = select_recipe_instance_with_lifecycle_lock(
+        &paths,
+        selector,
+        "--claude",
+        "Claude native extension recipe",
+    )?;
     ensure_instance_matches_managed_copy(&instance)?;
     // Capability is checked on the exact routed extension instance after any
     // best-effort heal and before opening the socket or emitting job_start.
@@ -2042,14 +2115,20 @@ fn auto_heal_extension_version_skew(
     if chatgpt_extension_source_dir().is_none() {
         return Ok(None);
     }
+    let _lifecycle_lock = acquire_extension_lifecycle_exclusive("auto-heal native extension")?;
     let previous_instance = select_extension_instance(paths, selector)?;
-    let update = prepare_managed_chatgpt_extension()?;
+    if extension_version_skew_message(previous_instance.extension_version.as_deref(), None)
+        .is_none()
+    {
+        return Ok(None);
+    }
+    let update = prepare_managed_chatgpt_extension_unlocked()?;
     let expected_version = update
         .manifest_version
         .as_deref()
         .context("managed extension copy has no stamped manifest version")?;
     ensure_reload_can_reach_managed_copy(&previous_instance, &update)?;
-    reload_extension(selector)?;
+    reload_extension_unlocked(selector)?;
     wait_for_extension_version(paths, selector, expected_version).map(Some)
 }
 
@@ -4812,6 +4891,39 @@ mod tests {
 
     #[test]
     #[serial]
+    fn lifecycle_lock_allows_parallel_recipes_and_rejects_mutation() {
+        let dir = TempDir::new().unwrap();
+        let source = dir.path().join("source");
+        write_extension_source_fixture(&source, YOETZ_CLI_VERSION);
+        let state = dir.path().join("state");
+        let manifest_dir = dir.path().join("native-hosts");
+        let _source_guard = EnvGuard::set(CHATGPT_EXTENSION_DIR_ENV, &source);
+        let _state_guard = EnvGuard::set("YOETZ_DIR", &state);
+        let _manifest_guard = EnvGuard::set("YOETZ_CHROME_NATIVE_MESSAGING_DIR", &manifest_dir);
+
+        let recipe_a = acquire_extension_lifecycle_shared("recipe A").unwrap();
+        let recipe_b = acquire_extension_lifecycle_shared("recipe B").unwrap();
+
+        let started_at = Instant::now();
+        let error = setup_extension().unwrap_err();
+        assert!(started_at.elapsed() < Duration::from_secs(1));
+        assert!(error.to_string().contains("extension_lifecycle_busy"));
+        assert!(!state.join("chatgpt-native-extension").exists());
+        assert!(!manifest_dir
+            .join(format!("{NATIVE_HOST_NAME}.json"))
+            .exists());
+
+        drop(recipe_b);
+        drop(recipe_a);
+        setup_extension().unwrap();
+        assert!(state.join("chatgpt-native-extension").exists());
+        assert!(manifest_dir
+            .join(format!("{NATIVE_HOST_NAME}.json"))
+            .exists());
+    }
+
+    #[test]
+    #[serial]
     fn sync_managed_extension_replaces_stale_copy_atomically() {
         let dir = TempDir::new().unwrap();
         let source = dir.path().join("source");
@@ -4958,7 +5070,7 @@ mod tests {
         let _source_guard = EnvGuard::set(CHATGPT_EXTENSION_DIR_ENV, &source);
         let _state_guard = EnvGuard::set("YOETZ_DIR", &state);
 
-        let result = prepare_managed_chatgpt_extension().unwrap();
+        let result = prepare_managed_chatgpt_extension_unlocked().unwrap();
 
         assert_eq!(result.source_dir, source.canonicalize().unwrap());
         assert_eq!(result.extension_dir, state.join("chatgpt-native-extension"));
@@ -4980,7 +5092,7 @@ mod tests {
         let _source_guard = EnvGuard::set(CHATGPT_EXTENSION_DIR_ENV, &source);
         let _state_guard = EnvGuard::set("YOETZ_DIR", &state);
 
-        let result = prepare_managed_chatgpt_extension().unwrap();
+        let result = prepare_managed_chatgpt_extension_unlocked().unwrap();
 
         assert_eq!(result.extension_dir, state.join("chatgpt-native-extension"));
         assert!(result.loaded_extension_dirs.contains(&result.extension_dir));

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, bail, Context, Result};
 use base64::{engine::general_purpose, Engine as _};
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use fs2::FileExt;
 use jsonschema::Validator;
 use litellm_rust::{
     ChatContentPart, ChatContentPartFile, ChatContentPartImageUrl, ChatContentPartText, ChatFile,
@@ -11,7 +12,7 @@ use serde::Serialize;
 use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use std::env;
-use std::fs;
+use std::fs::{self, File, OpenOptions};
 use std::io::{self, IsTerminal, Read};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -51,6 +52,7 @@ use http::send_json;
 /// simple queries when no explicit --max-output-tokens is provided.
 const REGISTRY_OUTPUT_TOKENS_CAP: usize = 16384;
 const DEFAULT_CHATGPT_RECIPE_PROMPT: &str = "Review the attached file and provide your analysis.";
+const BROWSER_RECIPE_SESSION_LOCK_FILENAME: &str = ".browser-recipe.lock";
 
 #[derive(Parser)]
 #[command(
@@ -2713,6 +2715,37 @@ fn browser_recipe_artifact_paths(bundle_path: Option<&Path>) -> Option<ArtifactP
     })
 }
 
+#[derive(Debug)]
+struct BrowserRecipeSessionLease {
+    _file: File,
+}
+
+fn acquire_browser_recipe_session_lease(
+    bundle_path: Option<&Path>,
+) -> Result<Option<BrowserRecipeSessionLease>> {
+    let Some(artifacts) = browser_recipe_artifact_paths(bundle_path) else {
+        return Ok(None);
+    };
+    let session_dir = PathBuf::from(artifacts.session_dir);
+    let lock_path = session_dir.join(BROWSER_RECIPE_SESSION_LOCK_FILENAME);
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .with_context(|| format!("open browser recipe session lock {}", lock_path.display()))?;
+    match FileExt::try_lock_exclusive(&file) {
+        Ok(()) => Ok(Some(BrowserRecipeSessionLease { _file: file })),
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => bail!(
+            "session_busy: browser recipe session {} already has an active writer; use one session directory per parallel run",
+            session_dir.display()
+        ),
+        Err(err) => Err(err)
+            .with_context(|| format!("lock browser recipe session {}", lock_path.display())),
+    }
+}
+
 fn maybe_write_followup_session_metadata(
     recipe_args: &BrowserRecipeArgs,
     current_prompt_hash: Option<&str>,
@@ -3173,8 +3206,7 @@ fn handle_browser_extension(
     let (kind, payload) = match args.command {
         BrowserExtensionCommand::Setup(args) => {
             let recipe = extension_site_scope(args.chatgpt, args.claude)?;
-            let install = browser_extension_native::install_host()?;
-            let extension_update = browser_extension_native::prepare_managed_chatgpt_extension()?;
+            let (install, extension_update) = browser_extension_native::setup_extension()?;
             let extension_dir = extension_update.extension_dir.clone();
             let source_dir = extension_update.source_dir.clone();
             let source_version = extension_update.source_version.clone();
@@ -4165,6 +4197,8 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             }
         }
         BrowserCommand::Recipe(recipe_args) => {
+            let _session_lease =
+                acquire_browser_recipe_session_lease(recipe_args.bundle.as_deref())?;
             let recipe_path = browser::resolve_recipe(&recipe_args.recipe)
                 .with_context(|| format!("resolve recipe {:?}", recipe_args.recipe))?;
             let content = fs::read_to_string(&recipe_path)
@@ -5187,6 +5221,39 @@ mod tests {
             artifacts.response_json.as_deref(),
             Some(expected_response_json.as_str())
         );
+    }
+
+    #[test]
+    fn browser_recipe_session_lease_rejects_concurrent_writers() {
+        let dir = TempDir::new().unwrap();
+        let bundle_md = dir.path().join("bundle.md");
+        fs::write(&bundle_md, "# bundle").unwrap();
+        fs::write(dir.path().join("bundle.json"), "{}").unwrap();
+
+        let first = acquire_browser_recipe_session_lease(Some(&bundle_md))
+            .unwrap()
+            .expect("managed bundle session should be locked");
+        let error = acquire_browser_recipe_session_lease(Some(&bundle_md)).unwrap_err();
+        assert!(error.to_string().contains("session_busy"));
+        assert!(error
+            .to_string()
+            .contains(dir.path().to_string_lossy().as_ref()));
+
+        drop(first);
+        assert!(acquire_browser_recipe_session_lease(Some(&bundle_md))
+            .unwrap()
+            .is_some());
+    }
+
+    #[test]
+    fn browser_recipe_session_lease_ignores_standalone_bundles() {
+        let dir = TempDir::new().unwrap();
+        let bundle = dir.path().join("review.md");
+        fs::write(&bundle, "# review").unwrap();
+
+        assert!(acquire_browser_recipe_session_lease(Some(&bundle))
+            .unwrap()
+            .is_none());
     }
 
     #[test]

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -18,6 +18,40 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, Instant};
 
+#[cfg(all(test, unix))]
+mod test_support {
+    use std::time::Duration;
+
+    pub(crate) struct ForkChild(libc::pid_t);
+
+    impl ForkChild {
+        #[allow(unsafe_code)]
+        pub(crate) fn sleep_for(duration: Duration) -> Self {
+            let pid = unsafe { libc::fork() };
+            assert!(pid >= 0, "fork test child");
+            if pid == 0 {
+                let micros =
+                    duration.as_micros().min(libc::useconds_t::MAX.into()) as libc::useconds_t;
+                unsafe {
+                    libc::usleep(micros);
+                    libc::_exit(0);
+                }
+            }
+            Self(pid)
+        }
+    }
+
+    impl Drop for ForkChild {
+        #[allow(unsafe_code)]
+        fn drop(&mut self) {
+            unsafe {
+                libc::kill(self.0, libc::SIGTERM);
+                libc::waitpid(self.0, std::ptr::null_mut(), 0);
+            }
+        }
+    }
+}
+
 mod browser;
 mod browser_extension_native;
 mod budget;
@@ -2720,6 +2754,12 @@ struct BrowserRecipeSessionLease {
     _file: File,
 }
 
+impl Drop for BrowserRecipeSessionLease {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self._file);
+    }
+}
+
 fn acquire_browser_recipe_session_lease(
     bundle_path: Option<&Path>,
 ) -> Result<Option<BrowserRecipeSessionLease>> {
@@ -5240,6 +5280,25 @@ mod tests {
             .contains(dir.path().to_string_lossy().as_ref()));
 
         drop(first);
+        assert!(acquire_browser_recipe_session_lease(Some(&bundle_md))
+            .unwrap()
+            .is_some());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn browser_recipe_session_lease_releases_a_fork_inherited_descriptor() {
+        let dir = TempDir::new().unwrap();
+        let bundle_md = dir.path().join("bundle.md");
+        fs::write(&bundle_md, "# bundle").unwrap();
+        fs::write(dir.path().join("bundle.json"), "{}").unwrap();
+        let lease = acquire_browser_recipe_session_lease(Some(&bundle_md))
+            .unwrap()
+            .expect("managed bundle session should be locked");
+        let _child = crate::test_support::ForkChild::sleep_for(Duration::from_secs(5));
+
+        drop(lease);
+
         assert!(acquire_browser_recipe_session_lease(Some(&bundle_md))
             .unwrap()
             .is_some());

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -439,8 +439,11 @@ each job owns a separate background tab. Profile selectors only choose among
 loaded profiles and are not required for ChatGPT parallelism. Claude is
 asymmetric because each job must keep its tab active through upload and accepted
 send; serialize Claude recipes within one loaded profile until per-profile
-activation coordination is available. Setup, update, and reload remain
-machine-global single-writer operations for both sites.
+activation coordination is available. Give every parallel recipe a distinct
+Yoetz bundle session directory; reusing one managed `bundle.md` fails with
+`session_busy` before browser work. Recipe runs share the lifecycle lock, while
+setup, update, reload, and auto-heal require its exclusive side and fail closed
+instead of changing the loaded artifact mid-run.
 
 ### Cookie sync (legacy fallback)
 


### PR DESCRIPTION
## Summary

- add a machine-global shared/exclusive lifecycle lock around native extension recipe runs and lifecycle mutations
- add a per-managed-session lease so concurrent browser recipes cannot overwrite the same response/followup artifacts
- reselect the native browser instance after auto-heal to close the lock-drop TOCTOU window
- explicitly unlock both guards on drop so forked children cannot prolong inherited locks
- create the lifecycle lock directory with the platform-appropriate path on Windows

## Operational consequence

The shared lifecycle lock is intentionally held for the whole recipe, including a ChatGPT Pro wait of up to 90 minutes. During that entire in-flight interval, setup, update, reload, and auto-heal fail fast with `extension_lifecycle_busy`. This is the frozen-artifact policy: a run may not observe a changing loaded extension.

The persistent `.browser-recipe.lock` file is not treated as an artifact: session enumeration reads child directories, while artifact consumers use exact filenames (`bundle.json`, `response.json`, `followup.json`, and model directories).

## Defect attribution

A Linux fork probe separately proved that close-only cleanup can leave a lock held by a child process that inherited the locked open file description, while explicit `FileExt::unlock` releases it. Two regressions acquire the lock before forking and fail without the explicit unlock.

The historical Test failure in dispatched run 29842869847 remains **unattributed**. This PR fixes the separately proven fork-inheritance defect; it does not claim that the historical flake has been root-caused or closed. The same historical run also exposed a deterministic Windows compile failure from calling a Unix-only helper; that defect is fixed separately in commit `1558453`.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --workspace` (CLI unit 592 passed, 0 failed, 2 ignored; CLI integration 39 passed; council integration 3 passed; daemon policy 3 passed; native host multiplex 1 passed; core 58 passed)
- `cargo test -p yoetz --bin yoetz fork_inherited_descriptor` (2 passed)
- `cargo clippy --workspace --all-targets -- -D warnings`
- Claude pre-commit reviews: PASS on the implementation delta and the release-baseline merge
- full dispatched CI on SHA `83c6204d7c69c7fc3f95be30ae4dc3d68d75ce5e`: https://github.com/avivsinai/yoetz/actions/runs/29846435217
  - Test: success
  - Real-Browser Smoke: success
  - Build ubuntu-latest: success
  - Build macos-latest: success
  - Build windows-latest: success

No live lifecycle command was run. The managed unreleased fixed extension remains untouched at `0.5.39.4`, with the expected conversation-assignment predicate present in both call sites. Merge is held for explicit Aviv GO.