### PR TITLE
fix(ci): close light-only gate bypasses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
       browser_changed: ${{ steps.detect.outputs.browser_changed }}
       build_os_matrix: ${{ steps.detect.outputs.build_os_matrix }}
       release_push: ${{ steps.detect.outputs.release_push }}
+      dependency_changed: ${{ steps.detect.outputs.dependency_changed }}
+      workflow_changed: ${{ steps.detect.outputs.workflow_changed }}
     env:
       PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
       PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
@@ -59,125 +61,42 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+      - name: Test change classifier
+        run: ./scripts/test-ci-classify-changes.sh
       - id: detect
         shell: bash
         run: |
           set -euo pipefail
 
-          full_build_matrix='["ubuntu-latest","macos-latest","windows-latest"]'
-          linux_build_matrix='["ubuntu-latest"]'
-          build_os_matrix="$linux_build_matrix"
-
-          emit_outputs() {
-            {
-              echo "light_only=$1"
-              echo "browser_changed=$2"
-              echo "build_os_matrix=$3"
-              echo "release_push=$4"
-            } >> "$GITHUB_OUTPUT"
-          }
-
           case "${GITHUB_EVENT_NAME}" in
             pull_request)
               base="$PR_BASE_SHA"
               head="$PR_HEAD_SHA"
-              if [[ "${PR_HEAD_REF:-}" == release/* ]]; then
-                # Release PRs only bump version metadata (CHANGELOG, Cargo.*,
-                # plugin/skill/extension manifests). release.yml is the real
-                # cross-platform build+publish gate and release.sh already ran
-                # local gates, so the heavy PR build/test/browser jobs here are
-                # pure redundancy. Treat the PR as light to skip them.
-                emit_outputs true false "$linux_build_matrix" false
-                exit 0
-              fi
+              head_ref="$PR_HEAD_REF"
+              subject="$PR_TITLE"
               ;;
             push)
-              commit_subject="${PUSH_COMMIT_MESSAGE%%$'\n'*}"
-              if [[ "$commit_subject" == chore\(release\):\ v* ]]; then
-                emit_outputs true false "$linux_build_matrix" true
-                exit 0
-              fi
               base="$PUSH_BEFORE_SHA"
               head="$GITHUB_SHA"
-              ;;
-            workflow_dispatch)
-              emit_outputs false true "$full_build_matrix" false
-              exit 0
+              head_ref=""
+              subject="${PUSH_COMMIT_MESSAGE%%$'\n'*}"
               ;;
             *)
-              emit_outputs false true "$linux_build_matrix" false
+              ./scripts/ci-classify-changes.sh \
+                "$GITHUB_EVENT_NAME" "" "" >> "$GITHUB_OUTPUT"
               exit 0
               ;;
           esac
 
-          if [[ -z "${base:-}" || "$base" == "0000000000000000000000000000000000000000" ]]; then
-            emit_outputs false true "$build_os_matrix" false
+          if [[ -z "${base:-}" || -z "${head:-}" || "$base" == "0000000000000000000000000000000000000000" ]]; then
+            ./scripts/ci-classify-changes.sh \
+              "$GITHUB_EVENT_NAME" "$head_ref" "$subject" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           mapfile -t files < <(git diff --name-only "$base" "$head")
-          if ((${#files[@]} == 0)); then
-            emit_outputs false true "$build_os_matrix" false
-            exit 0
-          fi
-
-          # A PR is "light-only" when every changed file matches one of these
-          # categories:
-          #   - release bookkeeping: Cargo.toml/lock, CHANGELOG.md, plugin /
-          #     skill manifests.
-          #   - documentation: any *.md, anything under docs/, README*.
-          #   - repo infrastructure: anything under .github/, .gitignore,
-          #     .gitleaks.toml, LICENSE*.
-          #
-          # Light-only PRs skip the heavy build / test / browser jobs. The
-          # required checks (Format, Clippy, Test) still RUN to keep the
-          # GitHub "required status checks" list satisfied without needing
-          # admin-bypass, but they short-circuit after checkout to keep the
-          # whole PR under a minute. See clippy / test jobs below.
-          #
-          # Ordinary PRs and main pushes intentionally use the Ubuntu build
-          # only. Cross-platform release builds run in release.yml at tag time
-          # (and on demand via workflow_dispatch); release/* PRs are treated as
-          # light here because they only bump version metadata.
-          # Bash case-pattern `*` matches any characters including `/`, so
-          # `docs/*` covers any depth under `docs/`.
-          light_only=true
-          browser_changed=false
-          for file in "${files[@]}"; do
-            matched=false
-            case "$file" in
-              Cargo.toml|Cargo.lock) matched=true ;;
-              CHANGELOG.md) matched=true ;;
-              .claude-plugin/plugin.json|.codex-plugin/plugin.json) matched=true ;;
-              skills/*/SKILL.md) matched=true ;;
-              *.md) matched=true ;;
-              docs/*) matched=true ;;
-              README*) matched=true ;;
-              .github/*) matched=true ;;
-              .gitignore|.gitleaks.toml) matched=true ;;
-              LICENSE*) matched=true ;;
-            esac
-
-            case "$file" in
-              extensions/*) browser_changed=true ;;
-              recipes/*) browser_changed=true ;;
-              scripts/build-chatgpt-native-extension.sh) browser_changed=true ;;
-              scripts/build-live-cdp-daemon.sh) browser_changed=true ;;
-              scripts/ci-real-browser-smoke.sh) browser_changed=true ;;
-              crates/yoetz-cli/src/*browser*) browser_changed=true ;;
-              crates/yoetz-cli/src/*chatgpt*) browser_changed=true ;;
-              crates/yoetz-cli/src/live_*) browser_changed=true ;;
-              crates/yoetz-cli/src/chrome_*) browser_changed=true ;;
-              crates/yoetz-cli/tests/*browser*) browser_changed=true ;;
-              crates/yoetz-cli/tests/*chatgpt*) browser_changed=true ;;
-            esac
-
-            if [[ "$matched" != "true" ]]; then
-              light_only=false
-            fi
-          done
-
-          emit_outputs "$light_only" "$browser_changed" "$build_os_matrix" false
+          ./scripts/ci-classify-changes.sh \
+            "$GITHUB_EVENT_NAME" "$head_ref" "$subject" "${files[@]}" >> "$GITHUB_OUTPUT"
 
   release-commit-fast-path:
     name: Release Commit Fast Path
@@ -245,7 +164,7 @@ jobs:
       - name: Light-only short-circuit
         if: needs.changes.outputs.light_only == 'true'
         run: |
-          echo "Skipping Clippy because this PR only touches docs / changelog / workflow files."
+          echo "Skipping Clippy because this PR only touches docs / changelog / release metadata."
           echo "See the 'Detect Light-Only Changes' job for the file set that triggered the fast path."
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         if: needs.changes.outputs.light_only != 'true'
@@ -270,7 +189,7 @@ jobs:
       - name: Light-only short-circuit
         if: needs.changes.outputs.light_only == 'true'
         run: |
-          echo "Skipping Test because this PR only touches docs / changelog / workflow files."
+          echo "Skipping Test because this PR only touches docs / changelog / release metadata."
           echo "See the 'Detect Light-Only Changes' job for the file set that triggered the fast path."
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         if: needs.changes.outputs.light_only != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,20 +83,20 @@ jobs:
               ;;
             *)
               ./scripts/ci-classify-changes.sh \
-                "$GITHUB_EVENT_NAME" "" "" >> "$GITHUB_OUTPUT"
+                "$GITHUB_EVENT_NAME" "" "" | tee -a "$GITHUB_OUTPUT"
               exit 0
               ;;
           esac
 
           if [[ -z "${base:-}" || -z "${head:-}" || "$base" == "0000000000000000000000000000000000000000" ]]; then
             ./scripts/ci-classify-changes.sh \
-              "$GITHUB_EVENT_NAME" "$head_ref" "$subject" >> "$GITHUB_OUTPUT"
+              "$GITHUB_EVENT_NAME" "$head_ref" "$subject" | tee -a "$GITHUB_OUTPUT"
             exit 0
           fi
 
           mapfile -t files < <(git diff --name-only "$base" "$head")
           ./scripts/ci-classify-changes.sh \
-            "$GITHUB_EVENT_NAME" "$head_ref" "$subject" "${files[@]}" >> "$GITHUB_OUTPUT"
+            "$GITHUB_EVENT_NAME" "$head_ref" "$subject" "${files[@]}" | tee -a "$GITHUB_OUTPUT"
 
   workflow-policy:
     name: Workflow Policy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,19 @@ jobs:
           ./scripts/ci-classify-changes.sh \
             "$GITHUB_EVENT_NAME" "$head_ref" "$subject" "${files[@]}" >> "$GITHUB_OUTPUT"
 
+  workflow-policy:
+    name: Workflow Policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Check immutable action pins
+        run: ./scripts/check-workflow-action-pins.sh
+      - name: Lint GitHub Actions workflows
+        uses: docker://rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 # actionlint 1.7.12
+        with:
+          args: -color
+
   release-commit-fast-path:
     name: Release Commit Fast Path
     needs: changes

--- a/scripts/check-workflow-action-pins.sh
+++ b/scripts/check-workflow-action-pins.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+files=()
+if (($# > 0)); then
+  files=("$@")
+else
+  while IFS= read -r workflow; do
+    files+=("$workflow")
+  done < <(find "${ROOT_DIR}/.github/workflows" -type f \( -name '*.yml' -o -name '*.yaml' \) | LC_ALL=C sort)
+fi
+
+violations=0
+for workflow in "${files[@]}"; do
+  if [[ ! -f "$workflow" ]]; then
+    echo "${workflow}: workflow file not found" >&2
+    violations=$((violations + 1))
+    continue
+  fi
+
+  line_number=0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_number=$((line_number + 1))
+    if [[ ! "$line" =~ ^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*(.*)$ ]]; then
+      continue
+    fi
+
+    action="$(trim "${BASH_REMATCH[2]%%#*}")"
+    if [[ "$action" == \"*\" || "$action" == \'*\' ]]; then
+      action="${action:1:${#action}-2}"
+    fi
+
+    case "$action" in
+      ./*)
+        continue
+        ;;
+      docker://*)
+        if [[ "$action" =~ ^docker://[^@[:space:]]+@sha256:[0-9a-fA-F]{64}$ ]]; then
+          continue
+        fi
+        echo "${workflow}:${line_number}: Docker action must use an immutable sha256 digest: ${action}" >&2
+        ;;
+      *)
+        if [[ "$action" =~ ^[^/@[:space:]]+/[^@[:space:]]+@[0-9a-fA-F]{40}$ ]]; then
+          continue
+        fi
+        echo "${workflow}:${line_number}: remote action must use a full 40-hex commit SHA: ${action}" >&2
+        ;;
+    esac
+    violations=$((violations + 1))
+  done <"$workflow"
+done
+
+if ((violations > 0)); then
+  echo "Found ${violations} mutable or invalid workflow action reference(s)." >&2
+  exit 1
+fi
+
+echo "Workflow action pins verified."

--- a/scripts/ci-classify-changes.sh
+++ b/scripts/ci-classify-changes.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LINUX_MATRIX='["ubuntu-latest"]'
+FULL_MATRIX='["ubuntu-latest","macos-latest","windows-latest"]'
+
+emit_outputs() {
+  printf 'light_only=%s\n' "$1"
+  printf 'browser_changed=%s\n' "$2"
+  printf 'build_os_matrix=%s\n' "$3"
+  printf 'release_push=%s\n' "$4"
+  printf 'dependency_changed=%s\n' "$5"
+  printf 'workflow_changed=%s\n' "$6"
+}
+
+if (($# < 3)); then
+  emit_outputs false true "$LINUX_MATRIX" false false false
+  exit 0
+fi
+
+event_name="$1"
+head_ref="$2"
+subject="$3"
+shift 3
+files=("$@")
+
+case "$event_name" in
+  workflow_dispatch)
+    emit_outputs false true "$FULL_MATRIX" false false false
+    exit 0
+    ;;
+  push)
+    if [[ "$subject" == chore\(release\):\ v* ]]; then
+      emit_outputs true false "$LINUX_MATRIX" true false false
+      exit 0
+    fi
+    ;;
+  pull_request) ;;
+  *)
+    emit_outputs false true "$LINUX_MATRIX" false false false
+    exit 0
+    ;;
+esac
+
+if ((${#files[@]} == 0)); then
+  emit_outputs false true "$LINUX_MATRIX" false false false
+  exit 0
+fi
+
+light_only=true
+browser_changed=false
+dependency_changed=false
+workflow_changed=false
+release_metadata_only=true
+
+for file in "${files[@]}"; do
+  case "$file" in
+    Cargo.toml | Cargo.lock)
+      dependency_changed=true
+      light_only=false
+      ;;
+    .github/*)
+      workflow_changed=true
+      light_only=false
+      ;;
+    CHANGELOG.md | .claude-plugin/plugin.json | .codex-plugin/plugin.json | skills/*/SKILL.md)
+      ;;
+    *.md | docs/* | README* | .gitignore | .gitleaks.toml | LICENSE*)
+      ;;
+    *)
+      light_only=false
+      ;;
+  esac
+
+  case "$file" in
+    CHANGELOG.md | Cargo.toml | Cargo.lock | .claude-plugin/plugin.json | .codex-plugin/plugin.json | extensions/chatgpt-native/manifest.json | skills/*/SKILL.md)
+      ;;
+    *)
+      release_metadata_only=false
+      ;;
+  esac
+
+  case "$file" in
+    extensions/* | recipes/* | scripts/build-chatgpt-native-extension.sh | scripts/build-live-cdp-daemon.sh | scripts/ci-real-browser-smoke.sh)
+      browser_changed=true
+      ;;
+    crates/yoetz-cli/src/*browser* | crates/yoetz-cli/src/*chatgpt* | crates/yoetz-cli/src/live_* | crates/yoetz-cli/src/chrome_* | crates/yoetz-cli/tests/*browser* | crates/yoetz-cli/tests/*chatgpt*)
+      browser_changed=true
+      ;;
+  esac
+done
+
+build_os_matrix="$LINUX_MATRIX"
+if [[ "$dependency_changed" == "true" ]]; then
+  build_os_matrix="$FULL_MATRIX"
+fi
+
+release_tag="${head_ref#release/}"
+if [[ "$event_name" == "pull_request" &&
+  "$head_ref" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*$ &&
+  "$subject" == "chore(release): ${release_tag}" &&
+  "$release_metadata_only" == "true" ]]; then
+  emit_outputs true false "$build_os_matrix" false "$dependency_changed" false
+  exit 0
+fi
+
+emit_outputs "$light_only" "$browser_changed" "$build_os_matrix" false "$dependency_changed" "$workflow_changed"

--- a/scripts/test-ci-classify-changes.sh
+++ b/scripts/test-ci-classify-changes.sh
@@ -126,5 +126,7 @@ grep -Fq "dependency_changed: \${{ steps.detect.outputs.dependency_changed }}" "
 grep -Fq "workflow_changed: \${{ steps.detect.outputs.workflow_changed }}" "$WORKFLOW" || fail "workflow does not publish workflow_changed"
 grep -Fq './scripts/test-ci-classify-changes.sh' "$WORKFLOW" || fail "workflow does not run the classifier table tests"
 grep -Fq "./scripts/ci-classify-changes.sh \\" "$WORKFLOW" || fail "workflow does not invoke the classifier"
+tee_count="$(grep -Fc "| tee -a \"\$GITHUB_OUTPUT\"" "$WORKFLOW" || true)"
+[[ "$tee_count" == "3" ]] || fail "workflow must log and publish all three classifier paths; found ${tee_count} tee invocations"
 
 echo "All CI classifier tests passed."

--- a/scripts/test-ci-classify-changes.sh
+++ b/scripts/test-ci-classify-changes.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLASSIFIER="${ROOT_DIR}/scripts/ci-classify-changes.sh"
+LINUX_MATRIX='["ubuntu-latest"]'
+FULL_MATRIX='["ubuntu-latest","macos-latest","windows-latest"]'
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+run_case() {
+  local name="$1"
+  local event_name="$2"
+  local head_ref="$3"
+  local subject="$4"
+  local expected_light_only="$5"
+  local expected_browser_changed="$6"
+  local expected_build_os_matrix="$7"
+  local expected_release_push="$8"
+  local expected_dependency_changed="$9"
+  local expected_workflow_changed="${10}"
+  shift 10
+
+  local output
+  if ! output="$(${CLASSIFIER} "$event_name" "$head_ref" "$subject" "$@")"; then
+    fail "${name}: classifier exited non-zero"
+  fi
+
+  local output_count
+  output_count="$(printf '%s\n' "$output" | sed -n '/^[a-z_][a-z_]*=/p' | wc -l | tr -d ' ')"
+  [[ "$output_count" == "6" ]] || fail "${name}: expected 6 outputs, got ${output_count}: ${output}"
+
+  local actual_light_only actual_browser_changed actual_build_os_matrix
+  local actual_release_push actual_dependency_changed actual_workflow_changed
+  actual_light_only="$(printf '%s\n' "$output" | sed -n 's/^light_only=//p')"
+  actual_browser_changed="$(printf '%s\n' "$output" | sed -n 's/^browser_changed=//p')"
+  actual_build_os_matrix="$(printf '%s\n' "$output" | sed -n 's/^build_os_matrix=//p')"
+  actual_release_push="$(printf '%s\n' "$output" | sed -n 's/^release_push=//p')"
+  actual_dependency_changed="$(printf '%s\n' "$output" | sed -n 's/^dependency_changed=//p')"
+  actual_workflow_changed="$(printf '%s\n' "$output" | sed -n 's/^workflow_changed=//p')"
+
+  [[ "$actual_light_only" == "$expected_light_only" ]] || fail "${name}: light_only=${actual_light_only}, want ${expected_light_only}"
+  [[ "$actual_browser_changed" == "$expected_browser_changed" ]] || fail "${name}: browser_changed=${actual_browser_changed}, want ${expected_browser_changed}"
+  [[ "$actual_build_os_matrix" == "$expected_build_os_matrix" ]] || fail "${name}: build_os_matrix=${actual_build_os_matrix}, want ${expected_build_os_matrix}"
+  [[ "$actual_release_push" == "$expected_release_push" ]] || fail "${name}: release_push=${actual_release_push}, want ${expected_release_push}"
+  [[ "$actual_dependency_changed" == "$expected_dependency_changed" ]] || fail "${name}: dependency_changed=${actual_dependency_changed}, want ${expected_dependency_changed}"
+  [[ "$actual_workflow_changed" == "$expected_workflow_changed" ]] || fail "${name}: workflow_changed=${actual_workflow_changed}, want ${expected_workflow_changed}"
+
+  echo "PASS: ${name}"
+}
+
+run_case "docs only stays light" \
+  pull_request feature/docs "docs: refresh guide" \
+  true false "$LINUX_MATRIX" false false false \
+  README.md docs/guide.md
+
+run_case "Cargo.lock gets the full build matrix" \
+  pull_request dependabot/cargo/time-0.3.47 "chore(deps): bump time" \
+  false false "$FULL_MATRIX" false true false \
+  Cargo.lock
+
+run_case "Cargo.toml plus docs stays dependency-heavy" \
+  pull_request feature/dependency "build: change dependency" \
+  false false "$FULL_MATRIX" false true false \
+  Cargo.toml docs/dependencies.md
+
+run_case "workflow changes fail out of the light path" \
+  pull_request fix/ci "ci: fix classifier" \
+  false false "$LINUX_MATRIX" false false true \
+  .github/workflows/ci.yml
+
+run_case "browser changes retain browser coverage" \
+  pull_request feature/claude "feat: update Claude adapter" \
+  false true "$LINUX_MATRIX" false false false \
+  extensions/chatgpt-native/src/sites/claude.js
+
+run_case "ordinary Rust changes keep the Linux build matrix" \
+  pull_request fix/parser "fix: reject invalid input" \
+  false false "$LINUX_MATRIX" false false false \
+  crates/yoetz-core/src/lib.rs
+
+run_case "valid release metadata uses the release fast path" \
+  pull_request release/v0.5.43 "chore(release): v0.5.43" \
+  true false "$FULL_MATRIX" false true false \
+  CHANGELOG.md Cargo.toml Cargo.lock \
+  .codex-plugin/plugin.json .claude-plugin/plugin.json \
+  extensions/chatgpt-native/manifest.json skills/yoetz/SKILL.md
+
+run_case "Cargo.lock alone on a valid release branch stays release-light" \
+  pull_request release/v0.5.43 "chore(release): v0.5.43" \
+  true false "$FULL_MATRIX" false true false \
+  Cargo.lock
+
+run_case "release branch with source fails closed" \
+  pull_request release/v0.5.43 "chore(release): v0.5.43" \
+  false false "$FULL_MATRIX" false true false \
+  Cargo.lock crates/yoetz-core/src/lib.rs
+
+run_case "release branch without the matching release title fails closed" \
+  pull_request release/v0.5.43 "chore: unrelated metadata" \
+  false false "$FULL_MATRIX" false true false \
+  Cargo.lock
+
+run_case "release commit push keeps its dedicated fast path" \
+  push "" "chore(release): v0.5.43" \
+  true false "$LINUX_MATRIX" true false false
+
+run_case "workflow dispatch requests the full matrix" \
+  workflow_dispatch "" "" \
+  false true "$FULL_MATRIX" false false false
+
+run_case "empty file lists fail closed" \
+  pull_request feature/empty "test: empty diff" \
+  false true "$LINUX_MATRIX" false false false
+
+run_case "unknown events fail closed" \
+  schedule "" "" \
+  false true "$LINUX_MATRIX" false false false \
+  README.md
+
+WORKFLOW="${ROOT_DIR}/.github/workflows/ci.yml"
+grep -Fq "dependency_changed: \${{ steps.detect.outputs.dependency_changed }}" "$WORKFLOW" || fail "workflow does not publish dependency_changed"
+grep -Fq "workflow_changed: \${{ steps.detect.outputs.workflow_changed }}" "$WORKFLOW" || fail "workflow does not publish workflow_changed"
+grep -Fq './scripts/test-ci-classify-changes.sh' "$WORKFLOW" || fail "workflow does not run the classifier table tests"
+grep -Fq "./scripts/ci-classify-changes.sh \\" "$WORKFLOW" || fail "workflow does not invoke the classifier"
+
+echo "All CI classifier tests passed."

--- a/scripts/test-workflow-action-pins.sh
+++ b/scripts/test-workflow-action-pins.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+POLICY="${ROOT_DIR}/scripts/check-workflow-action-pins.sh"
+FIXTURE_DIR="$(mktemp -d)"
+trap 'rm -rf -- "$FIXTURE_DIR"' EXIT
+fixture_counter=0
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+write_fixture() {
+  fixture_counter=$((fixture_counter + 1))
+  fixture_path="${FIXTURE_DIR}/fixture-${fixture_counter}.yml"
+  printf '%s\n' "$1" >"$fixture_path"
+}
+
+expect_pass() {
+  local name="$1"
+  local source="$2"
+  local output
+  write_fixture "$source"
+  if ! output="$(${POLICY} "$fixture_path" 2>&1)"; then
+    fail "${name}: expected pass, got: ${output}"
+  fi
+  echo "PASS: ${name}"
+}
+
+expect_fail() {
+  local name="$1"
+  local source="$2"
+  local output
+  write_fixture "$source"
+  if output="$(${POLICY} "$fixture_path" 2>&1)"; then
+    fail "${name}: expected failure, got: ${output}"
+  fi
+  echo "PASS: ${name}"
+}
+
+expect_pass "40-hex GitHub action pin" \
+  '    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0'
+
+expect_pass "quoted 40-hex reusable workflow pin" \
+  '    uses: "owner/repo/.github/workflows/reuse.yml@0123456789abcdef0123456789abcdef01234567"'
+
+expect_pass "local action path" \
+  '    - uses: ./.github/actions/check'
+
+expect_pass "Docker image digest" \
+  '    - uses: docker://rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667'
+
+expect_fail "mutable GitHub action tag" \
+  '    - uses: actions/checkout@v7'
+
+expect_fail "short GitHub action SHA" \
+  '    - uses: actions/checkout@9c091bb'
+
+expect_fail "mutable Docker image tag" \
+  '    - uses: docker://rhysd/actionlint:1.7.12'
+
+expect_fail "short Docker digest" \
+  '    - uses: docker://rhysd/actionlint@sha256:b1934ee5'
+
+expect_fail "missing remote action ref" \
+  '    - uses: actions/checkout'
+
+if ! current_output="$(${POLICY} 2>&1)"; then
+  fail "current workflows violate the pin policy: ${current_output}"
+fi
+echo "PASS: current workflows"
+
+CI_WORKFLOW="${ROOT_DIR}/.github/workflows/ci.yml"
+grep -Fq 'workflow-policy:' "$CI_WORKFLOW" || fail "CI is missing the workflow-policy job"
+grep -Fq 'name: Workflow Policy' "$CI_WORKFLOW" || fail "CI is missing the stable Workflow Policy check name"
+grep -Fq './scripts/check-workflow-action-pins.sh' "$CI_WORKFLOW" || fail "Workflow Policy does not enforce action pins"
+grep -Fq 'docker://rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667' "$CI_WORKFLOW" || fail "Workflow Policy does not use the approved immutable actionlint image"
+
+echo "All workflow action pin tests passed."


### PR DESCRIPTION
## Summary

- classify Cargo metadata as dependency-heavy and build it on Ubuntu, macOS, and Windows
- classify workflow changes as non-light so real Rust gates execute
- restrict release PR fast paths to generated release metadata with matching branch and title
- add a stable Workflow Policy job with actionlint and immutable action-pin enforcement

## Local verification

- `bash scripts/test-ci-classify-changes.sh`
- `bash scripts/test-workflow-action-pins.sh`
- `shellcheck` on all four policy/classifier scripts
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- YAML parse and `git diff --check`

## Required live proof before merge

- inspect Detect output for `light_only=false` and `workflow_changed=true`
- inspect Test and Clippy logs to confirm cargo commands ran instead of light-only echo steps
- terminal full workflow dispatch on this exact head, including all three Build OS jobs and Workflow Policy

Branch protection is intentionally unchanged.