### PR TITLE
fix(browser): warn on Claude artifact deliverables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Claude native recipes now detect file/artifact cards in the final assistant
+  turn and return a structured `artifact_unextracted` warning instead of
+  silently reporting a complete response while dropping the deliverable.
+- Built-in Claude prompts now require the deliverable to remain in the chat
+  message as plain Markdown, reducing artifact loss while preserving the
+  caller's task bytes exactly. Custom recipes remain unchanged.
+
 ## [0.5.44] - 2026-07-25
 
 ### Fixed

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -1289,6 +1289,7 @@ fn claude_recipe_payload_from_steps(
         model_used,
         model_selection_status,
         warnings,
+        warning_details: Vec::new(),
         fallback_used,
         conversation_id,
         conversation_url,

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -112,6 +112,9 @@ pub struct RecipeStep {
 pub struct RecipeContext {
     pub bundle_path: Option<String>,
     pub bundle_text: Option<String>,
+    /// A built-in-owned prompt inserted after all other recipe interpolation so
+    /// caller bytes such as `{{run_id}}` remain opaque.
+    pub opaque_prompt: Option<String>,
     pub profile_dir: Option<PathBuf>,
     pub profile_mode: BrowserProfileMode,
     pub fallback_used: bool,
@@ -5663,7 +5666,11 @@ fn json_string_literal(s: &str) -> String {
     serde_json::to_string(s).unwrap()
 }
 
-fn interpolate(value: &str, ctx: &RecipeContext, bundle_text: Option<&str>) -> Result<String> {
+pub(crate) fn interpolate(
+    value: &str,
+    ctx: &RecipeContext,
+    bundle_text: Option<&str>,
+) -> Result<String> {
     if (value.contains("{{bundle_path}}") || value.contains("{{bundle_path|json}}"))
         && ctx.bundle_path.is_none()
     {
@@ -5679,6 +5686,9 @@ fn interpolate(value: &str, ctx: &RecipeContext, bundle_text: Option<&str>) -> R
     // so that {{...}} patterns inside bundle_text don't trigger false errors.
     let mut known_vars: std::collections::HashSet<&str> =
         ctx.vars.keys().map(|s| s.as_str()).collect();
+    if ctx.opaque_prompt.is_some() {
+        known_vars.insert("prompt");
+    }
     known_vars.insert("bundle_path");
     known_vars.insert("bundle_text");
     let mut scan = value;
@@ -5699,8 +5709,55 @@ fn interpolate(value: &str, ctx: &RecipeContext, bundle_text: Option<&str>) -> R
         }
     }
 
-    // Perform substitutions — process |json filtered variants first so they
-    // aren't consumed by the plain replacement pass.
+    if let Some(prompt) = ctx.opaque_prompt.as_deref() {
+        return interpolate_with_opaque_prompt(value, ctx, bundle_text, prompt);
+    }
+
+    Ok(interpolate_replacements(value, ctx, bundle_text))
+}
+
+fn interpolate_with_opaque_prompt(
+    value: &str,
+    ctx: &RecipeContext,
+    bundle_text: Option<&str>,
+    prompt: &str,
+) -> Result<String> {
+    const PLAIN: &str = "{{prompt}}";
+    const JSON: &str = "{{prompt|json}}";
+    let mut remaining = value;
+    let mut out = String::with_capacity(value.len() + prompt.len());
+
+    loop {
+        let plain_at = remaining.find(PLAIN);
+        let json_at = remaining.find(JSON);
+        let next = match (plain_at, json_at) {
+            (Some(plain), Some(json)) if plain <= json => Some((plain, PLAIN, false)),
+            (Some(_), Some(json)) => Some((json, JSON, true)),
+            (Some(plain), None) => Some((plain, PLAIN, false)),
+            (None, Some(json)) => Some((json, JSON, true)),
+            (None, None) => None,
+        };
+        let Some((index, needle, as_json)) = next else {
+            out.push_str(&interpolate_replacements(remaining, ctx, bundle_text));
+            return Ok(out);
+        };
+        out.push_str(&interpolate_replacements(
+            &remaining[..index],
+            ctx,
+            bundle_text,
+        ));
+        if as_json {
+            out.push_str(&json_string_literal(prompt));
+        } else {
+            out.push_str(prompt);
+        }
+        remaining = &remaining[index + needle.len()..];
+    }
+}
+
+fn interpolate_replacements(value: &str, ctx: &RecipeContext, bundle_text: Option<&str>) -> String {
+    // Process |json filtered variants first so they aren't consumed by the
+    // plain replacement pass.
     let mut out = value.to_string();
     if let Some(path) = &ctx.bundle_path {
         out = out.replace("{{bundle_path|json}}", &json_string_literal(path));
@@ -5716,7 +5773,7 @@ fn interpolate(value: &str, ctx: &RecipeContext, bundle_text: Option<&str>) -> R
         out = out.replace("{{bundle_text|json}}", &json_string_literal(text));
         out = out.replace("{{bundle_text}}", text);
     }
-    Ok(out)
+    out
 }
 
 fn parse_recipe_var(entry: &str) -> Result<(String, String)> {
@@ -5878,6 +5935,7 @@ mod tests {
         RecipeContext {
             bundle_path: Some("/tmp/bundle.md".to_string()),
             bundle_text: Some("hello world".to_string()),
+            opaque_prompt: None,
             profile_dir: None,
             profile_mode: BrowserProfileMode::ProfileOnly,
             fallback_used: false,
@@ -6994,6 +7052,41 @@ browser_cdp = "http://evil.example.com:9222"
         let ctx = recipe_context();
         let result = interpolate("{{bundle_text}}", &ctx, Some("literal {{model}}")).unwrap();
         assert_eq!(result, "literal {{model}}");
+    }
+
+    #[test]
+    fn interpolate_inserts_opaque_prompt_after_other_recipe_vars() {
+        let mut ctx = recipe_context();
+        ctx.vars
+            .insert("run_id".to_string(), "run-actual".to_string());
+        ctx.opaque_prompt = Some("caller\r\nbytes {{run_id}}  \n".to_string());
+
+        let result = interpolate("before {{prompt}} after {{run_id}}", &ctx, None).unwrap();
+
+        assert_eq!(
+            result,
+            "before caller\r\nbytes {{run_id}}  \n after run-actual"
+        );
+    }
+
+    #[test]
+    fn interpolate_json_inserts_opaque_prompt_without_rewriting_its_bytes() {
+        let mut ctx = recipe_context();
+        ctx.vars
+            .insert("run_id".to_string(), "run-actual".to_string());
+        ctx.opaque_prompt = Some("caller\r\nbytes {{run_id}}  \n".to_string());
+
+        let result = interpolate(
+            "const prompt = {{prompt|json}}; const run = {{run_id|json}};",
+            &ctx,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            result,
+            r#"const prompt = "caller\r\nbytes {{run_id}}  \n"; const run = "run-actual";"#
+        );
     }
 
     #[test]

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -165,9 +165,21 @@ pub struct ExtensionRecipeResult {
     pub model_used: Option<String>,
     pub model_selection_status: ChatgptModelSelectionStatus,
     pub warnings: Vec<String>,
+    pub warning_details: Vec<Value>,
     pub conversation_id: Option<String>,
     pub conversation_url: Option<String>,
     pub diagnostics: ChatgptRecipeDiagnostics,
+}
+
+impl ExtensionRecipeResult {
+    fn warning_values(&self) -> Vec<Value> {
+        self.warnings
+            .iter()
+            .cloned()
+            .map(Value::String)
+            .chain(self.warning_details.iter().cloned())
+            .collect()
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -1594,7 +1606,7 @@ pub fn canary(
         "response": response.response,
         "model_used": response.model_used,
         "model_selection_status": response.model_selection_status,
-        "warnings": response.warnings,
+        "warnings": response.warning_values(),
     }))
 }
 
@@ -2941,6 +2953,18 @@ fn parse_recipe_result(envelope: ProtocolEnvelope) -> Result<ExtensionRecipeResu
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
+    let warning_details = envelope
+        .payload
+        .get("warnings")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter(|item| item.is_object())
+                .cloned()
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
     let conversation_id = envelope
         .payload
         .get("conversation_id")
@@ -2985,6 +3009,7 @@ fn parse_recipe_result(envelope: ProtocolEnvelope) -> Result<ExtensionRecipeResu
         model_used,
         model_selection_status,
         warnings,
+        warning_details,
         conversation_id,
         conversation_url,
         diagnostics,
@@ -4447,7 +4472,14 @@ mod tests {
                 "response": "done",
                 "model_used": "GPT-5.6 Sol Pro",
                 "model_selection_status": "selected",
-                "warnings": ["kept current"],
+                "warnings": [
+                    "kept current",
+                    {
+                        "code": "artifact_unextracted",
+                        "count": 1,
+                        "titles": ["Release plan"]
+                    }
+                ],
                 "conversation_id": "conv-123",
                 "conversation_url": "https://chatgpt.com/c/conv-123",
                 "extraction_method": "copy_scope_dom_fallback",
@@ -4468,6 +4500,14 @@ mod tests {
             ChatgptModelSelectionStatus::Selected
         );
         assert_eq!(result.warnings, vec!["kept current"]);
+        assert_eq!(
+            result.warning_details,
+            vec![json!({
+                "code": "artifact_unextracted",
+                "count": 1,
+                "titles": ["Release plan"]
+            })]
+        );
         assert_eq!(result.conversation_id.as_deref(), Some("conv-123"));
         assert_eq!(
             result.conversation_url.as_deref(),

--- a/crates/yoetz-cli/src/claude_recipe.rs
+++ b/crates/yoetz-cli/src/claude_recipe.rs
@@ -11,6 +11,12 @@ pub const CLAUDE_FABLE_MAX_MODEL: &str = "fable-5-max";
 pub const CLAUDE_FABLE_MAX_ALIAS: &str = "fable-max";
 pub const CLAUDE_REPORTED_MODEL: &str = "Fable 5 Max";
 pub const DEFAULT_INLINE_WARN_TOKENS: usize = 150_000;
+pub const OUTPUT_CHANNEL_CONTRACT: &str =
+    "Reply entirely in the chat message as plain markdown. Do not create artifacts, files, or documents.";
+
+pub fn render_builtin_prompt(caller_prompt: &str) -> String {
+    format!("{OUTPUT_CHANNEL_CONTRACT}\n\n{caller_prompt}")
+}
 
 pub fn canonical_fable_max_model(value: &str) -> Option<&'static str> {
     matches!(
@@ -58,6 +64,7 @@ pub struct ClaudeRecipeOutput {
     pub model_used: Option<String>,
     pub model_selection_status: WebModelSelectionStatus,
     pub warnings: Vec<String>,
+    pub warning_details: Vec<Value>,
     pub fallback_used: bool,
     pub conversation_id: Option<String>,
     pub conversation_url: Option<String>,
@@ -67,6 +74,13 @@ pub struct ClaudeRecipeOutput {
 
 impl ClaudeRecipeOutput {
     pub fn to_value(&self) -> Value {
+        let warnings = self
+            .warnings
+            .iter()
+            .cloned()
+            .map(Value::String)
+            .chain(self.warning_details.iter().cloned())
+            .collect::<Vec<_>>();
         json!({
             "status": "ok",
             "transport": self.transport,
@@ -75,7 +89,7 @@ impl ClaudeRecipeOutput {
             "model_strategy": "select",
             "model_used": self.model_used,
             "model_selection_status": self.model_selection_status,
-            "warnings": self.warnings,
+            "warnings": warnings,
             "fallback_used": self.fallback_used,
             "delivery_mode": "file_upload",
             "auto_paste_fallback": false,
@@ -137,6 +151,7 @@ mod tests {
             model_used: Some(CLAUDE_REPORTED_MODEL.to_string()),
             model_selection_status: WebModelSelectionStatus::Selected,
             warnings: Vec::new(),
+            warning_details: Vec::new(),
             fallback_used: false,
             conversation_id: Some("123e4567-e89b-12d3-a456-426614174000".to_string()),
             conversation_url: Some(
@@ -166,5 +181,22 @@ mod tests {
         );
         assert_eq!(canonical_fable_max_model("current"), None);
         assert_eq!(canonical_fable_max_model("opus-4.8"), None);
+    }
+
+    #[test]
+    fn builtin_prompt_has_a_stable_output_contract_and_preserves_caller_bytes() {
+        let caller_prompt = "  Review `alpha`.\r\nKeep this trailing newline.\n";
+        let rendered = render_builtin_prompt(caller_prompt);
+
+        assert_eq!(
+            rendered,
+            "Reply entirely in the chat message as plain markdown. Do not create artifacts, files, or documents.\n\n  Review `alpha`.\r\nKeep this trailing newline.\n"
+        );
+        assert_eq!(
+            rendered
+                .strip_prefix(OUTPUT_CHANNEL_CONTRACT)
+                .and_then(|value| value.strip_prefix("\n\n")),
+            Some(caller_prompt)
+        );
     }
 }

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -2439,6 +2439,7 @@ async fn run_claude_recipe_via_chrome_devtools_mcp(
         model_used: response.model_used,
         model_selection_status: response.model_selection_status,
         warnings: recipe_spec.warnings,
+        warning_details: Vec::new(),
         fallback_used,
         conversation_id: response.conversation_id,
         conversation_url: response.conversation_url,
@@ -2540,10 +2541,12 @@ fn build_claude_recipe_spec(
         .transpose()?;
     Ok(claude_recipe::ClaudeRecipeSpec {
         bundle_path: recipe_args.bundle.clone(),
-        prompt: recipe_vars
-            .get("prompt")
-            .cloned()
-            .unwrap_or_else(|| DEFAULT_CHATGPT_RECIPE_PROMPT.to_string()),
+        prompt: claude_recipe::render_builtin_prompt(
+            recipe_vars
+                .get("prompt")
+                .map(String::as_str)
+                .unwrap_or(DEFAULT_CHATGPT_RECIPE_PROMPT),
+        ),
         browser_context_id: recipe_vars
             .get("browser_context_id")
             .map(|value| value.trim().to_string())
@@ -2866,6 +2869,7 @@ fn run_recipe_via_chrome_extension_native<R: IntoBuiltinWebRecipe>(
                 model_used: response.model_used,
                 model_selection_status: response.model_selection_status,
                 warnings,
+                warning_details: response.warning_details,
                 fallback_used,
                 conversation_id: response.conversation_id,
                 conversation_url: response.conversation_url,
@@ -3450,6 +3454,7 @@ fn run_claude_recipe_via_dev_browser(
         model_used: response.model_used,
         model_selection_status: response.model_selection_status,
         warnings: response.warnings,
+        warning_details: Vec::new(),
         fallback_used,
         conversation_id: response.conversation_id,
         conversation_url: response.conversation_url,
@@ -7880,6 +7885,11 @@ mod tests {
             model_used: Some("Fable 5 Max".to_string()),
             model_selection_status: web_recipe::WebModelSelectionStatus::Selected,
             warnings: vec!["size warning".to_string()],
+            warning_details: vec![json!({
+                "code": "artifact_unextracted",
+                "count": 1,
+                "titles": ["Release plan"]
+            })],
             fallback_used: false,
             conversation_id: None,
             conversation_url: None,
@@ -7893,7 +7903,17 @@ mod tests {
         assert_eq!(payload["delivery_mode"], "file_upload");
         assert_eq!(payload["run_id"], "run-claude");
         assert_eq!(payload["elapsed_ms"], 1234);
-        assert_eq!(payload["warnings"], json!(["size warning"]));
+        assert_eq!(
+            payload["warnings"],
+            json!([
+                "size warning",
+                {
+                    "code": "artifact_unextracted",
+                    "count": 1,
+                    "titles": ["Release plan"]
+                }
+            ])
+        );
     }
 
     #[test]

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -3513,6 +3513,7 @@ fn run_recipe_via_agent_browser<R: IntoBuiltinWebRecipe>(
     let builtin_recipe = builtin_recipe.into_builtin_web_recipe();
     let is_chatgpt = builtin_recipe == Some(web_recipe::BuiltinWebRecipe::Chatgpt);
     let is_claude = builtin_recipe == Some(web_recipe::BuiltinWebRecipe::Claude);
+    let (recipe_vars, opaque_prompt) = prepare_agent_browser_prompt(is_claude, recipe_vars);
     let needs_auth = is_chatgpt || is_claude;
     let target_url = if is_claude {
         claude_web::CLAUDE_URL
@@ -3579,6 +3580,7 @@ fn run_recipe_via_agent_browser<R: IntoBuiltinWebRecipe>(
             .as_ref()
             .map(|path| path.to_string_lossy().to_string()),
         bundle_text,
+        opaque_prompt,
         profile_dir: Some(profile_dir),
         profile_mode,
         fallback_used,
@@ -3615,6 +3617,20 @@ fn run_recipe_via_agent_browser<R: IntoBuiltinWebRecipe>(
         );
         Ok(payload)
     }
+}
+
+fn prepare_agent_browser_prompt(
+    is_builtin_claude: bool,
+    mut recipe_vars: BTreeMap<String, String>,
+) -> (BTreeMap<String, String>, Option<String>) {
+    if !is_builtin_claude {
+        return (recipe_vars, None);
+    }
+    let caller_prompt = recipe_vars
+        .remove("prompt")
+        .unwrap_or_else(|| DEFAULT_CHATGPT_RECIPE_PROMPT.to_string());
+    let prompt = claude_recipe::render_builtin_prompt(&caller_prompt);
+    (recipe_vars, Some(prompt))
 }
 
 fn maybe_notify_browser_recipe_completion(
@@ -7874,6 +7890,75 @@ mod tests {
         assert!(claude_recipe::inline_size_warnings(Some(&bundle), 0)
             .unwrap()
             .is_empty());
+    }
+
+    #[test]
+    fn builtin_claude_agent_browser_prompt_crosses_the_transport_boundary_opaquely() {
+        let caller = "review\r\nliteral {{run_id}}  \n\n";
+        let vars = BTreeMap::from([
+            ("prompt".to_string(), caller.to_string()),
+            ("run_id".to_string(), "run-actual".to_string()),
+        ]);
+
+        let (vars, opaque_prompt) = prepare_agent_browser_prompt(true, vars);
+        assert!(!vars.contains_key("prompt"));
+        assert_eq!(vars["run_id"], "run-actual");
+        let context = browser::RecipeContext {
+            bundle_path: None,
+            bundle_text: None,
+            opaque_prompt,
+            profile_dir: None,
+            profile_mode: browser::BrowserProfileMode::ProfileOnly,
+            fallback_used: false,
+            use_stealth: false,
+            headed: false,
+            vars,
+            warnings: Vec::new(),
+            target_url: claude_web::CLAUDE_URL.to_string(),
+        };
+        let expanded = browser::interpolate("{{prompt}}", &context, None).unwrap();
+        let expected = format!("{}\n\n{}", claude_recipe::OUTPUT_CHANNEL_CONTRACT, caller);
+
+        assert_eq!(expanded.as_bytes(), expected.as_bytes());
+        assert_eq!(
+            expanded
+                .matches(claude_recipe::OUTPUT_CHANNEL_CONTRACT)
+                .count(),
+            1
+        );
+        assert!(expanded.contains("literal {{run_id}}  \n\n"));
+    }
+
+    #[test]
+    fn custom_agent_browser_recipe_keeps_ordinary_prompt_interpolation() {
+        let caller = "review\r\nliteral {{run_id}}  \n\n";
+        let vars = BTreeMap::from([
+            ("prompt".to_string(), caller.to_string()),
+            ("run_id".to_string(), "run-actual".to_string()),
+        ]);
+
+        let (prepared_vars, opaque_prompt) = prepare_agent_browser_prompt(false, vars.clone());
+
+        assert_eq!(prepared_vars, vars);
+        assert_eq!(opaque_prompt, None);
+        let context = browser::RecipeContext {
+            bundle_path: None,
+            bundle_text: None,
+            opaque_prompt,
+            profile_dir: None,
+            profile_mode: browser::BrowserProfileMode::ProfileOnly,
+            fallback_used: false,
+            use_stealth: false,
+            headed: false,
+            vars: prepared_vars,
+            warnings: Vec::new(),
+            target_url: "https://example.test/".to_string(),
+        };
+
+        assert_eq!(
+            browser::interpolate("{{prompt}}", &context, None).unwrap(),
+            "review\r\nliteral run-actual  \n\n"
+        );
     }
 
     #[test]

--- a/extensions/chatgpt-native/src/claude-dom.js
+++ b/extensions/chatgpt-native/src/claude-dom.js
@@ -304,6 +304,15 @@ export function extractResponse(root = document) {
   const turn = last?.closest?.("[data-testid*='turn'], article") ?? last;
   const body = last?.querySelector?.(".font-claude-response") ?? null;
   const text = responseBodyText(body);
+  const artifactCards = Array.from(
+    last?.querySelectorAll?.("[class*='group/artifact-block']") ?? []
+  );
+  const artifactBlocks = {
+    count: artifactCards.length,
+    titles: artifactCards
+      .map((element) => normalizeText(element.innerText || element.textContent))
+      .filter(Boolean)
+  };
   const globalCopyButtons = root.querySelectorAll(COPY_ACTION_SELECTOR).length;
   const scopedCopyButtons = turn?.querySelectorAll?.(COPY_ACTION_SELECTOR)?.length ?? 0;
   const isGenerating = isResponseGenerating(root);
@@ -313,7 +322,8 @@ export function extractResponse(root = document) {
       assistant_turns: assistants.length,
       copy_buttons: globalCopyButtons,
       stop_controls: root.querySelectorAll("button[aria-label='Stop response']").length,
-      thinking_rows: root.querySelectorAll("button[class*='group/status']").length
+      thinking_rows: root.querySelectorAll("button[class*='group/status']").length,
+      artifact_blocks: artifactBlocks.count
     },
     assistant_turn_snippets: assistants.slice(-3).map((element) => elementSummary(element)),
     page_text_chars: String(root.body?.innerText ?? "").length,
@@ -329,6 +339,7 @@ export function extractResponse(root = document) {
       preceding_user_count: precedingUserCount,
       copy_button_count: globalCopyButtons,
       has_copy_button: scopedCopyButtons > 0,
+      artifact_blocks: artifactBlocks,
       diagnostics
     };
   }
@@ -341,6 +352,7 @@ export function extractResponse(root = document) {
     preceding_user_count: precedingUserCount,
     copy_button_count: globalCopyButtons,
     has_copy_button: scopedCopyButtons > 0,
+    artifact_blocks: artifactBlocks,
     diagnostics
   };
 }

--- a/extensions/chatgpt-native/src/completion-warnings.js
+++ b/extensions/chatgpt-native/src/completion-warnings.js
@@ -1,0 +1,16 @@
+export function completionWarnings({
+  jobWarnings = [],
+  extraction,
+  emptyResponseWarning,
+  extractionWarnings = [],
+  finalityAnchor,
+  domOnlyFinalityWarning
+}) {
+  return [
+    ...(jobWarnings ?? []),
+    ...(extraction?.text ? [] : [emptyResponseWarning]),
+    ...(extraction?.warning ? [extraction.warning] : []),
+    ...(extractionWarnings ?? []),
+    ...(finalityAnchor === "dom_only" ? [domOnlyFinalityWarning] : [])
+  ];
+}

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -1,4 +1,5 @@
 import { ChunkAssembler, uint8ArrayToBase64 } from "./chunks.js";
+import { completionWarnings } from "./completion-warnings.js";
 import {
   EXTENSION_ID,
   NATIVE_HOST,
@@ -535,12 +536,14 @@ async function completeJobWithExtraction(job, extraction) {
       model_strategy: job.model_strategy ?? "select",
       model_used: job.model_used ?? null,
       model_selection_status: job.model_selection_status ?? "unavailable",
-      warnings: [
-        ...(job.warnings ?? []),
-        ...(extraction.text ? [] : [adapter.completion.emptyResponseWarning]),
-        ...(extraction.warning ? [extraction.warning] : []),
-        ...(finalityAnchor === "dom_only" ? [CHATGPT_DOM_ONLY_FINALITY_WARNING] : [])
-      ]
+      warnings: completionWarnings({
+        jobWarnings: job.warnings,
+        extraction,
+        emptyResponseWarning: adapter.completion.emptyResponseWarning,
+        extractionWarnings: adapter.completion.extractionWarnings?.(extraction),
+        finalityAnchor,
+        domOnlyFinalityWarning: CHATGPT_DOM_ONLY_FINALITY_WARNING
+      })
     }
   });
   const completeBytes = nativeEnvelopeByteLength(completeEnvelope);

--- a/extensions/chatgpt-native/src/sites/claude.js
+++ b/extensions/chatgpt-native/src/sites/claude.js
@@ -77,6 +77,19 @@ function completedExtraction(extraction, completionReason, stableForMs) {
   };
 }
 
+export function artifactUnextractedWarnings(extraction) {
+  const count = Number(extraction?.artifact_blocks?.count ?? 0);
+  if (!Number.isInteger(count) || count <= 0) return [];
+  const titles = Array.isArray(extraction?.artifact_blocks?.titles)
+    ? extraction.artifact_blocks.titles.filter((title) => typeof title === "string" && title)
+    : [];
+  return [{
+    code: "artifact_unextracted",
+    count,
+    titles
+  }];
+}
+
 export const claudeSiteAdapter = Object.freeze({
   recipe: "claude",
   displayName: "Claude",
@@ -112,6 +125,7 @@ export const claudeSiteAdapter = Object.freeze({
     renderRefreshMode: "none",
     finalAffordanceRequiresStableIdle: true,
     emptyResponseWarning: "empty Claude response extracted",
+    extractionWarnings: artifactUnextractedWarnings,
     isFreshBackendApiExtraction: () => false,
     hasFinalAssistantAffordance,
     hasStableIdleUnscopedCopyAffordance: () => false,

--- a/extensions/chatgpt-native/src/sites/claude.js
+++ b/extensions/chatgpt-native/src/sites/claude.js
@@ -48,23 +48,31 @@ function normalizedResponseText(value) {
 }
 
 function hasFinalAssistantAffordance(extraction) {
+  const artifactCount = Number(extraction?.artifact_blocks?.count ?? 0);
+  const hasArtifactCard = Number.isInteger(artifactCount)
+    && artifactCount > 0
+    && Number(extraction?.assistant_count ?? 0) > 0;
   return Boolean(
     !extraction?.is_generating
-    && extraction?.method === "assistant_dom"
-    && normalizedResponseText(extraction?.text)
+    && (
+      (extraction?.method === "assistant_dom" && normalizedResponseText(extraction?.text))
+      || hasArtifactCard
+    )
   );
 }
 
 function selectFinalAffordanceCandidate(candidate, extraction) {
+  if (!extraction) return { candidate, resetTimer: false };
   const candidateText = normalizedResponseText(candidate?.text);
   const nextText = normalizedResponseText(extraction?.text);
-  if (!candidate && extraction) return { candidate: extraction, resetTimer: true };
-  if (!nextText) return { candidate, resetTimer: false };
-  if (!candidateText) return { candidate: extraction, resetTimer: true };
-  if (nextText.length < candidateText.length || nextText === candidateText) {
+  if (!candidate) return { candidate: extraction, resetTimer: true };
+  if (nextText === candidateText) {
+    return { candidate: extraction, resetTimer: false };
+  }
+  if (nextText.length < candidateText.length) {
     return { candidate, resetTimer: false };
   }
-  return { candidate: extraction, resetTimer: nextText.length > candidateText.length };
+  return { candidate: extraction, resetTimer: true };
 }
 
 function completedExtraction(extraction, completionReason, stableForMs) {

--- a/extensions/chatgpt-native/tests/completion-warnings.test.js
+++ b/extensions/chatgpt-native/tests/completion-warnings.test.js
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { completionWarnings } from "../src/completion-warnings.js";
+
+test("artifact warning coexists with the generic empty-response warning", () => {
+  const artifactWarning = {
+    code: "artifact_unextracted",
+    count: 1,
+    titles: ["Release plan"]
+  };
+
+  assert.deepEqual(
+    completionWarnings({
+      extraction: { text: "" },
+      emptyResponseWarning: "empty Claude response extracted",
+      extractionWarnings: [artifactWarning]
+    }),
+    [
+      "empty Claude response extracted",
+      artifactWarning
+    ]
+  );
+});

--- a/extensions/chatgpt-native/tests/fake-claude.test.js
+++ b/extensions/chatgpt-native/tests/fake-claude.test.js
@@ -445,6 +445,71 @@ test("fake Claude completed scoped answer does not require a hover-only copy but
   assert.equal(claudeSiteAdapter.completion.finalAffordanceRequiresStableIdle, true);
 });
 
+test("fake Claude extraction reports artifact cards from only the final assistant root", () => {
+  const finalArtifact = fakeArtifactCard("Release plan / Document · MD / Download");
+  const finalPage = fakeClaudePage({
+    text: "Chat summary",
+    streaming: false,
+    copy: true,
+    artifacts: [finalArtifact]
+  });
+
+  assert.deepEqual(extractResponse(finalPage.root).artifact_blocks, {
+    count: 1,
+    titles: ["Release plan / Document · MD / Download"]
+  });
+
+  const resumedPage = fakeClaudePage({
+    text: "Current answer",
+    streaming: false,
+    copy: true
+  });
+  resumedPage.root.querySelectorAll = (selector) => {
+    if (selector === "[data-is-streaming]") {
+      return [
+        fakeClaudeAssistant({ text: "Earlier answer", artifacts: [finalArtifact] }),
+        resumedPage.assistant
+      ];
+    }
+    if (selector === "[data-testid='action-bar-copy']") return resumedPage.globalCopy;
+    if (selector === "button[aria-label='Stop response']") return [];
+    if (selector === "button[class*='group/status']") return [];
+    if (selector === "[data-testid='user-message']") return [];
+    return [];
+  };
+
+  assert.deepEqual(extractResponse(resumedPage.root).artifact_blocks, {
+    count: 0,
+    titles: []
+  });
+});
+
+test("fake Claude artifact detection survives an open side panel and stays silent without a card", () => {
+  const page = fakeClaudePage({
+    text: "Chat summary",
+    streaming: false,
+    copy: true,
+    artifacts: [fakeArtifactCard("Open deliverable")]
+  });
+  page.root.body.innerText = "Chat summary\nOpen side panel body";
+  page.root.body.textContent = page.root.body.innerText;
+
+  assert.deepEqual(extractResponse(page.root).artifact_blocks, {
+    count: 1,
+    titles: ["Open deliverable"]
+  });
+
+  const noArtifact = fakeClaudePage({
+    text: "Plain answer",
+    streaming: false,
+    copy: true
+  });
+  assert.deepEqual(extractResponse(noArtifact.root).artifact_blocks, {
+    count: 0,
+    titles: []
+  });
+});
+
 test("fake Claude conversation loader preserves changed and unavailable taxonomy", async () => {
   const originalLocation = globalThis.location;
   const requested = "123e4567-e89b-12d3-a456-426614174000";
@@ -497,32 +562,18 @@ test("fake Claude model acceptance requires Fable 5 and Max together", () => {
   }
 });
 
-function fakeClaudePage({ text, streaming, copy, thinking = false }) {
+function fakeClaudePage({ text, streaming, copy, thinking = false, artifacts = [] }) {
   const body = { innerText: text, textContent: text };
   const copyButton = {};
   const page = {
     globalCopy: copy ? [copyButton] : []
-  };
-  const assistant = {
-    streaming,
-    thinking,
-    getAttribute(name) {
-      return name === "data-is-streaming" ? String(this.streaming) : null;
-    },
-    querySelector(selector) {
-      if (selector === ".font-claude-response") return body;
-      if (selector === "button[class*='group/status']") return this.thinking ? {} : null;
-      return null;
-    },
-    closest() {
-      return turn;
-    }
   };
   const turn = {
     querySelectorAll(selector) {
       return selector === "[data-testid='action-bar-copy']" && copy ? [copyButton] : [];
     }
   };
+  const assistant = fakeClaudeAssistant({ text, streaming, thinking, artifacts, body, turn });
   const user = {
     compareDocumentPosition() {
       return 4;
@@ -591,6 +642,38 @@ function fakeClaudeThinkingClone({ statusCaption, hiddenCaption, answer }) {
       return selector === "button[class*='group/status']" ? [statusRow] : [];
     }
   };
+}
+
+function fakeClaudeAssistant({
+  text,
+  streaming = false,
+  thinking = false,
+  artifacts = [],
+  body = { innerText: text, textContent: text },
+  turn = { querySelectorAll: () => [] }
+}) {
+  return {
+    streaming,
+    thinking,
+    getAttribute(name) {
+      return name === "data-is-streaming" ? String(this.streaming) : null;
+    },
+    querySelector(selector) {
+      if (selector === ".font-claude-response") return body;
+      if (selector === "button[class*='group/status']") return this.thinking ? {} : null;
+      return null;
+    },
+    querySelectorAll(selector) {
+      return selector === "[class*='group/artifact-block']" ? artifacts : [];
+    },
+    closest() {
+      return turn;
+    }
+  };
+}
+
+function fakeArtifactCard(title) {
+  return { innerText: title, textContent: title };
 }
 
 class FakeDataTransfer {

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -448,6 +448,7 @@ test("service worker runs a Claude job through its adapter and probes the select
   const port = makePort();
   const sentToTabs = [];
   let sent = false;
+  let postSendExtractCount = 0;
   const conversationId = "123e4567-e89b-12d3-a456-426614174000";
 
   globalThis.chrome = chromeStub({
@@ -491,6 +492,7 @@ test("service worker runs a Claude job through its adapter and probes the select
               }
             };
           case "yoetz_extract_response":
+            if (sent) postSendExtractCount += 1;
             return {
               ok: true,
               payload: sent
@@ -504,8 +506,8 @@ test("service worker runs a Claude job through its adapter and probes the select
                     turn_index: 0,
                     conversation_id: conversationId,
                     artifact_blocks: {
-                      count: 1,
-                      titles: ["Release plan"]
+                      count: postSendExtractCount >= 2 ? 1 : 0,
+                      titles: postSendExtractCount >= 2 ? ["Release plan"] : []
                     }
                   }
                 : { method: "none", text: "", is_generating: false, assistant_count: 0, turn_index: -1 }
@@ -570,6 +572,146 @@ test("service worker runs a Claude job through its adapter and probes the select
       count: 1,
       titles: ["Release plan"]
     }]);
+    assert.equal(postSendExtractCount, 2);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker completes an artifact-only Claude response with both warnings", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  let sent = false;
+  const conversationId = "223e4567-e89b-12d3-a456-426614174000";
+
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async ({ url, active }) => {
+        assert.equal(url, "https://claude.ai/new?_yoetz=run_job_claude_artifact_only");
+        assert.equal(active, false);
+        return { id: 72 };
+      },
+      get: async (id) => ({
+        id,
+        status: "complete",
+        url: "https://claude.ai/new?_yoetz=run_job_claude_artifact_only"
+      }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: { recipe: "claude", url: "https://claude.ai/new" } };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return {
+              ok: true,
+              payload: {
+                status: "selected",
+                requested_model: "fable-5-max",
+                modelVerified: true,
+                maxVerified: true,
+                model_used: "Fable 5 Max"
+              }
+            };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return {
+              ok: true,
+              payload: {
+                sent: true,
+                conversation_id: conversationId,
+                submitted_user_count: 1,
+                submitted_assistant_count: 0
+              }
+            };
+          case "yoetz_extract_response":
+            return {
+              ok: true,
+              payload: sent
+                ? {
+                    method: "none",
+                    text: "",
+                    is_generating: false,
+                    assistant_count: 1,
+                    copy_button_count: 0,
+                    has_copy_button: false,
+                    turn_index: 0,
+                    conversation_id: conversationId,
+                    artifact_blocks: {
+                      count: 1,
+                      titles: ["Release plan"]
+                    }
+                  }
+                : {
+                    method: "none",
+                    text: "",
+                    is_generating: false,
+                    assistant_count: 0,
+                    turn_index: -1
+                  }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      },
+      group: async () => 1
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?claude_artifact_only=${Date.now()}`);
+    await eventually(() => port.messages.some((message) => message.type === "hello"));
+    port.messages.length = 0;
+
+    port.emit(envelope("job_start", "job_claude_artifact_only", {
+      recipe: "claude",
+      prompt: "review",
+      wait_interval_ms: 500,
+      wait_timeout_ms: 2500
+    }));
+    await eventually(() => port.messages.some((message) =>
+      message.job_id === "job_claude_artifact_only"
+      && (message.type === "job_error" || message.payload?.phase === "ready_for_file")
+    ));
+    const startError = port.messages.find((message) =>
+      message.type === "job_error" && message.job_id === "job_claude_artifact_only"
+    );
+    assert.equal(startError, undefined, JSON.stringify(startError?.payload));
+
+    port.emit(envelope("job_file_chunk", "job_claude_artifact_only", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "bundle.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+    await eventually(() => port.messages.some((message) =>
+      message.job_id === "job_claude_artifact_only"
+      && (message.type === "job_complete" || message.type === "job_error")
+    ));
+    const complete = port.messages.find((message) =>
+      message.type === "job_complete" && message.job_id === "job_claude_artifact_only"
+    );
+    assert.ok(complete, JSON.stringify(port.messages));
+    assert.equal(complete.payload.response, "");
+    assert.deepEqual(complete.payload.warnings, [
+      "empty Claude response extracted",
+      {
+        code: "artifact_unextracted",
+        count: 1,
+        titles: ["Release plan"]
+      }
+    ]);
+    assert.equal(
+      port.messages.some((message) =>
+        message.type === "job_error" && message.job_id === "job_claude_artifact_only"
+      ),
+      false
+    );
   } finally {
     globalThis.chrome = originalChrome;
   }

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -494,7 +494,7 @@ test("service worker runs a Claude job through its adapter and probes the select
             return {
               ok: true,
               payload: sent
-                ? {
+                  ? {
                     method: "assistant_dom",
                     text: "Claude answer",
                     is_generating: false,
@@ -502,7 +502,11 @@ test("service worker runs a Claude job through its adapter and probes the select
                     copy_button_count: 0,
                     has_copy_button: false,
                     turn_index: 0,
-                    conversation_id: conversationId
+                    conversation_id: conversationId,
+                    artifact_blocks: {
+                      count: 1,
+                      titles: ["Release plan"]
+                    }
                   }
                 : { method: "none", text: "", is_generating: false, assistant_count: 0, turn_index: -1 }
             };
@@ -561,6 +565,11 @@ test("service worker runs a Claude job through its adapter and probes the select
     assert.equal(complete.payload.completion_reason, "stable_idle");
     assert.equal(complete.payload.conversation_id, conversationId);
     assert.equal(complete.payload.conversation_url, `https://claude.ai/chat/${conversationId}`);
+    assert.deepEqual(complete.payload.warnings, [{
+      code: "artifact_unextracted",
+      count: 1,
+      titles: ["Release plan"]
+    }]);
   } finally {
     globalThis.chrome = originalChrome;
   }

--- a/recipes/claude.yaml
+++ b/recipes/claude.yaml
@@ -29,6 +29,8 @@ name: claude
 # from the extension isolated world. Finality requires a non-streaming last
 # assistant turn and no Stop response control; cloned group/status thinking rows
 # are excluded from answer text without mutating the live DOM.
+# The typed builtin path prepends an output-channel contract that keeps the
+# deliverable in the chat message; custom recipes remain caller-controlled.
 #
 # inline_warn_tokens is a heuristic quality guard, not a documented Claude
 # cutoff. Above it, claude.ai may use retrieval-backed file access. Set 0 to


### PR DESCRIPTION
## What
- detect artifact cards scoped to the final Claude assistant turn
- return a structured artifact_unextracted warning while preserving successful exit status
- prepend the built-in Claude output-channel contract without mutating caller prompt bytes
- keep custom recipe prompt interpolation unchanged

Addresses issue #343 steps 1-2; direct artifact extraction remains separate follow-up work.

## Review
- ChatGPT Pro reviewed the complete untruncated 13-file tree and returned APPROVED
- review run: 20260725T212939Z_01a3c9
- review bundle: 20260725_212935_FhKuQY

## Verification
- cargo +1.97.0 test --workspace
- cargo +1.97.0 clippy --workspace --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo +1.97.0 doc --workspace --no-deps
- cargo +1.97.0 fmt --all -- --check
- extension tests: 274 passed
- deterministic extension package: 19 files verified