### PR TITLE
Guard same-label native browser threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Browser recipe threads now hold a recipe-scoped per-label lock for the full
+  native run and metadata write, preventing concurrent agents from silently
+  interleaving prompts in one conversation. Collisions fail with actionable
+  holder details by default; `--on-thread-conflict wait[:<duration>]` and
+  `fork` provide explicit alternatives without ambiguously re-pointing labels.
+
 ## [0.5.43] - 2026-07-25
 ### Added
 

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -196,6 +196,13 @@ impl Drop for ExtensionLifecycleLock {
     }
 }
 
+pub(crate) struct ExtensionRecipeLease {
+    _lifecycle_lock: ExtensionLifecycleLock,
+    paths: ExtensionPaths,
+    instance: ExtensionInstanceStatus,
+    recipe: BuiltinWebRecipe,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ProtocolEnvelope {
     pub protocol_version: u32,
@@ -1649,33 +1656,91 @@ fn select_recipe_instance_with_lifecycle_lock(
     Ok((lifecycle_lock, instance))
 }
 
+pub(crate) fn acquire_chatgpt_recipe_lease(
+    spec: &ChatgptRecipeSpec,
+) -> Result<ExtensionRecipeLease> {
+    let bundle_path = spec
+        .bundle_path
+        .as_deref()
+        .context("chrome-extension-native transport requires `--bundle`")?;
+    validate_bundle_path(bundle_path)?;
+    acquire_extension_recipe_lease(
+        ExtensionInstanceSelector {
+            profile_email: spec.profile_email.as_deref(),
+            extension_instance_id: spec.extension_instance_id.as_deref(),
+            extension_profile_id: spec.extension_profile_id.as_deref(),
+        },
+        BuiltinWebRecipe::Chatgpt,
+        "--chatgpt",
+        "ChatGPT native extension recipe",
+    )
+}
+
+pub(crate) fn acquire_claude_recipe_lease(spec: &ClaudeRecipeSpec) -> Result<ExtensionRecipeLease> {
+    let bundle_path = spec
+        .bundle_path
+        .as_deref()
+        .context("chrome-extension-native transport requires `--bundle`")?;
+    validate_bundle_path(bundle_path)?;
+    acquire_extension_recipe_lease(
+        ExtensionInstanceSelector {
+            profile_email: spec.profile_email.as_deref(),
+            extension_instance_id: spec.extension_instance_id.as_deref(),
+            extension_profile_id: spec.extension_profile_id.as_deref(),
+        },
+        BuiltinWebRecipe::Claude,
+        "--claude",
+        "Claude native extension recipe",
+    )
+}
+
+fn acquire_extension_recipe_lease(
+    selector: ExtensionInstanceSelector<'_>,
+    recipe: BuiltinWebRecipe,
+    recipe_flag: &str,
+    action: &str,
+) -> Result<ExtensionRecipeLease> {
+    let paths = extension_paths()?;
+    let (lifecycle_lock, instance) =
+        select_recipe_instance_with_lifecycle_lock(&paths, selector, recipe_flag, action)?;
+    ensure_instance_matches_managed_copy(&instance)?;
+    if recipe == BuiltinWebRecipe::Claude {
+        ensure_instance_supports_recipe(&instance, "claude")?;
+    }
+    Ok(ExtensionRecipeLease {
+        _lifecycle_lock: lifecycle_lock,
+        paths,
+        instance,
+        recipe,
+    })
+}
+
 pub fn run_chatgpt_recipe(
     spec: &ChatgptRecipeSpec,
     format: OutputFormat,
 ) -> Result<ExtensionRecipeResult> {
+    let lease = acquire_chatgpt_recipe_lease(spec)?;
+    run_chatgpt_recipe_with_lease(spec, format, &lease)
+}
+
+pub(crate) fn run_chatgpt_recipe_with_lease(
+    spec: &ChatgptRecipeSpec,
+    format: OutputFormat,
+    lease: &ExtensionRecipeLease,
+) -> Result<ExtensionRecipeResult> {
+    if lease.recipe != BuiltinWebRecipe::Chatgpt {
+        bail!("native extension recipe lease does not belong to ChatGPT");
+    }
     let bundle_path = spec
         .bundle_path
         .as_deref()
         .context("chrome-extension-native transport requires `--bundle`")?;
     let bundle = validate_bundle_path(bundle_path)?;
-    let paths = extension_paths()?;
-    let selector = ExtensionInstanceSelector {
-        profile_email: spec.profile_email.as_deref(),
-        extension_instance_id: spec.extension_instance_id.as_deref(),
-        extension_profile_id: spec.extension_profile_id.as_deref(),
-    };
-    let (_lifecycle_lock, instance) = select_recipe_instance_with_lifecycle_lock(
-        &paths,
-        selector,
-        "--chatgpt",
-        "ChatGPT native extension recipe",
-    )?;
-    ensure_instance_matches_managed_copy(&instance)?;
-    let token = read_capability_token(&paths.token_path)?;
-    let mut stream = connect_socket(&instance.socket_path).with_context(|| {
+    let token = read_capability_token(&lease.paths.token_path)?;
+    let mut stream = connect_socket(&lease.instance.socket_path).with_context(|| {
         format!(
             "chrome-extension-native bridge is not connected at {}. Run `yoetz browser extension doctor --chatgpt`, then open Chrome with the Yoetz extension enabled.",
-            instance.socket_path.display()
+            lease.instance.socket_path.display()
         )
     })?;
     stream.set_read_timeout(Some(
@@ -1712,32 +1777,28 @@ pub fn run_claude_recipe(
     spec: &ClaudeRecipeSpec,
     format: OutputFormat,
 ) -> Result<ExtensionRecipeResult> {
+    let lease = acquire_claude_recipe_lease(spec)?;
+    run_claude_recipe_with_lease(spec, format, &lease)
+}
+
+pub(crate) fn run_claude_recipe_with_lease(
+    spec: &ClaudeRecipeSpec,
+    format: OutputFormat,
+    lease: &ExtensionRecipeLease,
+) -> Result<ExtensionRecipeResult> {
+    if lease.recipe != BuiltinWebRecipe::Claude {
+        bail!("native extension recipe lease does not belong to Claude");
+    }
     let bundle_path = spec
         .bundle_path
         .as_deref()
         .context("chrome-extension-native transport requires `--bundle`")?;
     let bundle = validate_bundle_path(bundle_path)?;
-    let paths = extension_paths()?;
-    let selector = ExtensionInstanceSelector {
-        profile_email: spec.profile_email.as_deref(),
-        extension_instance_id: spec.extension_instance_id.as_deref(),
-        extension_profile_id: spec.extension_profile_id.as_deref(),
-    };
-    let (_lifecycle_lock, instance) = select_recipe_instance_with_lifecycle_lock(
-        &paths,
-        selector,
-        "--claude",
-        "Claude native extension recipe",
-    )?;
-    ensure_instance_matches_managed_copy(&instance)?;
-    // Capability is checked on the exact routed extension instance after any
-    // best-effort heal and before opening the socket or emitting job_start.
-    ensure_instance_supports_recipe(&instance, "claude")?;
-    let token = read_capability_token(&paths.token_path)?;
-    let mut stream = connect_socket(&instance.socket_path).with_context(|| {
+    let token = read_capability_token(&lease.paths.token_path)?;
+    let mut stream = connect_socket(&lease.instance.socket_path).with_context(|| {
         format!(
             "chrome-extension-native bridge is not connected at {}. Run `yoetz browser extension doctor --claude`, then open Chrome with the Yoetz extension enabled.",
-            instance.socket_path.display()
+            lease.instance.socket_path.display()
         )
     })?;
     stream.set_read_timeout(Some(

--- a/crates/yoetz-cli/src/followup.rs
+++ b/crates/yoetz-cli/src/followup.rs
@@ -95,10 +95,9 @@ fn parse_thread_wait_duration(raw: &str) -> Option<Duration> {
         (number, "s")
     } else if let Some(number) = raw.strip_suffix('m') {
         (number, "m")
-    } else if let Some(number) = raw.strip_suffix('h') {
-        (number, "h")
     } else {
-        return None;
+        let number = raw.strip_suffix('h')?;
+        (number, "h")
     };
     let value = number.parse::<u64>().ok()?;
     if value == 0 {

--- a/crates/yoetz-cli/src/followup.rs
+++ b/crates/yoetz-cli/src/followup.rs
@@ -1,10 +1,16 @@
 use anyhow::{anyhow, bail, Context, Result};
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::fs;
-use std::io::Write;
+use std::fmt;
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::thread;
+use std::time::{Duration, Instant};
 use tempfile::NamedTempFile;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 #[cfg(test)]
 use crate::chatgpt_web::{self, ChatgptConversation};
@@ -20,6 +26,10 @@ pub(crate) struct FollowupMetadata {
     pub thread_label: Option<String>,
     #[serde(default)]
     pub thread_revision: u64,
+    #[serde(default)]
+    pub forked_from_label: Option<String>,
+    #[serde(default)]
+    pub forked_from_conversation_id: Option<String>,
     pub conversation_id: String,
     pub conversation_url: String,
     pub prompt_hash: String,
@@ -31,6 +41,160 @@ pub(crate) struct ResolvedFollowup {
     pub conversation: WebConversation,
     pub source_session_id: Option<String>,
     pub prior_prompt_hash: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) enum ThreadConflictPolicy {
+    #[default]
+    Fail,
+    Wait(Option<Duration>),
+    Fork,
+}
+
+impl FromStr for ThreadConflictPolicy {
+    type Err = String;
+
+    fn from_str(raw: &str) -> std::result::Result<Self, Self::Err> {
+        match raw {
+            "fail" => Ok(Self::Fail),
+            "wait" => Ok(Self::Wait(None)),
+            "fork" => Ok(Self::Fork),
+            _ => {
+                let Some(raw_duration) = raw.strip_prefix("wait:") else {
+                    return Err(thread_conflict_policy_error(raw));
+                };
+                parse_thread_wait_duration(raw_duration)
+                    .map(|duration| Self::Wait(Some(duration)))
+                    .ok_or_else(|| thread_conflict_policy_error(raw))
+            }
+        }
+    }
+}
+
+impl fmt::Display for ThreadConflictPolicy {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Fail => formatter.write_str("fail"),
+            Self::Wait(None) => formatter.write_str("wait"),
+            Self::Wait(Some(duration)) => write!(formatter, "wait:{}ms", duration.as_millis()),
+            Self::Fork => formatter.write_str("fork"),
+        }
+    }
+}
+
+fn thread_conflict_policy_error(raw: &str) -> String {
+    format!(
+        "invalid thread conflict policy `{raw}`; expected fail, wait, wait:<duration>, or fork (duration units: ms, s, m, h)"
+    )
+}
+
+fn parse_thread_wait_duration(raw: &str) -> Option<Duration> {
+    let (number, unit) = if let Some(number) = raw.strip_suffix("ms") {
+        (number, "ms")
+    } else if let Some(number) = raw.strip_suffix('s') {
+        (number, "s")
+    } else if let Some(number) = raw.strip_suffix('m') {
+        (number, "m")
+    } else if let Some(number) = raw.strip_suffix('h') {
+        (number, "h")
+    } else {
+        return None;
+    };
+    let value = number.parse::<u64>().ok()?;
+    if value == 0 {
+        return None;
+    }
+    match unit {
+        "ms" => Some(Duration::from_millis(value)),
+        "s" => Some(Duration::from_secs(value)),
+        "m" => value.checked_mul(60).map(Duration::from_secs),
+        "h" => value.checked_mul(60 * 60).map(Duration::from_secs),
+        _ => None,
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum PreparedThreadDisposition {
+    Labeled {
+        label: String,
+        resolved: Option<ResolvedFollowup>,
+    },
+    Forked {
+        from_label: String,
+        from_conversation_id: Option<String>,
+    },
+}
+
+#[derive(Debug)]
+pub(crate) struct PreparedThreadRun {
+    _lease: Option<ThreadLabelLease>,
+    disposition: PreparedThreadDisposition,
+}
+
+impl PreparedThreadRun {
+    pub(crate) fn disposition(&self) -> &PreparedThreadDisposition {
+        &self.disposition
+    }
+
+    pub(crate) fn thread_label_for_metadata(&self) -> Option<&str> {
+        match &self.disposition {
+            PreparedThreadDisposition::Labeled { label, .. } => Some(label),
+            PreparedThreadDisposition::Forked { .. } => None,
+        }
+    }
+
+    pub(crate) fn forked_from_label(&self) -> Option<&str> {
+        match &self.disposition {
+            PreparedThreadDisposition::Labeled { .. } => None,
+            PreparedThreadDisposition::Forked { from_label, .. } => Some(from_label),
+        }
+    }
+
+    pub(crate) fn forked_from_conversation_id(&self) -> Option<&str> {
+        match &self.disposition {
+            PreparedThreadDisposition::Labeled { .. } => None,
+            PreparedThreadDisposition::Forked {
+                from_conversation_id,
+                ..
+            } => from_conversation_id.as_deref(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ThreadLockHolder {
+    #[serde(rename = "holder_run_id")]
+    run_id: String,
+    pid: u32,
+    started_at: String,
+}
+
+impl ThreadLockHolder {
+    fn new(run_id: &str) -> Result<Self> {
+        Ok(Self {
+            run_id: run_id.to_string(),
+            pid: std::process::id(),
+            started_at: OffsetDateTime::now_utc()
+                .format(&Rfc3339)
+                .context("format thread lock start time")?,
+        })
+    }
+}
+
+#[derive(Debug)]
+struct ThreadLabelLease {
+    file: File,
+}
+
+impl Drop for ThreadLabelLease {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+enum ThreadLockOutcome {
+    Acquired(ThreadLabelLease),
+    Forked,
 }
 
 #[cfg(test)]
@@ -146,6 +310,216 @@ pub(crate) fn resolve_thread_target(
     }))
 }
 
+pub(crate) fn prepare_thread_run_in(
+    label: &str,
+    sessions_base: &Path,
+    recipe: BuiltinWebRecipe,
+    run_id: &str,
+    fresh: bool,
+    conflict_policy: &ThreadConflictPolicy,
+) -> Result<PreparedThreadRun> {
+    validate_thread_label(label)?;
+    let yoetz_root = sessions_base
+        .parent()
+        .ok_or_else(|| anyhow!("managed sessions directory has no Yoetz root parent"))?;
+    let lock_outcome =
+        acquire_thread_label_lock(yoetz_root, recipe, label, run_id, conflict_policy)?;
+
+    match lock_outcome {
+        ThreadLockOutcome::Acquired(lease) => {
+            let resolved = if fresh {
+                None
+            } else {
+                resolve_thread_target(label, sessions_base, recipe)?
+            };
+            Ok(PreparedThreadRun {
+                _lease: Some(lease),
+                disposition: PreparedThreadDisposition::Labeled {
+                    label: label.to_string(),
+                    resolved,
+                },
+            })
+        }
+        ThreadLockOutcome::Forked => {
+            let from_conversation_id = resolve_thread_target(label, sessions_base, recipe)?
+                .map(|resolved| resolved.conversation.id);
+            Ok(PreparedThreadRun {
+                _lease: None,
+                disposition: PreparedThreadDisposition::Forked {
+                    from_label: label.to_string(),
+                    from_conversation_id,
+                },
+            })
+        }
+    }
+}
+
+fn acquire_thread_label_lock(
+    yoetz_root: &Path,
+    recipe: BuiltinWebRecipe,
+    label: &str,
+    run_id: &str,
+    conflict_policy: &ThreadConflictPolicy,
+) -> Result<ThreadLockOutcome> {
+    let threads_root = yoetz_root.join("threads");
+    ensure_private_thread_dir(&threads_root)?;
+    let thread_dir = threads_root.join(recipe.as_str());
+    ensure_private_thread_dir(&thread_dir)?;
+    let lock_path = thread_dir.join(format!("{label}.lock"));
+    let mut options = OpenOptions::new();
+    options.create(true).read(true).write(true).truncate(false);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(&lock_path)
+        .with_context(|| format!("open thread lock {}", lock_path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&lock_path, fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("chmod 600 {}", lock_path.display()))?;
+    }
+    let holder = ThreadLockHolder::new(run_id)?;
+
+    match conflict_policy {
+        ThreadConflictPolicy::Fail | ThreadConflictPolicy::Fork => {
+            match FileExt::try_lock_exclusive(&file) {
+                Ok(()) => {
+                    write_thread_lock_holder(&mut file, &holder, &lock_path)?;
+                    Ok(ThreadLockOutcome::Acquired(ThreadLabelLease { file }))
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                    if matches!(conflict_policy, ThreadConflictPolicy::Fork) {
+                        Ok(ThreadLockOutcome::Forked)
+                    } else {
+                        Err(thread_busy_error(
+                            "thread_busy",
+                            label,
+                            recipe,
+                            &mut file,
+                            &lock_path,
+                        ))
+                    }
+                }
+                Err(err) => {
+                    Err(err).with_context(|| format!("lock thread {}", lock_path.display()))
+                }
+            }
+        }
+        ThreadConflictPolicy::Wait(None) => {
+            FileExt::lock_exclusive(&file)
+                .with_context(|| format!("wait for thread lock {}", lock_path.display()))?;
+            write_thread_lock_holder(&mut file, &holder, &lock_path)?;
+            Ok(ThreadLockOutcome::Acquired(ThreadLabelLease { file }))
+        }
+        ThreadConflictPolicy::Wait(Some(timeout)) => {
+            let started = Instant::now();
+            loop {
+                match FileExt::try_lock_exclusive(&file) {
+                    Ok(()) => {
+                        write_thread_lock_holder(&mut file, &holder, &lock_path)?;
+                        return Ok(ThreadLockOutcome::Acquired(ThreadLabelLease { file }));
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        let elapsed = started.elapsed();
+                        if elapsed >= *timeout {
+                            return Err(thread_busy_error(
+                                "thread_busy_timeout",
+                                label,
+                                recipe,
+                                &mut file,
+                                &lock_path,
+                            ));
+                        }
+                        thread::sleep(
+                            timeout
+                                .saturating_sub(elapsed)
+                                .min(Duration::from_millis(50)),
+                        );
+                    }
+                    Err(err) => {
+                        return Err(err)
+                            .with_context(|| format!("lock thread {}", lock_path.display()));
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn ensure_private_thread_dir(path: &Path) -> Result<()> {
+    fs::create_dir_all(path).with_context(|| format!("create {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("chmod 700 {}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn write_thread_lock_holder(
+    file: &mut File,
+    holder: &ThreadLockHolder,
+    lock_path: &Path,
+) -> Result<()> {
+    file.set_len(0)
+        .with_context(|| format!("truncate thread lock {}", lock_path.display()))?;
+    file.seek(SeekFrom::Start(0))
+        .with_context(|| format!("seek thread lock {}", lock_path.display()))?;
+    serde_json::to_writer(&mut *file, holder)
+        .with_context(|| format!("write thread lock holder {}", lock_path.display()))?;
+    file.write_all(b"\n")
+        .with_context(|| format!("finish thread lock holder {}", lock_path.display()))?;
+    file.flush()
+        .with_context(|| format!("flush thread lock holder {}", lock_path.display()))?;
+    file.sync_data()
+        .with_context(|| format!("sync thread lock holder {}", lock_path.display()))?;
+    Ok(())
+}
+
+fn thread_busy_error(
+    code: &str,
+    label: &str,
+    recipe: BuiltinWebRecipe,
+    file: &mut File,
+    lock_path: &Path,
+) -> anyhow::Error {
+    let holder = read_thread_lock_holder(file).unwrap_or_else(|| ThreadLockHolder {
+        run_id: "unknown".to_string(),
+        pid: 0,
+        started_at: "unknown".to_string(),
+    });
+    let holder_json = serde_json::to_string(&holder)
+        .unwrap_or_else(|_| r#"{"holder_run_id":"unknown","pid":0,"started_at":"unknown"}"#.into());
+    anyhow!(
+        "{code}: thread `{label}` for recipe `{}` is active; holder={holder_json}; wait for the holder to finish (or retry with `--on-thread-conflict wait:<duration>`), or use a distinct --thread label. Lock: {}",
+        recipe.as_str(),
+        lock_path.display(),
+    )
+}
+
+fn read_thread_lock_holder(file: &mut File) -> Option<ThreadLockHolder> {
+    // The winning process writes immediately after flock succeeds. A contender can
+    // observe the lock during that tiny window, so retry briefly before degrading.
+    for _ in 0..20 {
+        thread::sleep(Duration::from_millis(5));
+        if file.seek(SeekFrom::Start(0)).is_err() {
+            return None;
+        }
+        let mut raw = String::new();
+        if file.read_to_string(&mut raw).is_ok() {
+            if let Ok(holder) = serde_json::from_str(&raw) {
+                return Some(holder);
+            }
+        }
+    }
+    None
+}
+
 pub(crate) fn compute_prompt_hash(prompt: &str, bundle_path: Option<&Path>) -> Result<String> {
     let bundle_hash = if let Some(bundle_path) = bundle_path {
         let bundle_bytes = fs::read(bundle_path)
@@ -230,6 +604,7 @@ pub(crate) fn write_followup_metadata(
     )
 }
 
+#[cfg(test)]
 pub(crate) fn write_followup_metadata_for_recipe(
     session_dir: &Path,
     session_id: &str,
@@ -238,6 +613,31 @@ pub(crate) fn write_followup_metadata_for_recipe(
     prompt_hash: &str,
     thread_label: Option<&str>,
 ) -> Result<()> {
+    write_followup_metadata_for_recipe_with_lineage(
+        session_dir,
+        session_id,
+        recipe,
+        conversation,
+        prompt_hash,
+        thread_label,
+        None,
+        None,
+    )
+}
+
+pub(crate) fn write_followup_metadata_for_recipe_with_lineage(
+    session_dir: &Path,
+    session_id: &str,
+    recipe: BuiltinWebRecipe,
+    conversation: &WebConversation,
+    prompt_hash: &str,
+    thread_label: Option<&str>,
+    forked_from_label: Option<&str>,
+    forked_from_conversation_id: Option<&str>,
+) -> Result<()> {
+    if thread_label.is_some() && forked_from_label.is_some() {
+        bail!("thread metadata cannot be both labeled and forked");
+    }
     let path = followup_metadata_path(session_dir);
     let thread_revision = match thread_label {
         Some(label) => next_thread_revision(session_dir, recipe, label)?,
@@ -248,6 +648,8 @@ pub(crate) fn write_followup_metadata_for_recipe(
         recipe,
         thread_label: thread_label.map(str::to_string),
         thread_revision,
+        forked_from_label: forked_from_label.map(str::to_string),
+        forked_from_conversation_id: forked_from_conversation_id.map(str::to_string),
         conversation_id: conversation.id.clone(),
         conversation_url: conversation.url.clone(),
         prompt_hash: prompt_hash.to_string(),
@@ -730,5 +1132,330 @@ mod tests {
             resolved.prior_prompt_hash.as_deref(),
             Some("conv-fresh-hash")
         );
+    }
+
+    #[test]
+    fn thread_conflict_policy_parses_fail_wait_and_fork() {
+        assert_eq!(
+            "fail".parse::<ThreadConflictPolicy>().unwrap(),
+            ThreadConflictPolicy::Fail
+        );
+        assert_eq!(
+            "wait".parse::<ThreadConflictPolicy>().unwrap(),
+            ThreadConflictPolicy::Wait(None)
+        );
+        assert_eq!(
+            "wait:250ms".parse::<ThreadConflictPolicy>().unwrap(),
+            ThreadConflictPolicy::Wait(Some(std::time::Duration::from_millis(250)))
+        );
+        assert_eq!(
+            "wait:2m".parse::<ThreadConflictPolicy>().unwrap(),
+            ThreadConflictPolicy::Wait(Some(std::time::Duration::from_secs(120)))
+        );
+        assert_eq!(
+            "fork".parse::<ThreadConflictPolicy>().unwrap(),
+            ThreadConflictPolicy::Fork
+        );
+
+        for invalid in ["", "queue", "wait:", "wait:0s", "wait:1", "wait:1fortnight"] {
+            assert!(
+                invalid.parse::<ThreadConflictPolicy>().is_err(),
+                "{invalid}"
+            );
+        }
+    }
+
+    #[test]
+    fn same_recipe_and_label_fail_closed_with_actionable_holder_metadata() {
+        let root = tempdir().unwrap();
+        let sessions_dir = root.path().join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+
+        let first = prepare_thread_run_in(
+            "review-pr-341",
+            &sessions_dir,
+            BuiltinWebRecipe::Chatgpt,
+            "run-first",
+            false,
+            &ThreadConflictPolicy::Fail,
+        )
+        .unwrap();
+        let err = prepare_thread_run_in(
+            "review-pr-341",
+            &sessions_dir,
+            BuiltinWebRecipe::Chatgpt,
+            "run-second",
+            false,
+            &ThreadConflictPolicy::Fail,
+        )
+        .unwrap_err();
+        let message = format!("{err:#}");
+
+        assert!(message.contains("thread_busy"));
+        assert!(message.contains("\"holder_run_id\":\"run-first\""));
+        assert!(message.contains(&format!("\"pid\":{}", std::process::id())));
+        assert!(message.contains("\"started_at\":"));
+        assert!(message.contains("wait for the holder"));
+        assert!(message.contains("distinct --thread label"));
+
+        drop(first);
+        assert!(prepare_thread_run_in(
+            "review-pr-341",
+            &sessions_dir,
+            BuiltinWebRecipe::Chatgpt,
+            "run-third",
+            false,
+            &ThreadConflictPolicy::Fail,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn thread_locks_are_scoped_by_recipe_and_label() {
+        let root = tempdir().unwrap();
+        let sessions_dir = root.path().join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+
+        let _chatgpt = prepare_thread_run_in(
+            "review-pr-341",
+            &sessions_dir,
+            BuiltinWebRecipe::Chatgpt,
+            "run-chatgpt",
+            false,
+            &ThreadConflictPolicy::Fail,
+        )
+        .unwrap();
+        let _other_label = prepare_thread_run_in(
+            "review-pr-342",
+            &sessions_dir,
+            BuiltinWebRecipe::Chatgpt,
+            "run-other-label",
+            false,
+            &ThreadConflictPolicy::Fail,
+        )
+        .unwrap();
+        let _claude = prepare_thread_run_in(
+            "review-pr-341",
+            &sessions_dir,
+            BuiltinWebRecipe::Claude,
+            "run-claude",
+            false,
+            &ThreadConflictPolicy::Fail,
+        )
+        .unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            for path in [
+                root.path().join("threads"),
+                root.path().join("threads/chatgpt"),
+                root.path().join("threads/claude"),
+            ] {
+                let mode = fs::metadata(path).unwrap().permissions().mode() & 0o777;
+                assert_eq!(mode, 0o700);
+            }
+            let lock_mode = fs::metadata(root.path().join("threads/chatgpt/review-pr-341.lock"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(lock_mode, 0o600);
+        }
+    }
+
+    #[test]
+    fn bounded_wait_times_out_without_falling_through_to_fork() {
+        let root = tempdir().unwrap();
+        let sessions_dir = root.path().join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+
+        let _first = prepare_thread_run_in(
+            "review-pr-341",
+            &sessions_dir,
+            BuiltinWebRecipe::Chatgpt,
+            "run-first",
+            false,
+            &ThreadConflictPolicy::Fail,
+        )
+        .unwrap();
+        let started = std::time::Instant::now();
+        let err = prepare_thread_run_in(
+            "review-pr-341",
+            &sessions_dir,
+            BuiltinWebRecipe::Chatgpt,
+            "run-waiter",
+            false,
+            &ThreadConflictPolicy::Wait(Some(std::time::Duration::from_millis(40))),
+        )
+        .unwrap_err();
+
+        assert!(format!("{err:#}").contains("thread_busy_timeout"));
+        assert!(started.elapsed() >= std::time::Duration::from_millis(40));
+    }
+
+    #[test]
+    fn bounded_wait_resolves_the_newest_thread_after_the_holder_releases() {
+        let root = tempdir().unwrap();
+        let sessions_dir = root.path().join("sessions");
+        let completed_session = sessions_dir.join("20260725_170000_holder");
+        fs::create_dir_all(&completed_session).unwrap();
+
+        let first = prepare_thread_run_in(
+            "review-pr-341",
+            &sessions_dir,
+            BuiltinWebRecipe::Chatgpt,
+            "run-first",
+            false,
+            &ThreadConflictPolicy::Fail,
+        )
+        .unwrap();
+        let release = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(40));
+            write_followup_metadata_for_recipe(
+                &completed_session,
+                "20260725_170000_holder",
+                BuiltinWebRecipe::Chatgpt,
+                &WebConversation {
+                    id: "conversation-from-holder".to_string(),
+                    url: "https://chatgpt.com/c/conversation-from-holder".to_string(),
+                },
+                "holder-hash",
+                Some("review-pr-341"),
+            )
+            .unwrap();
+            drop(first);
+        });
+
+        let waiter = prepare_thread_run_in(
+            "review-pr-341",
+            &sessions_dir,
+            BuiltinWebRecipe::Chatgpt,
+            "run-waiter",
+            false,
+            &ThreadConflictPolicy::Wait(Some(std::time::Duration::from_secs(1))),
+        )
+        .unwrap();
+        release.join().unwrap();
+
+        match waiter.disposition() {
+            PreparedThreadDisposition::Labeled {
+                resolved: Some(resolved),
+                ..
+            } => assert_eq!(resolved.conversation.id, "conversation-from-holder"),
+            other => panic!("unexpected disposition: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fork_is_opt_in_fresh_and_never_repoints_the_original_label() {
+        let root = tempdir().unwrap();
+        let sessions_dir = root.path().join("sessions");
+        let original_session = sessions_dir.join("20260725_160000_original");
+        let fork_session = sessions_dir.join("20260725_170000_fork");
+        fs::create_dir_all(&original_session).unwrap();
+        fs::create_dir_all(&fork_session).unwrap();
+        write_followup_metadata_for_recipe(
+            &original_session,
+            "20260725_160000_original",
+            BuiltinWebRecipe::Chatgpt,
+            &WebConversation {
+                id: "original-conversation".to_string(),
+                url: "https://chatgpt.com/c/original-conversation".to_string(),
+            },
+            "original-hash",
+            Some("review-pr-341"),
+        )
+        .unwrap();
+
+        let _first = prepare_thread_run_in(
+            "review-pr-341",
+            &sessions_dir,
+            BuiltinWebRecipe::Chatgpt,
+            "run-first",
+            false,
+            &ThreadConflictPolicy::Fail,
+        )
+        .unwrap();
+        let forked = prepare_thread_run_in(
+            "review-pr-341",
+            &sessions_dir,
+            BuiltinWebRecipe::Chatgpt,
+            "run-fork",
+            false,
+            &ThreadConflictPolicy::Fork,
+        )
+        .unwrap();
+
+        let (forked_from_label, forked_from_conversation_id) = match forked.disposition() {
+            PreparedThreadDisposition::Forked {
+                from_label,
+                from_conversation_id,
+            } => (from_label.as_str(), from_conversation_id.as_deref()),
+            other => panic!("unexpected disposition: {other:?}"),
+        };
+        assert_eq!(forked_from_label, "review-pr-341");
+        assert_eq!(forked_from_conversation_id, Some("original-conversation"));
+
+        write_followup_metadata_for_recipe_with_lineage(
+            &fork_session,
+            "20260725_170000_fork",
+            BuiltinWebRecipe::Chatgpt,
+            &WebConversation {
+                id: "fork-conversation".to_string(),
+                url: "https://chatgpt.com/c/fork-conversation".to_string(),
+            },
+            "fork-hash",
+            None,
+            Some(forked_from_label),
+            forked_from_conversation_id,
+        )
+        .unwrap();
+
+        let fork_metadata = read_followup_metadata(&fork_session).unwrap().unwrap();
+        assert_eq!(fork_metadata.thread_label, None);
+        assert_eq!(
+            fork_metadata.forked_from_label.as_deref(),
+            Some("review-pr-341")
+        );
+        assert_eq!(
+            fork_metadata.forked_from_conversation_id.as_deref(),
+            Some("original-conversation")
+        );
+        let original =
+            resolve_thread_target("review-pr-341", &sessions_dir, BuiltinWebRecipe::Chatgpt)
+                .unwrap()
+                .unwrap();
+        assert_eq!(original.conversation.id, "original-conversation");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn thread_lock_release_is_not_pinned_by_a_forked_child_descriptor() {
+        let root = tempdir().unwrap();
+        let sessions_dir = root.path().join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+        let lease = prepare_thread_run_in(
+            "review-pr-341",
+            &sessions_dir,
+            BuiltinWebRecipe::Chatgpt,
+            "run-first",
+            false,
+            &ThreadConflictPolicy::Fail,
+        )
+        .unwrap();
+        let _child = crate::test_support::ForkChild::sleep_for(std::time::Duration::from_secs(5));
+
+        drop(lease);
+
+        assert!(prepare_thread_run_in(
+            "review-pr-341",
+            &sessions_dir,
+            BuiltinWebRecipe::Chatgpt,
+            "run-second",
+            false,
+            &ThreadConflictPolicy::Fail,
+        )
+        .is_ok());
     }
 }

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -355,7 +355,7 @@ struct BrowserRecipeArgs {
     #[arg(long, requires = "thread")]
     fresh: bool,
 
-    /// Same-label collision behavior: fail (default), wait[:<duration>], or fork.
+    /// Same-label collision behavior: fail (default), `wait[:<duration>]`, or fork.
     #[arg(long, value_name = "MODE", requires = "thread")]
     on_thread_conflict: Option<followup::ThreadConflictPolicy>,
 

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -355,6 +355,10 @@ struct BrowserRecipeArgs {
     #[arg(long, requires = "thread")]
     fresh: bool,
 
+    /// Same-label collision behavior: fail (default), wait[:<duration>], or fork.
+    #[arg(long, value_name = "MODE", requires = "thread")]
+    on_thread_conflict: Option<followup::ThreadConflictPolicy>,
+
     /// Allow the same prompt hash to be submitted to the same conversation.
     #[arg(long)]
     allow_duplicate_prompt: bool,
@@ -2680,6 +2684,65 @@ fn bundle_prompt_for_recipe(bundle_path: Option<&Path>) -> Result<Option<String>
     Ok(Some(bundle.prompt))
 }
 
+fn prepare_native_thread_run_in(
+    recipe_args: &BrowserRecipeArgs,
+    current_prompt_hash: Option<&str>,
+    recipe: web_recipe::BuiltinWebRecipe,
+    run_id: &str,
+    conversation_id: &mut Option<String>,
+    sessions_base: &Path,
+) -> Result<Option<followup::PreparedThreadRun>> {
+    let Some(thread_label) = recipe_args.thread.as_deref() else {
+        return Ok(None);
+    };
+    let default_policy = followup::ThreadConflictPolicy::default();
+    let conflict_policy = recipe_args
+        .on_thread_conflict
+        .as_ref()
+        .unwrap_or(&default_policy);
+    let prepared = followup::prepare_thread_run_in(
+        thread_label,
+        sessions_base,
+        recipe,
+        run_id,
+        recipe_args.fresh,
+        conflict_policy,
+    )?;
+
+    match prepared.disposition() {
+        followup::PreparedThreadDisposition::Labeled {
+            resolved: Some(resolved),
+            ..
+        } => {
+            let current_prompt_hash = current_prompt_hash
+                .ok_or_else(|| anyhow!("thread `{thread_label}` requires a current prompt hash"))?;
+            followup::guard_duplicate_prompt(
+                current_prompt_hash,
+                resolved.prior_prompt_hash.as_deref(),
+                recipe_args.allow_duplicate_prompt,
+                &resolved.conversation.id,
+                resolved.source_session_id.as_deref(),
+            )?;
+            *conversation_id = Some(resolved.conversation.id.clone());
+        }
+        followup::PreparedThreadDisposition::Labeled { resolved: None, .. } => {
+            *conversation_id = None;
+        }
+        followup::PreparedThreadDisposition::Forked {
+            from_label,
+            from_conversation_id,
+        } => {
+            *conversation_id = None;
+            eprintln!(
+                "warning: thread `{from_label}` is busy; starting an opt-in forked conversation that will not re-point the original label (forked_from_conversation_id={})",
+                from_conversation_id.as_deref().unwrap_or("unknown")
+            );
+        }
+    }
+
+    Ok(Some(prepared))
+}
+
 fn run_recipe_via_chrome_extension_native<R: IntoBuiltinWebRecipe>(
     ctx: &AppContext,
     recipe_args: &BrowserRecipeArgs,
@@ -2723,16 +2786,30 @@ fn run_recipe_via_chrome_extension_native<R: IntoBuiltinWebRecipe>(
     }
     let started_at = Instant::now();
 
-    let (payload, jsonl_event, notification_target) = match builtin_recipe {
+    let (payload, jsonl_event, notification_target, prepared_thread) = match builtin_recipe {
         web_recipe::BuiltinWebRecipe::Chatgpt => {
-            let recipe_spec = build_chatgpt_recipe_spec(recipe_args, recipe_vars)?;
-            let response = browser_extension_native::run_chatgpt_recipe(&recipe_spec, format)
-                .map_err(|err| {
-                    browser_extension_native::with_thread_conversation_recovery_hint(
-                        err,
-                        recipe_args.thread.as_deref(),
-                    )
-                })?;
+            let mut recipe_spec = build_chatgpt_recipe_spec(recipe_args, recipe_vars)?;
+            let native_lease =
+                browser_extension_native::acquire_chatgpt_recipe_lease(&recipe_spec)?;
+            let prepared_thread = prepare_native_thread_run_in(
+                recipe_args,
+                current_prompt_hash,
+                builtin_recipe,
+                &recipe_spec.run_id,
+                &mut recipe_spec.conversation_id,
+                &yoetz_core::session::session_base_dir(),
+            )?;
+            let response = browser_extension_native::run_chatgpt_recipe_with_lease(
+                &recipe_spec,
+                format,
+                &native_lease,
+            )
+            .map_err(|err| {
+                browser_extension_native::with_thread_conversation_recovery_hint(
+                    err,
+                    recipe_args.thread.as_deref(),
+                )
+            })?;
             let output = chatgpt_recipe::ChatgptRecipeOutput {
                 transport: browser_extension_native::TRANSPORT_NAME.to_string(),
                 backend: browser_extension_native::TRANSPORT_NAME.to_string(),
@@ -2752,18 +2829,32 @@ fn run_recipe_via_chrome_extension_native<R: IntoBuiltinWebRecipe>(
                 output.to_value(),
                 output.to_recipe_complete_event(),
                 recipe_spec.model,
+                prepared_thread,
             )
         }
         web_recipe::BuiltinWebRecipe::Claude => {
-            let recipe_spec =
+            let mut recipe_spec =
                 build_claude_recipe_spec(recipe_args, recipe_vars, preflight_warnings)?;
-            let response = browser_extension_native::run_claude_recipe(&recipe_spec, format)
-                .map_err(|err| {
-                    browser_extension_native::with_thread_conversation_recovery_hint(
-                        err,
-                        recipe_args.thread.as_deref(),
-                    )
-                })?;
+            let native_lease = browser_extension_native::acquire_claude_recipe_lease(&recipe_spec)?;
+            let prepared_thread = prepare_native_thread_run_in(
+                recipe_args,
+                current_prompt_hash,
+                builtin_recipe,
+                &recipe_spec.run_id,
+                &mut recipe_spec.conversation_id,
+                &yoetz_core::session::session_base_dir(),
+            )?;
+            let response = browser_extension_native::run_claude_recipe_with_lease(
+                &recipe_spec,
+                format,
+                &native_lease,
+            )
+            .map_err(|err| {
+                browser_extension_native::with_thread_conversation_recovery_hint(
+                    err,
+                    recipe_args.thread.as_deref(),
+                )
+            })?;
             let mut warnings = recipe_spec.warnings.clone();
             warnings.extend(response.warnings);
             warnings.sort();
@@ -2785,6 +2876,7 @@ fn run_recipe_via_chrome_extension_native<R: IntoBuiltinWebRecipe>(
                 output.to_value(),
                 output.to_recipe_complete_event(),
                 claude_recipe::CLAUDE_REPORTED_MODEL.to_string(),
+                prepared_thread,
             )
         }
     };
@@ -2794,10 +2886,11 @@ fn run_recipe_via_chrome_extension_native<R: IntoBuiltinWebRecipe>(
         current_prompt_hash,
         builtin_recipe,
         payload,
-        &jsonl_event,
+        jsonl_event,
         &notification_target,
         started_at,
         format,
+        prepared_thread.as_ref(),
     )
 }
 
@@ -2808,22 +2901,41 @@ fn complete_chrome_extension_native_recipe(
     current_prompt_hash: Option<&str>,
     builtin_recipe: web_recipe::BuiltinWebRecipe,
     mut payload: Value,
-    jsonl_event: &Value,
+    mut jsonl_event: Value,
     notification_target: &str,
     started_at: Instant,
     format: OutputFormat,
+    prepared_thread: Option<&followup::PreparedThreadRun>,
 ) -> Result<Value> {
     let completion = || -> Result<Value> {
         if let Some(thread_label) = recipe_args.thread.as_deref() {
             let current_prompt_hash = current_prompt_hash.ok_or_else(|| {
                 anyhow!("persist thread `{thread_label}` metadata: missing current prompt hash")
             })?;
-            write_followup_session_metadata_required(
+            let prepared_thread = prepared_thread.ok_or_else(|| {
+                anyhow!("persist thread `{thread_label}` metadata: missing thread lease")
+            })?;
+            write_prepared_thread_metadata_required(
                 recipe_args,
                 current_prompt_hash,
                 &payload,
                 builtin_recipe,
+                prepared_thread,
             )?;
+            if let followup::PreparedThreadDisposition::Forked {
+                from_label,
+                from_conversation_id,
+            } = prepared_thread.disposition()
+            {
+                let thread = json!({
+                    "label": Value::Null,
+                    "resolved": "forked",
+                    "forked_from_label": from_label,
+                    "forked_from_conversation_id": from_conversation_id,
+                });
+                payload["thread"] = thread.clone();
+                jsonl_event["thread"] = thread;
+            }
         }
         attach_browser_recipe_artifacts(&mut payload, recipe_args.bundle.as_deref())?;
         maybe_write_output(ctx, &payload)?;
@@ -3026,6 +3138,27 @@ fn write_followup_session_metadata(
     payload: &Value,
     recipe: web_recipe::BuiltinWebRecipe,
 ) -> Result<()> {
+    write_followup_session_metadata_with_lineage(
+        recipe_args,
+        current_prompt_hash,
+        payload,
+        recipe,
+        recipe_args.thread.as_deref(),
+        None,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_followup_session_metadata_with_lineage(
+    recipe_args: &BrowserRecipeArgs,
+    current_prompt_hash: &str,
+    payload: &Value,
+    recipe: web_recipe::BuiltinWebRecipe,
+    thread_label: Option<&str>,
+    forked_from_label: Option<&str>,
+    forked_from_conversation_id: Option<&str>,
+) -> Result<()> {
     let session_artifacts = browser_recipe_artifact_paths(recipe_args.bundle.as_deref())
         .ok_or_else(|| {
             anyhow!(
@@ -3060,16 +3193,19 @@ fn write_followup_session_metadata(
             session_dir.join("followup.json").display()
         )
     })?;
-    followup::write_followup_metadata_for_recipe(
+    followup::write_followup_metadata_for_recipe_with_lineage(
         &session_dir,
         &session_id,
         recipe,
         &conversation,
         current_prompt_hash,
-        recipe_args.thread.as_deref(),
+        thread_label,
+        forked_from_label,
+        forked_from_conversation_id,
     )
 }
 
+#[cfg(test)]
 fn write_followup_session_metadata_required(
     recipe_args: &BrowserRecipeArgs,
     current_prompt_hash: &str,
@@ -3082,6 +3218,29 @@ fn write_followup_session_metadata_required(
         .ok_or_else(|| anyhow!("required thread metadata needs --thread"))?;
     write_followup_session_metadata(recipe_args, current_prompt_hash, payload, recipe)
         .with_context(|| format!("persist thread `{thread_label}` metadata"))
+}
+
+fn write_prepared_thread_metadata_required(
+    recipe_args: &BrowserRecipeArgs,
+    current_prompt_hash: &str,
+    payload: &Value,
+    recipe: web_recipe::BuiltinWebRecipe,
+    prepared_thread: &followup::PreparedThreadRun,
+) -> Result<()> {
+    let requested_label = recipe_args
+        .thread
+        .as_deref()
+        .ok_or_else(|| anyhow!("required thread metadata needs --thread"))?;
+    write_followup_session_metadata_with_lineage(
+        recipe_args,
+        current_prompt_hash,
+        payload,
+        recipe,
+        prepared_thread.thread_label_for_metadata(),
+        prepared_thread.forked_from_label(),
+        prepared_thread.forked_from_conversation_id(),
+    )
+    .with_context(|| format!("persist thread `{requested_label}` metadata"))
 }
 
 fn maybe_write_followup_session_metadata(
@@ -4567,26 +4726,6 @@ async fn handle_browser(ctx: &AppContext, args: BrowserArgs, format: OutputForma
                         "conversation".to_string(),
                         resolved_followup.conversation.url.clone(),
                     );
-                } else if let Some(thread_label) = recipe_args.thread.as_deref() {
-                    if !recipe_args.fresh {
-                        if let Some(resolved_thread) = followup::resolve_thread_target(
-                            thread_label,
-                            &yoetz_core::session::session_base_dir(),
-                            recipe_kind,
-                        )? {
-                            followup::guard_duplicate_prompt(
-                                &current_prompt_hash,
-                                resolved_thread.prior_prompt_hash.as_deref(),
-                                recipe_args.allow_duplicate_prompt,
-                                &resolved_thread.conversation.id,
-                                resolved_thread.source_session_id.as_deref(),
-                            )?;
-                            recipe_vars.insert(
-                                "conversation".to_string(),
-                                resolved_thread.conversation.url,
-                            );
-                        }
-                    }
                 }
                 Some(current_prompt_hash)
             } else {
@@ -5474,6 +5613,7 @@ mod tests {
             followup: None,
             thread: Some("review-pr-341".to_string()),
             fresh: false,
+            on_thread_conflict: None,
             allow_duplicate_prompt: false,
             no_notify: false,
         }
@@ -5674,6 +5814,7 @@ mod tests {
                 followup: None,
                 thread: Some("review-pr-341".to_string()),
                 fresh: true,
+                on_thread_conflict: None,
                 allow_duplicate_prompt: false,
                 no_notify: false,
             };
@@ -5785,6 +5926,17 @@ mod tests {
         fs::write(dir.path().join("bundle.json"), "{}").unwrap();
         fs::create_dir(dir.path().join("response.json")).unwrap();
         let recipe_args = thread_recipe_args(bundle);
+        let sessions_dir = dir.path().join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+        let prepared_thread = followup::prepare_thread_run_in(
+            "review-pr-341",
+            &sessions_dir,
+            web_recipe::BuiltinWebRecipe::Chatgpt,
+            "run-test",
+            false,
+            &followup::ThreadConflictPolicy::Fail,
+        )
+        .unwrap();
 
         let err = complete_chrome_extension_native_recipe(
             &test_app_context(),
@@ -5796,10 +5948,11 @@ mod tests {
                 "response": "done",
                 "conversation_id": "final-conversation"
             }),
-            &json!({"status": "ok"}),
+            json!({"status": "ok"}),
             "GPT-5.6 Sol Pro",
             Instant::now(),
             OutputFormat::Text,
+            Some(&prepared_thread),
         )
         .unwrap_err();
 
@@ -7281,6 +7434,8 @@ mod tests {
             "--thread",
             "review-pr-341",
             "--fresh",
+            "--on-thread-conflict",
+            "wait:30s",
         ])
         .expect("thread args should parse");
 
@@ -7290,9 +7445,34 @@ mod tests {
             }) => {
                 assert_eq!(args.thread.as_deref(), Some("review-pr-341"));
                 assert!(args.fresh);
+                assert_eq!(
+                    args.on_thread_conflict,
+                    Some(followup::ThreadConflictPolicy::Wait(Some(
+                        Duration::from_secs(30)
+                    )))
+                );
             }
             _ => panic!("unexpected command parsed"),
         }
+    }
+
+    #[test]
+    fn browser_recipe_cli_rejects_thread_conflict_mode_without_thread() {
+        let result = Cli::try_parse_from([
+            "yoetz",
+            "browser",
+            "recipe",
+            "--recipe",
+            "chatgpt",
+            "--on-thread-conflict",
+            "fork",
+        ]);
+        let err = match result {
+            Ok(_) => panic!("thread conflict mode should require --thread"),
+            Err(err) => err,
+        };
+
+        assert!(err.to_string().contains("--thread"));
     }
 
     #[tokio::test]
@@ -7311,6 +7491,7 @@ mod tests {
             followup: None,
             thread: None,
             fresh: false,
+            on_thread_conflict: None,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7351,6 +7532,7 @@ mod tests {
             followup: None,
             thread: None,
             fresh: false,
+            on_thread_conflict: None,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7387,6 +7569,7 @@ mod tests {
             followup: None,
             thread: None,
             fresh: false,
+            on_thread_conflict: None,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7424,6 +7607,7 @@ mod tests {
             followup: None,
             thread: None,
             fresh: false,
+            on_thread_conflict: None,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7461,6 +7645,7 @@ mod tests {
             followup: None,
             thread: None,
             fresh: false,
+            on_thread_conflict: None,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7498,6 +7683,7 @@ mod tests {
             followup: None,
             thread: None,
             fresh: false,
+            on_thread_conflict: None,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7537,6 +7723,7 @@ mod tests {
             followup: None,
             thread: None,
             fresh: false,
+            on_thread_conflict: None,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7569,6 +7756,7 @@ mod tests {
             followup: None,
             thread: None,
             fresh: false,
+            on_thread_conflict: None,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7599,6 +7787,7 @@ mod tests {
             followup: None,
             thread: None,
             fresh: false,
+            on_thread_conflict: None,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7651,6 +7840,7 @@ mod tests {
             followup: None,
             thread: None,
             fresh: false,
+            on_thread_conflict: None,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7722,6 +7912,7 @@ mod tests {
             followup: None,
             thread: None,
             fresh: false,
+            on_thread_conflict: None,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7785,6 +7976,7 @@ mod tests {
             followup: None,
             thread: None,
             fresh: false,
+            on_thread_conflict: None,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7833,6 +8025,7 @@ mod tests {
             followup: None,
             thread: None,
             fresh: false,
+            on_thread_conflict: None,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7882,6 +8075,7 @@ mod tests {
             followup: None,
             thread: None,
             fresh: false,
+            on_thread_conflict: None,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7911,6 +8105,7 @@ mod tests {
             followup: None,
             thread: None,
             fresh: false,
+            on_thread_conflict: None,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7949,6 +8144,7 @@ mod tests {
             followup: None,
             thread: None,
             fresh: false,
+            on_thread_conflict: None,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -7987,6 +8183,7 @@ mod tests {
             followup: None,
             thread: None,
             fresh: false,
+            on_thread_conflict: None,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -8053,6 +8250,7 @@ mod tests {
             followup: None,
             thread: None,
             fresh: false,
+            on_thread_conflict: None,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -8089,6 +8287,7 @@ mod tests {
             followup: None,
             thread: None,
             fresh: false,
+            on_thread_conflict: None,
             allow_duplicate_prompt: false,
             no_notify: false,
         };
@@ -8136,6 +8335,7 @@ mod tests {
             followup: None,
             thread: None,
             fresh: false,
+            on_thread_conflict: None,
             allow_duplicate_prompt: false,
             no_notify: false,
         };


### PR DESCRIPTION
## Summary
- serialize same-label ChatGPT/Claude native runs with recipe-scoped flock leases
- add fail, bounded/unbounded wait, and opt-in fork conflict policies with lineage-safe metadata
- hold lifecycle then thread leases through browser completion and required metadata persistence

## Verification
- cargo test --workspace
- npm test --prefix extensions/chatgpt-native (264/264)
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all
- git diff --check

Closes #341