### PR TITLE
docs: record live Claude concurrency proof

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,12 +138,17 @@ recipe flows, treat `dev-browser` as a QuickJS/WASM runner, not Node.js:
   is hidden/zero-size, so resolve the exact selector rather than accessibility
   snapshots; use the native `input.files` setter so page-world handlers observe
   files assigned from the extension's isolated world.
-- Claude jobs open in background tabs. A July 2026 live probe completed an
-  entire Claude job in a never-focused tab: SPA mount, Fable 5 and Effort Max
-  verification, file upload, accepted send, response observation, and final
-  extraction all succeeded. Service-worker coverage proves two Claude jobs use
-  distinct background tabs through overlapping phases and that cancelling one
-  does not affect the other.
+- Claude jobs open in background tabs. On released `v0.5.42`, a live run proved
+  exactly two concurrent Claude recipes in one connected profile on an
+  Enterprise workspace account. The jobs overlapped for 125s and used distinct
+  conversations. Both verified Fable 5 and Effort Max. Tab non-activation has
+  separate evidence: the released adapter sets `activateOnCreate:false`, a
+  single-job live probe measured `tab_active=false` at every phase, and
+  service-worker coverage asserts that no tab activation call occurs. The
+  concurrency evidence covers two jobs, not higher fanout or other account
+  types. Service-worker coverage separately proves two Claude jobs use distinct
+  background tabs through overlapping phases and that cancelling one does not
+  affect the other.
   Base UI picker choreography needs settle pacing, attributed pointer-event
   hover fallback, and diagnostics for every verification leg. Early-exit and
   full-selection results must have the same acceptable shape.

--- a/README.md
+++ b/README.md
@@ -307,10 +307,18 @@ reload, and auto-heal require its exclusive side and fail with
 
 Independent ChatGPT and Claude recipe runs may share one connected extension
 profile: each job owns a separate background tab, and profile selectors are
-routing controls, not a prerequisite for parallelism. A July 2026 live probe
-completed Claude model selection, file upload, accepted send, response
-observation, and final extraction without ever activating the run tab. Both
-sites may run only against one frozen loaded artifact.
+routing controls, not a prerequisite for parallelism. On released `v0.5.42`, a
+live run proved exactly two concurrent Claude recipes in one connected profile
+on an Enterprise workspace account. The jobs overlapped for 125s and used
+distinct conversations. Both verified Fable 5 and Effort Max. Tab
+non-activation has separate evidence: the released adapter sets
+`activateOnCreate:false`, a single-job live probe measured `tab_active=false` at
+every phase, and service-worker coverage asserts that no tab activation call
+occurs. The concurrency evidence covers two jobs, not higher fanout or other
+account types. Service-worker coverage separately proves two Claude jobs use
+distinct background tabs through overlapping phases and that cancelling one
+does not affect the other. Both sites may run only against one frozen loaded
+artifact.
 Give each parallel recipe its own Yoetz bundle session directory; reusing one
 managed `bundle.md` fails with `session_busy` rather than overwriting that
 session's `response.json` or `followup.json`.

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -437,13 +437,20 @@ When multiple Chrome profiles have the extension loaded, pass
 Independent ChatGPT and Claude recipes may run concurrently through one
 connected profile: each job owns a separate background tab. Profile selectors
 only choose among loaded profiles and are not required for recipe parallelism.
-A July 2026 live probe completed Claude model selection, file upload, accepted
-send, response observation, and final extraction without ever activating the
-run tab. Give every parallel recipe a distinct Yoetz bundle session directory;
-reusing one managed `bundle.md` fails with `session_busy` before browser work.
-Recipe runs share the lifecycle lock, while setup, update, reload, and auto-heal
-require its exclusive side and fail closed instead of changing the loaded
-artifact mid-run.
+On released `v0.5.42`, a live run proved exactly two concurrent Claude recipes
+in one connected profile on an Enterprise workspace account. The jobs overlapped
+for 125s and used distinct conversations. Both verified Fable 5 and Effort Max.
+Tab non-activation has separate evidence: the released adapter sets
+`activateOnCreate:false`, a single-job live probe measured `tab_active=false` at
+every phase, and service-worker coverage asserts that no tab activation call
+occurs. The concurrency evidence covers two jobs, not higher fanout or other
+account types. Service-worker coverage separately proves two Claude jobs use
+distinct background tabs through overlapping phases and that cancelling one
+does not affect the other. Give every parallel recipe a distinct Yoetz bundle
+session directory; reusing one managed `bundle.md` fails with `session_busy`
+before browser work. Recipe runs share the lifecycle lock, while setup, update,
+reload, and auto-heal require its exclusive side and fail closed instead of
+changing the loaded artifact mid-run.
 
 ### Cookie sync (legacy fallback)
 


### PR DESCRIPTION
## Summary
- record the released v0.5.42 proof for exactly two concurrent Claude recipes in one Enterprise workspace profile
- keep live concurrency, live focus, adapter-policy, and service-worker evidence attributed separately
- state the tested boundary: two jobs, not higher fanout or other account types

## Validation
- `git diff --check`
- `cargo fmt --all -- --check`
- skill symlink content checks
- Claude peer review: PASS after correcting focus provenance

A dispatched full CI matrix is the gate of record. This docs change can ride the next release.