### PR TITLE
fix: reduce attended browser completion lag

### DIFF
--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -60,6 +60,13 @@ const AFFORDANCE_CONFIRM_POLL_MS = Math.max(
   250,
   Number(globalThis.__YOETZ_AFFORDANCE_CONFIRM_POLL_MS ?? 1500) || 1500
 );
+// Once assistant text is visible after send, shorten only the observation
+// cadence. The stable-idle threshold remains derived from the configured job
+// interval so adaptive polling cannot weaken finality.
+const POST_SEND_ASSISTANT_ACTIVITY_POLL_MS = Math.max(
+  250,
+  Number(globalThis.__YOETZ_POST_SEND_ASSISTANT_ACTIVITY_POLL_MS ?? 2000) || 2000
+);
 const MAX_NATIVE_OUTBOUND_BYTES = Math.max(
   1024,
   Number(globalThis.__YOETZ_MAX_NATIVE_OUTBOUND_BYTES ?? 64 * 1024 * 1024) || 64 * 1024 * 1024
@@ -1591,7 +1598,11 @@ async function waitForResponse(job) {
   let renderRefreshCandidate = null;
   let renderRefreshCandidateSinceMs = 0;
   let extractionFailureSinceMs = 0;
+  let lastResponseProgressAt = 0;
+  let lastResponseProgressGenerating = null;
+  let lastResponseProgressInterimTurn = false;
   let lastWaitingProgressAt = startedAt;
+  let reportedAwaitingFinalAffordance = false;
   const timeoutMs = responseWaitTimeoutMs(job);
   while (Date.now() - startedAt <= timeoutMs) {
     assertJobConnectionCurrent(job);
@@ -1621,8 +1632,21 @@ async function waitForResponse(job) {
       best = extraction;
     }
     if (postSend && extraction?.text) {
-      postResponseProgress(job, extraction);
-      assertJobConnectionCurrent(job);
+      const responseProgressState = interimTurnState(job, extraction);
+      const meaningfulProgressTransition = (
+        responseProgressState.interimAssistantTurn && !lastResponseProgressInterimTurn
+      ) || (
+        lastResponseProgressGenerating === true && !responseProgressState.generating
+      );
+      if (!lastResponseProgressAt
+          || meaningfulProgressTransition
+          || Date.now() - lastResponseProgressAt >= interval) {
+        postResponseProgress(job, extraction);
+        lastResponseProgressAt = Date.now();
+        assertJobConnectionCurrent(job);
+      }
+      lastResponseProgressGenerating = responseProgressState.generating;
+      lastResponseProgressInterimTurn = responseProgressState.interimAssistantTurn;
     }
     const extractionIdle = !extraction?.is_generating;
     const backendApiPending = Boolean(extraction?.backend_api_pending);
@@ -1818,12 +1842,17 @@ async function waitForResponse(job) {
       // Poll fast while confirming a latched final affordance so the short confirm
       // window is sampled across several ticks rather than overshot by a coarse poll.
       ? Math.min(interval, AFFORDANCE_CONFIRM_POLL_MS)
-      : (finalAffordanceWithoutScopedText
-          ? Math.min(interval, Math.max(finalAffordanceIdleMs, 500))
-          : interval);
+      : finalAffordanceWithoutScopedText
+        ? Math.min(interval, Math.max(finalAffordanceIdleMs, 500))
+      : postSendAssistantActivity
+        ? Math.min(interval, POST_SEND_ASSISTANT_ACTIVITY_POLL_MS)
+        : interval;
     const nowMs = Date.now();
     const elapsedMs = nowMs - startedAt;
-    if (nowMs - lastWaitingProgressAt >= WAITING_RESPONSE_PROGRESS_INTERVAL_MS) {
+    const enteredAwaitingFinalAffordance =
+      awaitingFinalAffordance && !reportedAwaitingFinalAffordance;
+    if (enteredAwaitingFinalAffordance
+        || nowMs - lastWaitingProgressAt >= WAITING_RESPONSE_PROGRESS_INTERVAL_MS) {
       const waitingDetail = {
         elapsed_ms: elapsedMs,
         timeout_ms: timeoutMs,
@@ -1841,6 +1870,7 @@ async function waitForResponse(job) {
         waitingDetail.inspect_command = inspectCommandForJob(job);
       }
       postWaitingResponseProgress(job, extraction, waitingDetail);
+      reportedAwaitingFinalAffordance ||= enteredAwaitingFinalAffordance;
       lastWaitingProgressAt = nowMs;
     }
     await sleep(nextDelay);

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -3271,6 +3271,304 @@ test("service worker emits low-noise waiting progress while ChatGPT is quiet", a
   }
 });
 
+test("service worker polls adaptively after post-send assistant text appears", async () => {
+  const originalChrome = globalThis.chrome;
+  const previousActivityPoll = globalThis.__YOETZ_POST_SEND_ASSISTANT_ACTIVITY_POLL_MS;
+  globalThis.__YOETZ_POST_SEND_ASSISTANT_ACTIVITY_POLL_MS = 250;
+  const port = makePort();
+  const postSendExtractionTimes = [];
+  let tabId = 0;
+  let sent = false;
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: verifiedSolProSelection() };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true } };
+          case "yoetz_extract_response": {
+            if (!sent) {
+              return { ok: true, payload: { method: "none", text: "", is_generating: false, assistant_count: 0, copy_button_count: 0, has_copy_button: false, turn_index: -1 } };
+            }
+            postSendExtractionTimes.push(Date.now());
+            const final = postSendExtractionTimes.length >= 5;
+            return {
+              ok: true,
+              payload: {
+                method: final ? "copy_scope_dom_fallback" : "assistant_dom_fallback",
+                text: final ? "Finished answer." : `Draft ${postSendExtractionTimes.length}`,
+                is_generating: !final,
+                assistant_count: 1,
+                user_count: 1,
+                preceding_user_count: 1,
+                copy_button_count: final ? 1 : 0,
+                has_copy_button: final,
+                turn_index: 0
+              }
+            };
+          }
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?adaptive_post_send_poll=${Date.now()}`);
+    port.emit(envelope("job_start", "job_adaptive_post_send_poll", {
+      prompt: "prompt",
+      wait_interval_ms: 1000,
+      wait_timeout_ms: 5000
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_adaptive_post_send_poll", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_adaptive_post_send_poll.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_complete"), 5000);
+    assert.ok(postSendExtractionTimes.length >= 2);
+    assert.ok(
+      postSendExtractionTimes[1] - postSendExtractionTimes[0] < 750,
+      `expected adaptive poll under 750ms, observed ${postSendExtractionTimes[1] - postSendExtractionTimes[0]}ms`
+    );
+    const responseObserved = port.messages.filter((message) =>
+      message.type === "job_progress" && message.payload?.phase === "response_observed"
+    );
+    assert.equal(
+      responseObserved.filter((message) => message.payload.response_in_progress).length,
+      1,
+      "adaptive polling must not multiply ordinary streaming progress output"
+    );
+  } finally {
+    globalThis.chrome = originalChrome;
+    if (previousActivityPoll === undefined) {
+      delete globalThis.__YOETZ_POST_SEND_ASSISTANT_ACTIVITY_POLL_MS;
+    } else {
+      globalThis.__YOETZ_POST_SEND_ASSISTANT_ACTIVITY_POLL_MS = previousActivityPoll;
+    }
+  }
+});
+
+test("service worker keeps stable-idle finality tied to the configured interval while polling fast", async () => {
+  const originalChrome = globalThis.chrome;
+  const previousActivityPoll = globalThis.__YOETZ_POST_SEND_ASSISTANT_ACTIVITY_POLL_MS;
+  const previousStableIdleMultiplier = globalThis.__YOETZ_STABLE_IDLE_INTERVAL_MULTIPLIER;
+  globalThis.__YOETZ_POST_SEND_ASSISTANT_ACTIVITY_POLL_MS = 250;
+  globalThis.__YOETZ_STABLE_IDLE_INTERVAL_MULTIPLIER = 3;
+  const port = makePort();
+  const postSendExtractionTimes = [];
+  const longAnswer = "Final Pro review paragraph with concrete evidence.\n".repeat(160).trim();
+  let tabId = 0;
+  let sent = false;
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: verifiedSolProSelection() };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true, submitted_assistant_count: 0 } };
+          case "yoetz_extract_response":
+            if (!sent) {
+              return { ok: true, payload: { method: "none", text: "", is_generating: false, assistant_count: 0, copy_button_count: 0, has_copy_button: false, turn_index: -1 } };
+            }
+            postSendExtractionTimes.push(Date.now());
+            return {
+              ok: true,
+              payload: {
+                // Long text plus an unscoped copy control selects the adaptive
+                // stable-idle path whose threshold must remain interval-derived.
+                method: "assistant_dom_fallback",
+                text: longAnswer,
+                is_generating: false,
+                assistant_count: 1,
+                user_count: 1,
+                preceding_user_count: 1,
+                copy_button_count: 1,
+                has_copy_button: false,
+                turn_index: 0,
+                diagnostics: {
+                  counts: { stop_controls: 0, copy_buttons: 1 }
+                }
+              }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?configured_interval_finality=${Date.now()}`);
+    port.emit(envelope("job_start", "job_configured_interval_finality", {
+      prompt: "prompt",
+      wait_interval_ms: 600,
+      wait_timeout_ms: 4000
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_configured_interval_finality", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_configured_interval_finality.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_complete"), 5000);
+    const stableForMs = port.messages.find((message) => message.type === "job_complete")?.payload?.stable_for_ms;
+    assert.ok(postSendExtractionTimes.length >= 6, "adaptive polling should sample repeatedly");
+    assert.ok(
+      postSendExtractionTimes[1] - postSendExtractionTimes[0] < 500,
+      `expected adaptive poll under 500ms, observed ${postSendExtractionTimes[1] - postSendExtractionTimes[0]}ms`
+    );
+    assert.ok(stableForMs >= 1800, `expected configured-interval threshold of 1800ms, observed ${stableForMs}ms`);
+  } finally {
+    globalThis.chrome = originalChrome;
+    if (previousActivityPoll === undefined) {
+      delete globalThis.__YOETZ_POST_SEND_ASSISTANT_ACTIVITY_POLL_MS;
+    } else {
+      globalThis.__YOETZ_POST_SEND_ASSISTANT_ACTIVITY_POLL_MS = previousActivityPoll;
+    }
+    if (previousStableIdleMultiplier === undefined) {
+      delete globalThis.__YOETZ_STABLE_IDLE_INTERVAL_MULTIPLIER;
+    } else {
+      globalThis.__YOETZ_STABLE_IDLE_INTERVAL_MULTIPLIER = previousStableIdleMultiplier;
+    }
+  }
+});
+
+test("service worker emits final-affordance waiting progress once across state flaps", async () => {
+  const originalChrome = globalThis.chrome;
+  const previousWaitingProgressInterval = globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS;
+  globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS = 60000;
+  const port = makePort();
+  let tabId = 0;
+  let sent = false;
+  let postSendExtractCount = 0;
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: verifiedSolProSelection() };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true } };
+          case "yoetz_extract_response": {
+            if (sent) {
+              postSendExtractCount += 1;
+            }
+            const generating = postSendExtractCount === 2;
+            return {
+              ok: true,
+              payload: sent
+                ? {
+                    method: "assistant_dom_fallback",
+                    text: "Settled text without final controls.",
+                    is_generating: generating,
+                    assistant_count: 1,
+                    user_count: 1,
+                    preceding_user_count: 1,
+                    copy_button_count: 0,
+                    has_copy_button: false,
+                    turn_index: 0
+                  }
+                : {
+                    method: "none",
+                    text: "",
+                    is_generating: false,
+                    assistant_count: 0,
+                    copy_button_count: 0,
+                    has_copy_button: false,
+                    turn_index: -1
+                  }
+            };
+          }
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?final_affordance_transition=${Date.now()}`);
+    port.emit(envelope("job_start", "job_final_affordance_transition", {
+      prompt: "prompt",
+      wait_interval_ms: 500,
+      wait_timeout_ms: 2200
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_final_affordance_transition", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_final_affordance_transition.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) => message.type === "job_error"), 4000);
+    const transitionEvents = port.messages.filter((message) =>
+      message.type === "job_progress"
+      && message.payload.phase === "waiting_response"
+      && message.payload.awaiting_final_affordance
+    );
+    assert.ok(postSendExtractCount >= 3, "test must exercise awaiting -> generating -> awaiting");
+    assert.equal(transitionEvents.length, 1);
+    assert.match(transitionEvents[0].payload.message, /waiting for final assistant controls/);
+    assert.equal(
+      transitionEvents[0].payload.inspect_command,
+      "yoetz browser extension inspect --chatgpt --run-id run_job_final_affordance_transition"
+    );
+  } finally {
+    globalThis.chrome = originalChrome;
+    if (previousWaitingProgressInterval === undefined) {
+      delete globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS;
+    } else {
+      globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS = previousWaitingProgressInterval;
+    }
+  }
+});
+
 test("service worker completion is structural and does not classify response text", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();


### PR DESCRIPTION
## Summary

- poll every 2 seconds once post-send assistant activity is visible, while keeping stable-idle finality derived from the configured interval
- emit `awaiting_final_affordance` immediately once per job instead of waiting for the periodic status timer
- keep outward response-progress events at the configured pre-change cadence
- add service-worker regressions for adaptive polling, configured-interval finality, progress throttling, and affordance-state flaps

## Known accepted cost

This patch deliberately increases post-send extraction frequency by roughly 15x at the default cadence (30 seconds to 2 seconds), potentially across the 90-minute default `wait_timeout_ms`. Each Claude extraction currently evaluates `String(root.body?.innerText).length` at `extensions/chatgpt-native/src/claude-dom.js:422`, which can force full-page layout. This cost was explicitly weighed and accepted for the attended-run responsiveness improvement; it is not treated as a defect or a landing blocker.

## Verification

- `node --test extensions/chatgpt-native/tests/*.test.js` — 287/287 passed
- `./scripts/build-chatgpt-native-extension.sh --check` — 19 package files verified
- `node --check` on both changed JavaScript files
- peer technical PASS after two review rounds on frozen diff SHA-256 `fba371ede37c8506d7119fa84ef58170254ab53af4c2de45f6b1ad375530895a`
