### PR TITLE
feat: run Claude recipes in background tabs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -200,9 +200,9 @@ holds.
   the stable-idle window. If that condition is not reached before
   `responseWaitTimeoutMs`, the job fails with `response_timeout`. The
   hover-dependent copy control is never a primary anchor; cloned
-  `group/status` thinking rows are excluded from response text. Claude jobs
-  open the tab active, stay foreground through upload and accepted send, and
-  restore the previous tab before the response wait.
+  `group/status` thinking rows are excluded from response text. Claude jobs use
+  independent background tabs for model selection, upload, accepted send, and
+  response extraction; cancelling one job removes only its owned tab.
 - Send acceptance: when `clickSend` commits but `waitForSendAccepted`
   cannot confirm a post-click signal within budget, the run fails with
   `send_acceptance_unknown` carrying `side_effect_started: true`. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Claude native-extension recipes now use independent background tabs, matching
+  ChatGPT parallelism without an activation lease. A live probe completed model
+  selection, file upload, accepted send, response observation, and final
+  extraction in a never-focused tab; service-worker coverage proves two Claude
+  jobs keep distinct tabs and cancellation remains isolated.
+
 ## [0.5.41] - 2026-07-21
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,14 +122,12 @@ recipe flows, treat `dev-browser` as a QuickJS/WASM runner, not Node.js:
   side of the lifecycle lock; setup/update/reload/auto-heal require the
   exclusive side and fail closed if a recipe is active. Recipe lanes may run
   only against one frozen loaded artifact.
-- Independent ChatGPT recipes may run concurrently through one connected
-  extension profile: each job owns a separate background tab. Profile selectors
-  route among loaded profiles; they are not required for ChatGPT parallelism.
+- Independent ChatGPT and Claude recipes may run concurrently through one
+  connected extension profile: each job owns a separate background tab. Profile
+  selectors route among loaded profiles; they are not required for recipe
+  parallelism.
   Every parallel recipe must use a distinct Yoetz bundle session directory;
   reusing one managed `bundle.md` fails with `session_busy` before browser work.
-  Claude is asymmetric because its tab must stay active through upload and
-  accepted send. Until per-profile activation coordination is implemented,
-  serialize Claude recipes within one loaded Chrome profile.
 - ChatGPT and Claude conversation resume use
   `--var conversation=<site-specific-id|url>` or `--followup`
   (native-extension only, no automatic context management); callers own the
@@ -140,11 +138,12 @@ recipe flows, treat `dev-browser` as a QuickJS/WASM runner, not Node.js:
   is hidden/zero-size, so resolve the exact selector rather than accessibility
   snapshots; use the native `input.files` setter so page-world handlers observe
   files assigned from the extension's isolated world.
-- Claude jobs currently open active through upload and accepted send, then
-  restore the previous tab before waiting for the response; ChatGPT jobs remain
-  background. A July 2026 live probe proved Claude's SPA, Fable 5, and Effort
-  Max all mount and verify in a never-focused tab. Background upload, send, and
-  response waiting remain unverified.
+- Claude jobs open in background tabs. A July 2026 live probe completed an
+  entire Claude job in a never-focused tab: SPA mount, Fable 5 and Effort Max
+  verification, file upload, accepted send, response observation, and final
+  extraction all succeeded. Service-worker coverage proves two Claude jobs use
+  distinct background tabs through overlapping phases and that cancelling one
+  does not affect the other.
   Base UI picker choreography needs settle pacing, attributed pointer-event
   hover fallback, and diagnostics for every verification leg. Early-exit and
   full-selection results must have the same acceptable shape.

--- a/README.md
+++ b/README.md
@@ -305,12 +305,12 @@ extension state. Recipe runs hold a shared lifecycle lock; setup, update,
 reload, and auto-heal require its exclusive side and fail with
 `extension_lifecycle_busy` instead of changing the loaded artifact mid-run.
 
-Independent ChatGPT recipe runs may share one connected extension profile: each
-job owns a separate background tab, and profile selectors are routing controls,
-not a prerequisite for parallelism. Claude is asymmetric because each job must
-keep its tab active through upload and accepted send. Until per-profile Claude
-activation coordination lands, serialize Claude recipe runs within one loaded
-Chrome profile. Both sites may run only against one frozen loaded artifact.
+Independent ChatGPT and Claude recipe runs may share one connected extension
+profile: each job owns a separate background tab, and profile selectors are
+routing controls, not a prerequisite for parallelism. A July 2026 live probe
+completed Claude model selection, file upload, accepted send, response
+observation, and final extraction without ever activating the run tab. Both
+sites may run only against one frozen loaded artifact.
 Give each parallel recipe its own Yoetz bundle session directory; reusing one
 managed `bundle.md` fails with `session_busy` rather than overwriting that
 session's `response.json` or `followup.json`.

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -275,11 +275,8 @@ async function startJob(message) {
   const url = job.expected_conversation_id
     ? adapter.conversationJobUrl(job.expected_conversation_id, job.run_id)
     : adapter.jobUrl(job.run_id);
-  const tabActivation = await createJobTab(url, adapter);
-  const tab = tabActivation.tab;
+  const tab = await createJobTab(url, adapter);
   job.tab_id = tab.id;
-  job.previous_active_tab_id = tabActivation.previousTabId;
-  job.restore_previous_after = tabActivation.restorePreviousAfter;
   job.updated_at = Date.now();
   await persistJob(job);
   const inspectCommand = inspectCommandForJob(job);
@@ -475,7 +472,6 @@ async function runJobWithFile(job, file) {
     assertSubmittedConversationCurrent(job, sendResult);
     assertJobConnectionCurrent(job);
     if (job.cancelled) return;
-    await restorePreviousTabForJob(job, "send");
     const inspectCommand = inspectCommandForJob(job);
     if (!postNative(progress(job, "prompt_sent", {
       timeout_ms: responseWaitTimeoutMs(job),
@@ -1378,45 +1374,7 @@ async function waitForSiteTab(tabId, adapter) {
 async function createJobTab(url, adapter) {
   const policy = adapter.tabActivation ?? {};
   const activateOnCreate = policy.activateOnCreate === true;
-  const restorePreviousAfter = typeof policy.restorePreviousAfter === "string"
-    ? policy.restorePreviousAfter
-    : null;
-  let previousTabId = null;
-  if (activateOnCreate && restorePreviousAfter) {
-    try {
-      const [previousTab] = await chrome.tabs.query({ active: true, currentWindow: true });
-      previousTabId = previousTab?.id ?? null;
-    } catch {
-      // Capturing focus is best effort; mounting the site is the correctness gate.
-    }
-  }
-  const tab = await chrome.tabs.create({ url, active: activateOnCreate });
-  return { tab, previousTabId, restorePreviousAfter };
-}
-
-async function restorePreviousTabForJob(job, phase) {
-  if (job.restore_previous_after !== phase) {
-    return;
-  }
-  await restorePreviousTab({
-    tab: { id: job.tab_id },
-    previousTabId: job.previous_active_tab_id
-  });
-  job.previous_active_tab_id = null;
-  job.restore_previous_after = null;
-  job.updated_at = Date.now();
-  await persistJob(job);
-}
-
-async function restorePreviousTab({ tab, previousTabId }) {
-  if (previousTabId == null || previousTabId === tab?.id) {
-    return;
-  }
-  try {
-    await chrome.tabs.update(previousTabId, { active: true });
-  } catch {
-    // The user may have closed or moved the prior tab while the site mounted.
-  }
+  return chrome.tabs.create({ url, active: activateOnCreate });
 }
 
 async function waitForContentScript(tabId, adapter) {

--- a/extensions/chatgpt-native/src/sites/chatgpt.js
+++ b/extensions/chatgpt-native/src/sites/chatgpt.js
@@ -212,6 +212,7 @@ export const chatgptSiteAdapter = Object.freeze({
   fetchConversationAnswer,
   tabActivation: Object.freeze({
     activateOnCreate: false,
+    // Explicit policy marker: background jobs never capture or restore focus.
     restorePreviousAfter: null
   }),
   auth: Object.freeze({

--- a/extensions/chatgpt-native/src/sites/claude.js
+++ b/extensions/chatgpt-native/src/sites/claude.js
@@ -94,8 +94,9 @@ export const claudeSiteAdapter = Object.freeze({
   isAllowedTabUrl: (url) => String(url ?? "").startsWith(`${CLAUDE_ORIGIN}/`),
   isAcceptableModelSelection,
   tabActivation: Object.freeze({
-    activateOnCreate: true,
-    restorePreviousAfter: "send"
+    activateOnCreate: false,
+    // Explicit policy marker: background jobs never capture or restore focus.
+    restorePreviousAfter: null
   }),
   auth: Object.freeze({
     noTabStatus: "no_claude_tab",

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -182,6 +182,166 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
   }
 });
 
+test("service worker runs two concurrent Claude jobs in background and isolates cancellation", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const createdTabs = [];
+  const updatedTabs = [];
+  const removedTabs = [];
+  const sentToTabs = [];
+  const jobTabs = new Map();
+  const sentJobs = new Set();
+  const extractedJobs = new Set();
+  const releasableJobs = new Set();
+  const conversationIds = new Map([
+    ["job_claude_cancel", "11111111-1111-4111-8111-111111111111"],
+    ["job_claude_survivor", "22222222-2222-4222-8222-222222222222"]
+  ]);
+  let tabId = 100;
+
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      query: async () => [{ id: 17, active: true }],
+      create: async (options) => {
+        const tab = { id: ++tabId, status: "complete", ...options };
+        createdTabs.push(tab);
+        return tab;
+      },
+      get: async (id) => createdTabs.find((tab) => tab.id === id),
+      update: async (id, options) => {
+        updatedTabs.push({ id, options });
+        return { id, ...options };
+      },
+      remove: async (id) => {
+        removedTabs.push(id);
+      },
+      sendMessage: async (id, message) => {
+        sentToTabs.push({ id, message });
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: { recipe: "claude" } };
+          case "yoetz_prepare_job":
+            jobTabs.set(message.job.job_id, id);
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: verifiedFableMaxSelection() };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt": {
+            const jobId = message.job.job_id;
+            sentJobs.add(jobId);
+            return {
+              ok: true,
+              payload: {
+                sent: true,
+                conversation_id: conversationIds.get(jobId),
+                submitted_user_count: 1,
+                submitted_assistant_count: 0
+              }
+            };
+          }
+          case "yoetz_extract_response": {
+            const jobId = message.job.job_id;
+            extractedJobs.add(jobId);
+            if (!sentJobs.has(jobId)) {
+              return { ok: true, payload: { method: "none", text: "", is_generating: false, assistant_count: 0, turn_index: -1 } };
+            }
+            const complete = releasableJobs.has(jobId);
+            return {
+              ok: true,
+              payload: {
+                method: "assistant_dom",
+                text: complete ? `answer ${jobId}` : `partial ${jobId}`,
+                is_generating: !complete,
+                assistant_count: 1,
+                copy_button_count: 0,
+                has_copy_button: false,
+                turn_index: 0,
+                conversation_id: conversationIds.get(jobId)
+              }
+            };
+          }
+          case "yoetz_cancel_send":
+            return { ok: true, payload: { stopped: true } };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      },
+      group: async () => 1
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?two_claude_background=${Date.now()}`);
+    await eventually(() => port.messages.some((message) => message.type === "hello"));
+
+    const jobs = ["job_claude_cancel", "job_claude_survivor"];
+    for (const jobId of jobs) {
+      port.emit(envelope("job_start", jobId, {
+        recipe: "claude",
+        prompt: `prompt ${jobId}`,
+        wait_interval_ms: 50,
+        wait_timeout_ms: 5000
+      }));
+    }
+    await eventually(() => port.messages.filter((message) =>
+      message.type === "job_progress" && message.payload?.phase === "ready_for_file"
+    ).length === 2);
+
+    assert.notEqual(jobTabs.get(jobs[0]), jobTabs.get(jobs[1]));
+    assert.deepEqual(createdTabs.map((tab) => tab.active), [false, false]);
+
+    for (const jobId of jobs) {
+      port.emit(envelope("job_file_chunk", jobId, {
+        sequence: 0,
+        total_chunks: 1,
+        total_bytes: 4,
+        filename: `${jobId}.md`,
+        mime_type: "text/markdown",
+        bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+      }));
+    }
+    await eventually(() => sentJobs.size === 2 && extractedJobs.size === 2);
+    assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
+
+    port.emit(envelope("job_cancel", "job_claude_cancel"));
+    await eventually(() => port.messages.some((message) =>
+      message.type === "job_cancel" && message.job_id === "job_claude_cancel"
+    ));
+    assert.deepEqual(removedTabs, [jobTabs.get("job_claude_cancel")]);
+    assert.ok(sentToTabs.some((item) =>
+      item.message.type === "yoetz_cancel_send" && item.message.job.job_id === "job_claude_cancel"
+    ));
+    assert.equal(sentToTabs.some((item) =>
+      item.message.type === "yoetz_cancel_send" && item.message.job.job_id === "job_claude_survivor"
+    ), false);
+    assert.equal(port.messages.some((message) =>
+      message.type === "job_complete" && message.job_id === "job_claude_cancel"
+    ), false);
+
+    releasableJobs.add("job_claude_survivor");
+    await eventually(() => port.messages.some((message) =>
+      message.type === "job_complete" && message.job_id === "job_claude_survivor"
+    ));
+    const survivor = port.messages.find((message) =>
+      message.type === "job_complete" && message.job_id === "job_claude_survivor"
+    );
+    assert.equal(survivor.payload.response, "answer job_claude_survivor");
+    assert.equal(survivor.payload.model_used, "Fable 5 Max");
+    assert.deepEqual(updatedTabs, []);
+
+    for (const jobId of jobs) {
+      const ownedTabIds = new Set(sentToTabs
+        .filter((item) => item.message.job?.job_id === jobId)
+        .map((item) => item.id));
+      assert.deepEqual([...ownedTabIds], [jobTabs.get(jobId)], `${jobId} must remain on its own tab`);
+    }
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker reconciles ChatGPT conversation assignment after the URL marker is dropped", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
@@ -287,27 +447,18 @@ test("service worker runs a Claude job through its adapter and probes the select
   const originalChrome = globalThis.chrome;
   const port = makePort();
   const sentToTabs = [];
-  const updatedTabs = [];
   let sent = false;
   const conversationId = "123e4567-e89b-12d3-a456-426614174000";
 
   globalThis.chrome = chromeStub({
     port,
     tabs: {
-      query: async (query) => {
-        assert.deepEqual(query, { active: true, currentWindow: true });
-        return [{ id: 17, active: true }];
-      },
       create: async ({ url, active }) => {
         assert.equal(url, "https://claude.ai/new?_yoetz=run_job_claude");
-        assert.equal(active, true);
+        assert.equal(active, false);
         return { id: 71 };
       },
       get: async (id) => ({ id, status: "complete", url: "https://claude.ai/new?_yoetz=run_job_claude" }),
-      update: async (id, options) => {
-        updatedTabs.push({ id, options });
-        return { id, ...options };
-      },
       sendMessage: async (id, message) => {
         sentToTabs.push({ id, message });
         switch (message.type) {
@@ -327,10 +478,8 @@ test("service worker runs a Claude job through its adapter and probes the select
               }
             };
           case "yoetz_upload_file":
-            assert.deepEqual(updatedTabs, []);
             return { ok: true, payload: { filename: message.file.filename, size: 4 } };
           case "yoetz_send_prompt":
-            assert.deepEqual(updatedTabs, []);
             sent = true;
             return {
               ok: true,
@@ -342,10 +491,6 @@ test("service worker runs a Claude job through its adapter and probes the select
               }
             };
           case "yoetz_extract_response":
-            assert.deepEqual(
-              updatedTabs,
-              sent ? [{ id: 17, options: { active: true } }] : []
-            );
             return {
               ok: true,
               payload: sent
@@ -396,7 +541,6 @@ test("service worker runs a Claude job through its adapter and probes the select
       sentToTabs.find((item) => item.message.type === "yoetz_probe")?.message.recipe,
       "claude"
     );
-    assert.deepEqual(updatedTabs, []);
 
     port.emit(envelope("job_file_chunk", "job_claude", {
       sequence: 0,
@@ -417,7 +561,6 @@ test("service worker runs a Claude job through its adapter and probes the select
     assert.equal(complete.payload.completion_reason, "stable_idle");
     assert.equal(complete.payload.conversation_id, conversationId);
     assert.equal(complete.payload.conversation_url, `https://claude.ai/chat/${conversationId}`);
-    assert.deepEqual(updatedTabs, [{ id: 17, options: { active: true } }]);
   } finally {
     globalThis.chrome = originalChrome;
   }
@@ -6431,6 +6574,16 @@ function verifiedSolProSelection() {
     requested_model: "gpt-5-6-sol-pro",
     family_status: "verified",
     effort_status: "verified"
+  };
+}
+
+function verifiedFableMaxSelection() {
+  return {
+    status: "selected",
+    requested_model: "fable-5-max",
+    modelVerified: true,
+    maxVerified: true,
+    model_used: "Fable 5 Max"
   };
 }
 

--- a/extensions/chatgpt-native/tests/sites.test.js
+++ b/extensions/chatgpt-native/tests/sites.test.js
@@ -42,8 +42,8 @@ test("Claude adapter owns UUID conversations, exact model policy, and DOM-only f
   assert.equal(adapter.isAllowedTabUrl(`https://claude.ai/chat/${conversationId}`), true);
   assert.equal(adapter.isAllowedTabUrl("https://chatgpt.com/"), false);
   assert.deepEqual(adapter.tabActivation, {
-    activateOnCreate: true,
-    restorePreviousAfter: "send"
+    activateOnCreate: false,
+    restorePreviousAfter: null
   });
   assert.equal(adapter.isAcceptableModelSelection({
     status: "selected",

--- a/recipes/claude.yaml
+++ b/recipes/claude.yaml
@@ -16,10 +16,9 @@ name: claude
 # thinking override stays rejected because the live picker has no independent
 # Thinking control. Picker opens are state-verified and paced; the model and Max
 # are re-read as visible aria-checked controls. Diagnostics expose every failed
-# leg. Claude tabs currently stay active through upload and accepted send, then
-# restore prior focus before the response wait. A July 2026 live probe proved
-# the SPA, Fable 5, and Max mount and verify in a never-focused tab; background
-# upload, send, and response waiting remain unverified.
+# leg. Claude tabs remain in the background for the full run. A July 2026 live
+# probe completed SPA mount, Fable 5 and Max verification, file upload, accepted
+# send, response observation, and final extraction in a never-focused tab.
 #
 # Conversation/followup: `conversation=<uuid|https://claude.ai/chat/<uuid>>`
 # and `--followup` are native-extension-only. Fallback transports reject them

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -434,16 +434,16 @@ When multiple Chrome profiles have the extension loaded, pass
 `--var profile_email=<email>` if Chrome exposes one, or the stable
 `--var extension_instance_id=<id>` shown by `status --chatgpt`.
 
-Independent ChatGPT recipes may run concurrently through one connected profile:
-each job owns a separate background tab. Profile selectors only choose among
-loaded profiles and are not required for ChatGPT parallelism. Claude is
-asymmetric because each job must keep its tab active through upload and accepted
-send; serialize Claude recipes within one loaded profile until per-profile
-activation coordination is available. Give every parallel recipe a distinct
-Yoetz bundle session directory; reusing one managed `bundle.md` fails with
-`session_busy` before browser work. Recipe runs share the lifecycle lock, while
-setup, update, reload, and auto-heal require its exclusive side and fail closed
-instead of changing the loaded artifact mid-run.
+Independent ChatGPT and Claude recipes may run concurrently through one
+connected profile: each job owns a separate background tab. Profile selectors
+only choose among loaded profiles and are not required for recipe parallelism.
+A July 2026 live probe completed Claude model selection, file upload, accepted
+send, response observation, and final extraction without ever activating the
+run tab. Give every parallel recipe a distinct Yoetz bundle session directory;
+reusing one managed `bundle.md` fails with `session_busy` before browser work.
+Recipe runs share the lifecycle lock, while setup, update, reload, and auto-heal
+require its exclusive side and fail closed instead of changing the loaded
+artifact mid-run.
 
 ### Cookie sync (legacy fallback)
 


### PR DESCRIPTION
## What

Claude jobs now open in **background** tabs, matching ChatGPT. `activateOnCreate: false`, `restorePreviousAfter: null`.

This makes concurrent Claude recipes work through one connected profile, and stops Claude runs stealing the user's focus mid-session.

## Why this is a deletion, not a feature

The design that justified focus-stealing was a single sentence in `CLAUDE.md`: *"Claude jobs must open active because its SPA may not mount in a never-focused tab."* That claim was never verified.

A live probe falsified it end to end. A complete Claude job ran in a never-focused tab with `tab_active=false` at **every** phase:

| phase | tab_active |
|---|---|
| tab_opened | false |
| model_selection (Fable 5 + Effort Max verified) | false |
| file_uploaded | false |
| prompt_sent | false |
| response_observed | false |
| post-completion re-read | false |

`recipe_complete` succeeded in 126s, `model_used=Fable 5 Max`, no warnings, no fallback.

So the planned FIFO active-tab lease — queue, `waiting_for_activation` heartbeats, queue/hold timeouts, generation tokens, tombstoned conversation claims — is **entirely unnecessary** and none of it was built. This PR removes machinery instead of adding it: `previous_active_tab_id`, `restorePreviousTabForJob`, and `restorePreviousTab` are deleted, and `createJobTab` is down to four lines.

## Coverage

New service-worker test: two concurrent Claude jobs use **distinct** tabs, both created inactive, run through overlapping phases, and cancelling one removes only its tab while the survivor completes. It asserts `updatedTabs` is empty — proving no `chrome.tabs.update` ever fires, so nothing can steal focus. Red before the change (`[true, true]` vs expected `[false, false]`).

## Scope of the claims

Docs deliberately distinguish what the **live probe** proved (one job, end to end) from what **service-worker coverage** proves (two concurrent jobs). Live two-job concurrency is not claimed here.

Serialization guidance is removed from `CLAUDE.md`, `README.md`, and `skills/yoetz/SKILL.md`.

## Verification

Full matrix green (run 29859260428) including `Build (windows-latest)`. 252 extension tests, 592 Rust unit tests, zero failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)