### PR TITLE
fix(browser): harden native response extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   interleaving prompts in one conversation. Collisions fail with actionable
   holder details by default; `--on-thread-conflict wait[:<duration>]` and
   `fork` provide explicit alternatives without ambiguously re-pointing labels.
+- Claude response extraction now removes the complete thinking/status row
+  structurally, preventing hidden caption copies from contaminating short
+  answers such as `ACK`.
 
 ## [0.5.43] - 2026-07-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Claude response extraction now removes the complete thinking/status row
   structurally, preventing hidden caption copies from contaminating short
   answers such as `ACK`.
+- ChatGPT response extraction no longer promotes a sibling response-action row
+  such as the `Sources` control over the model-authored answer.
 
 ## [0.5.43] - 2026-07-25
 ### Added

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -1253,7 +1253,19 @@ function assistantMessageTextEntry(turn) {
       text: normalizeText(textEntries.map((entry) => entry.text).join("\n\n"))
     };
   }
-  const fallback = cleanAssistantText(turn, { assistantTurn: turn });
+  // A copy control can infer a split action <div> as an assistant "turn" even when
+  // that row contains no model-authored content. For inferred non-article turns,
+  // accept only text structurally outside interactive controls; this rejects a
+  // response-action Sources row without dropping legitimate unwrapped div text.
+  const inferredText = !isAssistantMarkerNode(turn) && turn.tagName !== "ARTICLE"
+    ? textContentOutsideActionControls(turn)
+    : null;
+  if (inferredText !== null && !normalizeText(inferredText)) {
+    return { node: null, text: "" };
+  }
+  const fallback = inferredText === null
+    ? cleanAssistantText(turn, { assistantTurn: turn })
+    : cleanAssistantSourceText(inferredText, { assistantTurn: turn });
   return { node: turn, text: isModelStatusText(fallback) ? "" : fallback };
 }
 
@@ -1332,11 +1344,38 @@ function cleanAssistantText(node, options = {}) {
   // removes any code-block "Copy code", sr-only, thought/status, and control lines that
   // textContent may surface. Fall back to innerText only if textContent is empty (defensive).
   const source = assistantBodyTextOf(node, options.assistantTurn ?? node) || textOf(node);
+  return cleanAssistantSourceText(source, options);
+}
+
+function cleanAssistantSourceText(source, options = {}) {
   const lines = source
     .split(/\n+/)
     .map((line) => normalizeText(line))
     .filter((line) => line && !isAssistantControlLine(line, options));
   return normalizeText(lines.join("\n"));
+}
+
+function textContentOutsideActionControls(node) {
+  if (!node || node.tagName === "BUTTON" || node.getAttribute?.("role") === "button") {
+    return "";
+  }
+  const childNodes = Array.from(node.childNodes ?? []);
+  if (childNodes.length > 0) {
+    return childNodes
+      .map((child) => child?.nodeType === 3
+        ? String(child.textContent ?? "")
+        : textContentOutsideActionControls(child))
+      .join("");
+  }
+  const children = Array.from(node.children ?? []);
+  if (children.length > 0) {
+    const aggregate = normalizeText(node.textContent ?? "");
+    const childAggregate = normalizeText(children.map((child) => child.textContent ?? "").join(" "));
+    if (aggregate === childAggregate) {
+      return children.map((child) => textContentOutsideActionControls(child)).join("");
+    }
+  }
+  return String(node.textContent ?? "");
 }
 
 function isAssistantControlLine(line, options = {}) {

--- a/extensions/chatgpt-native/src/claude-dom.js
+++ b/extensions/chatgpt-native/src/claude-dom.js
@@ -411,21 +411,29 @@ function responseBodyText(body) {
   if (!sanitized) {
     return normalizeResponseText(body.innerText || body.textContent || "");
   }
-  const statusCaptions = [];
   for (const statusRow of sanitized.querySelectorAll?.("button[class*='group/status']") ?? []) {
-    const caption = normalizeResponseText(statusRow.innerText || statusRow.textContent || "");
-    if (caption) statusCaptions.push(caption);
-    statusRow.remove();
-  }
-  let text = normalizeResponseText(sanitized.innerText || sanitized.textContent || "");
-  for (const caption of statusCaptions) {
-    // Completed thinking can leave a hidden copy of the collapsed caption before the answer.
-    // Strip only an exact leading copy anchored to a status row observed in this response body.
-    if (text.startsWith(caption)) {
-      text = normalizeResponseText(text.slice(caption.length));
+    // Claude renders the visible status button and its hidden thinking caption as
+    // siblings in the first row of a two-row status/answer grid. Remove that
+    // structural row instead of trying to match its flattened text, which drifts
+    // with punctuation and duration badges.
+    const statusSubtree = thinkingStatusSubtree(statusRow, sanitized);
+    if (statusSubtree && statusSubtree !== sanitized) {
+      statusSubtree.remove();
+    } else {
+      statusRow.remove();
     }
   }
-  return text;
+  return normalizeResponseText(sanitized.innerText || sanitized.textContent || "");
+}
+
+function thinkingStatusSubtree(statusRow, body) {
+  for (let node = statusRow; node && node !== body; node = node.parentElement) {
+    const classTokens = String(node.getAttribute?.("class") ?? "").split(/\s+/);
+    if (classTokens.includes("row-start-1") && classTokens.includes("col-start-1")) {
+      return node;
+    }
+  }
+  return statusRow;
 }
 
 function assistantRoots(root) {

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -1234,6 +1234,48 @@ test("extractResponse uses the latest user transcript scope for split action row
   assert.equal(extraction.has_copy_button, true);
 });
 
+test("extractResponse does not promote a sibling response-action Sources button over assistant text", () => {
+  const user = new FakeElement("article", { "data-message-author-role": "user", class: "user-turn" }, "Review bundle");
+  const marker = new FakeElement("div", { "data-message-author-role": "assistant" }, "");
+  const markdown = new FakeElement("div", { class: "markdown prose" }, "PASS\nReview evidence only.");
+  const assistantTurn = new FakeElement("div", { class: "turn-messages" }, "PASS\nReview evidence only.")
+    .append(marker, markdown);
+  const copy = new FakeElement("button", { "aria-label": "Copy response" }, "Copy response");
+  const sources = new FakeElement("button", { "aria-label": "Sources" }, "Sources");
+  const actionRow = withChildNodes(
+    new FakeElement("div", { class: "agent-turn", "aria-label": "Response actions" }),
+    copy,
+    sources
+  );
+  const conversation = new FakeElement("main", { role: "main" }, "Review bundle PASS Review evidence only. Copy response Sources")
+    .append(user, assistantTurn, actionRow);
+  const body = new FakeElement("body", {}, "Review bundle PASS Review evidence only. Copy response Sources").append(conversation);
+  const doc = new FakeDocument(body);
+
+  const extraction = extractResponse(doc);
+
+  assert.equal(extraction.method, "copy_scope_dom_fallback");
+  assert.equal(extraction.text, "PASS\nReview evidence only.");
+  assert.equal(extraction.has_copy_button, true);
+});
+
+test("extractResponse preserves unmarked copy-scoped div text outside action controls", () => {
+  const copy = new FakeElement("button", { "aria-label": "Copy response" }, "Copy response");
+  const assistant = withChildNodes(
+    new FakeElement("div", { class: "agent-turn" }),
+    new FakeTextNode("Plain assistant answer"),
+    copy
+  );
+  const body = new FakeElement("body", {}, "Plain assistant answer Copy response").append(assistant);
+  const doc = new FakeDocument(body);
+
+  const extraction = extractResponse(doc);
+
+  assert.equal(extraction.method, "copy_scope_dom_fallback");
+  assert.equal(extraction.text, "Plain assistant answer");
+  assert.equal(extraction.has_copy_button, true);
+});
+
 test("extractResponse walks past plain thread wrappers to the transcript scope", () => {
   const userMarkdown = new FakeElement("div", { class: "markdown prose" }, "Review bundle");
   const user = new FakeElement("div", { class: "thread" }, "Review bundle")

--- a/extensions/chatgpt-native/tests/fake-claude.test.js
+++ b/extensions/chatgpt-native/tests/fake-claude.test.js
@@ -328,13 +328,79 @@ test("fake Claude extraction excludes collapsed thinking status text from the an
   assert.equal(extraction.text, answer);
 });
 
-test("fake Claude extraction strips a duplicated collapsed thinking caption prefix", () => {
+test("fake Claude extraction excludes a duplicated collapsed thinking subtree", () => {
   const caption = "Scrutinizing verification request authenticity and token protocol";
   const answer = "YOETZ-EXT-VERIFY-20260719-QOPHET";
   const contaminated = `${caption}${answer}`;
   const page = fakeClaudePage({ text: contaminated, streaming: false, copy: true });
+  page.body.cloneNode = () => fakeClaudeThinkingClone({
+    statusCaption: caption,
+    hiddenCaption: caption,
+    answer
+  });
+
+  const extraction = extractResponse(page.root);
+
+  assert.equal(extraction.text, answer);
+});
+
+test("fake Claude extraction excludes a thinking subtree when its hidden caption differs by punctuation", () => {
+  const statusCaption = "Thinking about acknowledging a direct instruction request.";
+  const hiddenCaption = "Thinking about acknowledging a direct instruction request";
+  const answer = "ACK";
+  const contaminated = `${hiddenCaption}${answer}`;
+  const page = fakeClaudePage({ text: contaminated, streaming: false, copy: true });
+  page.body.cloneNode = () => fakeClaudeThinkingClone({
+    statusCaption,
+    hiddenCaption,
+    answer
+  });
+
+  const extraction = extractResponse(page.root);
+
+  assert.equal(extraction.text, answer);
+});
+
+test("fake Claude extraction excludes a thinking subtree with a duration badge", () => {
+  const statusCaption = "Thinking about acknowledging a direct instruction request 12s";
+  const hiddenCaption = "Thinking about acknowledging a direct instruction request";
+  const answer = "ACK";
+  const contaminated = `${hiddenCaption}${answer}`;
+  const page = fakeClaudePage({ text: contaminated, streaming: false, copy: true });
+  page.body.cloneNode = () => fakeClaudeThinkingClone({
+    statusCaption,
+    hiddenCaption,
+    answer
+  });
+
+  const extraction = extractResponse(page.root);
+
+  assert.equal(extraction.text, answer);
+});
+
+test("fake Claude unmatched thinking layout removes only the status button and preserves answer text", () => {
+  const caption = "Thinking layout changed";
+  const answer = "ACK";
+  const page = fakeClaudePage({ text: `${caption}${answer}`, streaming: false, copy: true });
   page.body.cloneNode = () => {
-    let text = `${caption}\n${caption}\n${answer}`;
+    let text = `${caption}\n${answer}`;
+    const unsafeParent = {
+      getAttribute() {
+        return "";
+      },
+      remove() {
+        text = "";
+      }
+    };
+    const statusRow = {
+      parentElement: unsafeParent,
+      getAttribute() {
+        return "group/status";
+      },
+      remove() {
+        text = answer;
+      }
+    };
     return {
       get innerText() {
         return text;
@@ -343,13 +409,7 @@ test("fake Claude extraction strips a duplicated collapsed thinking caption pref
         return text;
       },
       querySelectorAll(selector) {
-        return selector === "button[class*='group/status']"
-          ? [{
-              innerText: caption,
-              textContent: caption,
-              remove: () => { text = contaminated; }
-            }]
-          : [];
+        return selector === "button[class*='group/status']" ? [statusRow] : [];
       }
     };
   };
@@ -487,6 +547,50 @@ function fakeClaudePage({ text, streaming, copy, thinking = false }) {
   page.assistant = assistant;
   page.body = body;
   return page;
+}
+
+function fakeClaudeThinkingClone({ statusCaption, hiddenCaption, answer }) {
+  let text = `${statusCaption}\n${hiddenCaption}\n${answer}`;
+  const contaminated = `${hiddenCaption}${answer}`;
+  const statusSubtree = {
+    getAttribute(name) {
+      return name === "class" ? "row-start-1 col-start-1 min-w-0" : null;
+    },
+    remove() {
+      text = answer;
+    }
+  };
+  const statusControl = {
+    parentElement: statusSubtree,
+    getAttribute() {
+      return "";
+    },
+    remove() {
+      text = contaminated;
+    }
+  };
+  const statusRow = {
+    parentElement: statusControl,
+    innerText: statusCaption,
+    textContent: statusCaption,
+    getAttribute() {
+      return "group/status";
+    },
+    remove() {
+      text = contaminated;
+    }
+  };
+  return {
+    get innerText() {
+      return text;
+    },
+    get textContent() {
+      return text;
+    },
+    querySelectorAll(selector) {
+      return selector === "button[class*='group/status']" ? [statusRow] : [];
+    }
+  };
 }
 
 class FakeDataTransfer {


### PR DESCRIPTION
## Summary
- exclude Claude's duplicate thinking/status grid row without risking removal of the answer container
- ignore ChatGPT action-only control rows such as `Sources` when selecting split assistant responses
- preserve explicit assistant/article extraction and legitimate answer text outside controls

## Runtime evidence
- Claude managed native extension run `20260725T191202Z_ba1489` returned exactly `ACK` with the duplicate thinking row present; extracted via `assistant_dom` with no fallback or warnings
- recovered ChatGPT run `20260725T183021Z_68c280` confirmed the pre-fix failure: the visible verdict was `PASS` but extraction returned exactly `Sources`

## Verification
- `git diff --check main...HEAD`
- `/Users/aviv.s/.cargo/bin/cargo +1.97.0 fmt --all -- --check`
- `npm test --prefix extensions/chatgpt-native` (269/269)
- `./scripts/build-chatgpt-native-extension.sh --check`
- full Rust workspace test, all-target/all-feature clippy with `-D warnings`, and strict rustdoc were green on the Sources commit; the combined tree changes only extension JS/tests and changelog
