### PR TITLE
fix(browser): preserve explicit assistant button responses

### DIFF
--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -1223,6 +1223,7 @@ function assistantMessageTextEntry(turn) {
     addContentNode(turn);
   }
   for (const selector of [
+    '[data-message-author-role="assistant"]',
     '[data-testid*="assistant-message"]',
     '[data-testid*="assistant-response"]',
     '[data-message-author-role="assistant"] [class*="markdown"]',

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -1077,6 +1077,32 @@ test("extractResponse preserves a legitimate answer button labeled Sources", () 
   assert.equal(extraction.text, "Choose Sources to continue.");
 });
 
+test("extractResponse preserves a button-only answer in an explicit nested assistant node", () => {
+  const user = new FakeElement("article", { "data-message-author-role": "user", class: "user-turn" }, "Choose an action");
+  const answerButton = withChildNodes(
+    new FakeElement("button", { "aria-label": "Sources" }),
+    new FakeTextNode("Sources")
+  );
+  const explicitAssistant = new FakeElement(
+    "div",
+    { "data-message-author-role": "assistant" },
+    "Sources"
+  ).append(answerButton);
+  const copy = new FakeElement("button", { "aria-label": "Copy response" }, "Copy response");
+  const assistantTurn = new FakeElement("div", { class: "turn-messages" }, "Sources Copy response")
+    .append(explicitAssistant, copy);
+  const conversation = new FakeElement("main", { role: "main" }, "Choose an action Sources Copy response")
+    .append(user, assistantTurn);
+  const body = new FakeElement("body", {}, "Choose an action Sources Copy response").append(conversation);
+  const doc = new FakeDocument(body);
+
+  const extraction = extractResponse(doc);
+
+  assert.equal(extraction.method, "copy_scope_dom_fallback");
+  assert.equal(extraction.text, "Sources");
+  assert.equal(extraction.has_copy_button, true);
+});
+
 test("extractResponse preserves legitimate answer markup titled Open source repository", () => {
   const user = new FakeElement("article", { "data-message-author-role": "user", class: "user-turn" }, "Where is the code?");
   const repositoryLink = withChildNodes(


### PR DESCRIPTION
## Summary
- collect bare nested `data-message-author-role="assistant"` nodes as explicit response content
- preserve legitimate button-only assistant answers before the copy-inferred control-only fallback runs
- cover a non-article wrapper with an explicit assistant answer button and sibling copy control

## Review finding
ChatGPT Pro found this edge case while reviewing the response-action-row fix after PR #353. This is the smallest owning-layer correction it requested.

## Verification
- focused extraction tests: 3/3
- full native extension suite: 270/270
- extension package check
- Rust formatting check
- `git diff --check`
