### PR TITLE
feat: add Claude attachment stall observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Claude upload timeouts now report per-leg readiness evidence for the file
   input, attachment, and send control, including which wait stage expired.
+- Added the opt-in `attachment_stall_timeout_ms` Claude recipe var. When set
+  above `upload_timeout_ms`, it observes the already-dispatched attachment to
+  that deadline and returns `attachment_stalled` with a timestamped readiness
+  trace. Its default of `0` preserves the existing upload-timeout behavior.
 
 ### Documentation
 

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -1589,6 +1589,7 @@ pub fn canary(
                 wait_timeout_ms: 180_000,
                 wait_interval_ms: 1_000,
                 upload_timeout_ms: 30_000,
+                attachment_stall_timeout_ms: 0,
                 send_timeout_ms: 120_000,
                 close_tab_on_complete,
                 warnings: Vec::new(),
@@ -1895,6 +1896,7 @@ fn claude_job_start_payload(spec: &ClaudeRecipeSpec, bundle: &BundleInfo) -> Val
         "wait_timeout_ms": spec.wait_timeout_ms,
         "wait_interval_ms": spec.wait_interval_ms,
         "upload_timeout_ms": spec.upload_timeout_ms,
+        "attachment_stall_timeout_ms": spec.attachment_stall_timeout_ms,
         "send_timeout_ms": spec.send_timeout_ms,
         "close_tab_on_complete": spec.close_tab_on_complete,
     })
@@ -3154,6 +3156,15 @@ fn append_job_error_detail(payload: &Value, message: &str, detail: &mut Vec<Stri
             detail.push(format!("inspect with: {inspect_command}"));
         }
     }
+    if let Some(trace) = payload.get("attachment_trace").and_then(Value::as_object) {
+        if let Ok(trace) = serde_json::to_string(trace) {
+            if trace.len() <= 4096 {
+                detail.push(format!("attachment_trace={trace}"));
+            } else {
+                detail.push(format!("attachment_trace=<omitted: {} bytes>", trace.len()));
+            }
+        }
+    }
 }
 
 fn emit_progress(format: OutputFormat, envelope: &ProtocolEnvelope) -> Result<()> {
@@ -4301,6 +4312,33 @@ mod tests {
     }
 
     #[test]
+    fn job_error_message_surfaces_attachment_trace() {
+        let message = job_error_message(&json!({
+            "code": "attachment_stalled",
+            "message": "Claude attachment stalled before readiness",
+            "attachment_trace": {
+                "final_chunk_ack_at_ms": 100,
+                "hard_timeout_pending_legs": ["matching_thumbnail"]
+            }
+        }));
+
+        assert!(message.contains("attachment_trace="));
+        assert!(message.contains("final_chunk_ack_at_ms"));
+        assert!(message.contains("matching_thumbnail"));
+    }
+
+    #[test]
+    fn job_error_message_marks_an_oversized_attachment_trace() {
+        let message = job_error_message(&json!({
+            "code": "attachment_stalled",
+            "message": "Claude attachment stalled before readiness",
+            "attachment_trace": { "diagnostic": "x".repeat(4097) }
+        }));
+
+        assert!(message.contains("attachment_trace=<omitted:"));
+    }
+
+    #[test]
     fn frame_round_trips_json_envelope() {
         let envelope = ProtocolEnvelope::new(
             "job_progress",
@@ -4369,6 +4407,7 @@ mod tests {
             wait_timeout_ms: 10_000,
             wait_interval_ms: 1_000,
             upload_timeout_ms: 2_000,
+            attachment_stall_timeout_ms: 420_000,
             send_timeout_ms: 3_000,
             close_tab_on_complete: false,
             warnings: vec!["size warning".to_string()],
@@ -4384,6 +4423,7 @@ mod tests {
         assert_eq!(payload["model_strategy"], "select");
         assert_eq!(payload["conversation_id"], conversation_id);
         assert_eq!(payload["extension_instance_id"], "ext_claude");
+        assert_eq!(payload["attachment_stall_timeout_ms"], 420_000);
         assert_eq!(payload["close_tab_on_complete"], false);
     }
 

--- a/crates/yoetz-cli/src/claude_recipe.rs
+++ b/crates/yoetz-cli/src/claude_recipe.rs
@@ -51,6 +51,7 @@ pub struct ClaudeRecipeSpec {
     pub wait_timeout_ms: u64,
     pub wait_interval_ms: u64,
     pub upload_timeout_ms: u64,
+    pub attachment_stall_timeout_ms: u64,
     pub send_timeout_ms: u64,
     pub close_tab_on_complete: bool,
     pub warnings: Vec<String>,

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -2533,6 +2533,15 @@ fn build_claude_recipe_spec(
     let poll_settings = dev_browser::resolve_chatgpt_poll_settings(recipe_vars)?;
     let upload_timeout_ms =
         dev_browser::resolve_chatgpt_upload_timeout_ms(recipe_vars, recipe_args.bundle.as_deref())?;
+    let attachment_stall_timeout_ms = recipe_vars
+        .get("attachment_stall_timeout_ms")
+        .map(|raw| {
+            raw.parse::<u64>().with_context(|| {
+                format!("invalid recipe var `attachment_stall_timeout_ms` value `{raw}`")
+            })
+        })
+        .transpose()?
+        .unwrap_or(0);
     let send_timeout_ms = dev_browser::resolve_chatgpt_send_timeout_ms(recipe_vars)?;
     claude_web::validate_thread_mode(recipe_vars.get("thread").map(String::as_str))?;
     let conversation = recipe_vars
@@ -2572,6 +2581,7 @@ fn build_claude_recipe_spec(
         wait_timeout_ms: poll_settings.timeout_ms,
         wait_interval_ms: poll_settings.interval_ms,
         upload_timeout_ms,
+        attachment_stall_timeout_ms,
         send_timeout_ms,
         close_tab_on_complete: !recipe_args.keep_tab,
         warnings: warnings.to_vec(),
@@ -8093,6 +8103,46 @@ mod tests {
         assert_eq!(spec.model, chatgpt_recipe::CHATGPT_SOL_PRO_MODEL);
         assert!(!recipe_vars.contains_key("model"));
         assert!(!recipe_vars.contains_key("extended"));
+    }
+
+    #[test]
+    fn builtin_claude_recipe_routes_attachment_stall_timeout_from_recipe_var_to_native_spec() {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../recipes/claude.yaml");
+        let content = fs::read_to_string(&path).expect("read recipes/claude.yaml");
+        let recipe: browser::Recipe = serde_yaml_ng::from_str(&content).expect("parse claude.yaml");
+        let defaults = browser::build_recipe_vars(recipe.defaults.as_ref(), &[])
+            .expect("build default recipe vars");
+        assert_eq!(
+            defaults
+                .get("attachment_stall_timeout_ms")
+                .map(String::as_str),
+            Some("0")
+        );
+        let recipe_args = BrowserRecipeArgs {
+            recipe: PathBuf::from("recipes/claude.yaml"),
+            transport: None,
+            allow_cdp_fallback: false,
+            keep_tab: false,
+            bundle: Some(PathBuf::from("/tmp/bundle.md")),
+            profile: None,
+            cdp: None,
+            browser_id: None,
+            model_strategy: chatgpt_recipe::ChatgptModelStrategy::Select,
+            vars: vec!["attachment_stall_timeout_ms=420000".to_string()],
+            followup: None,
+            thread: None,
+            fresh: false,
+            on_thread_conflict: None,
+            allow_duplicate_prompt: false,
+            no_notify: false,
+        };
+
+        let recipe_vars = browser::build_recipe_vars(recipe.defaults.as_ref(), &recipe_args.vars)
+            .expect("build recipe vars");
+        let spec = build_claude_recipe_spec(&recipe_args, &recipe_vars, &[]).unwrap();
+
+        assert_eq!(recipe_vars["attachment_stall_timeout_ms"], "420000");
+        assert_eq!(spec.attachment_stall_timeout_ms, 420_000);
     }
 
     #[test]

--- a/extensions/chatgpt-native/src/claude-dom.js
+++ b/extensions/chatgpt-native/src/claude-dom.js
@@ -116,28 +116,112 @@ export async function insertPrompt(root, prompt, options = {}) {
 
 export async function uploadFile(root, file, options = {}) {
   const timeoutMs = options.timeoutMs ?? 120000;
+  const stallTimeoutMs = Math.max(timeoutMs, options.stallTimeoutMs ?? timeoutMs);
+  const attachmentTrace = initialAttachmentTrace(options.initialAttachmentTrace);
   let timeoutStage = "file_input";
   try {
     const input = await waitFor(() => findFileInput(root), Math.min(timeoutMs, 20000));
+    attachmentTrace.input_resolved_at_ms = Date.now();
     const transfer = new DataTransfer();
     transfer.items.add(file);
     input.files = transfer.files;
+    attachmentTrace.files_assigned_at_ms = Date.now();
     input.dispatchEvent(new Event("change", { bubbles: true }));
+    attachmentTrace.change_dispatched_at_ms = Date.now();
     timeoutStage = "attachment_readiness";
-    await waitFor(() => {
-      const attachment = Array.from(root.querySelectorAll(ATTACHMENT_SELECTOR)).find((node) =>
-        normalizeText(node.querySelector("h3")?.textContent) === file.name
-        && Boolean(node.querySelector("button[aria-label='Remove']"))
-      );
-      const send = findSendButton(root);
-      return attachment && send && !send.disabled && send.getAttribute("aria-disabled") !== "true";
-    }, timeoutMs);
+    await waitForAttachmentReadiness(root, file.name, attachmentTrace, timeoutMs, stallTimeoutMs);
     return true;
   } catch (error) {
     if (error?.isClaudeWaitTimeout) {
       error.message = `${error.message}; upload diagnostics: ${claudeUploadDiagnosticSummary(root, file.name, timeoutStage)}`;
     }
     throw error;
+  }
+}
+
+const ATTACHMENT_READINESS_LEGS = Object.freeze([
+  "matching_thumbnail",
+  "remove_control",
+  "send_present",
+  "send_enabled"
+]);
+
+function initialAttachmentTrace(value) {
+  const trace = {};
+  const finalChunkAckAtMs = Number(value?.final_chunk_ack_at_ms);
+  if (Number.isFinite(finalChunkAckAtMs) && finalChunkAckAtMs >= 0) {
+    trace.final_chunk_ack_at_ms = finalChunkAckAtMs;
+  }
+  return trace;
+}
+
+function attachmentReadiness(root, filename) {
+  const matchingThumbnails = Array.from(root.querySelectorAll(ATTACHMENT_SELECTOR)).filter((node) =>
+    normalizeText(node.querySelector("h3")?.textContent) === filename
+  );
+  const removeControl = matchingThumbnails.some((node) =>
+    Boolean(node.querySelector("button[aria-label='Remove']"))
+  );
+  const send = findSendButton(root);
+  const sendPresent = Boolean(send);
+  const sendEnabled = sendPresent
+    && !send.disabled
+    && send.getAttribute("aria-disabled") !== "true";
+  return {
+    matching_thumbnail: matchingThumbnails.length > 0,
+    remove_control: removeControl,
+    send_present: sendPresent,
+    send_enabled: sendEnabled
+  };
+}
+
+function recordAttachmentReadiness(trace, readiness, now) {
+  for (const leg of ATTACHMENT_READINESS_LEGS) {
+    const timestampKey = `${leg}_at_ms`;
+    if (readiness[leg] && trace[timestampKey] === undefined) {
+      trace[timestampKey] = now;
+    }
+  }
+}
+
+function pendingAttachmentLegs(readiness) {
+  return ATTACHMENT_READINESS_LEGS.filter((leg) => !readiness[leg]);
+}
+
+async function waitForAttachmentReadiness(root, filename, trace, softTimeoutMs, stallTimeoutMs) {
+  const dispatchedAtMs = trace.change_dispatched_at_ms ?? Date.now();
+  const softDeadline = dispatchedAtMs + softTimeoutMs;
+  const hardDeadline = dispatchedAtMs + stallTimeoutMs;
+  while (true) {
+    const now = Date.now();
+    const readiness = attachmentReadiness(root, filename);
+    recordAttachmentReadiness(trace, readiness, now);
+    if (ATTACHMENT_READINESS_LEGS.every((leg) => readiness[leg])) {
+      return true;
+    }
+    if (now >= softDeadline && trace.soft_timeout_at_ms === undefined) {
+      trace.soft_timeout_at_ms = now;
+      trace.soft_timeout_pending_legs = pendingAttachmentLegs(readiness);
+    }
+    if (now >= hardDeadline) {
+      if (hardDeadline === softDeadline) {
+        const error = new Error(`Claude page did not reach the requested state within ${softTimeoutMs}ms`);
+        error.isClaudeWaitTimeout = true;
+        throw error;
+      }
+      trace.hard_timeout_at_ms = now;
+      trace.hard_timeout_pending_legs = pendingAttachmentLegs(readiness);
+      throw commandError(
+        "attachment_stalled",
+        `Claude attachment stalled before readiness within ${stallTimeoutMs}ms`,
+        {
+          phase: "upload",
+          side_effect_started: true,
+          attachment_trace: trace
+        }
+      );
+    }
+    await sleep(Math.min(100, Math.max(1, hardDeadline - now)));
   }
 }
 

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -118,7 +118,16 @@ async function uploadJobFile(job, filePayload) {
   const file = new File([bytes], filePayload.filename || "yoetz-bundle.md", {
     type: filePayload.mime_type || "text/markdown"
   });
-  await uploadFile(document, file, { timeoutMs: Number(job.upload_timeout_ms) || 120000 });
+  const timeoutMs = Number(job.upload_timeout_ms) || 120000;
+  const uploadOptions = { timeoutMs };
+  if (adapter.recipe === "claude") {
+    const stallTimeoutMs = Number(job.attachment_stall_timeout_ms);
+    if (Number.isFinite(stallTimeoutMs) && stallTimeoutMs > timeoutMs) {
+      uploadOptions.stallTimeoutMs = stallTimeoutMs;
+    }
+    uploadOptions.initialAttachmentTrace = job.attachment_trace;
+  }
+  await uploadFile(document, file, uploadOptions);
   return { filename: file.name, size: file.size };
 }
 
@@ -527,6 +536,9 @@ function errorResponse(error) {
   }
   if (typeof error?.side_effect_started === "boolean") {
     response.side_effect_started = error.side_effect_started;
+  }
+  if (error?.attachment_trace !== undefined) {
+    response.attachment_trace = error.attachment_trace;
   }
   for (const key of [
     "requested_conversation_id",

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -85,6 +85,24 @@ const LEGACY_JOBS_KEY = "jobs";
 // The full streaming text remains on the in-memory job for delta calculation; only the
 // tail is written to disk so a multi-MB Pro response cannot blow the 10MB session quota.
 const RESPONSE_TEXT_PERSIST_TAIL = 8 * 1024;
+const ATTACHMENT_TRACE_TIMESTAMP_KEYS = Object.freeze([
+  "final_chunk_ack_at_ms",
+  "input_resolved_at_ms",
+  "files_assigned_at_ms",
+  "change_dispatched_at_ms",
+  "matching_thumbnail_at_ms",
+  "remove_control_at_ms",
+  "send_present_at_ms",
+  "send_enabled_at_ms",
+  "soft_timeout_at_ms",
+  "hard_timeout_at_ms"
+]);
+const ATTACHMENT_TRACE_PENDING_LEGS = new Set([
+  "matching_thumbnail",
+  "remove_control",
+  "send_present",
+  "send_enabled"
+]);
 
 const jobs = new Map();
 const terminalJobIds = new Map();
@@ -421,6 +439,9 @@ async function acceptFileChunk(message) {
   }
 
   const file = chunks.takeFile(job.job_id);
+  if (job.recipe === "claude") {
+    job.attachment_trace = { final_chunk_ack_at_ms: Date.now() };
+  }
   job.status = "file_received";
   job.updated_at = Date.now();
   await persistJob(job);
@@ -1180,6 +1201,7 @@ function normalizeJob(message, adapter) {
     wait_timeout_ms: payload.wait_timeout_ms ?? DEFAULT_WAIT_TIMEOUT_MS,
     wait_interval_ms: payload.wait_interval_ms ?? 30000,
     upload_timeout_ms: payload.upload_timeout_ms ?? 120000,
+    attachment_stall_timeout_ms: payload.attachment_stall_timeout_ms ?? 0,
     send_timeout_ms: payload.send_timeout_ms ?? 120000,
     close_tab_on_complete: payload.close_tab_on_complete === true,
     browser_context_id: payload.browser_context_id ?? null,
@@ -1235,7 +1257,30 @@ function errorContextForJob(job, error = null) {
     detail.current_url = error?.current_url ?? job.submitted_url ?? null;
     detail.current_pathname = error?.current_pathname ?? null;
   }
+  const attachmentTrace = sanitizeAttachmentTrace(error?.attachment_trace);
+  if (attachmentTrace) {
+    detail.attachment_trace = attachmentTrace;
+  }
   return detail;
+}
+
+function sanitizeAttachmentTrace(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const trace = {};
+  for (const key of ATTACHMENT_TRACE_TIMESTAMP_KEYS) {
+    const timestamp = value[key];
+    if (Number.isSafeInteger(timestamp) && timestamp >= 0) {
+      trace[key] = timestamp;
+    }
+  }
+  for (const key of ["soft_timeout_pending_legs", "hard_timeout_pending_legs"]) {
+    if (Array.isArray(value[key])) {
+      trace[key] = value[key].filter((leg) => ATTACHMENT_TRACE_PENDING_LEGS.has(leg)).slice(0, 4);
+    }
+  }
+  return Object.keys(trace).length > 0 ? trace : null;
 }
 
 function jobErrorMessage(job, error, code, detail = {}) {
@@ -1488,6 +1533,9 @@ function tabCommandError(response) {
   }
   if (typeof response?.side_effect_started === "boolean") {
     error.side_effect_started = response.side_effect_started;
+  }
+  if (response?.attachment_trace !== undefined) {
+    error.attachment_trace = response.attachment_trace;
   }
   for (const key of [
     "requested_conversation_id",

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -72,6 +72,9 @@ export function markOwnership(_document, job) {
 
 export async function uploadFile(_document, file, options) {
   hooks.uploadFileCalls.push({ file_name: file.name, size: file.size, options });
+  if (hooks.uploadFileError) {
+    throw hooks.uploadFileError;
+  }
   return true;
 }
 
@@ -132,7 +135,7 @@ const dom = {
 };
 
 export const siteAdapter = {
-  recipe: "chatgpt",
+  recipe: hooks.recipe ?? "chatgpt",
   displayName: "ChatGPT",
   dom,
   fetchConversationAnswer,
@@ -188,6 +191,81 @@ test("content script resume path skips fresh enforcement and completes on reques
     const extracted = await send({ type: "yoetz_extract_response", job });
     assert.equal(extracted.ok, true);
     assert.equal(extracted.payload.conversation_id, "conv-123");
+  } finally {
+    restore();
+  }
+});
+
+test("content script preserves an attachment-stalled trace from the upload adapter", async () => {
+  const { send, hooks, restore } = await loadContentScript("attachment_trace", "https://chatgpt.com/c/conv-123?_yoetz=run_resume");
+  try {
+    const job = resumeJob();
+    const error = new Error("Claude attachment stalled");
+    error.code = "attachment_stalled";
+    error.phase = "upload";
+    error.side_effect_started = true;
+    error.attachment_trace = {
+      final_chunk_ack_at_ms: 100,
+      input_resolved_at_ms: 101,
+      files_assigned_at_ms: 102,
+      change_dispatched_at_ms: 103,
+      hard_timeout_at_ms: 420000,
+      hard_timeout_pending_legs: ["matching_thumbnail"]
+    };
+    hooks.uploadFileError = error;
+
+    const prepared = await send({ type: "yoetz_prepare_job", job });
+    assert.equal(prepared.ok, true);
+
+    const response = await send({
+      type: "yoetz_upload_file",
+      job,
+      file: {
+        filename: "bundle.md",
+        mime_type: "text/markdown",
+        bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+      }
+    });
+
+    assert.equal(response.ok, false);
+    assert.equal(response.code, "attachment_stalled");
+    assert.deepEqual(response.attachment_trace, error.attachment_trace);
+  } finally {
+    restore();
+  }
+});
+
+test("content script extends Claude attachment observation only when the stall window is opt in", async () => {
+  const { send, hooks, restore } = await loadContentScript("claude_opt_in_stall", "https://chatgpt.com/c/conv-123?_yoetz=run_resume");
+  try {
+    hooks.recipe = "claude";
+    const job = { ...resumeJob(), recipe: "claude" };
+    const prepared = await send({ type: "yoetz_prepare_job", job });
+    assert.equal(prepared.ok, true);
+
+    const defaultUpload = await send({
+      type: "yoetz_upload_file",
+      job,
+      file: {
+        filename: "bundle.md",
+        mime_type: "text/markdown",
+        bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+      }
+    });
+    assert.equal(defaultUpload.ok, true);
+    assert.equal(hooks.uploadFileCalls[0].options.stallTimeoutMs, undefined);
+
+    const optedInUpload = await send({
+      type: "yoetz_upload_file",
+      job: { ...job, attachment_stall_timeout_ms: 1500 },
+      file: {
+        filename: "bundle.md",
+        mime_type: "text/markdown",
+        bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+      }
+    });
+    assert.equal(optedInUpload.ok, true);
+    assert.equal(hooks.uploadFileCalls[1].options.stallTimeoutMs, 1500);
   } finally {
     restore();
   }

--- a/extensions/chatgpt-native/tests/fake-claude.test.js
+++ b/extensions/chatgpt-native/tests/fake-claude.test.js
@@ -119,6 +119,157 @@ test("fake Claude upload waits for the committed chip and re-enabled send", asyn
   }
 });
 
+test("fake Claude upload accepts a later duplicate thumbnail that has the remove control", async () => {
+  const previousDataTransfer = globalThis.DataTransfer;
+  globalThis.DataTransfer = FakeDataTransfer;
+  try {
+    const input = {
+      files: null,
+      dispatchEvent() {
+        return true;
+      }
+    };
+    const thumbnail = (hasRemoveControl) => ({
+      querySelector(selector) {
+        if (selector === "h3") return { textContent: "fixture.md" };
+        if (selector === "button[aria-label='Remove']") return hasRemoveControl ? {} : null;
+        return null;
+      }
+    });
+    const root = {
+      querySelector(selector) {
+        if (selector === "input[data-testid='file-upload']") return input;
+        if (selector === "button[aria-label='Send message']") {
+          return { disabled: false, getAttribute: () => null };
+        }
+        return null;
+      },
+      querySelectorAll(selector) {
+        return selector === "[data-testid='file-thumbnail']"
+          ? [thumbnail(false), thumbnail(true)]
+          : [];
+      }
+    };
+
+    await uploadFile(root, new File(["bundle"], "fixture.md", { type: "text/markdown" }), {
+      timeoutMs: 50
+    });
+  } finally {
+    globalThis.DataTransfer = previousDataTransfer;
+  }
+});
+
+test("fake Claude upload keeps observing after its soft deadline without redispatching", async () => {
+  const previousDataTransfer = globalThis.DataTransfer;
+  globalThis.DataTransfer = FakeDataTransfer;
+  try {
+    let attachment = null;
+    let dispatches = 0;
+    const send = {
+      disabled: true,
+      getAttribute: () => null
+    };
+    const input = {
+      files: null,
+      dispatchEvent(event) {
+        assert.equal(event.type, "change");
+        dispatches += 1;
+        const name = this.files[0].name;
+        setTimeout(() => {
+          attachment = {
+            querySelector(selector) {
+              if (selector === "h3") return { textContent: name };
+              if (selector === "button[aria-label='Remove']") return {};
+              return null;
+            }
+          };
+          send.disabled = false;
+        }, 150);
+        return true;
+      }
+    };
+    const root = {
+      querySelector(selector) {
+        if (selector === "input[data-testid='file-upload']") return input;
+        if (selector === "button[aria-label='Send message']") return send;
+        return null;
+      },
+      querySelectorAll(selector) {
+        return selector === "[data-testid='file-thumbnail']" && attachment ? [attachment] : [];
+      }
+    };
+
+    await uploadFile(root, new File(["bundle"], "fixture.md", { type: "text/markdown" }), {
+      timeoutMs: 50,
+      stallTimeoutMs: 300
+    });
+
+    assert.equal(dispatches, 1);
+    assert.equal(send.disabled, false);
+  } finally {
+    globalThis.DataTransfer = previousDataTransfer;
+  }
+});
+
+test("fake Claude upload reports a bounded attachment trace when it stalls", async () => {
+  const previousDataTransfer = globalThis.DataTransfer;
+  globalThis.DataTransfer = FakeDataTransfer;
+  try {
+    let dispatches = 0;
+    const input = {
+      files: null,
+      dispatchEvent() {
+        dispatches += 1;
+        return true;
+      }
+    };
+    const root = {
+      querySelector(selector) {
+        if (selector === "input[data-testid='file-upload']") return input;
+        if (selector === "button[aria-label='Send message']") {
+          return { disabled: true, getAttribute: () => "true" };
+        }
+        return null;
+      },
+      querySelectorAll(selector) {
+        return selector === "input[data-testid='file-upload']" ? [input] : [];
+      }
+    };
+    const finalChunkAckAtMs = Date.now();
+
+    await assert.rejects(
+      () => uploadFile(root, new File(["bundle"], "fixture.md", { type: "text/markdown" }), {
+        timeoutMs: 50,
+        stallTimeoutMs: 150,
+        initialAttachmentTrace: { final_chunk_ack_at_ms: finalChunkAckAtMs }
+      }),
+      (error) => {
+        assert.equal(error.code, "attachment_stalled");
+        assert.equal(error.phase, "upload");
+        assert.equal(error.side_effect_started, true);
+        assert.match(error.message, /attachment stalled/);
+        assert.equal(error.attachment_trace.final_chunk_ack_at_ms, finalChunkAckAtMs);
+        assert.ok(Number.isFinite(error.attachment_trace.input_resolved_at_ms));
+        assert.ok(Number.isFinite(error.attachment_trace.files_assigned_at_ms));
+        assert.ok(Number.isFinite(error.attachment_trace.change_dispatched_at_ms));
+        assert.ok(Number.isFinite(error.attachment_trace.soft_timeout_at_ms));
+        assert.ok(Number.isFinite(error.attachment_trace.hard_timeout_at_ms));
+        assert.deepEqual(error.attachment_trace.hard_timeout_pending_legs, [
+          "matching_thumbnail",
+          "remove_control",
+          "send_enabled"
+        ]);
+        assert.equal(JSON.stringify(error.attachment_trace).includes("fixture.md"), false);
+        return true;
+      }
+    );
+
+    assert.equal(dispatches, 1);
+  } finally {
+    globalThis.DataTransfer = previousDataTransfer;
+  }
+});
+
 test("fake Claude upload timeout reports each attachment readiness leg", async () => {
   const previousDataTransfer = globalThis.DataTransfer;
   globalThis.DataTransfer = FakeDataTransfer;

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -767,6 +767,89 @@ test("service worker reports a generic Claude model timeout as model_selection",
   }
 });
 
+test("service worker surfaces a Claude attachment-stalled trace in the job error", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  let uploadJob = null;
+  const attachmentTrace = {
+    final_chunk_ack_at_ms: 100,
+    input_resolved_at_ms: 101,
+    files_assigned_at_ms: 102,
+    change_dispatched_at_ms: 103,
+    soft_timeout_at_ms: 125000,
+    hard_timeout_at_ms: 420000,
+    hard_timeout_pending_legs: ["matching_thumbnail", "remove_control"]
+  };
+
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (options) => ({ id: 71, ...options }),
+      get: async (id) => ({ id, status: "complete", url: "https://claude.ai/new?_yoetz=run_job_claude_attachment_stalled" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: { recipe: "claude" } };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: verifiedFableMaxSelection() };
+          case "yoetz_upload_file":
+            uploadJob = message.job;
+            return {
+              ok: false,
+              code: "attachment_stalled",
+              error: "Claude attachment stalled before readiness",
+              phase: "upload",
+              side_effect_started: true,
+              attachment_trace: attachmentTrace
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?claude_attachment_trace=${Date.now()}`);
+    await eventually(() => port.messages.some((message) => message.type === "hello"));
+    port.messages.length = 0;
+
+    port.emit(envelope("job_start", "job_claude_attachment_stalled", {
+      recipe: "claude",
+      prompt: "review",
+      attachment_stall_timeout_ms: 420000
+    }));
+    await eventually(() => port.messages.some((message) =>
+      message.job_id === "job_claude_attachment_stalled"
+      && message.payload?.phase === "ready_for_file"
+    ));
+    port.emit(envelope("job_file_chunk", "job_claude_attachment_stalled", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "bundle.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) =>
+      message.type === "job_error" && message.job_id === "job_claude_attachment_stalled"
+    ));
+    const error = port.messages.find((message) =>
+      message.type === "job_error" && message.job_id === "job_claude_attachment_stalled"
+    );
+    assert.equal(error.payload.code, "attachment_stalled");
+    assert.equal(error.payload.phase, "upload");
+    assert.deepEqual(error.payload.attachment_trace, attachmentTrace);
+    assert.ok(Number.isSafeInteger(uploadJob?.attachment_trace?.final_chunk_ack_at_ms));
+    assert.equal(uploadJob?.attachment_stall_timeout_ms, 420000);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker surfaces Claude model mismatch legs in the job error", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();

--- a/recipes/claude.yaml
+++ b/recipes/claude.yaml
@@ -29,6 +29,9 @@ name: claude
 # from the extension isolated world. Finality requires a non-streaming last
 # assistant turn and no Stop response control; cloned group/status thinking rows
 # are excluded from answer text without mutating the live DOM.
+# attachment_stall_timeout_ms is an opt-in post-upload observation deadline.
+# Zero preserves the upload_timeout_ms failure behavior; set it above that soft
+# timeout only for a deliberate instrumented attachment investigation.
 # The typed builtin path prepends an output-channel contract that keeps the
 # deliverable in the chat message; custom recipes remain caller-controlled.
 #
@@ -40,6 +43,7 @@ defaults:
   prompt: Review the attached file and provide your analysis.
   thread: "fresh"
   upload_timeout_ms: "120000"
+  attachment_stall_timeout_ms: "0"
   upload_interval_ms: "2000"
   send_timeout_ms: "120000"
   wait_timeout_ms: "5400000"


### PR DESCRIPTION
## Summary

- Adds an opt-in `attachment_stall_timeout_ms` Claude recipe variable for observing a dispatched upload beyond the normal soft timeout.
- Returns a bounded, sanitized readiness trace when that observation reaches an attachment stall.
- Keeps the default at `0`, preserving current upload-timeout behavior exactly.

## Validation

- `npm test` (extensions/chatgpt-native)
- `cargo fmt --check`
- `cargo test -p yoetz browser_extension_native::tests`
- `cargo test -p yoetz builtin_claude_recipe_routes_attachment_stall_timeout_from_recipe_var_to_native_spec`
- `git diff --check`

## Hold

Do not merge. Aviv owns merge because `main` publishes the marketplace. No managed extension lifecycle or live recipe run was performed while the lifecycle lock is active.