### PR TITLE
test: isolate shared browser test state

### DIFF
--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -7476,7 +7476,7 @@ steps:
     #[cfg(unix)]
     #[test]
     fn force_kill_stale_daemon_preserves_recent_live_process() {
-        use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::fs::symlink;
         use std::os::unix::net::UnixListener;
 
         let dir = unique_unix_socket_dir("daemon_grace");
@@ -7487,13 +7487,12 @@ steps:
         }
 
         let script_path = dir.join("agent-browser");
-        fs::write(&script_path, "#!/bin/sh\nsleep 30\n").unwrap();
-        let mut perms = fs::metadata(&script_path).unwrap().permissions();
-        perms.set_mode(0o700);
-        fs::set_permissions(&script_path, perms).unwrap();
+        symlink("/bin/sleep", &script_path).unwrap();
 
-        let mut child = Command::new("/bin/sh").arg(&script_path).spawn().unwrap();
+        let mut child = Command::new(&script_path).arg("30").spawn().unwrap();
         fs::write(&pid_path, child.id().to_string()).unwrap();
+        thread::sleep(Duration::from_millis(100));
+        assert!(process_looks_like_agent_browser(child.id()));
 
         let action =
             force_kill_stale_daemon_with_paths(&pid_path, &sock_path, Duration::from_secs(30));

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
@@ -908,7 +908,11 @@ fn emit_stable_idle_warning(message: &str) {
 }
 
 fn approval_wait_message() -> String {
-    let timeout_secs = configured_ws_handshake_timeout_ms() / 1_000;
+    approval_wait_message_for_timeout_ms(configured_ws_handshake_timeout_ms())
+}
+
+fn approval_wait_message_for_timeout_ms(timeout_ms: u64) -> String {
+    let timeout_secs = timeout_ms / 1_000;
     format!(
         "live browser attach timed out ({timeout_secs}s). Chrome may be showing an \"Allow remote debugging?\" dialog — click Allow, then retry."
     )
@@ -1808,8 +1812,6 @@ async fn read_latest_assistant_text(client: &ChromeCdpClient) -> Result<String> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serial_test::serial;
-    use std::sync::{Mutex, MutexGuard, OnceLock};
 
     #[tokio::test]
     async fn run_errors_without_bundle() {
@@ -1845,41 +1847,6 @@ mod tests {
         );
     }
 
-    fn lock_env() -> MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
-    }
-
-    struct EnvVarGuard {
-        key: &'static str,
-        previous: Option<String>,
-    }
-
-    impl EnvVarGuard {
-        #[allow(unsafe_code)]
-        fn set(key: &'static str, value: &str) -> Self {
-            let previous = std::env::var(key).ok();
-            unsafe {
-                std::env::set_var(key, value);
-            }
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        #[allow(unsafe_code)]
-        fn drop(&mut self) {
-            match self.previous.as_deref() {
-                Some(value) => unsafe {
-                    std::env::set_var(self.key, value);
-                },
-                None => unsafe {
-                    std::env::remove_var(self.key);
-                },
-            }
-        }
-    }
-
     #[test]
     fn cdp_attach_hint_preserves_approval_dialog_errors() {
         // Approval-wait errors must pass through so the outer transport funnel
@@ -1895,11 +1862,8 @@ mod tests {
     }
 
     #[test]
-    #[serial]
-    fn approval_wait_message_uses_configured_handshake_timeout() {
-        let _guard = lock_env();
-        let _timeout = EnvVarGuard::set("YOETZ_CDP_WS_HANDSHAKE_TIMEOUT_MS", "120000");
-        assert!(approval_wait_message().contains("120s"));
+    fn approval_wait_message_formats_handshake_timeout() {
+        assert!(approval_wait_message_for_timeout_ms(120_000).contains("120s"));
     }
 
     #[tokio::test]

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
@@ -367,11 +367,21 @@ struct BrowserContextPage {
 
 impl ChromeCdpClient {
     pub async fn connect_to_running_chrome(cdp_endpoint: Option<&str>) -> Result<Self> {
+        Self::connect_to_running_chrome_with_handshake_timeout(cdp_endpoint, None).await
+    }
+
+    async fn connect_to_running_chrome_with_handshake_timeout(
+        cdp_endpoint: Option<&str>,
+        handshake_timeout: Option<Duration>,
+    ) -> Result<Self> {
         let ws_endpoint = resolve_canonical_ws_endpoint(cdp_endpoint)?;
-        let browser = Browser::connect_with_timeout(
-            ws_endpoint.clone(),
-            Duration::from_secs(CDP_SESSION_IDLE_TIMEOUT_SECS),
-        )
+        let idle_timeout = Duration::from_secs(CDP_SESSION_IDLE_TIMEOUT_SECS);
+        let browser = match handshake_timeout {
+            Some(timeout) => {
+                Browser::connect_with_timeouts(ws_endpoint.clone(), idle_timeout, timeout)
+            }
+            None => Browser::connect_with_timeout(ws_endpoint.clone(), idle_timeout),
+        }
         .with_context(|| format!("connecting to Chrome websocket `{ws_endpoint}` failed"))?;
 
         Ok(Self {
@@ -2975,33 +2985,6 @@ mod tests {
     };
     use tempfile::tempdir;
 
-    struct EnvVarGuard {
-        key: &'static str,
-        original: Option<std::ffi::OsString>,
-    }
-
-    impl EnvVarGuard {
-        #[allow(unsafe_code)]
-        fn set<K>(key: &'static str, value: K) -> Self
-        where
-            K: AsRef<std::ffi::OsStr>,
-        {
-            let original = std::env::var_os(key);
-            unsafe { std::env::set_var(key, value) };
-            Self { key, original }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        #[allow(unsafe_code)]
-        fn drop(&mut self) {
-            match &self.original {
-                Some(value) => unsafe { std::env::set_var(self.key, value) },
-                None => unsafe { std::env::remove_var(self.key) },
-            }
-        }
-    }
-
     fn devtools_active_port_test_paths(home: &Path) -> (PathBuf, PathBuf) {
         match std::env::consts::OS {
             "macos" => (
@@ -3926,7 +3909,6 @@ mod tests {
 
     #[test]
     fn connect_to_running_chrome_times_out_when_websocket_handshake_stalls() {
-        let _timeout_guard = EnvVarGuard::set("YOETZ_CDP_WS_HANDSHAKE_TIMEOUT_MS", "200");
         let (port, shutdown, handle) = spawn_stalled_websocket_server();
         let ws_endpoint = format!("ws://127.0.0.1:{port}/devtools/browser/stalled");
         let runtime = tokio::runtime::Builder::new_current_thread()
@@ -3934,9 +3916,12 @@ mod tests {
             .build()
             .expect("tokio runtime");
         let started = Instant::now();
-        let err = match runtime.block_on(ChromeCdpClient::connect_to_running_chrome(Some(
-            &ws_endpoint,
-        ))) {
+        let err = match runtime.block_on(
+            ChromeCdpClient::connect_to_running_chrome_with_handshake_timeout(
+                Some(&ws_endpoint),
+                Some(Duration::from_millis(200)),
+            ),
+        ) {
             Ok(_) => panic!("stalled websocket handshake should time out"),
             Err(err) => err,
         };

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/client.rs
@@ -1509,10 +1509,16 @@ pub fn fingerprint_for_ws_endpoint(ws_endpoint: &str) -> BrowserFingerprint {
 }
 
 pub fn discover_running_chrome_targets() -> Vec<RunningChromeTarget> {
+    discover_running_chrome_targets_from_candidates(devtools_active_port_candidates())
+}
+
+fn discover_running_chrome_targets_from_candidates(
+    candidates: impl IntoIterator<Item = PathBuf>,
+) -> Vec<RunningChromeTarget> {
     let mut seen = BTreeSet::new();
     let mut targets = Vec::new();
 
-    for source_path in devtools_active_port_candidates() {
+    for source_path in candidates {
         let Ok(contents) = std::fs::read_to_string(&source_path) else {
             continue;
         };
@@ -2416,12 +2422,17 @@ fn is_localhost_host(endpoint: &Url) -> bool {
 }
 
 fn devtools_active_port_candidates() -> Vec<PathBuf> {
-    let home = home_dir_candidates();
+    devtools_active_port_candidates_from_homes(home_dir_candidates())
+}
+
+fn devtools_active_port_candidates_from_homes(
+    homes: impl IntoIterator<Item = PathBuf>,
+) -> Vec<PathBuf> {
     let mut candidates = Vec::new();
     let mut seen = BTreeSet::new();
     match std::env::consts::OS {
         "macos" => {
-            for home in home {
+            for home in homes {
                 for path in [
                     home.join("Library/Application Support/Google/Chrome/DevToolsActivePort"),
                     home.join("Library/Application Support/Google/Chrome Canary/DevToolsActivePort"),
@@ -2446,7 +2457,7 @@ fn devtools_active_port_candidates() -> Vec<PathBuf> {
             }
         }
         "windows" => {
-            for home in home {
+            for home in homes {
                 for path in [
                     home.join("AppData/Local/Google/Chrome/User Data/DevToolsActivePort"),
                     home.join("AppData/Local/Google/Chrome Beta/User Data/DevToolsActivePort"),
@@ -2473,7 +2484,7 @@ fn devtools_active_port_candidates() -> Vec<PathBuf> {
             }
         }
         _ => {
-            for home in home {
+            for home in homes {
                 for path in [
                     home.join(".config/google-chrome/DevToolsActivePort"),
                     home.join(".config/chromium/DevToolsActivePort"),
@@ -4018,7 +4029,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(unsafe_code)]
     fn discover_running_chrome_targets_skips_unhealthy_active_port_files() {
         let home = tempdir().unwrap();
         let (stale_path, healthy_path) = devtools_active_port_test_paths(home.path());
@@ -4026,10 +4036,8 @@ mod tests {
         write_devtools_active_port(&stale_path, port + 1, "stale");
         write_devtools_active_port(&healthy_path, port, "healthy");
 
-        let _home = EnvVarGuard::set("HOME", home.path().as_os_str());
-        let _profile = EnvVarGuard::set("USERPROFILE", home.path().as_os_str());
-
-        let targets = discover_running_chrome_targets();
+        let candidates = devtools_active_port_candidates_from_homes([home.path().to_path_buf()]);
+        let targets = discover_running_chrome_targets_from_candidates(candidates);
 
         shutdown.store(true, Ordering::Relaxed);
         let _ = handle.join();

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -27,9 +27,6 @@ use std::sync::{Arc, OnceLock};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
-#[cfg(test)]
-use yoetz_core::paths::home_dir;
-
 use crate::chatgpt_recipe::AnyhowResultExt;
 use crate::claude_recipe::AnyhowResultExt as ClaudeAnyhowResultExt;
 use crate::web_recipe::{WebModelSelectionStatus, WebRecipeTransportPhase};
@@ -94,16 +91,6 @@ impl Default for ChatgptPollSettings {
             interval_ms: CHATGPT_POLL_INTERVAL_MS_DEFAULT,
         }
     }
-}
-
-/// dev-browser tmp directory for file staging.
-#[cfg(test)]
-#[allow(dead_code)]
-fn dev_browser_tmp_dir() -> PathBuf {
-    home_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join(".dev-browser")
-        .join("tmp")
 }
 
 fn command_is_available(bin: &str) -> bool {
@@ -531,13 +518,10 @@ pub fn run_script_connect_with_endpoint(
     run_script_connect_with_browser_and_endpoint(script, timeout_secs, None, cdp_endpoint)
 }
 
-/// Stage a file into dev-browser's tmp directory so scripts can read it
-/// via `readFile(name)`.
+/// Stage a file in a caller-owned test directory.
 #[cfg(test)]
-#[allow(dead_code)]
-pub fn stage_file(name: &str, content: &str) -> Result<PathBuf> {
-    let tmp_dir = dev_browser_tmp_dir();
-    fs::create_dir_all(&tmp_dir)
+fn stage_file(tmp_dir: &Path, name: &str, content: &str) -> Result<PathBuf> {
+    fs::create_dir_all(tmp_dir)
         .with_context(|| format!("create dev-browser tmp dir: {}", tmp_dir.display()))?;
     let path = tmp_dir.join(name);
     fs::write(&path, content).with_context(|| format!("write staged file: {}", path.display()))?;
@@ -2306,19 +2290,45 @@ mod tests {
     use std::ffi::{OsStr, OsString};
 
     #[test]
-    fn test_dev_browser_tmp_dir() {
-        let dir = dev_browser_tmp_dir();
-        assert!(dir.to_string_lossy().contains(".dev-browser"));
-        assert!(dir.to_string_lossy().ends_with("tmp"));
-    }
-
-    #[test]
     fn test_stage_file() {
-        let path = stage_file("test_stage.txt", "hello world").unwrap();
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let path = stage_file(tmp_dir.path(), "test_stage.txt", "hello world").unwrap();
         assert!(path.exists());
         let content = fs::read_to_string(&path).unwrap();
         assert_eq!(content, "hello world");
-        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn parallel_stage_file_callers_do_not_overwrite_each_other() {
+        use std::sync::{Arc, Barrier};
+
+        let first_tmp = tempfile::tempdir().unwrap();
+        let second_tmp = tempfile::tempdir().unwrap();
+        let first_root = first_tmp.path().to_path_buf();
+        let second_root = second_tmp.path().to_path_buf();
+        let both_written = Arc::new(Barrier::new(2));
+        let first = std::thread::spawn({
+            let both_written = Arc::clone(&both_written);
+            move || {
+                let path = stage_file(&first_root, "parallel-stage.txt", "first").unwrap();
+                both_written.wait();
+                let content = fs::read_to_string(&path).unwrap();
+                (path, content)
+            }
+        });
+        let second = std::thread::spawn(move || {
+            let path = stage_file(&second_root, "parallel-stage.txt", "second").unwrap();
+            both_written.wait();
+            let content = fs::read_to_string(&path).unwrap();
+            (path, content)
+        });
+
+        let (first_path, first_content) = first.join().unwrap();
+        let (second_path, second_content) = second.join().unwrap();
+
+        assert_eq!(first_content, "first");
+        assert_eq!(second_content, "second");
+        assert_ne!(first_path, second_path);
     }
 
     #[cfg(unix)]
@@ -2326,10 +2336,10 @@ mod tests {
     fn stage_file_sets_owner_only_permissions() {
         use std::os::unix::fs::PermissionsExt;
 
-        let path = stage_file("test_permissions.txt", "secret").unwrap();
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let path = stage_file(tmp_dir.path(), "test_permissions.txt", "secret").unwrap();
         let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600);
-        let _ = fs::remove_file(&path);
     }
 
     #[test]

--- a/vendor/headless_chrome/src/browser/mod.rs
+++ b/vendor/headless_chrome/src/browser/mod.rs
@@ -128,9 +128,36 @@ impl Browser {
         debug_ws_url: String,
         idle_browser_timeout: Duration,
     ) -> Result<Self> {
+        Self::connect_with_optional_handshake_timeout(debug_ws_url, idle_browser_timeout, None)
+    }
+
+    /// Connect to an externally-launched Chrome process with separate idle and
+    /// initial websocket handshake timeouts.
+    pub fn connect_with_timeouts(
+        debug_ws_url: String,
+        idle_browser_timeout: Duration,
+        handshake_timeout: Duration,
+    ) -> Result<Self> {
+        Self::connect_with_optional_handshake_timeout(
+            debug_ws_url,
+            idle_browser_timeout,
+            Some(handshake_timeout),
+        )
+    }
+
+    fn connect_with_optional_handshake_timeout(
+        debug_ws_url: String,
+        idle_browser_timeout: Duration,
+        handshake_timeout: Option<Duration>,
+    ) -> Result<Self> {
         let url = Url::parse(&debug_ws_url)?;
 
-        let transport = Arc::new(Transport::new(url, None, idle_browser_timeout)?);
+        let transport = Arc::new(match handshake_timeout {
+            Some(timeout) => {
+                Transport::new_with_handshake_timeout(url, None, idle_browser_timeout, timeout)?
+            }
+            None => Transport::new(url, None, idle_browser_timeout)?,
+        });
         trace!("created transport");
 
         Self::create_browser(None, transport, idle_browser_timeout, false)

--- a/vendor/headless_chrome/src/browser/transport/mod.rs
+++ b/vendor/headless_chrome/src/browser/transport/mod.rs
@@ -77,9 +77,44 @@ impl Transport {
         process_id: Option<u32>,
         idle_browser_timeout: Duration,
     ) -> Result<Self> {
+        Self::new_with_optional_handshake_timeout(
+            ws_url,
+            process_id,
+            idle_browser_timeout,
+            None,
+        )
+    }
+
+    pub(crate) fn new_with_handshake_timeout(
+        ws_url: Url,
+        process_id: Option<u32>,
+        idle_browser_timeout: Duration,
+        handshake_timeout: Duration,
+    ) -> Result<Self> {
+        Self::new_with_optional_handshake_timeout(
+            ws_url,
+            process_id,
+            idle_browser_timeout,
+            Some(handshake_timeout),
+        )
+    }
+
+    fn new_with_optional_handshake_timeout(
+        ws_url: Url,
+        process_id: Option<u32>,
+        idle_browser_timeout: Duration,
+        handshake_timeout: Option<Duration>,
+    ) -> Result<Self> {
         let (messages_tx, messages_rx) = mpsc::channel();
-        let web_socket_connection =
-            Arc::new(WebSocketConnection::new(&ws_url, process_id, messages_tx)?);
+        let web_socket_connection = Arc::new(match handshake_timeout {
+            Some(timeout) => WebSocketConnection::new_with_handshake_timeout(
+                &ws_url,
+                process_id,
+                messages_tx,
+                timeout,
+            )?,
+            None => WebSocketConnection::new(&ws_url, process_id, messages_tx)?,
+        });
 
         let waiting_call_registry = Arc::new(WaitingCallRegistry::new());
 

--- a/vendor/headless_chrome/src/browser/transport/web_socket_connection.rs
+++ b/vendor/headless_chrome/src/browser/transport/web_socket_connection.rs
@@ -41,6 +41,26 @@ impl WebSocketConnection {
     ) -> Result<Self> {
         let (connection, _) = Self::websocket_connection(ws_url)?;
 
+        Ok(Self::from_connection(connection, process_id, messages_tx))
+    }
+
+    pub(crate) fn new_with_handshake_timeout(
+        ws_url: &Url,
+        process_id: Option<u32>,
+        messages_tx: mpsc::Sender<RoutedMessage>,
+        handshake_timeout: Duration,
+    ) -> Result<Self> {
+        let (connection, _) =
+            Self::websocket_connection_with_handshake_timeout(ws_url, handshake_timeout)?;
+
+        Ok(Self::from_connection(connection, process_id, messages_tx))
+    }
+
+    fn from_connection(
+        connection: TungsteniteWebsocketConnection,
+        process_id: Option<u32>,
+        messages_tx: mpsc::Sender<RoutedMessage>,
+    ) -> Self {
         let connection = Arc::new(Mutex::new(connection));
 
         let thread = {
@@ -52,11 +72,11 @@ impl WebSocketConnection {
             })
         };
 
-        Ok(Self {
+        Self {
             connection,
             thread,
             process_id,
-        })
+        }
     }
 
     pub fn shutdown(&self) {
@@ -166,9 +186,19 @@ impl WebSocketConnection {
         tungstenite::WebSocket<MaybeTlsStream<TcpStream>>,
         Response<Option<Vec<u8>>>,
     )> {
+        Self::websocket_connection_with_handshake_timeout(ws_url, handshake_timeout_duration())
+    }
+
+    fn websocket_connection_with_handshake_timeout(
+        ws_url: &Url,
+        handshake_timeout: Duration,
+    ) -> Result<(
+        tungstenite::WebSocket<MaybeTlsStream<TcpStream>>,
+        Response<Option<Vec<u8>>>,
+    )> {
         let mut client = websocket_connection_with_timeout(
             ws_url,
-            handshake_timeout_duration(),
+            handshake_timeout,
             Some(
                 WebSocketConfig::default()
                     .accept_unmasked_frames(true)


### PR DESCRIPTION
Closes #325.

## What changed

- inject Chrome discovery candidates and home roots instead of mutating `HOME` / `USERPROFILE`
- isolate dev-browser staging tests under caller-owned temp directories
- stabilize the recent-live-daemon fixture with a persistent `agent-browser` process identity
- inject CDP handshake timeouts through the vendored transport and pure approval-message formatter instead of mutating process-global env

Each hazard is a separate peer-reviewed commit with a deterministic red-before / green-after reproduction. Production timeout env behavior remains supported and unchanged.

## Attribution boundary

This sweep does not explain the historical Wave 1b `lifecycle_lock_allows_parallel_recipes_and_rejects_mutation` failure. Its error used the test own TempDir lock path, every `YOETZ_DIR` setter is serial, and no #325 hazard owns lifecycle lock resolution. Keep that failure open and unattributed. Fork-inherited descriptors remain a leading inference only: no recurrence after #328 would weakly support it; recurrence would falsify it.

Observation, not diagnosis: on 2026-07-22 Claude saw roughly 18 `live_attach` tests fail under self-inflicted concurrent Cargo/build-lock load; all passed in isolation and on a clean rerun. This records load sensitivity without assigning a cause.

## Local verification

- `cargo test --workspace --bins -- --test-threads=1`: 592 passed, 0 failed, 2 ignored
- `cargo test --workspace`: green (592 bin + 39 CLI + 3 council + 3 daemon-policy + 1 native-host + 58 core)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --workspace`
- `cargo fmt --all -- --check`
- `git diff --check`