### PR TITLE
Exclude citation chrome from ChatGPT answers

### DIFF
--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -1216,6 +1216,7 @@ fn chatgpt_recipe_payload_from_steps(steps: &[Value], fallback_used: bool) -> Va
         auto_paste_fallback: false,
         conversation_id: None,
         conversation_url: None,
+        diagnostics: chatgpt_recipe::ChatgptRecipeDiagnostics::default(),
     };
     let mut payload = output.to_value();
     if let Some(object) = payload.as_object_mut() {

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use thiserror::Error;
 
 use crate::chatgpt_recipe::{
-    ChatgptModelSelectionStatus, ChatgptRecipeSpec, ChatgptTransportPhase,
+    ChatgptModelSelectionStatus, ChatgptRecipeDiagnostics, ChatgptRecipeSpec, ChatgptTransportPhase,
 };
 use crate::claude_recipe::ClaudeRecipeSpec;
 use crate::web_recipe::BuiltinWebRecipe;
@@ -144,6 +144,7 @@ pub struct ExtensionRecipeResult {
     pub warnings: Vec<String>,
     pub conversation_id: Option<String>,
     pub conversation_url: Option<String>,
+    pub diagnostics: ChatgptRecipeDiagnostics,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -2866,6 +2867,35 @@ fn parse_recipe_result(envelope: ProtocolEnvelope) -> Result<ExtensionRecipeResu
         .get("conversation_url")
         .and_then(Value::as_str)
         .map(str::to_string);
+    let diagnostics = ChatgptRecipeDiagnostics {
+        extraction_method: envelope
+            .payload
+            .get("extraction_method")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        completion_reason: envelope
+            .payload
+            .get("completion_reason")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        finality_anchor: envelope
+            .payload
+            .get("finality_anchor")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        stable_for_ms: envelope
+            .payload
+            .get("stable_for_ms")
+            .and_then(Value::as_u64),
+        assistant_turn_count: envelope
+            .payload
+            .get("assistant_turn_count")
+            .and_then(Value::as_u64),
+        copy_button_count: envelope
+            .payload
+            .get("copy_button_count")
+            .and_then(Value::as_u64),
+    };
     Ok(ExtensionRecipeResult {
         response,
         model_used,
@@ -2873,6 +2903,7 @@ fn parse_recipe_result(envelope: ProtocolEnvelope) -> Result<ExtensionRecipeResu
         warnings,
         conversation_id,
         conversation_url,
+        diagnostics,
     })
 }
 
@@ -4326,6 +4357,12 @@ mod tests {
                 "warnings": ["kept current"],
                 "conversation_id": "conv-123",
                 "conversation_url": "https://chatgpt.com/c/conv-123",
+                "extraction_method": "copy_scope_dom_fallback",
+                "completion_reason": "copy_button",
+                "finality_anchor": "dom_only",
+                "stable_for_ms": 5000,
+                "assistant_turn_count": 2,
+                "copy_button_count": 1,
             }),
         );
 
@@ -4343,6 +4380,21 @@ mod tests {
             result.conversation_url.as_deref(),
             Some("https://chatgpt.com/c/conv-123")
         );
+        assert_eq!(
+            result.diagnostics.extraction_method.as_deref(),
+            Some("copy_scope_dom_fallback")
+        );
+        assert_eq!(
+            result.diagnostics.completion_reason.as_deref(),
+            Some("copy_button")
+        );
+        assert_eq!(
+            result.diagnostics.finality_anchor.as_deref(),
+            Some("dom_only")
+        );
+        assert_eq!(result.diagnostics.stable_for_ms, Some(5000));
+        assert_eq!(result.diagnostics.assistant_turn_count, Some(2));
+        assert_eq!(result.diagnostics.copy_button_count, Some(1));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/chatgpt_recipe.rs
+++ b/crates/yoetz-cli/src/chatgpt_recipe.rs
@@ -127,6 +127,16 @@ pub struct ChatgptRecipeSpec {
     pub close_tab_on_complete: bool,
 }
 
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ChatgptRecipeDiagnostics {
+    pub extraction_method: Option<String>,
+    pub completion_reason: Option<String>,
+    pub finality_anchor: Option<String>,
+    pub stable_for_ms: Option<u64>,
+    pub assistant_turn_count: Option<u64>,
+    pub copy_button_count: Option<u64>,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ChatgptRecipeOutput {
     pub transport: String,
@@ -141,6 +151,7 @@ pub struct ChatgptRecipeOutput {
     pub auto_paste_fallback: bool,
     pub conversation_id: Option<String>,
     pub conversation_url: Option<String>,
+    pub diagnostics: ChatgptRecipeDiagnostics,
 }
 
 impl ChatgptRecipeOutput {
@@ -159,6 +170,12 @@ impl ChatgptRecipeOutput {
             "auto_paste_fallback": self.auto_paste_fallback,
             "conversation_id": self.conversation_id,
             "conversation_url": self.conversation_url,
+            "extraction_method": self.diagnostics.extraction_method,
+            "completion_reason": self.diagnostics.completion_reason,
+            "finality_anchor": self.diagnostics.finality_anchor,
+            "stable_for_ms": self.diagnostics.stable_for_ms,
+            "assistant_turn_count": self.diagnostics.assistant_turn_count,
+            "copy_button_count": self.diagnostics.copy_button_count,
         })
     }
 
@@ -177,6 +194,12 @@ impl ChatgptRecipeOutput {
             "auto_paste_fallback": self.auto_paste_fallback,
             "conversation_id": self.conversation_id,
             "conversation_url": self.conversation_url,
+            "extraction_method": self.diagnostics.extraction_method,
+            "completion_reason": self.diagnostics.completion_reason,
+            "finality_anchor": self.diagnostics.finality_anchor,
+            "stable_for_ms": self.diagnostics.stable_for_ms,
+            "assistant_turn_count": self.diagnostics.assistant_turn_count,
+            "copy_button_count": self.diagnostics.copy_button_count,
         })
     }
 }
@@ -201,6 +224,14 @@ mod tests {
             auto_paste_fallback: true,
             conversation_id: Some("conv-123".to_string()),
             conversation_url: Some("https://chatgpt.com/c/conv-123".to_string()),
+            diagnostics: ChatgptRecipeDiagnostics {
+                extraction_method: Some("copy_scope_dom_fallback".to_string()),
+                completion_reason: Some("copy_button".to_string()),
+                finality_anchor: Some("dom_only".to_string()),
+                stable_for_ms: Some(5000),
+                assistant_turn_count: Some(2),
+                copy_button_count: Some(1),
+            },
         };
 
         let payload = output.to_value();
@@ -220,10 +251,22 @@ mod tests {
             payload["conversation_url"],
             "https://chatgpt.com/c/conv-123"
         );
+        assert_eq!(payload["extraction_method"], "copy_scope_dom_fallback");
+        assert_eq!(payload["completion_reason"], "copy_button");
+        assert_eq!(payload["finality_anchor"], "dom_only");
+        assert_eq!(payload["stable_for_ms"], 5000);
+        assert_eq!(payload["assistant_turn_count"], 2);
+        assert_eq!(payload["copy_button_count"], 1);
 
         let event = output.to_recipe_complete_event();
         assert_eq!(event["conversation_id"], "conv-123");
         assert_eq!(event["conversation_url"], "https://chatgpt.com/c/conv-123");
+        assert_eq!(event["extraction_method"], "copy_scope_dom_fallback");
+        assert_eq!(event["completion_reason"], "copy_button");
+        assert_eq!(event["finality_anchor"], "dom_only");
+        assert_eq!(event["stable_for_ms"], 5000);
+        assert_eq!(event["assistant_turn_count"], 2);
+        assert_eq!(event["copy_button_count"], 1);
     }
 
     #[test]

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -2270,6 +2270,7 @@ async fn run_recipe_via_chrome_devtools_mcp(
         auto_paste_fallback: false,
         conversation_id: None,
         conversation_url: None,
+        diagnostics: chatgpt_recipe::ChatgptRecipeDiagnostics::default(),
     }
     .to_value();
     maybe_write_output(ctx, &payload)?;
@@ -2301,6 +2302,7 @@ async fn run_recipe_via_chrome_devtools_mcp(
                 auto_paste_fallback: false,
                 conversation_id: payload["conversation_id"].as_str().map(str::to_owned),
                 conversation_url: payload["conversation_url"].as_str().map(str::to_owned),
+                diagnostics: chatgpt_recipe::ChatgptRecipeDiagnostics::default(),
             }
             .to_recipe_complete_event();
             write_jsonl("browser.recipe", &event)?;
@@ -2659,6 +2661,7 @@ fn run_recipe_via_chrome_extension_native<R: IntoBuiltinWebRecipe>(
                 auto_paste_fallback: false,
                 conversation_id: response.conversation_id,
                 conversation_url: response.conversation_url,
+                diagnostics: response.diagnostics,
             };
             (
                 output.to_value(),
@@ -2963,6 +2966,7 @@ fn run_recipe_via_dev_browser<R: IntoBuiltinWebRecipe>(
         auto_paste_fallback,
         conversation_id: None,
         conversation_url: None,
+        diagnostics: chatgpt_recipe::ChatgptRecipeDiagnostics::default(),
     };
     let payload = output.to_value();
     maybe_write_output(ctx, &payload)?;
@@ -7314,6 +7318,7 @@ mod tests {
             auto_paste_fallback: true,
             conversation_id: Some("conv-123".to_string()),
             conversation_url: Some("https://chatgpt.com/c/conv-123".to_string()),
+            diagnostics: crate::chatgpt_recipe::ChatgptRecipeDiagnostics::default(),
         };
 
         let event = output.to_recipe_complete_event();

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -1035,6 +1035,7 @@ function standaloneAssistantSegment(root, conversation, ordered, marker, latestU
         && nodePrecedes(root, latestUser, node)
         && isVisible(node, { allowDisabled: true })
         && !isInsideUserTurn(node)
+        && !isCitationSourceAffordance(node)
         && !isNonConversationChrome(node);
     });
   const textEntries = markdownNodes
@@ -1228,7 +1229,9 @@ function assistantMessageTextEntry(turn) {
     '[class*="markdown"]'
   ]) {
     for (const node of Array.from(turn.querySelectorAll?.(selector) ?? [])) {
-      if (!looksLikeUserTurn(node) && isAssistantContentNode(node, turn)) {
+      if (!looksLikeUserTurn(node)
+          && !isCitationSourceAffordance(node, turn)
+          && isAssistantContentNode(node, turn)) {
         addContentNode(node);
       }
     }
@@ -1236,7 +1239,10 @@ function assistantMessageTextEntry(turn) {
   const leafContentNodes = leafNodes(contentNodes);
   const textEntries = [];
   for (const node of leafContentNodes) {
-    const text = cleanAssistantText(node, { preserveContentStatusText: node !== turn });
+    const text = cleanAssistantText(node, {
+      preserveContentStatusText: node !== turn,
+      assistantTurn: turn
+    });
     if (text) {
       textEntries.push({ node, text });
     }
@@ -1247,7 +1253,7 @@ function assistantMessageTextEntry(turn) {
       text: normalizeText(textEntries.map((entry) => entry.text).join("\n\n"))
     };
   }
-  const fallback = cleanAssistantText(turn);
+  const fallback = cleanAssistantText(turn, { assistantTurn: turn });
   return { node: turn, text: isModelStatusText(fallback) ? "" : fallback };
 }
 
@@ -1276,13 +1282,73 @@ function leafNodes(nodes) {
   return nodes.filter((node) => !nodes.some((other) => other !== node && containsNode(node, other)));
 }
 
+function isCitationSourceAffordance(node, turn = null) {
+  for (let current = node; current; current = current.parentElement) {
+    const tag = String(current.tagName ?? "").toLowerCase();
+    const role = String(current.getAttribute?.("role") ?? "");
+    const testId = String(current.getAttribute?.("data-testid") ?? "");
+    const ariaLabel = String(current.getAttribute?.("aria-label") ?? "");
+    const title = String(current.getAttribute?.("title") ?? "");
+    const className = String(current.getAttribute?.("class") ?? "");
+    const semanticMarker = `${role} ${testId} ${ariaLabel} ${title}`;
+    const interactive = tag === "button"
+      || tag === "summary"
+      || role === "button"
+      || current.getAttribute?.("aria-expanded") !== null;
+    const explicitCitationMarker = /\b(citations?|sources?)\b/i.test(semanticMarker)
+      || /\b(citations?|sources?)(?:[-_]|$)/i.test(testId)
+      || (interactive && /\b(citations?|sources?)\b/i.test(className));
+    const exactInteractiveLabel = interactive
+      && /^sources?$/i.test(normalizeText(textOf(current)));
+    if (explicitCitationMarker || exactInteractiveLabel) {
+      return true;
+    }
+    if (current === turn) {
+      return false;
+    }
+  }
+  return false;
+}
+
+function assistantBodyTextOf(node, turn = node) {
+  const hasCitationAffordance = flattenTree(node)
+    .some((candidate) => candidate !== node && isCitationSourceAffordance(candidate, turn));
+  if (!hasCitationAffordance) {
+    return bodyTextOf(node);
+  }
+  return normalizeText(textContentWithoutCitationAffordances(node, turn));
+}
+
+function textContentWithoutCitationAffordances(node, turn) {
+  if (node !== turn && isCitationSourceAffordance(node, turn)) {
+    return "";
+  }
+  const childNodes = Array.from(node?.childNodes ?? []);
+  if (childNodes.length > 0) {
+    return childNodes
+      .map((child) => child?.nodeType === 3
+        ? String(child.textContent ?? "")
+        : textContentWithoutCitationAffordances(child, turn))
+      .filter(Boolean)
+      .join("\n");
+  }
+  const children = Array.from(node?.children ?? []);
+  if (children.length > 0) {
+    return children
+      .map((child) => textContentWithoutCitationAffordances(child, turn))
+      .filter(Boolean)
+      .join("\n");
+  }
+  return String(node?.textContent ?? "");
+}
+
 function cleanAssistantText(node, options = {}) {
   // Body text MUST come from textContent, not innerText: a virtualized/clipped long answer node
   // returns only its rendered head via innerText (observed live as a single "I"). textContent
   // returns the full DOM text regardless of layout. Per-line control/status stripping below then
   // removes any code-block "Copy code", sr-only, thought/status, and control lines that
   // textContent may surface. Fall back to innerText only if textContent is empty (defensive).
-  const source = bodyTextOf(node) || textOf(node);
+  const source = assistantBodyTextOf(node, options.assistantTurn ?? node) || textOf(node);
   const lines = source
     .split(/\n+/)
     .map((line) => normalizeText(line))

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -1284,27 +1284,12 @@ function leafNodes(nodes) {
 
 function isCitationSourceAffordance(node, turn = null) {
   for (let current = node; current; current = current.parentElement) {
-    const tag = String(current.tagName ?? "").toLowerCase();
-    const role = String(current.getAttribute?.("role") ?? "");
-    const testId = String(current.getAttribute?.("data-testid") ?? "");
-    const ariaLabel = String(current.getAttribute?.("aria-label") ?? "");
-    const title = String(current.getAttribute?.("title") ?? "");
-    const className = String(current.getAttribute?.("class") ?? "");
-    const semanticMarker = `${role} ${testId} ${ariaLabel} ${title}`;
-    const interactive = tag === "button"
-      || tag === "summary"
-      || role === "button"
-      || current.getAttribute?.("aria-expanded") !== null;
-    const explicitCitationMarker = /\b(citations?|sources?)\b/i.test(semanticMarker)
-      || /\b(citations?|sources?)(?:[-_]|$)/i.test(testId)
-      || (interactive && /\b(citations?|sources?)\b/i.test(className));
-    const exactInteractiveLabel = interactive
-      && /^sources?$/i.test(normalizeText(textOf(current)));
-    if (explicitCitationMarker || exactInteractiveLabel) {
-      return true;
-    }
     if (current === turn) {
       return false;
+    }
+    const testId = String(current.getAttribute?.("data-testid") ?? "");
+    if (testId === "citations-button" || classTokens(current).includes("group/footnote")) {
+      return true;
     }
   }
   return false;
@@ -1329,15 +1314,13 @@ function textContentWithoutCitationAffordances(node, turn) {
       .map((child) => child?.nodeType === 3
         ? String(child.textContent ?? "")
         : textContentWithoutCitationAffordances(child, turn))
-      .filter(Boolean)
-      .join("\n");
+      .join("");
   }
   const children = Array.from(node?.children ?? []);
   if (children.length > 0) {
     return children
       .map((child) => textContentWithoutCitationAffordances(child, turn))
-      .filter(Boolean)
-      .join("\n");
+      .join("");
   }
   return String(node?.textContent ?? "");
 }

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -1590,8 +1590,8 @@ async function waitForResponse(job) {
     const backendApiFinal = Boolean(scopedExtractionCandidate && completion.isFreshBackendApiExtraction(extraction));
     const finalAffordance = Boolean(scopedExtractionCandidate && completion.hasFinalAssistantAffordance(extraction));
     const finalStructuralResponse = finalAffordance || backendApiFinal;
-    // Broad page text is diagnostic only; final controls without scoped text
-    // means extraction failed, not that page chrome is safe to return.
+    // Broad page text is diagnostic only; final controls without scoped answer
+    // text means extraction failed, not that page chrome is safe to return.
     const finalAffordanceWithoutScopedText = Boolean(
       postSendAssistantActivity
       && extraction?.method === "page_text_fallback"

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -127,6 +127,25 @@ class FakeElement {
   }
 }
 
+class FakeTextNode {
+  constructor(text) {
+    this.nodeType = 3;
+    this.textContent = text;
+    this.parentElement = null;
+  }
+}
+
+function withChildNodes(element, ...nodes) {
+  element.childNodes = nodes;
+  element.children = nodes.filter((node) => node?.nodeType !== 3);
+  for (const node of nodes) {
+    node.parentElement = element;
+  }
+  element.textContent = nodes.map((node) => String(node.textContent ?? "")).join("");
+  element.innerText = element.textContent;
+  return element;
+}
+
 class FakeDocument {
   constructor(body) {
     this.body = body;
@@ -1005,7 +1024,7 @@ test("extractResponse returns all rendered markdown blocks from one assistant tu
 
 test("extractResponse excludes a nested Sources citation affordance from the assistant answer", () => {
   const user = new FakeElement("article", { "data-message-author-role": "user", class: "user-turn" }, "Review bundle");
-  const answer = new FakeElement("div", { class: "prose" }, "PASS\nReview evidence only.");
+  const answer = new FakeElement("div", { class: "markdown prose" }, "PASS\nReview evidence only.");
   const sources = new FakeElement("button", {
     "aria-label": "Sources",
     "aria-expanded": "false",
@@ -1027,6 +1046,127 @@ test("extractResponse excludes a nested Sources citation affordance from the ass
   assert.equal(extraction.method, "copy_scope_dom_fallback");
   assert.equal(extraction.text, "PASS\nReview evidence only.");
   assert.equal(extraction.has_copy_button, true);
+});
+
+test("extractResponse preserves a legitimate answer button labeled Sources", () => {
+  const user = new FakeElement("article", { "data-message-author-role": "user", class: "user-turn" }, "Choose an action");
+  const answerButton = withChildNodes(
+    new FakeElement("button", { "aria-label": "Sources" }),
+    new FakeTextNode("Sources")
+  );
+  const answer = withChildNodes(
+    new FakeElement("div", { class: "markdown prose" }),
+    new FakeTextNode("Choose "),
+    answerButton,
+    new FakeTextNode(" to continue.")
+  );
+  const copy = new FakeElement("button", { "aria-label": "Copy" }, "Copy");
+  const assistant = new FakeElement(
+    "article",
+    { "data-message-author-role": "assistant" },
+    "Choose Sources to continue.\nCopy"
+  ).append(answer, copy);
+  const conversation = new FakeElement("main", { role: "main" }, "Choose an action Choose Sources to continue. Copy")
+    .append(user, assistant);
+  const body = new FakeElement("body", {}, "Choose an action Choose Sources to continue. Copy").append(conversation);
+  const doc = new FakeDocument(body);
+
+  const extraction = extractResponse(doc);
+
+  assert.equal(extraction.method, "copy_scope_dom_fallback");
+  assert.equal(extraction.text, "Choose Sources to continue.");
+});
+
+test("extractResponse preserves legitimate answer markup titled Open source repository", () => {
+  const user = new FakeElement("article", { "data-message-author-role": "user", class: "user-turn" }, "Where is the code?");
+  const repositoryLink = withChildNodes(
+    new FakeElement("a", { title: "Open source repository" }),
+    new FakeTextNode("the repository")
+  );
+  const answer = withChildNodes(
+    new FakeElement("div", { class: "markdown prose" }),
+    new FakeTextNode("Visit "),
+    repositoryLink,
+    new FakeTextNode(" now.")
+  );
+  const copy = new FakeElement("button", { "aria-label": "Copy" }, "Copy");
+  const assistant = new FakeElement(
+    "article",
+    { "data-message-author-role": "assistant" },
+    "Visit the repository now.\nCopy"
+  ).append(answer, copy);
+  const conversation = new FakeElement("main", { role: "main" }, "Where is the code? Visit the repository now. Copy")
+    .append(user, assistant);
+  const body = new FakeElement("body", {}, "Where is the code? Visit the repository now. Copy").append(conversation);
+  const doc = new FakeDocument(body);
+
+  const extraction = extractResponse(doc);
+
+  assert.equal(extraction.method, "copy_scope_dom_fallback");
+  assert.equal(extraction.text, "Visit the repository now.");
+});
+
+test("extractResponse excludes a localized citation widget by stable structural class", () => {
+  const user = new FakeElement("article", { "data-message-author-role": "user", class: "user-turn" }, "Revisar");
+  const citation = withChildNodes(
+    new FakeElement("button", { "aria-label": "Fuentes", class: "group/footnote bg-transparent" }),
+    new FakeTextNode("Fuentes")
+  );
+  const answer = withChildNodes(
+    new FakeElement("div", { class: "markdown prose" }),
+    new FakeTextNode("APROBADO"),
+    citation
+  );
+  const copy = new FakeElement("button", { "aria-label": "Copy" }, "Copy");
+  const assistant = new FakeElement(
+    "article",
+    { "data-message-author-role": "assistant" },
+    "APROBADO Fuentes Copy"
+  ).append(answer, copy);
+  const conversation = new FakeElement("main", { role: "main" }, "Revisar APROBADO Fuentes Copy")
+    .append(user, assistant);
+  const body = new FakeElement("body", {}, "Revisar APROBADO Fuentes Copy").append(conversation);
+  const doc = new FakeDocument(body);
+
+  const extraction = extractResponse(doc);
+
+  assert.equal(extraction.method, "copy_scope_dom_fallback");
+  assert.equal(extraction.text, "APROBADO");
+});
+
+test("extractResponse preserves interleaved textContent semantics while removing a citation subtree", () => {
+  const user = new FakeElement("article", { "data-message-author-role": "user", class: "user-turn" }, "Review");
+  const emphasis = withChildNodes(
+    new FakeElement("strong"),
+    new FakeTextNode("inline")
+  );
+  const citation = withChildNodes(
+    new FakeElement("button", { "aria-label": "Sources", class: "group/footnote bg-transparent" }),
+    new FakeTextNode("Sources")
+  );
+  const answer = withChildNodes(
+    new FakeElement("div", { class: "markdown prose" }),
+    new FakeTextNode("Review "),
+    emphasis,
+    new FakeTextNode(" answer"),
+    citation,
+    new FakeTextNode(" after.")
+  );
+  const copy = new FakeElement("button", { "aria-label": "Copy" }, "Copy");
+  const assistant = new FakeElement(
+    "article",
+    { "data-message-author-role": "assistant" },
+    "Review inline answerSources after.\nCopy"
+  ).append(answer, copy);
+  const conversation = new FakeElement("main", { role: "main" }, "Review Review inline answerSources after. Copy")
+    .append(user, assistant);
+  const body = new FakeElement("body", {}, "Review Review inline answerSources after. Copy").append(conversation);
+  const doc = new FakeDocument(body);
+
+  const extraction = extractResponse(doc);
+
+  assert.equal(extraction.method, "copy_scope_dom_fallback");
+  assert.equal(extraction.text, "Review inline answer after.");
 });
 
 test("extractResponse does not promote a Sources-only citation affordance to assistant text", () => {

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -1003,6 +1003,77 @@ test("extractResponse returns all rendered markdown blocks from one assistant tu
   assert.equal(extraction.has_copy_button, true);
 });
 
+test("extractResponse excludes a nested Sources citation affordance from the assistant answer", () => {
+  const user = new FakeElement("article", { "data-message-author-role": "user", class: "user-turn" }, "Review bundle");
+  const answer = new FakeElement("div", { class: "prose" }, "PASS\nReview evidence only.");
+  const sources = new FakeElement("button", {
+    "aria-label": "Sources",
+    "aria-expanded": "false",
+    "data-testid": "citations-button"
+  }, "Sources").append(new FakeElement("div", { class: "markdown" }, "Sources"));
+  const copy = new FakeElement("button", { "aria-label": "Copy" }, "Copy");
+  const assistant = new FakeElement(
+    "article",
+    { "data-message-author-role": "assistant" },
+    "PASS\nReview evidence only.\nSources\nCopy"
+  ).append(answer, sources, copy);
+  const conversation = new FakeElement("main", { role: "main" }, "Review bundle PASS Review evidence only. Sources Copy")
+    .append(user, assistant);
+  const body = new FakeElement("body", {}, "Review bundle PASS Review evidence only. Sources Copy").append(conversation);
+  const doc = new FakeDocument(body);
+
+  const extraction = extractResponse(doc);
+
+  assert.equal(extraction.method, "copy_scope_dom_fallback");
+  assert.equal(extraction.text, "PASS\nReview evidence only.");
+  assert.equal(extraction.has_copy_button, true);
+});
+
+test("extractResponse does not promote a Sources-only citation affordance to assistant text", () => {
+  const user = new FakeElement("article", { "data-message-author-role": "user", class: "user-turn" }, "Review bundle");
+  const sources = new FakeElement("button", {
+    "aria-label": "Sources",
+    "aria-expanded": "false",
+    "data-testid": "citations-button"
+  }, "Sources").append(new FakeElement("div", { class: "markdown" }, "Sources"));
+  const copy = new FakeElement("button", { "aria-label": "Copy" }, "Copy");
+  const assistant = new FakeElement("article", { "data-message-author-role": "assistant" }, "Sources\nCopy")
+    .append(sources, copy);
+  const conversation = new FakeElement("main", { role: "main" }, "Review bundle Sources Copy")
+    .append(user, assistant);
+  const body = new FakeElement("body", {}, "Review bundle Sources Copy").append(conversation);
+  const doc = new FakeDocument(body);
+
+  const extraction = extractResponse(doc);
+
+  assert.equal(extraction.method, "page_text_fallback");
+  assert.equal(extraction.turn_index, -1);
+});
+
+test("extractResponse preserves a legitimate Sources heading and answer content", () => {
+  const user = new FakeElement("article", { "data-message-author-role": "user", class: "user-turn" }, "List sources");
+  const answer = new FakeElement(
+    "div",
+    { class: "markdown prose" },
+    "Sources\n- Architecture.md\n- PLAN.md"
+  );
+  const copy = new FakeElement("button", { "aria-label": "Copy" }, "Copy");
+  const assistant = new FakeElement(
+    "article",
+    { "data-message-author-role": "assistant" },
+    "Sources\n- Architecture.md\n- PLAN.md\nCopy"
+  ).append(answer, copy);
+  const conversation = new FakeElement("main", { role: "main" }, "List sources Sources Architecture PLAN Copy")
+    .append(user, assistant);
+  const body = new FakeElement("body", {}, "List sources Sources Architecture PLAN Copy").append(conversation);
+  const doc = new FakeDocument(body);
+
+  const extraction = extractResponse(doc);
+
+  assert.equal(extraction.method, "copy_scope_dom_fallback");
+  assert.equal(extraction.text, "Sources\n- Architecture.md\n- PLAN.md");
+});
+
 test("extractResponse uses the latest user transcript scope for split action rows", () => {
   const user = new FakeElement("article", { "data-message-author-role": "user", class: "user-turn" }, "Review bundle");
   const marker = new FakeElement("div", { "data-message-author-role": "assistant" }, "");

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -3109,6 +3109,104 @@ test("service worker completion is structural and does not classify response tex
   }
 });
 
+test("service worker fails closed on Sources-only DOM chrome when backend finality is unavailable", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  let tabId = 0;
+  let sent = false;
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/c/conv-sources" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: verifiedSolProSelection() };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return {
+              ok: true,
+              payload: {
+                sent: true,
+                conversation_id: "conv-sources",
+                submitted_user_count: 1,
+                submitted_assistant_count: 0
+              }
+            };
+          case "yoetz_extract_response":
+            return {
+              ok: true,
+              payload: sent
+                ? {
+                    method: "page_text_fallback",
+                    text: "Review bundle Sources Copy",
+                    is_generating: false,
+                    assistant_count: 1,
+                    user_count: 1,
+                    preceding_user_count: 1,
+                    copy_button_count: 1,
+                    has_copy_button: true,
+                    turn_index: 0,
+                    conversation_id: "conv-sources"
+                  }
+                : {
+                    method: "none",
+                    text: "",
+                    is_generating: false,
+                    assistant_count: 0,
+                    user_count: 0,
+                    copy_button_count: 0,
+                    has_copy_button: false,
+                    turn_index: -1
+                  }
+            };
+          case "yoetz_fetch_conversation":
+            throw new Error("backend API unavailable");
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?sources_only_dom=${Date.now()}`);
+    port.emit(envelope("job_start", "job_sources_only_dom", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 2000
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_sources_only_dom", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_sources_only_dom.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) =>
+      message.type === "job_error" && message.payload.code === "response_extraction_failed"
+    ));
+    assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
+    const error = port.messages.find((message) =>
+      message.type === "job_error" && message.payload.code === "response_extraction_failed"
+    );
+    assert.equal(error.payload.extraction_method, "page_text_fallback");
+    assert.equal(error.payload.response_length, 26);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker accepts a scoped single-letter assistant markdown response", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();


### PR DESCRIPTION
Fixes the live DOM-only finality incident where a nested citation widget displaced the assistant body and Yoetz returned `Sources` as a clean success.

- excludes citation/source affordances structurally before assistant leaf selection
- preserves legitimate answer content headed `Sources`
- fails closed through the existing page-text fallback when no scoped answer remains
- keeps answer-text grading out of finality decisions
- propagates extraction/finality diagnostics through Rust recipe output

Verification at `0e61e3f`:
- extension suite: 260/260
- full `cargo test -p yoetz`: 641 passed, 2 Chrome-only ignored
- `cargo fmt --all -- --check`
- `git diff --check`
- exact-tree Claude review: PASS

This is the narrow DOM root-cause fix. API-content-primary ordering and Claude artifact work remain separate in #343.