### PR TITLE
feat(browser): add addressable recipe threads

### DIFF
--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -61,6 +61,29 @@ struct FrameTooLargeError {
     max: usize,
 }
 
+#[derive(Debug, Error)]
+#[error("{message}")]
+struct ConversationJobError {
+    message: String,
+}
+
+pub(crate) fn is_conversation_job_error(err: &anyhow::Error) -> bool {
+    err.chain()
+        .any(|cause| cause.downcast_ref::<ConversationJobError>().is_some())
+}
+
+pub(crate) fn with_thread_conversation_recovery_hint(
+    err: anyhow::Error,
+    thread_label: Option<&str>,
+) -> anyhow::Error {
+    match (thread_label, is_conversation_job_error(&err)) {
+        (Some(label), true) => err.context(format!(
+            "thread `{label}` could not resume its saved conversation; start a new conversation with `--thread {label} --fresh`"
+        )),
+        _ => err,
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct InstallHostResult {
     pub status: &'static str,
@@ -2903,13 +2926,22 @@ fn job_error(envelope: ProtocolEnvelope) -> anyhow::Error {
 
 fn job_error_for_recipe(envelope: ProtocolEnvelope, recipe: BuiltinWebRecipe) -> anyhow::Error {
     let message = job_error_message(&envelope.payload);
+    let is_conversation_error = envelope
+        .payload
+        .get("code")
+        .and_then(Value::as_str)
+        .is_some_and(|code| code.starts_with("conversation_"));
     let phase = envelope.payload.get("phase").and_then(Value::as_str);
     let side_effect_started = envelope
         .payload
         .get("side_effect_started")
         .and_then(Value::as_bool)
         .unwrap_or(false);
-    let err = anyhow!("{message}");
+    let err = if is_conversation_error {
+        anyhow::Error::new(ConversationJobError { message })
+    } else {
+        anyhow!("{message}")
+    };
     if !side_effect_started {
         return err;
     }
@@ -5590,6 +5622,12 @@ mod tests {
         assert!(text.contains("current URL https://chatgpt.com/c/conv-404?_yoetz=run_conv"));
         assert!(text.contains("phase upload"));
         assert!(text.contains("yoetz browser extension inspect --chatgpt --run-id run_conv"));
+        assert!(is_conversation_job_error(&err));
+        assert!(format!(
+            "{:#}",
+            with_thread_conversation_recovery_hint(err, Some("review-pr-341"))
+        )
+        .contains("--thread review-pr-341 --fresh"));
     }
 
     #[test]
@@ -5613,9 +5651,15 @@ mod tests {
         assert!(text.contains("tab 920272522"));
         assert!(text.contains("phase upload"));
         assert!(text.contains("yoetz browser extension inspect --chatgpt --run-id run_ready"));
+        assert!(!is_conversation_job_error(&err));
         assert_eq!(
             crate::chatgpt_recipe::terminal_fallback_phase(&err),
             Some(ChatgptTransportPhase::Upload)
         );
+        assert!(!format!(
+            "{:#}",
+            with_thread_conversation_recovery_hint(err, Some("review-pr-341"))
+        )
+        .contains("--fresh"));
     }
 }

--- a/crates/yoetz-cli/src/followup.rs
+++ b/crates/yoetz-cli/src/followup.rs
@@ -2,12 +2,14 @@ use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
+use tempfile::NamedTempFile;
 
 #[cfg(test)]
 use crate::chatgpt_web::{self, ChatgptConversation};
 use crate::web_recipe::{BuiltinWebRecipe, WebConversation};
-use yoetz_core::session::{list_sessions_in, write_json};
+use yoetz_core::session::list_sessions_in;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct FollowupMetadata {
@@ -16,6 +18,8 @@ pub(crate) struct FollowupMetadata {
     pub recipe: BuiltinWebRecipe,
     #[serde(default)]
     pub thread_label: Option<String>,
+    #[serde(default)]
+    pub thread_revision: u64,
     pub conversation_id: String,
     pub conversation_url: String,
     pub prompt_hash: String,
@@ -107,24 +111,39 @@ pub(crate) fn resolve_thread_target(
     recipe: BuiltinWebRecipe,
 ) -> Result<Option<ResolvedFollowup>> {
     validate_thread_label(label)?;
+    let mut latest: Option<FollowupMetadata> = None;
     for session in list_sessions_in(sessions_base)? {
-        let Some(metadata) = read_followup_metadata(&session.path)? else {
-            continue;
+        let metadata = match read_followup_metadata(&session.path) {
+            Ok(Some(metadata)) => metadata,
+            Ok(None) => continue,
+            Err(err) => {
+                eprintln!(
+                    "warning: skipping unreadable followup metadata in session `{}`: {err:#}",
+                    session.id
+                );
+                continue;
+            }
         };
         if metadata.recipe != recipe || metadata.thread_label.as_deref() != Some(label) {
             continue;
         }
-        return Ok(Some(ResolvedFollowup {
-            recipe,
-            conversation: WebConversation {
-                id: metadata.conversation_id,
-                url: metadata.conversation_url,
-            },
-            source_session_id: Some(metadata.session_id),
-            prior_prompt_hash: Some(metadata.prompt_hash),
-        }));
+        if latest
+            .as_ref()
+            .is_some_and(|current| current.thread_revision >= metadata.thread_revision)
+        {
+            continue;
+        }
+        latest = Some(metadata);
     }
-    Ok(None)
+    Ok(latest.map(|metadata| ResolvedFollowup {
+        recipe,
+        conversation: WebConversation {
+            id: metadata.conversation_id,
+            url: metadata.conversation_url,
+        },
+        source_session_id: Some(metadata.session_id),
+        prior_prompt_hash: Some(metadata.prompt_hash),
+    }))
 }
 
 pub(crate) fn compute_prompt_hash(prompt: &str, bundle_path: Option<&Path>) -> Result<String> {
@@ -220,15 +239,70 @@ pub(crate) fn write_followup_metadata_for_recipe(
     thread_label: Option<&str>,
 ) -> Result<()> {
     let path = followup_metadata_path(session_dir);
+    let thread_revision = match thread_label {
+        Some(label) => next_thread_revision(session_dir, recipe, label)?,
+        None => 0,
+    };
     let metadata = FollowupMetadata {
         session_id: session_id.to_string(),
         recipe,
         thread_label: thread_label.map(str::to_string),
+        thread_revision,
         conversation_id: conversation.id.clone(),
         conversation_url: conversation.url.clone(),
         prompt_hash: prompt_hash.to_string(),
     };
-    write_json(&path, &metadata)?;
+    write_followup_metadata_atomically(&path, &metadata)?;
+    Ok(())
+}
+
+fn next_thread_revision(
+    session_dir: &Path,
+    recipe: BuiltinWebRecipe,
+    thread_label: &str,
+) -> Result<u64> {
+    let sessions_base = session_dir
+        .parent()
+        .ok_or_else(|| anyhow!("thread metadata session has no sessions directory parent"))?;
+    let mut max_revision = 0;
+    for session in list_sessions_in(sessions_base)? {
+        let metadata = match read_followup_metadata(&session.path) {
+            Ok(Some(metadata)) => metadata,
+            Ok(None) => continue,
+            Err(err) => {
+                eprintln!(
+                    "warning: skipping unreadable followup metadata in session `{}` while assigning thread revision: {err:#}",
+                    session.id
+                );
+                continue;
+            }
+        };
+        if metadata.recipe == recipe && metadata.thread_label.as_deref() == Some(thread_label) {
+            max_revision = max_revision.max(metadata.thread_revision);
+        }
+    }
+    max_revision
+        .checked_add(1)
+        .ok_or_else(|| anyhow!("thread `{thread_label}` revision overflow"))
+}
+
+fn write_followup_metadata_atomically(path: &Path, metadata: &FollowupMetadata) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("followup metadata path has no parent"))?;
+    let mut temp = NamedTempFile::new_in(parent)
+        .with_context(|| format!("create temporary followup metadata in {}", parent.display()))?;
+    serde_json::to_writer_pretty(temp.as_file_mut(), metadata)
+        .with_context(|| format!("serialize followup metadata {}", path.display()))?;
+    temp.as_file_mut()
+        .write_all(b"\n")
+        .with_context(|| format!("write temporary followup metadata for {}", path.display()))?;
+    temp.as_file()
+        .sync_all()
+        .with_context(|| format!("sync temporary followup metadata for {}", path.display()))?;
+    temp.persist(path)
+        .map_err(|err| err.error)
+        .with_context(|| format!("atomically replace followup metadata {}", path.display()))?;
     Ok(())
 }
 
@@ -555,6 +629,106 @@ mod tests {
             resolve_thread_target("unknown-thread", &sessions_dir, BuiltinWebRecipe::Chatgpt)
                 .unwrap()
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn thread_resolution_skips_corrupt_unrelated_session_metadata() {
+        let root = tempdir().unwrap();
+        let sessions_dir = root.path().join("sessions");
+        let corrupt = sessions_dir.join("20260711_040000_corrupt");
+        let matching = sessions_dir.join("20260711_030000_matching");
+        fs::create_dir_all(&corrupt).unwrap();
+        fs::create_dir_all(&matching).unwrap();
+        fs::write(corrupt.join("followup.json"), "{not-json").unwrap();
+        write_followup_metadata_for_recipe(
+            &matching,
+            "20260711_030000_matching",
+            BuiltinWebRecipe::Chatgpt,
+            &WebConversation {
+                id: "conv-match".to_string(),
+                url: "https://chatgpt.com/c/conv-match".to_string(),
+            },
+            "matching-hash",
+            Some("review-pr-341"),
+        )
+        .unwrap();
+
+        let resolved =
+            resolve_thread_target("review-pr-341", &sessions_dir, BuiltinWebRecipe::Chatgpt)
+                .unwrap()
+                .unwrap();
+
+        assert_eq!(resolved.conversation.id, "conv-match");
+    }
+
+    #[test]
+    fn followup_metadata_write_replaces_existing_file_atomically() {
+        let root = tempdir().unwrap();
+        let session = root.path().join("sessions").join("session-atomic");
+        fs::create_dir_all(&session).unwrap();
+        fs::write(session.join("followup.json"), "{partial").unwrap();
+
+        write_followup_metadata_for_recipe(
+            &session,
+            "session-atomic",
+            BuiltinWebRecipe::Chatgpt,
+            &WebConversation {
+                id: "conv-atomic".to_string(),
+                url: "https://chatgpt.com/c/conv-atomic".to_string(),
+            },
+            "atomic-hash",
+            Some("review-pr-341"),
+        )
+        .unwrap();
+
+        let metadata = read_followup_metadata(&session).unwrap().unwrap();
+        assert_eq!(metadata.session_id, "session-atomic");
+        assert_eq!(metadata.conversation_id, "conv-atomic");
+        assert!(fs::read_dir(&session).unwrap().all(|entry| !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains(".tmp")));
+    }
+
+    #[test]
+    fn rewriting_older_session_repoints_thread_label() {
+        let root = tempdir().unwrap();
+        let sessions_dir = root.path().join("sessions");
+        let older = sessions_dir.join("20260711_010000_older");
+        let newer = sessions_dir.join("20260711_020000_newer");
+        fs::create_dir_all(&older).unwrap();
+        fs::create_dir_all(&newer).unwrap();
+
+        for (session, id, conversation) in [
+            (&older, "20260711_010000_older", "conv-old"),
+            (&newer, "20260711_020000_newer", "conv-newer"),
+            (&older, "20260711_010000_older", "conv-fresh"),
+        ] {
+            write_followup_metadata_for_recipe(
+                session,
+                id,
+                BuiltinWebRecipe::Chatgpt,
+                &WebConversation {
+                    id: conversation.to_string(),
+                    url: format!("https://chatgpt.com/c/{conversation}"),
+                },
+                &format!("{conversation}-hash"),
+                Some("review-pr-341"),
+            )
+            .unwrap();
+        }
+
+        let resolved =
+            resolve_thread_target("review-pr-341", &sessions_dir, BuiltinWebRecipe::Chatgpt)
+                .unwrap()
+                .unwrap();
+
+        assert_eq!(resolved.conversation.id, "conv-fresh");
+        assert_eq!(
+            resolved.prior_prompt_hash.as_deref(),
+            Some("conv-fresh-hash")
         );
     }
 }

--- a/crates/yoetz-cli/src/followup.rs
+++ b/crates/yoetz-cli/src/followup.rs
@@ -14,6 +14,8 @@ pub(crate) struct FollowupMetadata {
     pub session_id: String,
     #[serde(default)]
     pub recipe: BuiltinWebRecipe,
+    #[serde(default)]
+    pub thread_label: Option<String>,
     pub conversation_id: String,
     pub conversation_url: String,
     pub prompt_hash: String,
@@ -85,6 +87,46 @@ where
     })
 }
 
+pub(crate) fn validate_thread_label(label: &str) -> Result<()> {
+    let mut chars = label.chars();
+    let Some(first) = chars.next() else {
+        bail!("thread label must match ^[A-Za-z0-9][A-Za-z0-9_.-]{{0,63}}$");
+    };
+    if !first.is_ascii_alphanumeric()
+        || label.len() > 64
+        || !chars.all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '.' | '-'))
+    {
+        bail!("invalid thread label `{label}`; expected ^[A-Za-z0-9][A-Za-z0-9_.-]{{0,63}}$");
+    }
+    Ok(())
+}
+
+pub(crate) fn resolve_thread_target(
+    label: &str,
+    sessions_base: &Path,
+    recipe: BuiltinWebRecipe,
+) -> Result<Option<ResolvedFollowup>> {
+    validate_thread_label(label)?;
+    for session in list_sessions_in(sessions_base)? {
+        let Some(metadata) = read_followup_metadata(&session.path)? else {
+            continue;
+        };
+        if metadata.recipe != recipe || metadata.thread_label.as_deref() != Some(label) {
+            continue;
+        }
+        return Ok(Some(ResolvedFollowup {
+            recipe,
+            conversation: WebConversation {
+                id: metadata.conversation_id,
+                url: metadata.conversation_url,
+            },
+            source_session_id: Some(metadata.session_id),
+            prior_prompt_hash: Some(metadata.prompt_hash),
+        }));
+    }
+    Ok(None)
+}
+
 pub(crate) fn compute_prompt_hash(prompt: &str, bundle_path: Option<&Path>) -> Result<String> {
     let bundle_hash = if let Some(bundle_path) = bundle_path {
         let bundle_bytes = fs::read(bundle_path)
@@ -131,9 +173,20 @@ pub(crate) fn guard_duplicate_prompt(
 pub(crate) fn validate_followup_args(
     followup: Option<&str>,
     conversation_var: Option<&str>,
+    thread: Option<&str>,
+    fresh: bool,
 ) -> Result<()> {
-    if followup.is_some() && conversation_var.is_some() {
-        bail!("--followup is mutually exclusive with --var conversation=");
+    let selector_count = usize::from(followup.is_some())
+        + usize::from(conversation_var.is_some())
+        + usize::from(thread.is_some());
+    if selector_count > 1 {
+        bail!("--thread, --followup, and --var conversation= are mutually exclusive");
+    }
+    if fresh && thread.is_none() {
+        bail!("--fresh requires --thread");
+    }
+    if let Some(label) = thread {
+        validate_thread_label(label)?;
     }
     Ok(())
 }
@@ -154,6 +207,7 @@ pub(crate) fn write_followup_metadata(
             url: conversation.url.clone(),
         },
         prompt_hash,
+        None,
     )
 }
 
@@ -163,11 +217,13 @@ pub(crate) fn write_followup_metadata_for_recipe(
     recipe: BuiltinWebRecipe,
     conversation: &WebConversation,
     prompt_hash: &str,
+    thread_label: Option<&str>,
 ) -> Result<()> {
     let path = followup_metadata_path(session_dir);
     let metadata = FollowupMetadata {
         session_id: session_id.to_string(),
         recipe,
+        thread_label: thread_label.map(str::to_string),
         conversation_id: conversation.id.clone(),
         conversation_url: conversation.url.clone(),
         prompt_hash: prompt_hash.to_string(),
@@ -239,12 +295,37 @@ mod tests {
     }
 
     #[test]
-    fn followup_args_are_mutually_exclusive_with_conversation_var() {
-        assert!(validate_followup_args(Some("session-1"), None).is_ok());
-        assert!(validate_followup_args(None, Some("https://chatgpt.com/c/conv-1")).is_ok());
-        let err = validate_followup_args(Some("session-1"), Some("https://chatgpt.com/c/conv-1"))
-            .unwrap_err();
-        assert!(err.to_string().contains("mutually exclusive"));
+    fn conversation_selectors_are_pairwise_mutually_exclusive() {
+        let selectors = [
+            (
+                Some("session-1"),
+                Some("https://chatgpt.com/c/conv-1"),
+                None,
+            ),
+            (Some("session-1"), None, Some("review-pr-341")),
+            (
+                None,
+                Some("https://chatgpt.com/c/conv-1"),
+                Some("review-pr-341"),
+            ),
+        ];
+        for (followup, conversation, thread) in selectors {
+            let err = validate_followup_args(followup, conversation, thread, false).unwrap_err();
+            assert!(err.to_string().contains("mutually exclusive"));
+        }
+    }
+
+    #[test]
+    fn fresh_requires_a_valid_thread_label() {
+        assert!(validate_followup_args(None, None, Some("review-pr_341.v2"), true).is_ok());
+        assert!(validate_followup_args(None, None, None, true)
+            .unwrap_err()
+            .to_string()
+            .contains("requires --thread"));
+        for invalid in ["", "../escape", "-leading", "space label", "é"] {
+            assert!(validate_followup_args(None, None, Some(invalid), false).is_err());
+        }
+        assert!(validate_followup_args(None, None, Some(&"a".repeat(65)), false).is_err());
     }
 
     #[test]
@@ -338,6 +419,7 @@ mod tests {
 
         let metadata = read_followup_metadata(root.path()).unwrap().unwrap();
         assert_eq!(metadata.recipe, BuiltinWebRecipe::Chatgpt);
+        assert_eq!(metadata.thread_label, None);
     }
 
     #[test]
@@ -357,6 +439,7 @@ mod tests {
                 url: "https://chatgpt.com/c/shared-id".to_string(),
             },
             "chatgpt-hash",
+            None,
         )
         .unwrap();
         write_followup_metadata_for_recipe(
@@ -368,6 +451,7 @@ mod tests {
                 url: "https://claude.ai/chat/shared-id".to_string(),
             },
             "claude-hash",
+            None,
         )
         .unwrap();
 
@@ -389,6 +473,88 @@ mod tests {
         assert_eq!(
             resolved.source_session_id.as_deref(),
             Some("20260711_010000_claude")
+        );
+    }
+
+    #[test]
+    fn thread_resolution_uses_newest_matching_recipe_and_skips_legacy_files() {
+        let root = tempdir().unwrap();
+        let sessions_dir = root.path().join("sessions");
+        let legacy = sessions_dir.join("20260711_020000_legacy");
+        let old_chatgpt = sessions_dir.join("20260711_000000_chatgpt");
+        let new_chatgpt = sessions_dir.join("20260711_030000_chatgpt");
+        let claude = sessions_dir.join("20260711_040000_claude");
+        for path in [&legacy, &old_chatgpt, &new_chatgpt, &claude] {
+            fs::create_dir_all(path).unwrap();
+        }
+        fs::write(
+            legacy.join("followup.json"),
+            r#"{
+              "session_id": "20260711_020000_legacy",
+              "conversation_id": "legacy",
+              "conversation_url": "https://chatgpt.com/c/legacy",
+              "prompt_hash": "legacy-hash"
+            }"#,
+        )
+        .unwrap();
+        for (path, session_id, recipe, conversation_id, hash) in [
+            (
+                &old_chatgpt,
+                "20260711_000000_chatgpt",
+                BuiltinWebRecipe::Chatgpt,
+                "old-chatgpt",
+                "old-hash",
+            ),
+            (
+                &new_chatgpt,
+                "20260711_030000_chatgpt",
+                BuiltinWebRecipe::Chatgpt,
+                "new-chatgpt",
+                "new-hash",
+            ),
+            (
+                &claude,
+                "20260711_040000_claude",
+                BuiltinWebRecipe::Claude,
+                "claude-conversation",
+                "claude-hash",
+            ),
+        ] {
+            let host = match recipe {
+                BuiltinWebRecipe::Chatgpt => "https://chatgpt.com/c/",
+                BuiltinWebRecipe::Claude => "https://claude.ai/chat/",
+            };
+            write_followup_metadata_for_recipe(
+                path,
+                session_id,
+                recipe,
+                &WebConversation {
+                    id: conversation_id.to_string(),
+                    url: format!("{host}{conversation_id}"),
+                },
+                hash,
+                Some("review-pr-341"),
+            )
+            .unwrap();
+        }
+
+        let chatgpt =
+            resolve_thread_target("review-pr-341", &sessions_dir, BuiltinWebRecipe::Chatgpt)
+                .unwrap()
+                .unwrap();
+        assert_eq!(chatgpt.conversation.id, "new-chatgpt");
+        assert_eq!(chatgpt.prior_prompt_hash.as_deref(), Some("new-hash"));
+
+        let claude =
+            resolve_thread_target("review-pr-341", &sessions_dir, BuiltinWebRecipe::Claude)
+                .unwrap()
+                .unwrap();
+        assert_eq!(claude.conversation.id, "claude-conversation");
+
+        assert!(
+            resolve_thread_target("unknown-thread", &sessions_dir, BuiltinWebRecipe::Chatgpt)
+                .unwrap()
+                .is_none()
         );
     }
 }

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -347,6 +347,14 @@ struct BrowserRecipeArgs {
     #[arg(long)]
     followup: Option<String>,
 
+    /// Address a reusable conversation by a stable semantic label.
+    #[arg(long, value_name = "LABEL")]
+    thread: Option<String>,
+
+    /// Start a new conversation and re-point --thread at its final conversation.
+    #[arg(long, requires = "thread")]
+    fresh: bool,
+
     /// Allow the same prompt hash to be submitted to the same conversation.
     #[arg(long)]
     allow_duplicate_prompt: bool,
@@ -2807,10 +2815,13 @@ fn maybe_write_followup_session_metadata(
     else {
         return;
     };
+    // The final job_complete conversation_id is authoritative: ChatGPT may begin under a
+    // WEB: scaffold reassigned by isExpectedConversationIdAssignment in
+    // extensions/chatgpt-native/src/sites/chatgpt.js. Keep the URL as a legacy fallback.
     let Some(conversation_raw) = payload
-        .get("conversation_url")
+        .get("conversation_id")
         .and_then(Value::as_str)
-        .or_else(|| payload.get("conversation_id").and_then(Value::as_str))
+        .or_else(|| payload.get("conversation_url").and_then(Value::as_str))
     else {
         return;
     };
@@ -2847,6 +2858,7 @@ fn maybe_write_followup_session_metadata(
         recipe,
         &conversation,
         current_prompt_hash,
+        recipe_args.thread.as_deref(),
     ) {
         eprintln!(
             "warning: could not write followup metadata {}: {err}",
@@ -4259,6 +4271,9 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             let builtin_recipe = builtin_web_recipe(&recipe, &recipe_path);
             let is_chatgpt = builtin_recipe == Some(web_recipe::BuiltinWebRecipe::Chatgpt);
             let is_claude = builtin_recipe == Some(web_recipe::BuiltinWebRecipe::Claude);
+            if builtin_recipe.is_none() && (recipe_args.thread.is_some() || recipe_args.fresh) {
+                bail!("--thread and --fresh require a built-in ChatGPT or Claude recipe");
+            }
             let current_prompt_hash = if let Some(recipe_kind) = builtin_recipe {
                 apply_chatgpt_prompt_default(&recipe_args, &mut recipe_vars)?;
                 let current_prompt_hash = followup::compute_prompt_hash(
@@ -4268,11 +4283,13 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         .unwrap_or_default(),
                     recipe_args.bundle.as_deref(),
                 )?;
+                followup::validate_followup_args(
+                    recipe_args.followup.as_deref(),
+                    recipe_vars.get("conversation").map(String::as_str),
+                    recipe_args.thread.as_deref(),
+                    recipe_args.fresh,
+                )?;
                 if let Some(followup_raw) = recipe_args.followup.as_deref() {
-                    followup::validate_followup_args(
-                        Some(followup_raw),
-                        recipe_vars.get("conversation").map(String::as_str),
-                    )?;
                     let resolved_followup = followup::resolve_followup_target_for_recipe(
                         followup_raw,
                         &yoetz_core::session::session_base_dir(),
@@ -4301,6 +4318,26 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         "conversation".to_string(),
                         resolved_followup.conversation.url.clone(),
                     );
+                } else if let Some(thread_label) = recipe_args.thread.as_deref() {
+                    if !recipe_args.fresh {
+                        if let Some(resolved_thread) = followup::resolve_thread_target(
+                            thread_label,
+                            &yoetz_core::session::session_base_dir(),
+                            recipe_kind,
+                        )? {
+                            followup::guard_duplicate_prompt(
+                                &current_prompt_hash,
+                                resolved_thread.prior_prompt_hash.as_deref(),
+                                recipe_args.allow_duplicate_prompt,
+                                &resolved_thread.conversation.id,
+                                resolved_thread.source_session_id.as_deref(),
+                            )?;
+                            recipe_vars.insert(
+                                "conversation".to_string(),
+                                resolved_thread.conversation.url,
+                            );
+                        }
+                    }
                 }
                 Some(current_prompt_hash)
             } else {
@@ -5321,6 +5358,66 @@ mod tests {
         assert!(acquire_browser_recipe_session_lease(Some(&bundle))
             .unwrap()
             .is_none());
+    }
+
+    #[test]
+    fn thread_writeback_uses_final_completion_conversation_for_both_sites() {
+        for (recipe, final_id, final_url) in [
+            (
+                web_recipe::BuiltinWebRecipe::Chatgpt,
+                "final-chatgpt-conversation",
+                "https://chatgpt.com/c/final-chatgpt-conversation",
+            ),
+            (
+                web_recipe::BuiltinWebRecipe::Claude,
+                "123e4567-e89b-12d3-a456-426614174000",
+                "https://claude.ai/chat/123e4567-e89b-12d3-a456-426614174000",
+            ),
+        ] {
+            let dir = TempDir::new().unwrap();
+            let bundle = dir.path().join("bundle.md");
+            fs::write(&bundle, "# bundle").unwrap();
+            fs::write(dir.path().join("bundle.json"), "{}").unwrap();
+            let recipe_args = BrowserRecipeArgs {
+                recipe: PathBuf::from(format!("recipes/{}.yaml", recipe.as_str())),
+                model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
+                transport: None,
+                allow_cdp_fallback: false,
+                bundle: Some(bundle),
+                profile: None,
+                cdp: None,
+                browser_id: None,
+                vars: vec![],
+                followup: None,
+                thread: Some("review-pr-341".to_string()),
+                fresh: true,
+                allow_duplicate_prompt: false,
+                no_notify: false,
+            };
+            let completion_payload = json!({
+                "requested_conversation_id": "WEB:scaffold-that-must-not-be-persisted",
+                "conversation_id": final_id,
+                "conversation_url": "https://chatgpt.com/c/WEB:scaffold-that-must-not-be-persisted",
+            });
+
+            maybe_write_followup_session_metadata(
+                &recipe_args,
+                Some("prompt-hash"),
+                &completion_payload,
+                recipe,
+            );
+
+            let metadata = followup::read_followup_metadata(dir.path())
+                .unwrap()
+                .unwrap();
+            assert_eq!(metadata.thread_label.as_deref(), Some("review-pr-341"));
+            assert_eq!(metadata.conversation_id, final_id);
+            assert_eq!(metadata.conversation_url, final_url);
+            assert_ne!(
+                metadata.conversation_id,
+                "WEB:scaffold-that-must-not-be-persisted"
+            );
+        }
     }
 
     #[test]
@@ -6623,6 +6720,31 @@ mod tests {
         }
     }
 
+    #[test]
+    fn browser_recipe_cli_accepts_thread_and_fresh() {
+        let cli = Cli::try_parse_from([
+            "yoetz",
+            "browser",
+            "recipe",
+            "--recipe",
+            "chatgpt",
+            "--thread",
+            "review-pr-341",
+            "--fresh",
+        ])
+        .expect("thread args should parse");
+
+        match cli.command {
+            Commands::Browser(BrowserArgs {
+                command: BrowserCommand::Recipe(args),
+            }) => {
+                assert_eq!(args.thread.as_deref(), Some("review-pr-341"));
+                assert!(args.fresh);
+            }
+            _ => panic!("unexpected command parsed"),
+        }
+    }
+
     #[tokio::test]
     async fn run_recipe_via_chrome_devtools_mcp_rejects_non_builtin_recipes() {
         let recipe_args = BrowserRecipeArgs {
@@ -6637,6 +6759,8 @@ mod tests {
             model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
+            thread: None,
+            fresh: false,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -6675,6 +6799,8 @@ mod tests {
             model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
+            thread: None,
+            fresh: false,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -6709,6 +6835,8 @@ mod tests {
             model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
+            thread: None,
+            fresh: false,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -6744,6 +6872,8 @@ mod tests {
             model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
+            thread: None,
+            fresh: false,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -6779,6 +6909,8 @@ mod tests {
             model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
+            thread: None,
+            fresh: false,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -6814,6 +6946,8 @@ mod tests {
             model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
+            thread: None,
+            fresh: false,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -6851,6 +6985,8 @@ mod tests {
             model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
+            thread: None,
+            fresh: false,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -6881,6 +7017,8 @@ mod tests {
             model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
+            thread: None,
+            fresh: false,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -6909,6 +7047,8 @@ mod tests {
             model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
+            thread: None,
+            fresh: false,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -6959,6 +7099,8 @@ mod tests {
             model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
+            thread: None,
+            fresh: false,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7028,6 +7170,8 @@ mod tests {
             model_strategy: chatgpt_recipe::ChatgptModelStrategy::Current,
             vars: vec![],
             followup: None,
+            thread: None,
+            fresh: false,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7089,6 +7233,8 @@ mod tests {
             model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
+            thread: None,
+            fresh: false,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7135,6 +7281,8 @@ mod tests {
             model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
+            thread: None,
+            fresh: false,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7182,6 +7330,8 @@ mod tests {
             model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec!["prompt=Explicit prompt".to_string()],
             followup: None,
+            thread: None,
+            fresh: false,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7209,6 +7359,8 @@ mod tests {
             model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
+            thread: None,
+            fresh: false,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7244,6 +7396,8 @@ mod tests {
             model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
+            thread: None,
+            fresh: false,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7279,6 +7433,8 @@ mod tests {
             model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
+            thread: None,
+            fresh: false,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7341,6 +7497,8 @@ mod tests {
             model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
+            thread: None,
+            fresh: false,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7375,6 +7533,8 @@ mod tests {
             model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
+            thread: None,
+            fresh: false,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7420,6 +7580,8 @@ mod tests {
             model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
             vars: vec![],
             followup: None,
+            thread: None,
+            fresh: false,
             allow_duplicate_prompt: false,
             no_notify: false,
         };

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -1317,6 +1317,10 @@ fn recipe_should_auto_discover_cdp_target(
         && (!extension_native_will_route || (requested_extension_native && allow_cdp_fallback))
 }
 
+fn recipe_should_probe_live_browser_routes(thread_label: Option<&str>) -> bool {
+    thread_label.is_none()
+}
+
 fn recipe_should_auto_select_extension_native<R: IntoBuiltinWebRecipe>(
     requested_transport: Option<browser::RecipeTransport>,
     builtin_recipe: R,
@@ -1370,13 +1374,19 @@ fn recipe_transport_error_detail_for_recipe(
     builtin_recipe: Option<web_recipe::BuiltinWebRecipe>,
 ) -> String {
     let mut detail = recipe_transport_error_detail(err);
-    if let Some((recipe, _phase)) = web_recipe::terminal_fallback_marker(err)
+    if let Some((recipe, phase)) = web_recipe::terminal_fallback_marker(err)
         .or_else(|| {
             chatgpt_recipe::terminal_fallback_phase(err)
                 .map(|phase| (web_recipe::BuiltinWebRecipe::Chatgpt, phase))
         })
         .filter(|(recipe, _)| builtin_recipe.is_none_or(|expected| expected == *recipe))
     {
+        if phase == web_recipe::WebRecipeTransportPhase::PostCompletion {
+            detail.push_str(
+                "\nPost-completion status: browser/model run completed, but local finalization failed; do not rerun because the completed request may produce a duplicate submission.",
+            );
+            return detail;
+        }
         if let Some(run_id) = recipe_vars
             .get("run_id")
             .map(String::as_str)
@@ -1469,6 +1479,12 @@ fn recipe_should_stop_live_transport_fallback(
     // targets and auto-selected targets remain advisory.
     selected_cdp_target.is_some_and(browser::ResolvedCdpTarget::is_authoritative)
         && !matches!(transport, browser::RecipeTransport::Manual)
+}
+
+fn should_print_native_cdp_fallback_hint(thread_label: Option<&str>, err: &anyhow::Error) -> bool {
+    thread_label.is_none()
+        && web_recipe::terminal_fallback_marker(err).is_none()
+        && chatgpt_recipe::terminal_fallback_phase(err).is_none()
 }
 
 /// A transport is "pure live-CDP" if its only way to drive the browser is
@@ -1601,6 +1617,24 @@ fn constrain_chatgpt_transports_for_conversation<R: IntoBuiltinWebRecipe>(
         .collect()
 }
 
+fn constrain_builtin_transports_for_conversation_or_thread<R: IntoBuiltinWebRecipe>(
+    transports: Vec<browser::RecipeTransport>,
+    recipe_vars: &std::collections::BTreeMap<String, String>,
+    thread_label: Option<&str>,
+    builtin_recipe: R,
+) -> Vec<browser::RecipeTransport> {
+    let builtin_recipe = builtin_recipe.into_builtin_web_recipe();
+    if builtin_recipe.is_some() && thread_label.is_some() {
+        return transports
+            .into_iter()
+            .filter(|transport| {
+                matches!(transport, browser::RecipeTransport::ChromeExtensionNative)
+            })
+            .collect();
+    }
+    constrain_chatgpt_transports_for_conversation(transports, recipe_vars, builtin_recipe)
+}
+
 fn ensure_chatgpt_transport_constraints_allow_any<R: IntoBuiltinWebRecipe>(
     transports: &[browser::RecipeTransport],
     requested: Option<browser::RecipeTransport>,
@@ -1643,6 +1677,42 @@ fn ensure_chatgpt_transport_constraints_allow_any<R: IntoBuiltinWebRecipe>(
     }
 
     Ok(())
+}
+
+fn ensure_builtin_transport_constraints_allow_any<R: IntoBuiltinWebRecipe>(
+    transports: &[browser::RecipeTransport],
+    requested: Option<browser::RecipeTransport>,
+    recipe_vars: &std::collections::BTreeMap<String, String>,
+    thread_label: Option<&str>,
+    builtin_recipe: R,
+) -> Result<()> {
+    let builtin_recipe = builtin_recipe.into_builtin_web_recipe();
+    if transports.is_empty() {
+        if let (Some(label), Some(recipe)) = (thread_label, builtin_recipe) {
+            let requested = requested
+                .map(recipe_transport_name)
+                .map(|name| format!("requested transport `{name}`"))
+                .unwrap_or_else(|| "configured transports".to_string());
+            let setup = match recipe {
+                web_recipe::BuiltinWebRecipe::Chatgpt => {
+                    "Install the Yoetz Chrome extension (`yoetz browser extension setup --chatgpt`) or pass --transport chrome-extension-native."
+                }
+                web_recipe::BuiltinWebRecipe::Claude => {
+                    "Install or update the Yoetz Chrome extension (`yoetz browser extension setup --claude`) so the selected instance advertises Claude support."
+                }
+            };
+            bail!(
+                "{} thread `{label}` requires chrome-extension-native; {requested} is not compatible. {setup}",
+                recipe.display_name()
+            );
+        }
+    }
+    ensure_chatgpt_transport_constraints_allow_any(
+        transports,
+        requested,
+        recipe_vars,
+        builtin_recipe,
+    )
 }
 
 fn live_attach_owner_present(summary: &live_attach::DaemonSummary) -> bool {
@@ -2612,6 +2682,7 @@ fn run_recipe_via_chrome_extension_native<R: IntoBuiltinWebRecipe>(
     ctx: &AppContext,
     recipe_args: &BrowserRecipeArgs,
     recipe_vars: &BTreeMap<String, String>,
+    current_prompt_hash: Option<&str>,
     format: OutputFormat,
     builtin_recipe: R,
     preflight_warnings: &[String],
@@ -2650,10 +2721,16 @@ fn run_recipe_via_chrome_extension_native<R: IntoBuiltinWebRecipe>(
     }
     let started_at = Instant::now();
 
-    let (mut payload, jsonl_event, notification_target) = match builtin_recipe {
+    let (payload, jsonl_event, notification_target) = match builtin_recipe {
         web_recipe::BuiltinWebRecipe::Chatgpt => {
             let recipe_spec = build_chatgpt_recipe_spec(recipe_args, recipe_vars)?;
-            let response = browser_extension_native::run_chatgpt_recipe(&recipe_spec, format)?;
+            let response = browser_extension_native::run_chatgpt_recipe(&recipe_spec, format)
+                .map_err(|err| {
+                    browser_extension_native::with_thread_conversation_recovery_hint(
+                        err,
+                        recipe_args.thread.as_deref(),
+                    )
+                })?;
             let output = chatgpt_recipe::ChatgptRecipeOutput {
                 transport: browser_extension_native::TRANSPORT_NAME.to_string(),
                 backend: browser_extension_native::TRANSPORT_NAME.to_string(),
@@ -2677,7 +2754,13 @@ fn run_recipe_via_chrome_extension_native<R: IntoBuiltinWebRecipe>(
         web_recipe::BuiltinWebRecipe::Claude => {
             let recipe_spec =
                 build_claude_recipe_spec(recipe_args, recipe_vars, preflight_warnings)?;
-            let response = browser_extension_native::run_claude_recipe(&recipe_spec, format)?;
+            let response = browser_extension_native::run_claude_recipe(&recipe_spec, format)
+                .map_err(|err| {
+                    browser_extension_native::with_thread_conversation_recovery_hint(
+                        err,
+                        recipe_args.thread.as_deref(),
+                    )
+                })?;
             let mut warnings = recipe_spec.warnings.clone();
             warnings.extend(response.warnings);
             warnings.sort();
@@ -2702,28 +2785,73 @@ fn run_recipe_via_chrome_extension_native<R: IntoBuiltinWebRecipe>(
             )
         }
     };
-    attach_browser_recipe_artifacts(&mut payload, recipe_args.bundle.as_deref())?;
-    maybe_write_output(ctx, &payload)?;
-    match format {
-        OutputFormat::Json => {
-            write_json(&payload)?;
-        }
-        OutputFormat::Jsonl => {
-            write_jsonl("browser.recipe", &jsonl_event)?;
-        }
-        OutputFormat::Text | OutputFormat::Markdown => {
-            println!("{}", payload["response"].as_str().unwrap_or_default());
-        }
-    }
-    maybe_notify_browser_recipe_completion(
+    complete_chrome_extension_native_recipe(
         ctx,
-        recipe_args.no_notify,
-        notification_target.as_str(),
-        &payload,
-        started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
-        None,
-    );
-    Ok(payload)
+        recipe_args,
+        current_prompt_hash,
+        builtin_recipe,
+        payload,
+        &jsonl_event,
+        &notification_target,
+        started_at,
+        format,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn complete_chrome_extension_native_recipe(
+    ctx: &AppContext,
+    recipe_args: &BrowserRecipeArgs,
+    current_prompt_hash: Option<&str>,
+    builtin_recipe: web_recipe::BuiltinWebRecipe,
+    mut payload: Value,
+    jsonl_event: &Value,
+    notification_target: &str,
+    started_at: Instant,
+    format: OutputFormat,
+) -> Result<Value> {
+    let completion = || -> Result<Value> {
+        if let Some(thread_label) = recipe_args.thread.as_deref() {
+            let current_prompt_hash = current_prompt_hash.ok_or_else(|| {
+                anyhow!("persist thread `{thread_label}` metadata: missing current prompt hash")
+            })?;
+            write_followup_session_metadata_required(
+                recipe_args,
+                current_prompt_hash,
+                &payload,
+                builtin_recipe,
+            )?;
+        }
+        attach_browser_recipe_artifacts(&mut payload, recipe_args.bundle.as_deref())?;
+        maybe_write_output(ctx, &payload)?;
+        match format {
+            OutputFormat::Json => {
+                write_json(&payload)?;
+            }
+            OutputFormat::Jsonl => {
+                write_jsonl("browser.recipe", &jsonl_event)?;
+            }
+            OutputFormat::Text | OutputFormat::Markdown => {
+                println!("{}", payload["response"].as_str().unwrap_or_default());
+            }
+        }
+        maybe_notify_browser_recipe_completion(
+            ctx,
+            recipe_args.no_notify,
+            notification_target,
+            &payload,
+            started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
+            None,
+        );
+        Ok(payload)
+    };
+    completion().map_err(|err| {
+        web_recipe::mark_terminal_fallback_phase(
+            err,
+            builtin_recipe,
+            web_recipe::WebRecipeTransportPhase::PostCompletion,
+        )
+    })
 }
 
 fn attach_browser_recipe_artifacts(payload: &mut Value, bundle_path: Option<&Path>) -> Result<()> {
@@ -2765,6 +2893,75 @@ fn browser_recipe_artifact_paths(bundle_path: Option<&Path>) -> Option<ArtifactP
     })
 }
 
+fn validate_thread_persistence_preflight_in(
+    recipe_args: &BrowserRecipeArgs,
+    sessions_base: &Path,
+) -> Result<()> {
+    let Some(thread_label) = recipe_args.thread.as_deref() else {
+        return Ok(());
+    };
+    let bundle_path = recipe_args.bundle.as_deref().ok_or_else(|| {
+        anyhow!(
+            "thread `{thread_label}` requires a managed bundle session with bundle.md and bundle.json"
+        )
+    })?;
+    if bundle_path.file_name().and_then(|name| name.to_str()) != Some("bundle.md") {
+        bail!("thread `{thread_label}` bundle must be named bundle.md");
+    }
+    let session_dir = bundle_path
+        .parent()
+        .ok_or_else(|| anyhow!("thread `{thread_label}` bundle has no session directory"))?;
+    let bundle_json = session_dir.join("bundle.json");
+
+    ensure_regular_file(bundle_path, "bundle.md", thread_label)?;
+    ensure_regular_file(&bundle_json, "bundle.json", thread_label)?;
+    let canonical_base = fs::canonicalize(sessions_base).with_context(|| {
+        format!(
+            "thread `{thread_label}` canonicalize managed sessions directory {}",
+            sessions_base.display()
+        )
+    })?;
+    let canonical_session = fs::canonicalize(session_dir).with_context(|| {
+        format!(
+            "thread `{thread_label}` canonicalize session directory {}",
+            session_dir.display()
+        )
+    })?;
+    if canonical_session.parent() != Some(canonical_base.as_path()) {
+        bail!(
+            "thread `{thread_label}` session must be a direct child of the managed sessions directory {}",
+            canonical_base.display()
+        );
+    }
+
+    let followup_path = session_dir.join("followup.json");
+    match fs::symlink_metadata(&followup_path) {
+        Ok(metadata) if metadata.file_type().is_file() => {}
+        Ok(_) => bail!(
+            "thread `{thread_label}` followup.json must be a regular file when it already exists"
+        ),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+        Err(err) => {
+            return Err(err).with_context(|| {
+                format!(
+                    "thread `{thread_label}` inspect existing {}",
+                    followup_path.display()
+                )
+            });
+        }
+    }
+    Ok(())
+}
+
+fn ensure_regular_file(path: &Path, name: &str, thread_label: &str) -> Result<()> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("thread `{thread_label}` inspect {}", path.display()))?;
+    if !metadata.file_type().is_file() {
+        bail!("thread `{thread_label}` {name} must be a regular file");
+    }
+    Ok(())
+}
+
 #[derive(Debug)]
 struct BrowserRecipeSessionLease {
     _file: File,
@@ -2802,29 +2999,38 @@ fn acquire_browser_recipe_session_lease(
     }
 }
 
-fn maybe_write_followup_session_metadata(
+fn acquire_browser_recipe_session_lease_in(
     recipe_args: &BrowserRecipeArgs,
-    current_prompt_hash: Option<&str>,
-    payload: &Value,
-    recipe: web_recipe::BuiltinWebRecipe,
-) {
-    let Some(current_prompt_hash) = current_prompt_hash else {
-        return;
-    };
-    let Some(session_artifacts) = browser_recipe_artifact_paths(recipe_args.bundle.as_deref())
-    else {
-        return;
-    };
+    sessions_base: &Path,
+) -> Result<Option<BrowserRecipeSessionLease>> {
+    validate_thread_persistence_preflight_in(recipe_args, sessions_base)?;
+    acquire_browser_recipe_session_lease(recipe_args.bundle.as_deref())
+}
+
+fn final_conversation_identity(payload: &Value) -> Option<&str> {
     // The final job_complete conversation_id is authoritative: ChatGPT may begin under a
     // WEB: scaffold reassigned by isExpectedConversationIdAssignment in
     // extensions/chatgpt-native/src/sites/chatgpt.js. Keep the URL as a legacy fallback.
-    let Some(conversation_raw) = payload
+    payload
         .get("conversation_id")
         .and_then(Value::as_str)
         .or_else(|| payload.get("conversation_url").and_then(Value::as_str))
-    else {
-        return;
-    };
+}
+
+fn write_followup_session_metadata(
+    recipe_args: &BrowserRecipeArgs,
+    current_prompt_hash: &str,
+    payload: &Value,
+    recipe: web_recipe::BuiltinWebRecipe,
+) -> Result<()> {
+    let session_artifacts = browser_recipe_artifact_paths(recipe_args.bundle.as_deref())
+        .ok_or_else(|| {
+            anyhow!(
+                "followup metadata requires a managed bundle session with bundle.md and bundle.json"
+            )
+        })?;
+    let conversation_raw = final_conversation_identity(payload)
+        .ok_or_else(|| anyhow!("missing authoritative final conversation identity"))?;
 
     let session_dir = PathBuf::from(session_artifacts.session_dir);
     let session_id = session_dir
@@ -2844,22 +3050,59 @@ fn maybe_write_followup_session_metadata(
         web_recipe::BuiltinWebRecipe::Claude => {
             claude_web::normalize_conversation(conversation_raw)
         }
-    };
-    let Ok(conversation) = conversation else {
-        eprintln!(
-            "warning: could not normalize followup conversation for metadata {}",
+    }
+    .with_context(|| {
+        format!(
+            "normalize final conversation identity for metadata {}",
             session_dir.join("followup.json").display()
-        );
-        return;
-    };
-    if let Err(err) = followup::write_followup_metadata_for_recipe(
+        )
+    })?;
+    followup::write_followup_metadata_for_recipe(
         &session_dir,
         &session_id,
         recipe,
         &conversation,
         current_prompt_hash,
         recipe_args.thread.as_deref(),
-    ) {
+    )
+}
+
+fn write_followup_session_metadata_required(
+    recipe_args: &BrowserRecipeArgs,
+    current_prompt_hash: &str,
+    payload: &Value,
+    recipe: web_recipe::BuiltinWebRecipe,
+) -> Result<()> {
+    let thread_label = recipe_args
+        .thread
+        .as_deref()
+        .ok_or_else(|| anyhow!("required thread metadata needs --thread"))?;
+    write_followup_session_metadata(recipe_args, current_prompt_hash, payload, recipe)
+        .with_context(|| format!("persist thread `{thread_label}` metadata"))
+}
+
+fn maybe_write_followup_session_metadata(
+    recipe_args: &BrowserRecipeArgs,
+    current_prompt_hash: Option<&str>,
+    payload: &Value,
+    recipe: web_recipe::BuiltinWebRecipe,
+) {
+    let Some(current_prompt_hash) = current_prompt_hash else {
+        return;
+    };
+    if browser_recipe_artifact_paths(recipe_args.bundle.as_deref()).is_none()
+        || final_conversation_identity(payload).is_none()
+    {
+        return;
+    }
+    if let Err(err) =
+        write_followup_session_metadata(recipe_args, current_prompt_hash, payload, recipe)
+    {
+        let session_dir = recipe_args
+            .bundle
+            .as_deref()
+            .and_then(Path::parent)
+            .unwrap_or_else(|| Path::new("."));
         eprintln!(
             "warning: could not write followup metadata {}: {err}",
             session_dir.join("followup.json").display()
@@ -4257,8 +4500,10 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             }
         }
         BrowserCommand::Recipe(recipe_args) => {
-            let _session_lease =
-                acquire_browser_recipe_session_lease(recipe_args.bundle.as_deref())?;
+            let _session_lease = acquire_browser_recipe_session_lease_in(
+                &recipe_args,
+                &yoetz_core::session::session_base_dir(),
+            )?;
             let recipe_path = browser::resolve_recipe(&recipe_args.recipe)
                 .with_context(|| format!("resolve recipe {:?}", recipe_args.recipe))?;
             let content = fs::read_to_string(&recipe_path)
@@ -4403,17 +4648,23 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
             } else {
                 Vec::new()
             };
-            let mut resolved_cdp_target = browser::resolve_cdp_target_with_selector(
-                recipe_args.cdp.as_deref(),
-                recipe_args.browser_id.as_deref(),
-                &ctx.browser_defaults,
-                recipe_should_auto_discover_cdp_target(
-                    managed_profile_only,
-                    requested_extension_native,
-                    extension_native_will_route,
-                    effective_allow_cdp_fallback,
-                ),
-            )?;
+            let probe_live_browser_routes =
+                recipe_should_probe_live_browser_routes(recipe_args.thread.as_deref());
+            let mut resolved_cdp_target = if probe_live_browser_routes {
+                browser::resolve_cdp_target_with_selector(
+                    recipe_args.cdp.as_deref(),
+                    recipe_args.browser_id.as_deref(),
+                    &ctx.browser_defaults,
+                    recipe_should_auto_discover_cdp_target(
+                        managed_profile_only,
+                        requested_extension_native,
+                        extension_native_will_route,
+                        effective_allow_cdp_fallback,
+                    ),
+                )?
+            } else {
+                None
+            };
             maybe_print_auto_selected_cdp_target(resolved_cdp_target.as_ref(), format);
             let base_transports = browser::maybe_select_extension_native_for_builtin(
                 browser::recipe_transports(&recipe, builtin_recipe),
@@ -4430,8 +4681,8 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 effective_allow_cdp_fallback,
                 builtin_recipe,
             )?;
-            let live_attach_owner_is_present =
-                live_attach_owner_present(&live_attach::inspect_daemon_sync());
+            let live_attach_owner_is_present = probe_live_browser_routes
+                && live_attach_owner_present(&live_attach::inspect_daemon_sync());
             let prefer_auto_connect = builtin_recipe.is_some()
                 && !managed_profile_only
                 && !recipe_uses_exact_browser_context_selector(&recipe_vars)
@@ -4449,15 +4700,17 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                 &recipe_vars,
                 builtin_recipe,
             );
-            let transports = constrain_chatgpt_transports_for_conversation(
+            let transports = constrain_builtin_transports_for_conversation_or_thread(
                 transports,
                 &recipe_vars,
+                recipe_args.thread.as_deref(),
                 builtin_recipe,
             );
-            ensure_chatgpt_transport_constraints_allow_any(
+            ensure_builtin_transport_constraints_allow_any(
                 &transports,
                 recipe_args.transport,
                 &recipe_vars,
+                recipe_args.thread.as_deref(),
                 builtin_recipe,
             )?;
             maybe_print_auto_selected_extension_native_transport(
@@ -4534,6 +4787,7 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                             ctx,
                             &recipe_args,
                             &recipe_vars,
+                            current_prompt_hash.as_deref(),
                             format,
                             builtin_recipe,
                             &preflight_warnings,
@@ -4553,13 +4807,15 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         ) {
                             maybe_remember_cdp_target(resolved_cdp_target.as_ref(), format);
                         }
-                        if let Some(recipe_kind) = builtin_recipe {
-                            maybe_write_followup_session_metadata(
-                                &recipe_args,
-                                current_prompt_hash.as_deref(),
-                                &_payload,
-                                recipe_kind,
-                            );
+                        if recipe_args.thread.is_none() {
+                            if let Some(recipe_kind) = builtin_recipe {
+                                maybe_write_followup_session_metadata(
+                                    &recipe_args,
+                                    current_prompt_hash.as_deref(),
+                                    &_payload,
+                                    recipe_kind,
+                                );
+                            }
                         }
                         return Ok(());
                     }
@@ -4601,8 +4857,10 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         }
                         if matches!(transport, browser::RecipeTransport::ChromeExtensionNative)
                             && !effective_allow_cdp_fallback
-                            && web_recipe::terminal_fallback_marker(&err).is_none()
-                            && chatgpt_recipe::terminal_fallback_phase(&err).is_none()
+                            && should_print_native_cdp_fallback_hint(
+                                recipe_args.thread.as_deref(),
+                                &err,
+                            )
                             && matches!(format, OutputFormat::Text | OutputFormat::Markdown)
                         {
                             eprintln!(
@@ -5197,6 +5455,26 @@ mod tests {
         }
     }
 
+    fn thread_recipe_args(bundle: PathBuf) -> BrowserRecipeArgs {
+        BrowserRecipeArgs {
+            recipe: PathBuf::from("recipes/chatgpt.yaml"),
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
+            transport: None,
+            allow_cdp_fallback: false,
+            keep_tab: false,
+            bundle: Some(bundle),
+            profile: None,
+            cdp: None,
+            browser_id: None,
+            vars: vec![],
+            followup: None,
+            thread: Some("review-pr-341".to_string()),
+            fresh: false,
+            allow_duplicate_prompt: false,
+            no_notify: false,
+        }
+    }
+
     fn temp_schema_path() -> PathBuf {
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -5383,6 +5661,7 @@ mod tests {
                 model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
                 transport: None,
                 allow_cdp_fallback: false,
+                keep_tab: false,
                 bundle: Some(bundle),
                 profile: None,
                 cdp: None,
@@ -5418,6 +5697,127 @@ mod tests {
                 "WEB:scaffold-that-must-not-be-persisted"
             );
         }
+    }
+
+    #[test]
+    fn required_thread_writeback_rejects_missing_final_conversation_identity() {
+        let dir = TempDir::new().unwrap();
+        let bundle = dir.path().join("bundle.md");
+        fs::write(&bundle, "# bundle").unwrap();
+        fs::write(dir.path().join("bundle.json"), "{}").unwrap();
+        let recipe_args = thread_recipe_args(bundle);
+
+        let err = write_followup_session_metadata_required(
+            &recipe_args,
+            "prompt-hash",
+            &json!({"status": "ok", "response": "done"}),
+            web_recipe::BuiltinWebRecipe::Chatgpt,
+        )
+        .unwrap_err();
+
+        assert!(format!("{err:#}").contains("missing authoritative final conversation identity"));
+        assert!(!dir.path().join("followup.json").exists());
+    }
+
+    #[test]
+    fn required_thread_writeback_propagates_persistence_failure() {
+        let dir = TempDir::new().unwrap();
+        let bundle = dir.path().join("bundle.md");
+        fs::write(&bundle, "# bundle").unwrap();
+        fs::write(dir.path().join("bundle.json"), "{}").unwrap();
+        fs::create_dir(dir.path().join("followup.json")).unwrap();
+        let recipe_args = thread_recipe_args(bundle);
+
+        let err = write_followup_session_metadata_required(
+            &recipe_args,
+            "prompt-hash",
+            &json!({
+                "status": "ok",
+                "response": "done",
+                "conversation_id": "final-conversation"
+            }),
+            web_recipe::BuiltinWebRecipe::Chatgpt,
+        )
+        .unwrap_err();
+
+        assert!(format!("{err:#}").contains("persist thread `review-pr-341`"));
+    }
+
+    #[test]
+    fn non_thread_followup_writeback_remains_best_effort() {
+        let dir = TempDir::new().unwrap();
+        let bundle = dir.path().join("bundle.md");
+        fs::write(&bundle, "# bundle").unwrap();
+        fs::write(dir.path().join("bundle.json"), "{}").unwrap();
+        fs::create_dir(dir.path().join("followup.json")).unwrap();
+        let mut recipe_args = thread_recipe_args(bundle);
+        recipe_args.thread = None;
+
+        maybe_write_followup_session_metadata(
+            &recipe_args,
+            Some("prompt-hash"),
+            &json!({"status": "ok", "response": "missing identity"}),
+            web_recipe::BuiltinWebRecipe::Chatgpt,
+        );
+        maybe_write_followup_session_metadata(
+            &recipe_args,
+            Some("prompt-hash"),
+            &json!({
+                "status": "ok",
+                "response": "persistence fails",
+                "conversation_id": "final-conversation"
+            }),
+            web_recipe::BuiltinWebRecipe::Chatgpt,
+        );
+
+        assert!(dir.path().join("followup.json").is_dir());
+    }
+
+    #[test]
+    fn thread_metadata_is_persisted_before_artifact_completion() {
+        let dir = TempDir::new().unwrap();
+        let bundle = dir.path().join("bundle.md");
+        fs::write(&bundle, "# bundle").unwrap();
+        fs::write(dir.path().join("bundle.json"), "{}").unwrap();
+        fs::create_dir(dir.path().join("response.json")).unwrap();
+        let recipe_args = thread_recipe_args(bundle);
+
+        let err = complete_chrome_extension_native_recipe(
+            &test_app_context(),
+            &recipe_args,
+            Some("prompt-hash"),
+            web_recipe::BuiltinWebRecipe::Chatgpt,
+            json!({
+                "status": "ok",
+                "response": "done",
+                "conversation_id": "final-conversation"
+            }),
+            &json!({"status": "ok"}),
+            "GPT-5.6 Sol Pro",
+            Instant::now(),
+            OutputFormat::Text,
+        )
+        .unwrap_err();
+
+        assert!(format!("{err:#}").contains("response.json"));
+        assert_eq!(
+            web_recipe::terminal_fallback_marker(&err),
+            Some((
+                web_recipe::BuiltinWebRecipe::Chatgpt,
+                web_recipe::WebRecipeTransportPhase::PostCompletion,
+            ))
+        );
+        assert!(recipe_should_stop_live_transport_fallback(
+            &err,
+            None,
+            browser::RecipeTransport::ChromeExtensionNative,
+            &BTreeMap::new(),
+        ));
+        let metadata = followup::read_followup_metadata(dir.path())
+            .unwrap()
+            .unwrap();
+        assert_eq!(metadata.thread_label.as_deref(), Some("review-pr-341"));
+        assert_eq!(metadata.conversation_id, "final-conversation");
     }
 
     #[test]
@@ -6157,6 +6557,152 @@ mod tests {
         assert!(message.contains("conversation requires chrome-extension-native"));
         assert!(message.contains("configured transports"));
         assert!(message.contains("yoetz browser extension setup --chatgpt"));
+    }
+
+    #[test]
+    fn thread_rejects_explicit_non_native_transport_for_both_sites() {
+        let vars = BTreeMap::new();
+        for recipe in [
+            web_recipe::BuiltinWebRecipe::Chatgpt,
+            web_recipe::BuiltinWebRecipe::Claude,
+        ] {
+            let transports = constrain_builtin_transports_for_conversation_or_thread(
+                vec![browser::RecipeTransport::ChromeDevtoolsMcp],
+                &vars,
+                Some("review-pr-341"),
+                Some(recipe),
+            );
+            let err = ensure_builtin_transport_constraints_allow_any(
+                &transports,
+                Some(browser::RecipeTransport::ChromeDevtoolsMcp),
+                &vars,
+                Some("review-pr-341"),
+                Some(recipe),
+            )
+            .unwrap_err();
+            let message = err.to_string();
+            assert!(message.contains("thread `review-pr-341` requires chrome-extension-native"));
+            assert!(message.contains("requested transport `chrome-devtools-mcp`"));
+        }
+    }
+
+    #[test]
+    fn thread_rejects_auto_selected_routes_when_native_is_unavailable() {
+        let vars = BTreeMap::new();
+        let transports = constrain_builtin_transports_for_conversation_or_thread(
+            vec![
+                browser::RecipeTransport::ChromeDevtoolsMcp,
+                browser::RecipeTransport::DevBrowser,
+                browser::RecipeTransport::AgentBrowser,
+                browser::RecipeTransport::Manual,
+            ],
+            &vars,
+            Some("review-pr-341"),
+            Some(web_recipe::BuiltinWebRecipe::Chatgpt),
+        );
+        assert!(transports.is_empty());
+        let err = ensure_builtin_transport_constraints_allow_any(
+            &transports,
+            None,
+            &vars,
+            Some("review-pr-341"),
+            Some(web_recipe::BuiltinWebRecipe::Chatgpt),
+        )
+        .unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("thread `review-pr-341` requires chrome-extension-native"));
+        assert!(message.contains("configured transports"));
+    }
+
+    #[test]
+    fn thread_rejects_external_managed_bundle_lookalike_before_locking() {
+        let root = TempDir::new().unwrap();
+        let sessions_base = root.path().join("sessions");
+        let external_session = root.path().join("external").join("session-lookalike");
+        fs::create_dir_all(&sessions_base).unwrap();
+        fs::create_dir_all(&external_session).unwrap();
+        fs::write(external_session.join("bundle.md"), "# bundle").unwrap();
+        fs::write(external_session.join("bundle.json"), "{}").unwrap();
+        let recipe_args = thread_recipe_args(external_session.join("bundle.md"));
+
+        let err =
+            acquire_browser_recipe_session_lease_in(&recipe_args, &sessions_base).unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("direct child of the managed sessions directory"));
+        assert!(!external_session
+            .join(BROWSER_RECIPE_SESSION_LOCK_FILENAME)
+            .exists());
+    }
+
+    #[test]
+    fn thread_accepts_canonical_managed_session_with_regular_artifacts() {
+        let root = TempDir::new().unwrap();
+        let sessions_base = root.path().join("sessions");
+        let session = sessions_base.join("20260725_120000_abcdef");
+        fs::create_dir_all(&session).unwrap();
+        fs::write(session.join("bundle.md"), "# bundle").unwrap();
+        fs::write(session.join("bundle.json"), "{}").unwrap();
+        let recipe_args = thread_recipe_args(session.join("bundle.md"));
+
+        assert!(validate_thread_persistence_preflight_in(&recipe_args, &sessions_base).is_ok());
+    }
+
+    #[test]
+    fn thread_rejects_non_regular_bundle_artifacts_and_followup_target() {
+        let root = TempDir::new().unwrap();
+        let sessions_base = root.path().join("sessions");
+
+        let bundle_dir_session = sessions_base.join("bundle-dir");
+        fs::create_dir_all(bundle_dir_session.join("bundle.md")).unwrap();
+        fs::write(bundle_dir_session.join("bundle.json"), "{}").unwrap();
+        let err = validate_thread_persistence_preflight_in(
+            &thread_recipe_args(bundle_dir_session.join("bundle.md")),
+            &sessions_base,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("bundle.md must be a regular file"));
+
+        let json_dir_session = sessions_base.join("json-dir");
+        fs::create_dir_all(json_dir_session.join("bundle.json")).unwrap();
+        fs::write(json_dir_session.join("bundle.md"), "# bundle").unwrap();
+        let err = validate_thread_persistence_preflight_in(
+            &thread_recipe_args(json_dir_session.join("bundle.md")),
+            &sessions_base,
+        )
+        .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("bundle.json must be a regular file"));
+
+        let followup_dir_session = sessions_base.join("followup-dir");
+        fs::create_dir_all(followup_dir_session.join("followup.json")).unwrap();
+        fs::write(followup_dir_session.join("bundle.md"), "# bundle").unwrap();
+        fs::write(followup_dir_session.join("bundle.json"), "{}").unwrap();
+        let err = validate_thread_persistence_preflight_in(
+            &thread_recipe_args(followup_dir_session.join("bundle.md")),
+            &sessions_base,
+        )
+        .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("followup.json must be a regular file"));
+    }
+
+    #[test]
+    fn thread_never_probes_live_browser_routes_or_prints_cdp_fallback_hint() {
+        let err = anyhow!("native extension unavailable");
+
+        assert!(!recipe_should_probe_live_browser_routes(Some(
+            "review-pr-341"
+        )));
+        assert!(!should_print_native_cdp_fallback_hint(
+            Some("review-pr-341"),
+            &err,
+        ));
+        assert!(recipe_should_probe_live_browser_routes(None));
+        assert!(should_print_native_cdp_fallback_hint(None, &err));
     }
 
     #[test]
@@ -7371,6 +7917,7 @@ mod tests {
             &ctx,
             &recipe_args,
             &recipe_vars,
+            None,
             OutputFormat::Json,
             true,
             &[],
@@ -7408,6 +7955,7 @@ mod tests {
             &ctx,
             &recipe_args,
             &recipe_vars,
+            None,
             OutputFormat::Json,
             true,
             &[],
@@ -7445,6 +7993,7 @@ mod tests {
             &ctx,
             &recipe_args,
             &recipe_vars,
+            None,
             OutputFormat::Json,
             true,
             &[],
@@ -7631,6 +8180,31 @@ mod tests {
         assert!(detail.contains("window.name `yoetz:run-123`"));
         assert!(detail.contains("extension marker prefix `yoetz-chatgpt-native:run-123:`"));
         assert!(detail.contains("duplicate submission"));
+    }
+
+    #[test]
+    fn recipe_transport_error_detail_for_post_completion_forbids_rerun_and_tab_recovery() {
+        let err = web_recipe::mark_terminal_fallback_phase(
+            anyhow::anyhow!("persist thread metadata failed"),
+            web_recipe::BuiltinWebRecipe::Chatgpt,
+            web_recipe::WebRecipeTransportPhase::PostCompletion,
+        );
+        let vars = BTreeMap::from([("run_id".to_string(), "run-complete".to_string())]);
+
+        let detail = recipe_transport_error_detail_for_recipe(
+            &err,
+            &vars,
+            Some(web_recipe::BuiltinWebRecipe::Chatgpt),
+        );
+
+        assert!(detail.contains("browser/model run completed"));
+        assert!(detail.contains("local finalization failed"));
+        assert!(detail.contains("do not rerun"));
+        assert!(detail.contains("duplicate"));
+        assert!(!detail.contains("Manual recovery"));
+        assert!(!detail.contains("continue in"));
+        assert!(!detail.contains("inspect"));
+        assert!(!detail.contains("chatgpt.com"));
     }
 
     #[test]

--- a/crates/yoetz-cli/src/web_recipe.rs
+++ b/crates/yoetz-cli/src/web_recipe.rs
@@ -73,6 +73,7 @@ pub enum WebRecipeTransportPhase {
     Upload,
     Send,
     WaitResponse,
+    PostCompletion,
 }
 
 impl fmt::Display for WebRecipeTransportPhase {
@@ -81,6 +82,7 @@ impl fmt::Display for WebRecipeTransportPhase {
             Self::Upload => "upload",
             Self::Send => "send",
             Self::WaitResponse => "wait_response",
+            Self::PostCompletion => "post_completion",
         })
     }
 }


### PR DESCRIPTION
## Summary

Implements issue #341 steps 1-2 only:

- add recipe-scoped --thread LABEL and --fresh for built-in ChatGPT and Claude recipes
- resolve labels newest-first with a backward-compatible monotonic thread revision, so an intentional fresh run reliably re-points the label
- require chrome-extension-native for labeled runs and avoid CDP discovery or fallback advice
- persist the authoritative final conversation identity atomically before artifacts, output, or notification; fail closed for labeled runs while preserving best-effort writeback for ordinary runs
- validate managed session paths before lock creation, skip corrupt unrelated metadata safely, and give stale-label failures the exact --fresh recovery path

Plain --followup writeback now prefers the final conversation_id over conversation_url; this avoids persisting ChatGPT WEB scaffold identities. Step 3 concurrency policy, reporting/session list, and docs remain out of scope and issue #341 stays open.

## Validation

- focused thread tests: 23 passed
- post-completion renderer tests: 2 passed
- full yoetz binary units: 612 passed, 2 ignored
- native job error and atomic persistence tests: passed
- cargo clippy -p yoetz --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check

No real-site browser E2E was run; that remains a release acceptance gate.