### PR TITLE
docs: document upload_timeout_ms and send_timeout_ms recipe vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- Document the `upload_timeout_ms` and `send_timeout_ms` recipe vars alongside
+  `wait_timeout_ms` in the yoetz skill, including the upload default of 120000
+  plus 5000 per MiB of bundle. Both overrides already existed for the `chatgpt`
+  and `claude` recipes but appeared in no guidance, so callers hitting the
+  125000 bound on a small bundle had no documented lever.
+
 ## [0.5.45] - 2026-07-26
 ### Fixed
 

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -257,6 +257,25 @@ upload/send/wait error, use
 `yoetz browser extension inspect --chatgpt --run-id <run-id>` before deciding
 whether an intentional rerun is safe.
 
+The two pre-response phases take the same kind of override, for both the
+`chatgpt` and `claude` recipes: `--var upload_timeout_ms=<milliseconds>` bounds
+the bundle attach and `--var send_timeout_ms=<milliseconds>` bounds the send.
+Send defaults to 120000. Upload defaults to 120000 plus 5000 per MiB of bundle,
+rounded up and capped at 3600000, so any non-empty sub-MiB bundle is bounded at
+125000; an empty bundle stays at 120000. Not every terminal upload error is a
+timeout — the phase also fails closed on invalid conversation, manual handoff,
+and rejected file chunks — but the specific `Claude page did not reach the
+requested state within <n>ms` error means the attachment thumbnail and an enabled
+send control never both appeared within that bound. Read that bound as processing
+latency, not transfer capacity: a small bundle can exhaust it when the site is
+slow to accept an attachment, and the attach can still land after the deadline,
+so raising `upload_timeout_ms` is the lever rather than an immediate rerun.
+Inspect the preserved tab before any rerun — use
+`yoetz browser extension inspect --claude --run-id <run-id>` for Claude runs, the
+`--chatgpt` form above for ChatGPT — because a late attach leaves a real
+attachment on that tab even though no conversation was created, so rerunning
+blind can duplicate the upload.
+
 If progress says `waiting for final assistant controls`, ChatGPT has exposed
 post-send assistant text but not a final scoped action affordance yet. Do not
 treat the visible text as complete and do not start a duplicate run; use the


### PR DESCRIPTION
## Why

A caller running `--recipe claude` hit the upload phase bound at 125000ms on a 68KB bundle and reported that the bound was fixed with no override available. It isn't: `upload_timeout_ms` and `send_timeout_ms` have been caller-overridable for both the `chatgpt` and `claude` recipes (`build_claude_recipe_spec` / `build_chatgpt_recipe_spec` → `dev_browser::resolve_chatgpt_upload_timeout_ms`). They were simply documented nowhere, while `wait_timeout_ms` is documented twice in the skill. The lever existed and was undiscoverable, so the wrong conclusion was the reasonable one.

Docs only. No behavior change, no Rust touched, no version metadata touched.

## What this documents

- `--var upload_timeout_ms=<ms>` and `--var send_timeout_ms=<ms>` for both recipes; send defaults to 120000.
- The upload default derivation: 120000 plus 5000 per MiB `div_ceil`, capped at 3600000 — hence 125000 for any non-empty sub-MiB bundle, and 120000 for a zero-byte one.
- Which upload failures are timeouts. The phase also fails closed on invalid conversation, manual handoff, and rejected/oversize chunks, so only the `Claude page did not reach the requested state within <n>ms` error implies the thumbnail-plus-enabled-send predicate (`extensions/chatgpt-native/src/claude-dom.js:124-131`) was never satisfied.
- That the bound is attachment **acceptance latency**, not transfer capacity — a small bundle can exhaust it, and the attach can still land after the deadline.
- Claude runs route to `yoetz browser extension inspect --claude --run-id <run-id>`; the surrounding guidance was ChatGPT-only.
- A late attach leaves a real attachment on the preserved tab **even though no conversation was created**, so a blind rerun can duplicate the upload. "No conversation" is not "clean tab."

## Evidence

On the reported run the attach did complete, late: the preserved tab was later found holding `[data-testid='file-thumbnail']` with `h3` = `bundle.md`, a `button[aria-label='Remove']`, and an enabled `Send message`, with `conversation_id` still null and no turns. That is exactly the predicate the detector waits on, so the detector was watching the right signal and it resolved after the deadline.

## Deliberately not included

The default is **not** recalibrated. Cold-start correlation is suggestive — the failing run was the first claude recipe after an extension clear/reload, and a warm rerun four minutes later on the same instance cleared upload and completed end to end — but that is two samples and the magnitude is unmeasured (the tab was read ~25 min later, so the attach landed after 125s but we don't know whether at 130s or 600s). Recalibrating a default shared by both recipes off an unquantified tail would be a guess. The discriminating run is a cold extension with `--var upload_timeout_ms=600000 --debug`; if it lands near 150s, `scale_chatgpt_upload_timeout_ms` wants a floor rather than a pure 5000/MiB curve.

## Verification

- CI `check-skills` equivalent run locally: both `.claude/skills/yoetz` and `.agents/skills/yoetz` symlink targets correct, `diff -rq skills/yoetz .claude/skills/yoetz` clean.
- `git diff --check` clean.
- Peer-reviewed by codex through two rounds; three correctness findings applied (over-broad timeout claim, ChatGPT-only inspect command, zero-byte boundary) and approved on the exact frozen diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)