### PR TITLE
Clarify browser extension timeout diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Browser-extension inspect output now labels the current chip state at inspect
+  time as `current_model_chip_state` instead of the misleading
+  `model_selection` for both ChatGPT and Claude recipes.
+
+### Added
+
+- Claude upload timeouts now report per-leg readiness evidence for the file
+  input, attachment, and send control, including which wait stage expired.
+
 ### Documentation
 
 - Document the `upload_timeout_ms` and `send_timeout_ms` recipe vars alongside

--- a/extensions/chatgpt-native/src/claude-dom.js
+++ b/extensions/chatgpt-native/src/claude-dom.js
@@ -116,20 +116,29 @@ export async function insertPrompt(root, prompt, options = {}) {
 
 export async function uploadFile(root, file, options = {}) {
   const timeoutMs = options.timeoutMs ?? 120000;
-  const input = await waitFor(() => findFileInput(root), Math.min(timeoutMs, 20000));
-  const transfer = new DataTransfer();
-  transfer.items.add(file);
-  input.files = transfer.files;
-  input.dispatchEvent(new Event("change", { bubbles: true }));
-  await waitFor(() => {
-    const attachment = Array.from(root.querySelectorAll(ATTACHMENT_SELECTOR)).find((node) =>
-      normalizeText(node.querySelector("h3")?.textContent) === file.name
-      && Boolean(node.querySelector("button[aria-label='Remove']"))
-    );
-    const send = findSendButton(root);
-    return attachment && send && !send.disabled && send.getAttribute("aria-disabled") !== "true";
-  }, timeoutMs);
-  return true;
+  let timeoutStage = "file_input";
+  try {
+    const input = await waitFor(() => findFileInput(root), Math.min(timeoutMs, 20000));
+    const transfer = new DataTransfer();
+    transfer.items.add(file);
+    input.files = transfer.files;
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+    timeoutStage = "attachment_readiness";
+    await waitFor(() => {
+      const attachment = Array.from(root.querySelectorAll(ATTACHMENT_SELECTOR)).find((node) =>
+        normalizeText(node.querySelector("h3")?.textContent) === file.name
+        && Boolean(node.querySelector("button[aria-label='Remove']"))
+      );
+      const send = findSendButton(root);
+      return attachment && send && !send.disabled && send.getAttribute("aria-disabled") !== "true";
+    }, timeoutMs);
+    return true;
+  } catch (error) {
+    if (error?.isClaudeWaitTimeout) {
+      error.message = `${error.message}; upload diagnostics: ${claudeUploadDiagnosticSummary(root, file.name, timeoutStage)}`;
+    }
+    throw error;
+  }
 }
 
 export async function ensureFreshChat(root = document, job = {}, options = {}) {
@@ -594,6 +603,55 @@ function elementSummary(element) {
   };
 }
 
+function claudeUploadDiagnosticSummary(root, filename, timeoutStage) {
+  const inputs = Array.from(root.querySelectorAll?.(FILE_INPUT_SELECTOR) ?? []);
+  const thumbnails = Array.from(root.querySelectorAll?.(ATTACHMENT_SELECTOR) ?? []);
+  const send = findSendButton(root);
+  const observations = thumbnails.map((thumbnail) => {
+    const label = normalizeText(
+      thumbnail.querySelector?.("h3")?.textContent
+      || thumbnail.getAttribute?.("aria-label")
+      || thumbnail.getAttribute?.("title")
+    );
+    const text = normalizeText(thumbnail.innerText || thumbnail.textContent);
+    const busy = thumbnail.getAttribute?.("aria-busy") === "true"
+      || Boolean(thumbnail.querySelector?.([
+        "[role='progressbar']",
+        "[aria-busy='true']",
+        "[data-state*='loading']"
+      ].join(", ")))
+      || /\b(uploading|attaching|processing|scanning)\b/i.test(text);
+    const failureNode = thumbnail.querySelector?.(
+      "[role='alert'], [data-testid*='error'], [aria-live='assertive']"
+    );
+    const failureText = normalizeText(failureNode?.innerText || failureNode?.textContent);
+    const failure = failureText || (
+      /\b(upload|attach|file)\b.*\b(failed|error)\b/i.test(text) ? text.slice(0, 200) : ""
+    );
+    return {
+      label,
+      matchesFilename: label === filename,
+      removePresent: Boolean(thumbnail.querySelector?.("button[aria-label='Remove']")),
+      busy,
+      failure
+    };
+  });
+  const filenameMatch = observations.find((item) => item.matchesFilename);
+  return [
+    `file_input_count=${inputs.length}`,
+    `thumbnail_count=${thumbnails.length}`,
+    `thumbnail_labels=${JSON.stringify(observations.map((item) => item.label))}`,
+    `filename_match=${Boolean(filenameMatch)}`,
+    `remove_present=${Boolean(filenameMatch?.removePresent)}`,
+    `attachment_busy=${JSON.stringify(observations.filter((item) => item.busy).map((item) => item.label))}`,
+    `attachment_failures=${JSON.stringify(observations.filter((item) => item.failure).map((item) => item.failure))}`,
+    `send_present=${Boolean(send)}`,
+    `send_disabled=${send ? Boolean(send.disabled) : null}`,
+    `send_aria_disabled=${JSON.stringify(send?.getAttribute?.("aria-disabled") ?? null)}`,
+    `timeout_stage=${JSON.stringify(timeoutStage)}`
+  ].join(", ");
+}
+
 async function waitForReadyComposer(root, timeoutMs) {
   try {
     return await waitFor(() => findComposer(root), timeoutMs);
@@ -621,7 +679,9 @@ async function waitFor(read, timeoutMs) {
     value = read();
   }
   if (!value) {
-    throw new Error(`Claude page did not reach the requested state within ${timeoutMs}ms`);
+    const error = new Error(`Claude page did not reach the requested state within ${timeoutMs}ms`);
+    error.isClaudeWaitTimeout = true;
+    throw error;
   }
   return value;
 }

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -252,7 +252,7 @@ async function inspectPage(runId, options = {}) {
     ownership: parsed,
     active_job_ids: Array.from(activeJobs.keys()),
     extraction,
-    model_selection: modelSelectionDiagnostics(document),
+    current_model_chip_state: modelSelectionDiagnostics(document),
     // Runtime build marker for the CONTENT SCRIPT specifically. Content scripts already injected
     // into open tabs do NOT refresh when the extension is reloaded (only the service worker
     // does), so a stale content script can emit old diagnostics (e.g. snippets without

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -104,7 +104,7 @@ export function extractResponse() {
 }
 
 export function modelSelectionDiagnostics() {
-  return {};
+  return hooks.modelSelectionDiagnostics ?? {};
 }
 
 function conversationIdFromLocation() {
@@ -232,6 +232,32 @@ test("content script auth probe reports manual handoff without job side effects"
     assert.deepEqual(hooks.ensureFreshChatCalls, []);
     assert.deepEqual(hooks.ensureConversationLoadedCalls, []);
     assert.deepEqual(hooks.markOwnershipCalls, []);
+  } finally {
+    restore();
+  }
+});
+
+test("content script inspect labels model diagnostics as current chip state", async () => {
+  const { send, hooks, restore } = await loadContentScript(
+    "inspect_current_model_chip",
+    "https://chatgpt.com/c/conv-123?_yoetz=run-inspect"
+  );
+  try {
+    globalThis.window.name = "yoetz-chatgpt-native:run-inspect:job-inspect";
+    hooks.modelSelectionDiagnostics = {
+      modelChip: "GPT-5.6 Sol Pro",
+      modelVerified: true
+    };
+
+    const response = await send({
+      type: "yoetz_inspect_page",
+      run_id: "run-inspect",
+      recipe: "chatgpt"
+    });
+
+    assert.equal(response.ok, true);
+    assert.deepEqual(response.payload.current_model_chip_state, hooks.modelSelectionDiagnostics);
+    assert.equal(response.payload.model_selection, undefined);
   } finally {
     restore();
   }

--- a/extensions/chatgpt-native/tests/fake-claude.test.js
+++ b/extensions/chatgpt-native/tests/fake-claude.test.js
@@ -119,6 +119,139 @@ test("fake Claude upload waits for the committed chip and re-enabled send", asyn
   }
 });
 
+test("fake Claude upload timeout reports each attachment readiness leg", async () => {
+  const previousDataTransfer = globalThis.DataTransfer;
+  globalThis.DataTransfer = FakeDataTransfer;
+  try {
+    const input = {
+      files: null,
+      dispatchEvent() {
+        return true;
+      }
+    };
+    const attachment = {
+      textContent: "fixture.md Processing",
+      getAttribute(name) {
+        if (name === "aria-busy") return "true";
+        return null;
+      },
+      querySelector(selector) {
+        if (selector === "h3") return { textContent: "fixture.md" };
+        if (selector === "[role='progressbar']") return {};
+        return null;
+      },
+      querySelectorAll() {
+        return [];
+      }
+    };
+    const root = {
+      querySelector(selector) {
+        if (selector === "input[data-testid='file-upload']") return input;
+        if (selector === "button[aria-label='Send message']") {
+          return { disabled: true, getAttribute: () => "true" };
+        }
+        return null;
+      },
+      querySelectorAll(selector) {
+        if (selector === "input[data-testid='file-upload']") return [input];
+        if (selector === "[data-testid='file-thumbnail']") return [attachment];
+        return [];
+      }
+    };
+
+    await assert.rejects(
+      () => uploadFile(root, new File(["bundle"], "fixture.md", { type: "text/markdown" }), {
+        timeoutMs: 1
+      }),
+      (error) => {
+        assert.match(error.message, /file_input_count=1/);
+        assert.match(error.message, /thumbnail_count=1/);
+        assert.match(error.message, /thumbnail_labels=\["fixture\.md"\]/);
+        assert.match(error.message, /filename_match=true/);
+        assert.match(error.message, /remove_present=false/);
+        assert.match(error.message, /attachment_busy=\["fixture\.md"\]/);
+        assert.match(error.message, /attachment_failures=\[\]/);
+        assert.match(error.message, /send_present=true/);
+        assert.match(error.message, /send_disabled=true/);
+        assert.match(error.message, /send_aria_disabled="true"/);
+        assert.match(error.message, /timeout_stage="attachment_readiness"/);
+        return true;
+      }
+    );
+  } finally {
+    globalThis.DataTransfer = previousDataTransfer;
+  }
+});
+
+test("fake Claude upload timeout reports an absent send control", async () => {
+  const previousDataTransfer = globalThis.DataTransfer;
+  globalThis.DataTransfer = FakeDataTransfer;
+  try {
+    const input = {
+      files: null,
+      dispatchEvent() {
+        return true;
+      }
+    };
+    const attachment = {
+      textContent: "fixture.md",
+      getAttribute: () => null,
+      querySelector(selector) {
+        if (selector === "h3") return { textContent: "fixture.md" };
+        if (selector === "button[aria-label='Remove']") return {};
+        return null;
+      }
+    };
+    const root = {
+      querySelector(selector) {
+        return selector === "input[data-testid='file-upload']" ? input : null;
+      },
+      querySelectorAll(selector) {
+        if (selector === "input[data-testid='file-upload']") return [input];
+        if (selector === "[data-testid='file-thumbnail']") return [attachment];
+        return [];
+      }
+    };
+
+    await assert.rejects(
+      () => uploadFile(root, new File(["bundle"], "fixture.md", { type: "text/markdown" }), {
+        timeoutMs: 1
+      }),
+      (error) => {
+        assert.match(error.message, /filename_match=true/);
+        assert.match(error.message, /remove_present=true/);
+        assert.match(error.message, /attachment_busy=\[\]/);
+        assert.match(error.message, /attachment_failures=\[\]/);
+        assert.match(error.message, /send_present=false/);
+        assert.match(error.message, /send_disabled=null/);
+        assert.match(error.message, /send_aria_disabled=null/);
+        assert.match(error.message, /timeout_stage="attachment_readiness"/);
+        return true;
+      }
+    );
+  } finally {
+    globalThis.DataTransfer = previousDataTransfer;
+  }
+});
+
+test("fake Claude upload timeout identifies the file-input wait", async () => {
+  const root = {
+    querySelector: () => null,
+    querySelectorAll: () => []
+  };
+
+  await assert.rejects(
+    () => uploadFile(root, new File(["bundle"], "fixture.md", { type: "text/markdown" }), {
+      timeoutMs: 1
+    }),
+    (error) => {
+      assert.match(error.message, /file_input_count=0/);
+      assert.match(error.message, /timeout_stage="file_input"/);
+      return true;
+    }
+  );
+});
+
 test("fake Claude model picker drives hover-only Max then closes", async () => {
   const fixture = makeClaudeModelFixture();
   const previousPointerEvent = globalThis.PointerEvent;


### PR DESCRIPTION
## Summary
- report per-leg Claude upload readiness evidence only when a wait times out
- identify the timed-out upload stage and distinguish absent versus disabled send controls
- label inspect-time model diagnostics as `current_model_chip_state` for both ChatGPT and Claude

## Verification
- `cd extensions/chatgpt-native && npm test` (278 passed)
- `git diff --check`

## Holds
- no managed-extension update or reload
- no live browser run or 184KB case