### PR TITLE
Close owned browser tabs after successful recipes

### DIFF
--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -1334,6 +1334,15 @@ fn auth_doctor_check_from_payload(payload: &Value, recipe: BuiltinWebRecipe) -> 
     if let Some(selection) = payload.get("selection").and_then(Value::as_str) {
         detail.push(format!("selection={selection}"));
     }
+    if let Some(count) = payload.get("yoetz_owned_tabs_open").and_then(Value::as_u64) {
+        detail.push(format!("yoetz_owned_tabs_open={count}"));
+    }
+    if let Some(count) = payload
+        .get("yoetz_owned_complete_tabs_open")
+        .and_then(Value::as_u64)
+    {
+        detail.push(format!("yoetz_owned_complete_tabs_open={count}"));
+    }
     if let Some(url) = payload
         .get("url")
         .or_else(|| payload.get("tab_url"))
@@ -1501,6 +1510,8 @@ pub fn canary(
         .path()
         .join(format!("yoetz-{}-native-canary.md", recipe.as_str()));
     fs::write(&bundle_path, "Reply with exactly OK.\n")?;
+    // A successful automated canary should not leave a diagnostic tab behind.
+    let close_tab_on_complete = true;
     let response = match recipe {
         BuiltinWebRecipe::Chatgpt => run_chatgpt_recipe(
             &ChatgptRecipeSpec {
@@ -1518,6 +1529,7 @@ pub fn canary(
                 wait_interval_ms: 1_000,
                 upload_timeout_ms: 30_000,
                 send_timeout_ms: 120_000,
+                close_tab_on_complete,
             },
             OutputFormat::Json,
         )?,
@@ -1535,6 +1547,7 @@ pub fn canary(
                 wait_interval_ms: 1_000,
                 upload_timeout_ms: 30_000,
                 send_timeout_ms: 120_000,
+                close_tab_on_complete,
                 warnings: Vec::new(),
             },
             OutputFormat::Json,
@@ -1763,6 +1776,7 @@ fn chatgpt_job_start_payload(spec: &ChatgptRecipeSpec, bundle: &BundleInfo) -> V
         "wait_interval_ms": spec.wait_interval_ms,
         "upload_timeout_ms": spec.upload_timeout_ms,
         "send_timeout_ms": spec.send_timeout_ms,
+        "close_tab_on_complete": spec.close_tab_on_complete,
     })
 }
 
@@ -1785,6 +1799,7 @@ fn claude_job_start_payload(spec: &ClaudeRecipeSpec, bundle: &BundleInfo) -> Val
         "wait_interval_ms": spec.wait_interval_ms,
         "upload_timeout_ms": spec.upload_timeout_ms,
         "send_timeout_ms": spec.send_timeout_ms,
+        "close_tab_on_complete": spec.close_tab_on_complete,
     })
 }
 
@@ -4175,11 +4190,13 @@ mod tests {
             wait_interval_ms: 1_000,
             upload_timeout_ms: 2_000,
             send_timeout_ms: 3_000,
+            close_tab_on_complete: true,
         };
 
         let payload = chatgpt_job_start_payload(&spec, &bundle);
 
         assert_eq!(payload["conversation_id"], "conv-123");
+        assert_eq!(payload["close_tab_on_complete"], true);
     }
 
     #[test]
@@ -4204,6 +4221,7 @@ mod tests {
             wait_interval_ms: 1_000,
             upload_timeout_ms: 2_000,
             send_timeout_ms: 3_000,
+            close_tab_on_complete: false,
             warnings: vec!["size warning".to_string()],
         };
 
@@ -4217,6 +4235,7 @@ mod tests {
         assert_eq!(payload["model_strategy"], "select");
         assert_eq!(payload["conversation_id"], conversation_id);
         assert_eq!(payload["extension_instance_id"], "ext_claude");
+        assert_eq!(payload["close_tab_on_complete"], false);
     }
 
     #[test]
@@ -4323,6 +4342,28 @@ mod tests {
         assert_eq!(
             result.conversation_url.as_deref(),
             Some("https://chatgpt.com/c/conv-123")
+        );
+    }
+
+    #[test]
+    fn job_complete_parsing_tolerates_absent_tab_reporting_fields() {
+        let envelope = ProtocolEnvelope::new(
+            "job_complete",
+            Some("job_old_extension".to_string()),
+            Some("run_old_extension".to_string()),
+            json!({
+                "response": "done",
+                "conversation_id": "conv-old-extension",
+                "conversation_url": "https://chatgpt.com/c/conv-old-extension"
+            }),
+        );
+
+        let result = parse_recipe_result(envelope).unwrap();
+
+        assert_eq!(result.response, "done");
+        assert_eq!(
+            result.conversation_url.as_deref(),
+            Some("https://chatgpt.com/c/conv-old-extension")
         );
     }
 
@@ -4602,7 +4643,9 @@ mod tests {
             "message": "ChatGPT login required in this Chrome profile",
             "tab_id": 7,
             "selection": "active_non_yoetz_chatgpt_tab",
-            "url": "https://chatgpt.com/auth/login"
+            "url": "https://chatgpt.com/auth/login",
+            "yoetz_owned_tabs_open": 3,
+            "yoetz_owned_complete_tabs_open": 1
         }));
 
         assert_eq!(check.name, "chatgpt_auth");
@@ -4610,6 +4653,8 @@ mod tests {
         assert!(check.detail.contains("login_required"));
         assert!(check.detail.contains("tab_id=7"));
         assert!(check.detail.contains("active_non_yoetz_chatgpt_tab"));
+        assert!(check.detail.contains("yoetz_owned_tabs_open=3"));
+        assert!(check.detail.contains("yoetz_owned_complete_tabs_open=1"));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/chatgpt_recipe.rs
+++ b/crates/yoetz-cli/src/chatgpt_recipe.rs
@@ -124,6 +124,7 @@ pub struct ChatgptRecipeSpec {
     pub wait_interval_ms: u64,
     pub upload_timeout_ms: u64,
     pub send_timeout_ms: u64,
+    pub close_tab_on_complete: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/crates/yoetz-cli/src/claude_recipe.rs
+++ b/crates/yoetz-cli/src/claude_recipe.rs
@@ -46,6 +46,7 @@ pub struct ClaudeRecipeSpec {
     pub wait_interval_ms: u64,
     pub upload_timeout_ms: u64,
     pub send_timeout_ms: u64,
+    pub close_tab_on_complete: bool,
     pub warnings: Vec<String>,
 }
 
@@ -126,6 +127,32 @@ pub fn inline_size_warnings(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn claude_recipe_output_keeps_conversation_url_at_top_level() {
+        let output = ClaudeRecipeOutput {
+            transport: "chrome-extension-native".to_string(),
+            backend: "chrome-extension-native".to_string(),
+            response: "done".to_string(),
+            model_used: Some(CLAUDE_REPORTED_MODEL.to_string()),
+            model_selection_status: WebModelSelectionStatus::Selected,
+            warnings: Vec::new(),
+            fallback_used: false,
+            conversation_id: Some("123e4567-e89b-12d3-a456-426614174000".to_string()),
+            conversation_url: Some(
+                "https://claude.ai/chat/123e4567-e89b-12d3-a456-426614174000".to_string(),
+            ),
+            run_id: "run-claude".to_string(),
+            elapsed_ms: 42,
+        };
+
+        let payload = output.to_value();
+
+        assert_eq!(
+            payload["conversation_url"],
+            "https://claude.ai/chat/123e4567-e89b-12d3-a456-426614174000"
+        );
+    }
 
     #[test]
     fn exact_model_aliases_canonicalize_and_other_models_fail_closed() {

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -321,6 +321,10 @@ struct BrowserRecipeArgs {
     #[arg(long)]
     allow_cdp_fallback: bool,
 
+    /// Keep the yoetz-owned browser tab open after successful completion.
+    #[arg(long)]
+    keep_tab: bool,
+
     #[arg(long)]
     bundle: Option<PathBuf>,
 
@@ -2431,6 +2435,7 @@ fn build_chatgpt_recipe_spec(
         wait_interval_ms: poll_settings.interval_ms,
         upload_timeout_ms,
         send_timeout_ms,
+        close_tab_on_complete: !recipe_args.keep_tab,
     })
 }
 
@@ -2481,6 +2486,7 @@ fn build_claude_recipe_spec(
         wait_interval_ms: poll_settings.interval_ms,
         upload_timeout_ms,
         send_timeout_ms,
+        close_tab_on_complete: !recipe_args.keep_tab,
         warnings: warnings.to_vec(),
     })
 }
@@ -6543,6 +6549,30 @@ mod tests {
     }
 
     #[test]
+    fn browser_recipe_keep_tab_flag_defaults_off_and_can_be_enabled() {
+        for (extra_args, expected_keep_tab) in
+            [(Vec::<&str>::new(), false), (vec!["--keep-tab"], true)]
+        {
+            let mut argv = vec![
+                "yoetz",
+                "browser",
+                "recipe",
+                "--recipe",
+                "recipes/chatgpt.yaml",
+            ];
+            argv.extend(extra_args);
+            let cli = Cli::try_parse_from(argv).expect("browser recipe args should parse");
+
+            match cli.command {
+                Commands::Browser(BrowserArgs {
+                    command: BrowserCommand::Recipe(args),
+                }) => assert_eq!(args.keep_tab, expected_keep_tab),
+                _ => panic!("unexpected command parsed"),
+            }
+        }
+    }
+
+    #[test]
     fn browser_sync_cookies_cli_accepts_profile_path() {
         let cli = Cli::try_parse_from([
             "yoetz",
@@ -6599,6 +6629,7 @@ mod tests {
             recipe: PathBuf::from("recipes/claude.yaml"),
             transport: None,
             allow_cdp_fallback: false,
+            keep_tab: false,
             bundle: None,
             profile: None,
             cdp: None,
@@ -6636,6 +6667,7 @@ mod tests {
             recipe: PathBuf::from("recipes/chatgpt.yaml"),
             transport: None,
             allow_cdp_fallback: false,
+            keep_tab: false,
             bundle: None,
             profile: Some(PathBuf::from("/tmp/ignored")),
             cdp: None,
@@ -6669,6 +6701,7 @@ mod tests {
             recipe: PathBuf::from("recipes/chatgpt.yaml"),
             transport: None,
             allow_cdp_fallback: false,
+            keep_tab: false,
             bundle: Some(PathBuf::from("/tmp/bundle.md")),
             profile: None,
             cdp: None,
@@ -6703,6 +6736,7 @@ mod tests {
             recipe: PathBuf::from("recipes/chatgpt.yaml"),
             transport: None,
             allow_cdp_fallback: false,
+            keep_tab: false,
             bundle: None,
             profile: None,
             cdp: None,
@@ -6737,6 +6771,7 @@ mod tests {
             recipe: PathBuf::from("recipes/chatgpt.yaml"),
             transport: None,
             allow_cdp_fallback: false,
+            keep_tab: false,
             bundle: Some(PathBuf::from("/tmp/bundle.md")),
             profile: None,
             cdp: None,
@@ -6771,6 +6806,7 @@ mod tests {
             recipe: PathBuf::from("recipes/chatgpt.yaml"),
             transport: None,
             allow_cdp_fallback: false,
+            keep_tab: false,
             bundle: Some(PathBuf::from("/tmp/bundle.md")),
             profile: None,
             cdp: None,
@@ -6807,6 +6843,7 @@ mod tests {
             recipe: PathBuf::from("recipes/chatgpt.yaml"),
             transport: None,
             allow_cdp_fallback: false,
+            keep_tab: false,
             bundle: Some(bundle_path.clone()),
             profile: None,
             cdp: None,
@@ -6836,6 +6873,7 @@ mod tests {
             recipe: PathBuf::from("recipes/chatgpt.yaml"),
             transport: None,
             allow_cdp_fallback: false,
+            keep_tab: false,
             bundle: Some(bundle_path.clone()),
             profile: None,
             cdp: None,
@@ -6863,6 +6901,7 @@ mod tests {
             recipe: PathBuf::from("recipes/chatgpt.yaml"),
             transport: None,
             allow_cdp_fallback: false,
+            keep_tab: false,
             bundle: Some(PathBuf::from("/tmp/bundle.md")),
             profile: None,
             cdp: None,
@@ -6912,6 +6951,7 @@ mod tests {
             recipe: PathBuf::from("recipes/chatgpt.yaml"),
             transport: None,
             allow_cdp_fallback: false,
+            keep_tab: false,
             bundle: Some(PathBuf::from("/tmp/bundle.md")),
             profile: None,
             cdp: None,
@@ -6980,6 +7020,7 @@ mod tests {
             recipe: PathBuf::from("recipes/claude.yaml"),
             transport: None,
             allow_cdp_fallback: false,
+            keep_tab: false,
             bundle: Some(PathBuf::from("/tmp/bundle.md")),
             profile: None,
             cdp: None,
@@ -7040,6 +7081,7 @@ mod tests {
             recipe: PathBuf::from("recipes/chatgpt.yaml"),
             transport: None,
             allow_cdp_fallback: false,
+            keep_tab: false,
             bundle: Some(PathBuf::from("/tmp/bundle.md")),
             profile: None,
             cdp: None,
@@ -7085,6 +7127,7 @@ mod tests {
             recipe: PathBuf::from("recipes/chatgpt.yaml"),
             transport: None,
             allow_cdp_fallback: false,
+            keep_tab: false,
             bundle: Some(bundle_md),
             profile: None,
             cdp: None,
@@ -7131,6 +7174,7 @@ mod tests {
             recipe: PathBuf::from("recipes/chatgpt.yaml"),
             transport: None,
             allow_cdp_fallback: false,
+            keep_tab: false,
             bundle: Some(bundle_md),
             profile: None,
             cdp: None,
@@ -7157,6 +7201,7 @@ mod tests {
             recipe: PathBuf::from("recipes/chatgpt.yaml"),
             transport: Some(browser::RecipeTransport::ChromeExtensionNative),
             allow_cdp_fallback: false,
+            keep_tab: false,
             bundle: Some(PathBuf::from("/tmp/missing-bundle.md")),
             profile: None,
             cdp: None,
@@ -7191,6 +7236,7 @@ mod tests {
             recipe: PathBuf::from("recipes/chatgpt.yaml"),
             transport: Some(browser::RecipeTransport::ChromeExtensionNative),
             allow_cdp_fallback: false,
+            keep_tab: false,
             bundle: Some(PathBuf::from("/tmp/missing-bundle.md")),
             profile: None,
             cdp: None,
@@ -7225,6 +7271,7 @@ mod tests {
             recipe: PathBuf::from("recipes/chatgpt.yaml"),
             transport: Some(browser::RecipeTransport::ChromeExtensionNative),
             allow_cdp_fallback: false,
+            keep_tab: false,
             bundle: Some(PathBuf::from("/tmp/bundle.md")),
             profile: None,
             cdp: None,
@@ -7286,6 +7333,7 @@ mod tests {
             recipe: PathBuf::from("recipes/chatgpt.yaml"),
             transport: None,
             allow_cdp_fallback: false,
+            keep_tab: false,
             bundle: Some(PathBuf::from("/tmp/bundle.md")),
             profile: None,
             cdp: None,
@@ -7319,6 +7367,7 @@ mod tests {
             recipe: PathBuf::from("recipes/claude.yaml"),
             transport: Some(browser::RecipeTransport::DevBrowser),
             allow_cdp_fallback: false,
+            keep_tab: false,
             bundle: Some(PathBuf::from("/tmp/claude-bundle.md")),
             profile: None,
             cdp: None,
@@ -7363,6 +7412,7 @@ mod tests {
             recipe: PathBuf::from("recipes/chatgpt.yaml"),
             transport: None,
             allow_cdp_fallback: false,
+            keep_tab: false,
             bundle: Some(PathBuf::from("/tmp/bundle.md")),
             profile: None,
             cdp: None,

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -572,9 +572,34 @@ async function completeJobWithExtraction(job, extraction) {
     await recordTerminalDeliveryLost(job, "wait_response");
     return;
   }
+  await closeOwnedTabOnComplete(job);
   rememberTerminalJob(job.job_id);
   jobs.delete(job.job_id);
   chunks.discard(job.job_id);
+}
+
+async function closeOwnedTabOnComplete(job) {
+  if (!job.close_tab_on_complete || !job.tab_id) {
+    return;
+  }
+  let phase = "tab_closed";
+  let detail = { tab_id: job.tab_id };
+  try {
+    await chrome.tabs.remove(job.tab_id);
+    job.tab_disposition = "closed";
+  } catch (error) {
+    job.tab_disposition = "close_failed";
+    phase = "tab_close_failed";
+    detail = {
+      tab_id: job.tab_id,
+      error: String(error?.message ?? error)
+    };
+  }
+  await persistJob(job);
+  // The native host currently releases the per-job client after job_complete,
+  // so this progress event is intentionally unrouted until host routing grows
+  // an explicit post-terminal channel. The persisted shard is authoritative.
+  postNative(progress(job, phase, detail));
 }
 
 function conversationIdForJob(job, extraction = null) {
@@ -669,6 +694,7 @@ async function cancelJob(message) {
 
   postNative(progress(job, "cancelled", {
     tab_id: job.tab_id,
+    tab_disposition: "closed",
     stop_clicked: stopClicked,
     stop_confirmed: stopConfirmed,
     generation_idle: stopConfirmed,
@@ -682,6 +708,7 @@ async function cancelJob(message) {
     capability_token: job.capability_token,
     payload: {
       cancelled: true,
+      tab_disposition: "closed",
       stop_clicked: stopClicked,
       stop_confirmed: stopConfirmed,
       generation_idle: stopConfirmed,
@@ -758,13 +785,15 @@ async function handleDoctorAuthProbe(message) {
 
 async function probeSiteAuthentication(adapter) {
   const tabs = await chrome.tabs.query({ url: adapter.tabQueryPattern });
+  const ownedTabCounts = await countOwnedTabs(tabs, adapter);
   const selected = selectSiteAuthProbeTab(tabs, adapter);
   if (!selected) {
     return {
       status: adapter.auth.noTabStatus,
       authenticated: false,
       message: `No ${adapter.displayName} tab is open in this Chrome profile; open ${adapter.homeUrl} and rerun doctor`,
-      inspected_tabs: 0
+      inspected_tabs: 0,
+      ...ownedTabCounts
     };
   }
   try {
@@ -775,7 +804,8 @@ async function probeSiteAuthentication(adapter) {
       tab_url: selected.tab.url ?? null,
       tab_title: selected.tab.title ?? null,
       selection: selected.selection,
-      inspected_tabs: selected.total
+      inspected_tabs: selected.total,
+      ...ownedTabCounts
     };
   } catch (error) {
     return {
@@ -786,9 +816,50 @@ async function probeSiteAuthentication(adapter) {
       tab_url: selected.tab.url ?? null,
       tab_title: selected.tab.title ?? null,
       selection: selected.selection,
-      inspected_tabs: selected.total
+      inspected_tabs: selected.total,
+      ...ownedTabCounts
     };
   }
+}
+
+async function countOwnedTabs(tabs, adapter) {
+  const stored = await chrome.storage.session.get(null);
+  const storedJobs = Object.entries(stored)
+    .filter(([key, job]) =>
+      key.startsWith(JOBS_KEY_PREFIX)
+      && Number.isFinite(job?.tab_id)
+    )
+    .map(([, job]) => job);
+  const shardedTabIds = new Set(storedJobs.map((job) => job.tab_id));
+  const ownedTabIds = new Set(
+    (tabs ?? [])
+      .filter((tab) =>
+        isYoetzOwnedTab(tab, adapter)
+        || shardedTabIds.has(tab?.id)
+      )
+      .map((tab) => tab.id)
+  );
+  const completeTabIds = new Set(
+    storedJobs
+      .filter((job) =>
+        job.status === "complete"
+        && job.close_tab_on_complete === true
+        && job.tab_disposition !== "closed"
+      )
+      .map((job) => job.tab_id)
+  );
+  return {
+    yoetz_owned_tabs_open: ownedTabIds.size,
+    yoetz_owned_complete_tabs_open: [...ownedTabIds]
+      .filter((tabId) => completeTabIds.has(tabId))
+      .length
+  };
+}
+
+function isYoetzOwnedTab(tab, adapter) {
+  return Boolean(tab?.id)
+    && adapter.isAllowedTabUrl(tab.url)
+    && new URL(tab.url).searchParams.has("_yoetz");
 }
 
 function selectSiteAuthProbeTab(tabs, adapter) {
@@ -796,7 +867,7 @@ function selectSiteAuthProbeTab(tabs, adapter) {
     .filter((tab) => tab?.id && adapter.isAllowedTabUrl(tab.url))
     .map((tab) => ({
       tab,
-      yoetzOwned: new URL(tab.url).searchParams.has("_yoetz")
+      yoetzOwned: isYoetzOwnedTab(tab, adapter)
     }));
   if (candidates.length === 0) {
     return null;
@@ -1101,6 +1172,7 @@ function normalizeJob(message, adapter) {
     wait_interval_ms: payload.wait_interval_ms ?? 30000,
     upload_timeout_ms: payload.upload_timeout_ms ?? 120000,
     send_timeout_ms: payload.send_timeout_ms ?? 120000,
+    close_tab_on_complete: payload.close_tab_on_complete === true,
     browser_context_id: payload.browser_context_id ?? null,
     profile_email: payload.profile_email ?? null,
     extension_instance_id: payload.extension_instance_id ?? null,
@@ -2246,6 +2318,11 @@ function cleanupTerminalJobIds() {
 
 async function failJob(job, code, message, detail = {}) {
   const { terminal_status: terminalStatus, ...payloadDetail } = detail;
+  if (job?.tab_id) {
+    // "kept" means Yoetz did not close the tab on this failure path. It does
+    // not assert that the user has not already closed the tab independently.
+    payloadDetail.tab_disposition = "kept";
+  }
   if (job) {
     job.status = terminalStatus ?? "failed";
     job.updated_at = Date.now();

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -684,9 +684,11 @@ async function cancelJob(message) {
   // here through the tabGroups API instead of chrome.tabs.remove. This runs only
   // after the awaited cancelSend above resolves, so we never destroy the page
   // mid-abort.
+  let tabDisposition = job.tab_id ? "close_failed" : "closed";
   if (job.tab_id && chrome.tabs?.remove) {
     try {
       await chrome.tabs.remove(job.tab_id);
+      tabDisposition = "closed";
     } catch {
       // Tab already closed by the user, or removal racing with navigation.
     }
@@ -694,7 +696,7 @@ async function cancelJob(message) {
 
   postNative(progress(job, "cancelled", {
     tab_id: job.tab_id,
-    tab_disposition: "closed",
+    tab_disposition: tabDisposition,
     stop_clicked: stopClicked,
     stop_confirmed: stopConfirmed,
     generation_idle: stopConfirmed,
@@ -708,7 +710,7 @@ async function cancelJob(message) {
     capability_token: job.capability_token,
     payload: {
       cancelled: true,
-      tab_disposition: "closed",
+      tab_disposition: tabDisposition,
       stop_clicked: stopClicked,
       stop_confirmed: stopConfirmed,
       generation_idle: stopConfirmed,
@@ -830,7 +832,11 @@ async function countOwnedTabs(tabs, adapter) {
       && Number.isFinite(job?.tab_id)
     )
     .map(([, job]) => job);
-  const shardedTabIds = new Set(storedJobs.map((job) => job.tab_id));
+  const shardedTabIds = new Set(
+    storedJobs
+      .filter((job) => job.tab_disposition !== "closed")
+      .map((job) => job.tab_id)
+  );
   const ownedTabIds = new Set(
     (tabs ?? [])
       .filter((tab) =>

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -767,7 +767,7 @@ test("service worker doctor auth probe prefers active non-owned ChatGPT tab and 
     assert.equal(complete.payload.manual_handoff.state, "login_required");
     assert.equal(complete.payload.tab_id, 2);
     assert.equal(complete.payload.selection, "active_non_yoetz_chatgpt_tab");
-    assert.equal(complete.payload.yoetz_owned_tabs_open, 4);
+    assert.equal(complete.payload.yoetz_owned_tabs_open, 3);
     assert.equal(complete.payload.yoetz_owned_complete_tabs_open, 1);
     assert.deepEqual(sentToTabs.map((item) => item.id), [2]);
   } finally {
@@ -6296,10 +6296,10 @@ test("service worker cancelJob removes the tab but warns may_still_be_running wh
   }
 });
 
-test("service worker cancelJob on an already-idle response removes the tab and reports confirmed_idle", async () => {
+test("service worker cancelJob reports close_failed when tab removal throws after confirmed idle", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
-  const removedTabs = [];
+  const removeAttempts = [];
   let createdTabId = 0;
   let sent = false;
   globalThis.chrome = chromeStub({
@@ -6308,7 +6308,8 @@ test("service worker cancelJob on an already-idle response removes the tab and r
       create: async (opts) => ({ id: ++createdTabId, ...opts }),
       get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
       remove: async (id) => {
-        removedTabs.push(id);
+        removeAttempts.push(id);
+        throw new Error("tabs.remove failed");
       },
       sendMessage: async (_id, message) => {
         switch (message.type) {
@@ -6365,13 +6366,20 @@ test("service worker cancelJob on an already-idle response removes the tab and r
     port.emit(envelope("job_cancel", "job_cancel_idle"));
     await eventually(() => port.messages.some((m) => m.type === "job_cancel" && m.job_id === "job_cancel_idle"));
 
-    assert.deepEqual(removedTabs, [createdTabId], "already-idle cancel must still remove the tab");
+    assert.deepEqual(removeAttempts, [createdTabId]);
     const cancelEnvelope = port.messages.find((m) => m.type === "job_cancel" && m.job_id === "job_cancel_idle");
     assert.equal(cancelEnvelope.payload.cancelled, true);
+    assert.equal(cancelEnvelope.payload.tab_disposition, "close_failed");
     assert.equal(cancelEnvelope.payload.stop_clicked, false);
     assert.equal(cancelEnvelope.payload.stop_confirmed, true);
     assert.equal(cancelEnvelope.payload.generation_idle, true);
     assert.equal(cancelEnvelope.payload.may_still_be_running, false);
+    const cancelledProgress = port.messages.find((m) =>
+      m.type === "job_progress"
+      && m.job_id === "job_cancel_idle"
+      && m.payload?.phase === "cancelled"
+    );
+    assert.equal(cancelledProgress.payload.tab_disposition, "close_failed");
   } finally {
     globalThis.chrome = originalChrome;
   }

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -685,15 +685,46 @@ test("service worker surfaces Claude model mismatch legs in the job error", asyn
 test("service worker doctor auth probe prefers active non-owned ChatGPT tab and surfaces login", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
+  const storage = makeStorage();
   const sentToTabs = [];
+  await storage.set({
+    "jobs.job_complete_leak": {
+      job_id: "job_complete_leak",
+      tab_id: 1,
+      status: "complete",
+      close_tab_on_complete: true
+    },
+    "jobs.job_active_owned": {
+      job_id: "job_active_owned",
+      tab_id: 4,
+      status: "waiting_response"
+    },
+    "jobs.job_kept_complete": {
+      job_id: "job_kept_complete",
+      tab_id: 5,
+      status: "complete",
+      close_tab_on_complete: false
+    },
+    "jobs.job_closed_complete": {
+      job_id: "job_closed_complete",
+      tab_id: 6,
+      status: "complete",
+      close_tab_on_complete: true,
+      tab_disposition: "closed"
+    }
+  });
   globalThis.chrome = chromeStub({
     port,
+    storage,
     profileEmail: "work@example.com",
     tabs: {
       query: async () => [
-        { id: 1, url: "https://chatgpt.com/?_yoetz=run_job", title: "Yoetz job", active: true },
+        { id: 1, url: "https://chatgpt.com/c/completed", title: "Yoetz job", active: false },
         { id: 2, url: "https://chatgpt.com/", title: "ChatGPT", active: true },
-        { id: 3, url: "https://chatgpt.com/c/older", title: "Older ChatGPT", active: false }
+        { id: 3, url: "https://chatgpt.com/c/older", title: "Older ChatGPT", active: false },
+        { id: 4, url: "https://chatgpt.com/c/active?_yoetz=run_active", title: "Active Yoetz job", active: false },
+        { id: 5, url: "https://chatgpt.com/c/kept", title: "Kept Yoetz job", active: false },
+        { id: 6, url: "https://chatgpt.com/c/closed", title: "Stale closed shard", active: false }
       ],
       create: async () => {
         throw new Error("doctor auth probe must not open a tab");
@@ -736,6 +767,8 @@ test("service worker doctor auth probe prefers active non-owned ChatGPT tab and 
     assert.equal(complete.payload.manual_handoff.state, "login_required");
     assert.equal(complete.payload.tab_id, 2);
     assert.equal(complete.payload.selection, "active_non_yoetz_chatgpt_tab");
+    assert.equal(complete.payload.yoetz_owned_tabs_open, 4);
+    assert.equal(complete.payload.yoetz_owned_complete_tabs_open, 1);
     assert.deepEqual(sentToTabs.map((item) => item.id), [2]);
   } finally {
     globalThis.chrome = originalChrome;
@@ -924,6 +957,7 @@ test("service worker rejects invalid conversation ids before opening a tab", asy
       assert.equal(error.payload.code, "invalid_conversation");
       assert.equal(error.payload.phase, "upload");
       assert.equal(error.payload.side_effect_started, false);
+      assert.equal(error.payload.tab_disposition, undefined);
       assert.deepEqual(createdTabs, []);
     } finally {
       globalThis.chrome = originalChrome;
@@ -1206,6 +1240,7 @@ test("service worker fails unavailable conversations with inspectable terminal e
     assert.equal(error.payload.requested_conversation_id, "conv-404");
     assert.equal(error.payload.current_url, currentUrl);
     assert.equal(error.payload.inspect_command, "yoetz browser extension inspect --chatgpt --run-id run_job_unavailable");
+    assert.equal(error.payload.tab_disposition, "kept");
     assert.match(error.payload.message, /requested conversation conv-404/);
     assert.match(error.payload.message, /current URL https:\/\/chatgpt\.com\/c\/conv-404\?_yoetz=run_job_unavailable/);
     assert.match(error.payload.message, /phase upload/);
@@ -1248,6 +1283,7 @@ test("service worker marks manual handoff as terminal after tab side effects", a
     assert.equal(error.payload.code, "manual_handoff");
     assert.equal(error.payload.phase, "upload");
     assert.equal(error.payload.side_effect_started, true);
+    assert.equal(error.payload.tab_disposition, "kept");
   } finally {
     globalThis.chrome = originalChrome;
   }
@@ -3220,6 +3256,7 @@ test("service worker reports oversized completed responses before native deliver
     assert.equal(error.payload.side_effect_started, true);
     assert.equal(error.payload.response_length, 2048);
     assert.equal(error.payload.max_native_message_bytes, 1024);
+    assert.equal(error.payload.tab_disposition, "kept");
     assert.equal(error.payload.inspect_command, "yoetz browser extension inspect --chatgpt --run-id run_job_oversized_completed_response");
     assert.ok(error.payload.native_message_bytes > error.payload.max_native_message_bytes);
     assert.match(error.payload.message, /too large to deliver/);
@@ -5960,6 +5997,13 @@ test("service worker cancelJob isolates one of two active ChatGPT jobs", async (
     const cancelEnvelope = port.messages.find((m) => m.type === "job_cancel" && m.job_id === "job_cancel_a");
     assert.equal(cancelEnvelope.payload.cancelled, true);
     assert.equal(cancelEnvelope.payload.stop_clicked, true);
+    assert.equal(cancelEnvelope.payload.tab_disposition, "closed");
+    const cancelledProgress = port.messages.find((m) =>
+      m.type === "job_progress"
+      && m.job_id === "job_cancel_a"
+      && m.payload?.phase === "cancelled"
+    );
+    assert.equal(cancelledProgress.payload.tab_disposition, "closed");
 
     survivorCanComplete = true;
     await eventually(() => port.messages.some((m) => m.type === "job_complete" && m.job_id === "job_survivor_b"));
@@ -6333,6 +6377,75 @@ test("service worker cancelJob on an already-idle response removes the tab and r
   }
 });
 
+test("service worker closes an owned tab only after delivering a gated successful completion", async () => {
+  const result = await runSuccessfulCompletionCase({
+    jobId: "job_close_success",
+    closeTabOnComplete: true
+  });
+
+  assert.deepEqual(result.removedTabs, [result.tabId]);
+  assert.ok(
+    result.events.indexOf("post:job_complete") < result.events.indexOf(`remove:${result.tabId}`),
+    `expected job_complete delivery before tab removal, got ${result.events.join(", ")}`
+  );
+  const closed = result.messages.find((message) =>
+    message.type === "job_progress" && message.payload?.phase === "tab_closed"
+  );
+  assert.equal(closed.payload.tab_id, result.tabId);
+  assert.equal(result.shard.status, "complete");
+  assert.equal(result.shard.tab_disposition, "closed");
+});
+
+test("service worker preserves legacy success behavior when the close gate is absent", async () => {
+  const result = await runSuccessfulCompletionCase({
+    jobId: "job_close_legacy"
+  });
+
+  assert.deepEqual(result.removedTabs, []);
+  assert.equal(
+    result.messages.some((message) =>
+      message.type === "job_progress"
+      && ["tab_closed", "tab_close_failed"].includes(message.payload?.phase)
+    ),
+    false
+  );
+  assert.equal(result.shard.status, "complete");
+  assert.equal(result.shard.tab_disposition, undefined);
+});
+
+test("service worker keeps the tab when successful completion delivery is lost", async () => {
+  const result = await runSuccessfulCompletionCase({
+    jobId: "job_close_delivery_lost",
+    closeTabOnComplete: true,
+    failCompleteDelivery: true
+  });
+
+  assert.deepEqual(result.removedTabs, []);
+  assert.equal(result.shard.status, "terminal_delivery_lost");
+  assert.equal(result.shard.tab_disposition, undefined);
+});
+
+test("service worker reports close failure without changing successful terminal status", async () => {
+  const result = await runSuccessfulCompletionCase({
+    jobId: "job_close_failure",
+    closeTabOnComplete: true,
+    removeError: new Error("tabs.remove failed")
+  });
+
+  assert.deepEqual(result.removedTabs, []);
+  const failed = result.messages.find((message) =>
+    message.type === "job_progress" && message.payload?.phase === "tab_close_failed"
+  );
+  assert.equal(failed.payload.tab_id, result.tabId);
+  assert.equal(failed.payload.error, "tabs.remove failed");
+  assert.equal(result.shard.status, "complete");
+  assert.equal(result.shard.tab_disposition, "close_failed");
+  assert.equal(
+    result.messages.some((message) => message.type === "job_error"),
+    false
+  );
+});
+
 test("service worker resumes waiting_for_file jobs after service-worker restart", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
@@ -6566,6 +6679,156 @@ test("service worker still fails receiving_file jobs after service-worker restar
     globalThis.chrome = originalChrome;
   }
 });
+
+async function runSuccessfulCompletionCase({
+  jobId,
+  closeTabOnComplete,
+  failCompleteDelivery = false,
+  removeError = null
+}) {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const storage = makeStorage();
+  const removedTabs = [];
+  const events = [];
+  let tabId = 0;
+  let sent = false;
+
+  const originalPostMessage = port.postMessage.bind(port);
+  port.postMessage = (message) => {
+    events.push(`post:${message.type}`);
+    return originalPostMessage(message);
+  };
+  port.throwOnPostMessage = (message) =>
+    failCompleteDelivery && message.type === "job_complete";
+
+  globalThis.chrome = chromeStub({
+    port,
+    storage,
+    tabs: {
+      create: async (options) => ({ id: ++tabId, ...options }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      remove: async (id) => {
+        events.push(`remove:${id}`);
+        if (removeError) {
+          throw removeError;
+        }
+        removedTabs.push(id);
+      },
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: verifiedSolProSelection() };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return {
+              ok: true,
+              payload: {
+                sent: true,
+                conversation_id: `conv-${jobId}`,
+                submitted_assistant_count: 0
+              }
+            };
+          case "yoetz_fetch_conversation":
+            return {
+              ok: true,
+              payload: {
+                method: "backend_api",
+                text: "done",
+                is_generating: false,
+                node_fresh: true,
+                node_id: `answer-${jobId}`,
+                conversation_id: `conv-${jobId}`,
+                assistant_count: 1,
+                turn_index: 0,
+                copy_button_count: 0,
+                has_copy_button: false
+              }
+            };
+          case "yoetz_extract_response":
+            return {
+              ok: true,
+              payload: sent
+                ? {
+                    method: "assistant_dom_fallback",
+                    text: "done",
+                    is_generating: false,
+                    assistant_count: 1,
+                    user_count: 1,
+                    preceding_user_count: 1,
+                    copy_button_count: 1,
+                    has_copy_button: true,
+                    turn_index: 0,
+                    conversation_id: `conv-${jobId}`
+                  }
+                : {
+                    method: "none",
+                    text: "",
+                    is_generating: false,
+                    assistant_count: 0,
+                    user_count: 0,
+                    copy_button_count: 0,
+                    has_copy_button: false,
+                    turn_index: -1
+                  }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?close_success_case=${jobId}_${Date.now()}`);
+    const payload = {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 2000
+    };
+    if (closeTabOnComplete !== undefined) {
+      payload.close_tab_on_complete = closeTabOnComplete;
+    }
+    port.emit(envelope("job_start", jobId, payload));
+    await eventually(() => port.messages.some((message) =>
+      message.type === "job_progress" && message.payload?.phase === "ready_for_file"
+    ));
+    port.emit(envelope("job_file_chunk", jobId, {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: `${jobId}.md`,
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    const terminalStatus = failCompleteDelivery ? "terminal_delivery_lost" : "complete";
+    await eventually(async () =>
+      (await storage.get(`jobs.${jobId}`))[`jobs.${jobId}`]?.status === terminalStatus
+    );
+    if (closeTabOnComplete && !failCompleteDelivery) {
+      await eventually(async () => {
+        const shard = (await storage.get(`jobs.${jobId}`))[`jobs.${jobId}`];
+        return ["closed", "close_failed"].includes(shard?.tab_disposition);
+      });
+    }
+    return {
+      events,
+      messages: [...port.messages],
+      removedTabs,
+      tabId,
+      shard: (await storage.get(`jobs.${jobId}`))[`jobs.${jobId}`]
+    };
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+}
 
 function verifiedSolProSelection() {
   return {


### PR DESCRIPTION
Implements #340 steps 1–3 and the doctor metric follow-up.

- adds `--keep-tab` to ChatGPT and Claude browser recipes
- closes Yoetz-owned tabs only after successful terminal delivery
- persists and reports closed / kept / close_failed dispositions
- exposes owned and leaked completed-tab counts in doctor output
- preserves legacy behavior across version skew

Verification:
- `cargo check -p yoetz --tests`
- focused Rust recipe/payload tests
- `cargo fmt --all -- --check`
- extension suite: 256/256

Not included: restore-time cleanup and inspect/docs work from #340 steps 4–6. Do not auto-close the issue.