### PR TITLE
fix: fail closed when Claude credits are exhausted

### DIFF
--- a/extensions/chatgpt-native/src/claude-dom.js
+++ b/extensions/chatgpt-native/src/claude-dom.js
@@ -9,6 +9,15 @@ const ATTACHMENT_SELECTOR = "[data-testid='file-thumbnail']";
 const COPY_ACTION_SELECTOR = "[data-testid='action-bar-copy']";
 const ASSISTANT_SELECTOR = "[data-is-streaming]";
 const MODEL_MENU_SETTLE_MS = 300;
+const SWITCH_MODELS_CONTROL_SELECTOR = "button, a, [role='button'], [role='link']";
+const CONVERSATION_CONTENT_SELECTOR = [
+  COMPOSER_SELECTOR,
+  "[data-testid='user-message']",
+  "[data-testid*='turn']",
+  "[data-is-streaming]",
+  "article"
+].join(", ");
+const USAGE_CREDITS_PROVIDER_MESSAGE = "Your org is out of usage credits for the month. We let your admin know. Switch models to continue chatting.";
 
 export function ownedWindowName(job) {
   return `${YOETZ_WINDOW_PREFIX}${job.run_id}:${job.job_id}`;
@@ -58,6 +67,31 @@ export function classifyWaitManualHandoff({ url = "", title = "" } = {}) {
   return classifyManualHandoff({ url, title, text: "" });
 }
 
+export function classifyBlockingState(root = document) {
+  const switchModels = visibleElements(root, SWITCH_MODELS_CONTROL_SELECTOR)
+    .filter((element) => normalizeText(element.innerText || element.textContent).toLowerCase() === "switch models")
+    .filter((element) => !element.closest?.(CONVERSATION_CONTENT_SELECTOR));
+  for (const control of switchModels) {
+    let container = control;
+    while (container) {
+      const text = normalizeText(container.innerText || container.textContent).toLowerCase();
+      if (text === USAGE_CREDITS_PROVIDER_MESSAGE.toLowerCase()
+          && isActuallyVisible(root, container)
+          && !container.querySelector?.(CONVERSATION_CONTENT_SELECTOR)) {
+        return {
+          state: "usage_credits_exhausted",
+          code: "usage_credits_exhausted",
+          requested_model: "fable-5-max",
+          provider_message: USAGE_CREDITS_PROVIDER_MESSAGE,
+          message: "Claude cannot run Fable 5 Max because this organization is out of monthly usage credits. Yoetz did not switch models."
+        };
+      }
+      container = container.parentElement;
+    }
+  }
+  return null;
+}
+
 export function findComposer(root = document) {
   return root.querySelector(COMPOSER_SELECTOR);
 }
@@ -86,7 +120,12 @@ export function assertOwnedPage(win, job) {
 }
 
 export async function insertPrompt(root, prompt, options = {}) {
-  const composer = await waitFor(() => findComposer(root), options.timeoutMs ?? 20000);
+  const composer = await waitForClaudeState(
+    root,
+    () => findComposer(root),
+    options.timeoutMs ?? 20000,
+    { phase: "send", side_effect_started: true, send_committed: false }
+  );
   composer.focus();
   const text = String(prompt ?? "");
   if (composer.isContentEditable || composer.getAttribute("contenteditable") === "true") {
@@ -242,6 +281,11 @@ export async function ensureConversationLoaded(root = document, conversationId, 
   const timeoutMs = options.timeoutMs ?? 120000;
   const deadline = Date.now() + timeoutMs;
   while (Date.now() <= deadline) {
+    throwIfBlockingState(root, {
+      phase: "upload",
+      side_effect_started: false,
+      send_committed: false
+    });
     const currentId = conversationIdFromLocation();
     if (currentId && currentId !== conversationId) {
       throw commandError(
@@ -302,9 +346,9 @@ export async function ensureConversationLoaded(root = document, conversationId, 
 
 export async function configureModelState(root, job = {}) {
   const timeoutMs = Number(job.model_selection_timeout_ms) || 10000;
-  const modelButton = await waitFor(() => root.querySelector(MODEL_SELECTOR), 20000);
-  await openModelMenu(modelButton, timeoutMs);
-  const fable = await waitForOptional(() => visibleElements(root, "[role='menuitemradio']")
+  const modelButton = await waitForModelState(root, () => root.querySelector(MODEL_SELECTOR), 20000);
+  await openModelMenu(root, modelButton, timeoutMs);
+  const fable = await waitForModelOptional(root, () => visibleElements(root, "[role='menuitemradio']")
     .find((element) => normalizeText(element.innerText || element.textContent).toLowerCase().startsWith("fable 5")), timeoutMs);
   if (!fable) {
     const diagnostics = modelSelectionDiagnostics(root);
@@ -324,25 +368,27 @@ export async function configureModelState(root, job = {}) {
     return alreadySelected;
   }
 
+  throwIfModelBlocked(root);
   fable.click();
-  await settleAfterMenuSelection(modelButton, timeoutMs);
+  await settleAfterMenuSelection(root, modelButton, timeoutMs);
 
-  await openModelMenu(modelButton, timeoutMs);
-  const effortTrigger = await waitFor(() => root.querySelector("[data-testid='effort-menu-trigger']"), timeoutMs);
+  await openModelMenu(root, modelButton, timeoutMs);
+  const effortTrigger = await waitForModelState(root, () => root.querySelector("[data-testid='effort-menu-trigger']"), timeoutMs);
   dispatchHover(effortTrigger);
-  const max = await waitFor(() => root.querySelector("[role='menuitemradio'][data-testid='effort-option-max']"), timeoutMs);
+  const max = await waitForModelState(root, () => root.querySelector("[role='menuitemradio'][data-testid='effort-option-max']"), timeoutMs);
+  throwIfModelBlocked(root);
   max.click();
-  await settleAfterMenuSelection(modelButton, timeoutMs);
+  await settleAfterMenuSelection(root, modelButton, timeoutMs);
 
   await closeModelMenu(root, modelButton);
   await sleep(MODEL_MENU_SETTLE_MS);
-  await openModelMenu(modelButton, timeoutMs);
-  const verificationEffort = await waitFor(() => root.querySelector("[data-testid='effort-menu-trigger']"), timeoutMs);
+  await openModelMenu(root, modelButton, timeoutMs);
+  const verificationEffort = await waitForModelState(root, () => root.querySelector("[data-testid='effort-menu-trigger']"), timeoutMs);
   dispatchHover(verificationEffort);
   // Live picker DOM captured 2026-07-21 exposes Fable 5 as a checked
   // menuitemradio and Max as effort-option-max; it has no independent Thinking
   // control. Keep both remaining legs as positive, post-click re-reads.
-  await waitFor(() => root.querySelector("[role='menuitemradio'][data-testid='effort-option-max']"), timeoutMs);
+  await waitForModelState(root, () => root.querySelector("[role='menuitemradio'][data-testid='effort-option-max']"), timeoutMs);
   const diagnostics = modelSelectionDiagnostics(root);
   const menuClosed = await closeModelMenu(root, modelButton);
   await sleep(MODEL_MENU_SETTLE_MS);
@@ -359,12 +405,16 @@ export async function configureModelState(root, job = {}) {
 }
 
 export async function clickSend(root, options = {}) {
-  const send = await waitFor(() => {
+  const send = await waitForClaudeState(root, () => {
     const candidate = findSendButton(root);
     return candidate && !candidate.disabled && candidate.getAttribute("aria-disabled") !== "true"
       ? candidate
       : null;
-  }, options.timeoutMs ?? 120000);
+  }, options.timeoutMs ?? 120000, {
+    phase: "send",
+    side_effect_started: true,
+    send_committed: false
+  });
   send.click();
   return true;
 }
@@ -379,6 +429,14 @@ export function sendAcceptanceBaseline(root = document) {
 export async function waitForSendAccepted(root, baseline = {}, options = {}) {
   const timeoutMs = options.timeoutMs ?? 120000;
   return waitFor(() => {
+    const blockingState = classifyBlockingState(root);
+    if (blockingState) {
+      throw blockingStateError(blockingState, {
+        phase: "send",
+        side_effect_started: true,
+        send_committed: true
+      });
+    }
     const userCount = userTurnCount(root);
     const assistantCount = assistantRoots(root).length;
     const generating = isResponseGenerating(root);
@@ -563,7 +621,7 @@ function conversationIdFromLocation() {
   return match ? decodeURIComponent(match[1]) : null;
 }
 
-async function openModelMenu(button, timeoutMs) {
+async function openModelMenu(root, button, timeoutMs) {
   if (button.getAttribute("aria-expanded") === "true") {
     await sleep(MODEL_MENU_SETTLE_MS);
     if (button.getAttribute("aria-expanded") === "true") {
@@ -573,8 +631,10 @@ async function openModelMenu(button, timeoutMs) {
 
   const attemptTimeoutMs = Math.max(100, Math.min(timeoutMs, 1000));
   for (let attempt = 0; attempt < 2; attempt += 1) {
+    throwIfModelBlocked(root);
     button.click();
-    const opened = await waitForOptional(
+    const opened = await waitForModelOptional(
+      root,
       () => button.getAttribute("aria-expanded") === "true",
       attemptTimeoutMs
     );
@@ -588,12 +648,13 @@ async function openModelMenu(button, timeoutMs) {
   throw new Error(`Claude model menu did not open within ${timeoutMs}ms`);
 }
 
-async function settleAfterMenuSelection(modelButton, timeoutMs) {
-  await waitFor(() => modelButton.getAttribute("aria-expanded") !== "true", timeoutMs);
+async function settleAfterMenuSelection(root, modelButton, timeoutMs) {
+  await waitForModelState(root, () => modelButton.getAttribute("aria-expanded") !== "true", timeoutMs);
   await sleep(MODEL_MENU_SETTLE_MS);
 }
 
 async function verifyAlreadySelectedModel(root, modelButton, fable, timeoutMs) {
+  throwIfModelBlocked(root);
   const modelChip = normalizeText(modelButton.innerText || modelButton.textContent);
   if (fable.getAttribute("aria-checked") !== "true" || !/\bFable 5\b.*\bMax\b/i.test(modelChip)) {
     return null;
@@ -604,7 +665,8 @@ async function verifyAlreadySelectedModel(root, modelButton, fable, timeoutMs) {
     return null;
   }
   dispatchHover(effortTrigger);
-  const max = await waitForOptional(
+  const max = await waitForModelOptional(
+    root,
     () => root.querySelector("[role='menuitemradio'][data-testid='effort-option-max']"),
     timeoutMs
   );
@@ -658,22 +720,61 @@ async function closeModelMenu(root, modelButton) {
     bubbles: true,
     cancelable: true
   }));
-  const escaped = await waitForOptional(
+  const escaped = await waitForModelOptional(
+    root,
     () => modelButton.getAttribute("aria-expanded") !== "true",
     1000
   );
   if (escaped) {
     return true;
   }
+  throwIfModelBlocked(root);
   modelButton.click();
-  return Boolean(await waitForOptional(
+  return Boolean(await waitForModelOptional(
+    root,
     () => modelButton.getAttribute("aria-expanded") !== "true",
     2000
   ));
 }
 
 function visibleElements(root, selector) {
-  return Array.from(root.querySelectorAll(selector)).filter((element) => element.getClientRects().length > 0);
+  return Array.from(root.querySelectorAll?.(selector) ?? []).filter((element) => isActuallyVisible(root, element));
+}
+
+function isActuallyVisible(root, element) {
+  const viewWidth = Number(root.defaultView?.innerWidth);
+  const viewHeight = Number(root.defaultView?.innerHeight);
+  for (let node = element; node; node = node.parentElement) {
+    if (node.hidden || node.getAttribute?.("aria-hidden") === "true") {
+      return false;
+    }
+    if (node.getClientRects?.().length === 0) {
+      return false;
+    }
+    const style = root.defaultView?.getComputedStyle?.(node);
+    if (style && (
+      style.display === "none"
+      || style.visibility === "hidden"
+      || style.visibility === "collapse"
+      || (style.opacity !== "" && Number(style.opacity) === 0)
+    )) {
+      return false;
+    }
+    const rect = node.getBoundingClientRect?.();
+    if (rect && Number.isFinite(viewWidth) && viewWidth > 0 && Number.isFinite(viewHeight) && viewHeight > 0) {
+      const left = Number(rect.left ?? 0);
+      const top = Number(rect.top ?? 0);
+      const right = Number(rect.right ?? (left + Number(rect.width ?? 0)));
+      const bottom = Number(rect.bottom ?? (top + Number(rect.height ?? 0)));
+      if (!(bottom > 0 && right > 0 && top < viewHeight && left < viewWidth)) {
+        return false;
+      }
+    }
+    if (node === root.documentElement) {
+      break;
+    }
+  }
+  return true;
 }
 
 function elementSummary(element) {
@@ -738,7 +839,11 @@ function claudeUploadDiagnosticSummary(root, filename, timeoutStage) {
 
 async function waitForReadyComposer(root, timeoutMs) {
   try {
-    return await waitFor(() => findComposer(root), timeoutMs);
+    return await waitForClaudeState(root, () => findComposer(root), timeoutMs, {
+      phase: "upload",
+      side_effect_started: false,
+      send_committed: false
+    });
   } catch (error) {
     const handoff = classifyManualHandoff({
       url: globalThis.location?.href,
@@ -770,10 +875,36 @@ async function waitFor(read, timeoutMs) {
   return value;
 }
 
-async function waitForOptional(read, timeoutMs) {
+async function waitForClaudeState(root, read, timeoutMs, detail) {
+  return waitFor(() => {
+    throwIfBlockingState(root, detail);
+    return read();
+  }, timeoutMs);
+}
+
+function waitForModelState(root, read, timeoutMs) {
+  return waitForClaudeState(root, read, timeoutMs, {
+    phase: "model_selection",
+    side_effect_started: false,
+    send_committed: false
+  });
+}
+
+function throwIfModelBlocked(root) {
+  throwIfBlockingState(root, {
+    phase: "model_selection",
+    side_effect_started: false,
+    send_committed: false
+  });
+}
+
+async function waitForModelOptional(root, read, timeoutMs) {
   try {
-    return await waitFor(read, timeoutMs);
-  } catch {
+    return await waitForModelState(root, read, timeoutMs);
+  } catch (error) {
+    if (error?.code === "usage_credits_exhausted") {
+      throw error;
+    }
     return null;
   }
 }
@@ -783,6 +914,20 @@ function commandError(code, message, detail = {}) {
   error.code = code;
   Object.assign(error, detail);
   return error;
+}
+
+function blockingStateError(blockingState, detail = {}) {
+  return commandError(blockingState.code, blockingState.message, {
+    ...blockingState,
+    ...detail
+  });
+}
+
+function throwIfBlockingState(root, detail) {
+  const blockingState = classifyBlockingState(root);
+  if (blockingState) {
+    throw blockingStateError(blockingState, detail);
+  }
 }
 
 function sleep(ms) {

--- a/extensions/chatgpt-native/src/claude-dom.js
+++ b/extensions/chatgpt-native/src/claude-dom.js
@@ -9,6 +9,7 @@ const ATTACHMENT_SELECTOR = "[data-testid='file-thumbnail']";
 const COPY_ACTION_SELECTOR = "[data-testid='action-bar-copy']";
 const ASSISTANT_SELECTOR = "[data-is-streaming]";
 const MODEL_MENU_SETTLE_MS = 300;
+const BLOCKING_STATE_SCAN_INTERVAL_MS = 1000;
 const SWITCH_MODELS_CONTROL_SELECTOR = "button, a, [role='button'], [role='link']";
 const CONVERSATION_CONTENT_SELECTOR = [
   COMPOSER_SELECTOR,
@@ -17,7 +18,13 @@ const CONVERSATION_CONTENT_SELECTOR = [
   "[data-is-streaming]",
   "article"
 ].join(", ");
+// Visible claude.ai web banner observed in an Aviv-provided screenshot on
+// 2026-07-27. This is screenshot provenance, not a captured DOM fixture; match
+// stable credit-exhaustion language while the structural control/container
+// guards carry false-positive resistance.
 const USAGE_CREDITS_PROVIDER_MESSAGE = "Your org is out of usage credits for the month. We let your admin know. Switch models to continue chatting.";
+const USAGE_CREDITS_TEXT_PATTERN = /\bout of usage credits\b/i;
+const blockingStateScanCache = new WeakMap();
 
 export function ownedWindowName(job) {
   return `${YOETZ_WINDOW_PREFIX}${job.run_id}:${job.job_id}`;
@@ -67,29 +74,47 @@ export function classifyWaitManualHandoff({ url = "", title = "" } = {}) {
   return classifyManualHandoff({ url, title, text: "" });
 }
 
-export function classifyBlockingState(root = document) {
-  const switchModels = visibleElements(root, SWITCH_MODELS_CONTROL_SELECTOR)
-    .filter((element) => normalizeText(element.innerText || element.textContent).toLowerCase() === "switch models")
-    .filter((element) => !element.closest?.(CONVERSATION_CONTENT_SELECTOR));
-  for (const control of switchModels) {
-    let container = control;
-    while (container) {
-      const text = normalizeText(container.innerText || container.textContent).toLowerCase();
-      if (text === USAGE_CREDITS_PROVIDER_MESSAGE.toLowerCase()
-          && isActuallyVisible(root, container)
-          && !container.querySelector?.(CONVERSATION_CONTENT_SELECTOR)) {
-        return {
-          state: "usage_credits_exhausted",
-          code: "usage_credits_exhausted",
-          requested_model: "fable-5-max",
-          provider_message: USAGE_CREDITS_PROVIDER_MESSAGE,
-          message: "Claude cannot run Fable 5 Max because this organization is out of monthly usage credits. Yoetz did not switch models."
-        };
-      }
-      container = container.parentElement;
-    }
+export function classifyBlockingState(root = document, { forceScan = false } = {}) {
+  const pageText = normalizeText(root.body?.textContent || root.documentElement?.textContent);
+  if (pageText && !USAGE_CREDITS_TEXT_PATTERN.test(pageText)) {
+    return null;
   }
-  return null;
+  const now = Date.now();
+  const cached = blockingStateScanCache.get(root);
+  if (!forceScan && cached && now - cached.scanned_at_ms < BLOCKING_STATE_SCAN_INTERVAL_MS) {
+    return cached.value;
+  }
+  const candidates = Array.from(root.querySelectorAll?.("body *") ?? []);
+  const container = candidates
+    .filter((element) => USAGE_CREDITS_TEXT_PATTERN.test(normalizeText(element.textContent)))
+    .filter((element) => !element.closest?.(CONVERSATION_CONTENT_SELECTOR))
+    .filter((element) => !element.querySelector?.(CONVERSATION_CONTENT_SELECTOR))
+    .filter((element) => isStrictlyVisibleBannerElement(root, element))
+    .sort((left, right) => normalizeText(left.textContent).length - normalizeText(right.textContent).length)
+    .at(0);
+  if (!container) {
+    blockingStateScanCache.set(root, { scanned_at_ms: now, value: null });
+    return null;
+  }
+  const switchControl = Array.from(root.querySelectorAll?.(SWITCH_MODELS_CONTROL_SELECTOR) ?? [])
+    .filter((element) => normalizeText(element.textContent).toLowerCase() === "switch models")
+    .filter((element) => isDescendantOrSelf(element, container))
+    .filter((element) => isStrictlyVisibleBannerElement(root, element))
+    .at(0);
+  const text = normalizeText(container.innerText || container.textContent);
+  const blockingState = {
+    state: "usage_credits_exhausted",
+    code: "usage_credits_exhausted",
+    requested_model: "fable-5-max",
+    provider_message: text || USAGE_CREDITS_PROVIDER_MESSAGE,
+    provider_dom: {
+      container: elementDiagnostic(container),
+      switch_models_control: switchControl ? elementDiagnostic(switchControl) : { found: false }
+    },
+    message: "Claude cannot run Fable 5 Max because this organization is out of monthly usage credits. Yoetz did not switch models."
+  };
+  blockingStateScanCache.set(root, { scanned_at_ms: now, value: blockingState });
+  return blockingState;
 }
 
 export function findComposer(root = document) {
@@ -738,10 +763,30 @@ async function closeModelMenu(root, modelButton) {
 }
 
 function visibleElements(root, selector) {
-  return Array.from(root.querySelectorAll?.(selector) ?? []).filter((element) => isActuallyVisible(root, element));
+  return Array.from(root.querySelectorAll?.(selector) ?? [])
+    .filter((element) => element.getClientRects().length > 0);
 }
 
-function isActuallyVisible(root, element) {
+function isDescendantOrSelf(element, ancestor) {
+  for (let node = element; node; node = node.parentElement) {
+    if (node === ancestor) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function elementDiagnostic(element) {
+  return {
+    found: true,
+    tag: String(element?.tagName ?? "").toLowerCase() || null,
+    role: element?.getAttribute?.("role") ?? null,
+    testid: element?.getAttribute?.("data-testid") ?? null,
+    class_fragment: normalizeText(element?.getAttribute?.("class")).slice(0, 160) || null
+  };
+}
+
+function isStrictlyVisibleBannerElement(root, element) {
   const viewWidth = Number(root.defaultView?.innerWidth);
   const viewHeight = Number(root.defaultView?.innerHeight);
   for (let node = element; node; node = node.parentElement) {
@@ -895,7 +940,7 @@ function throwIfModelBlocked(root) {
     phase: "model_selection",
     side_effect_started: false,
     send_committed: false
-  });
+  }, { forceScan: true });
 }
 
 async function waitForModelOptional(root, read, timeoutMs) {
@@ -923,8 +968,8 @@ function blockingStateError(blockingState, detail = {}) {
   });
 }
 
-function throwIfBlockingState(root, detail) {
-  const blockingState = classifyBlockingState(root);
+function throwIfBlockingState(root, detail, options) {
+  const blockingState = classifyBlockingState(root, options);
   if (blockingState) {
     throw blockingStateError(blockingState, detail);
   }

--- a/extensions/chatgpt-native/src/claude-dom.js
+++ b/extensions/chatgpt-native/src/claude-dom.js
@@ -11,6 +11,12 @@ const ASSISTANT_SELECTOR = "[data-is-streaming]";
 const MODEL_MENU_SETTLE_MS = 300;
 const BLOCKING_STATE_SCAN_INTERVAL_MS = 1000;
 const SWITCH_MODELS_CONTROL_SELECTOR = "button, a, [role='button'], [role='link']";
+// Keep control corroboration inside a local notice subtree rather than allowing
+// an unrelated page-level model control to validate matching text elsewhere.
+const MAX_CONTROL_SURFACE_DEPTH = 8;
+// A provider notice is short; this rejects broad page/sidebar wrappers when the
+// control-backed fallback is needed because no semantic live region exists.
+const MAX_CONTROL_SURFACE_TEXT_CHARS = 1000;
 const CONVERSATION_CONTENT_SELECTOR = [
   COMPOSER_SELECTOR,
   "[data-testid='user-message']",
@@ -85,28 +91,36 @@ export function classifyBlockingState(root = document, { forceScan = false } = {
     return cached.value;
   }
   const candidates = Array.from(root.querySelectorAll?.("body *") ?? []);
-  const container = candidates
+  const switchControls = Array.from(root.querySelectorAll?.(SWITCH_MODELS_CONTROL_SELECTOR) ?? [])
+    .filter((element) => /^switch models?$/i.test(normalizeText(element.innerText || element.textContent)))
+    .filter((element) => isStrictlyVisibleBannerElement(root, element));
+  const surfaces = candidates
     .filter((element) => USAGE_CREDITS_TEXT_PATTERN.test(normalizeText(element.textContent)))
     .filter((element) => !element.closest?.(CONVERSATION_CONTENT_SELECTOR))
-    .filter((element) => !element.querySelector?.(CONVERSATION_CONTENT_SELECTOR))
-    .filter((element) => isStrictlyVisibleBannerElement(root, element))
-    .sort((left, right) => normalizeText(left.textContent).length - normalizeText(right.textContent).length)
-    .at(0);
-  if (!container) {
+    .map((element) => notificationSurfaceFor(element, root)
+      ?? controlBackedSurfaceFor(element, switchControls, root))
+    .filter(Boolean)
+    .filter((surface, index, all) => all.indexOf(surface) === index)
+    .filter((surface) => !surface.closest?.(CONVERSATION_CONTENT_SELECTOR))
+    .filter((surface) => !surface.querySelector?.(CONVERSATION_CONTENT_SELECTOR))
+    .filter((surface) => isStrictlyVisibleBannerElement(root, surface))
+    .map((surface) => ({ surface, text: normalizeText(surface.innerText) }))
+    .filter(({ text }) => isUsageCreditsMessage(text))
+    .sort((left, right) => left.text.length - right.text.length);
+  const match = surfaces.at(0);
+  if (!match) {
     blockingStateScanCache.set(root, { scanned_at_ms: now, value: null });
     return null;
   }
-  const switchControl = Array.from(root.querySelectorAll?.(SWITCH_MODELS_CONTROL_SELECTOR) ?? [])
-    .filter((element) => normalizeText(element.textContent).toLowerCase() === "switch models")
+  const container = match.surface;
+  const switchControl = switchControls
     .filter((element) => isDescendantOrSelf(element, container))
-    .filter((element) => isStrictlyVisibleBannerElement(root, element))
     .at(0);
-  const text = normalizeText(container.innerText || container.textContent);
   const blockingState = {
     state: "usage_credits_exhausted",
     code: "usage_credits_exhausted",
     requested_model: "fable-5-max",
-    provider_message: text || USAGE_CREDITS_PROVIDER_MESSAGE,
+    provider_message: match.text || USAGE_CREDITS_PROVIDER_MESSAGE,
     provider_dom: {
       container: elementDiagnostic(container),
       switch_models_control: switchControl ? elementDiagnostic(switchControl) : { found: false }
@@ -767,6 +781,49 @@ function visibleElements(root, selector) {
     .filter((element) => element.getClientRects().length > 0);
 }
 
+function isUsageCreditsMessage(text) {
+  return USAGE_CREDITS_TEXT_PATTERN.test(text);
+}
+
+function notificationSurfaceFor(element, root) {
+  for (let node = element; node && node !== root.body && node !== root.documentElement; node = node.parentElement) {
+    const role = normalizeText(node.getAttribute?.("role")).toLowerCase();
+    const ariaLive = normalizeText(node.getAttribute?.("aria-live")).toLowerCase();
+    if (role === "alert" || role === "status" || (ariaLive && ariaLive !== "off")) {
+      return node;
+    }
+  }
+  return null;
+}
+
+function controlBackedSurfaceFor(element, controls, root) {
+  const ancestors = [];
+  for (
+    let node = element, depth = 0;
+    node && node !== root.body && node !== root.documentElement && depth < MAX_CONTROL_SURFACE_DEPTH;
+    node = node.parentElement, depth += 1
+  ) {
+    ancestors.push(node);
+  }
+  for (const control of controls) {
+    for (
+      let node = control, depth = 0;
+      node && node !== root.body && node !== root.documentElement && depth < MAX_CONTROL_SURFACE_DEPTH;
+      node = node.parentElement, depth += 1
+    ) {
+      if (!ancestors.includes(node)) {
+        continue;
+      }
+      const text = normalizeText(node.innerText);
+      if (text.length <= MAX_CONTROL_SURFACE_TEXT_CHARS && isUsageCreditsMessage(text)) {
+        return node;
+      }
+      break;
+    }
+  }
+  return null;
+}
+
 function isDescendantOrSelf(element, ancestor) {
   for (let node = element; node; node = node.parentElement) {
     if (node === ancestor) {
@@ -789,11 +846,12 @@ function elementDiagnostic(element) {
 function isStrictlyVisibleBannerElement(root, element) {
   const viewWidth = Number(root.defaultView?.innerWidth);
   const viewHeight = Number(root.defaultView?.innerHeight);
+  let paintedIntersection = Number.isFinite(viewWidth) && viewWidth > 0
+    && Number.isFinite(viewHeight) && viewHeight > 0
+    ? { left: 0, top: 0, right: viewWidth, bottom: viewHeight }
+    : null;
   for (let node = element; node; node = node.parentElement) {
     if (node.hidden || node.getAttribute?.("aria-hidden") === "true") {
-      return false;
-    }
-    if (node.getClientRects?.().length === 0) {
       return false;
     }
     const style = root.defaultView?.getComputedStyle?.(node);
@@ -802,17 +860,49 @@ function isStrictlyVisibleBannerElement(root, element) {
       || style.visibility === "hidden"
       || style.visibility === "collapse"
       || (style.opacity !== "" && Number(style.opacity) === 0)
+      || style.contentVisibility === "hidden"
+      || (style.clipPath && style.clipPath !== "none")
+      || (style.clip && style.clip !== "auto" && style.clip !== "none")
     )) {
       return false;
     }
-    const rect = node.getBoundingClientRect?.();
-    if (rect && Number.isFinite(viewWidth) && viewWidth > 0 && Number.isFinite(viewHeight) && viewHeight > 0) {
+    const displayContents = style?.display === "contents";
+    const clientRects = node.getClientRects?.();
+    if (node === element && !displayContents && clientRects?.length === 0) {
+      return false;
+    }
+    const boundingRect = node.getBoundingClientRect?.();
+    const rect = displayContents
+      ? null
+      : hasLayoutCoordinates(boundingRect)
+        ? boundingRect
+        : hasLayoutCoordinates(clientRects?.[0])
+          ? clientRects[0]
+          : null;
+    if (rect && paintedIntersection) {
       const left = Number(rect.left ?? 0);
       const top = Number(rect.top ?? 0);
       const right = Number(rect.right ?? (left + Number(rect.width ?? 0)));
       const bottom = Number(rect.bottom ?? (top + Number(rect.height ?? 0)));
-      if (!(bottom > 0 && right > 0 && top < viewHeight && left < viewWidth)) {
+      if (node === element && (!(right > left) || !(bottom > top))) {
         return false;
+      }
+      const clipsOverflow = node !== element && style && [
+        style.overflow,
+        style.overflowX,
+        style.overflowY
+      ].some((value) => value === "hidden" || value === "clip");
+      if (node === element || clipsOverflow) {
+        paintedIntersection = {
+          left: Math.max(paintedIntersection.left, left),
+          top: Math.max(paintedIntersection.top, top),
+          right: Math.min(paintedIntersection.right, right),
+          bottom: Math.min(paintedIntersection.bottom, bottom)
+        };
+        if (!(paintedIntersection.right > paintedIntersection.left)
+            || !(paintedIntersection.bottom > paintedIntersection.top)) {
+          return false;
+        }
       }
     }
     if (node === root.documentElement) {
@@ -820,6 +910,11 @@ function isStrictlyVisibleBannerElement(root, element) {
     }
   }
   return true;
+}
+
+function hasLayoutCoordinates(rect) {
+  return Boolean(rect) && ["left", "top", "right", "bottom", "width", "height"]
+    .some((key) => Number.isFinite(Number(rect[key])));
 }
 
 function elementSummary(element) {

--- a/extensions/chatgpt-native/src/claude-dom.js
+++ b/extensions/chatgpt-native/src/claude-dom.js
@@ -97,15 +97,27 @@ export function classifyBlockingState(root = document, { forceScan = false } = {
   const surfaces = candidates
     .filter((element) => USAGE_CREDITS_TEXT_PATTERN.test(normalizeText(element.textContent)))
     .filter((element) => !element.closest?.(CONVERSATION_CONTENT_SELECTOR))
-    .map((element) => notificationSurfaceFor(element, root)
-      ?? controlBackedSurfaceFor(element, switchControls, root))
-    .filter(Boolean)
-    .filter((surface, index, all) => all.indexOf(surface) === index)
-    .filter((surface) => !surface.closest?.(CONVERSATION_CONTENT_SELECTOR))
-    .filter((surface) => !surface.querySelector?.(CONVERSATION_CONTENT_SELECTOR))
-    .filter((surface) => isStrictlyVisibleBannerElement(root, surface))
-    .map((surface) => ({ surface, text: normalizeText(surface.innerText) }))
-    .filter(({ text }) => isUsageCreditsMessage(text))
+    .map((element) => ({
+      surface: notificationSurfaceFor(element, root)
+        ?? controlBackedSurfaceFor(element, switchControls, root)
+    }))
+    .filter(({ surface }) => Boolean(surface))
+    .filter(({ surface }, index, all) => all.findIndex((entry) => entry.surface === surface) === index)
+    .map(({ surface }) => ({
+      surface,
+      controlCorroborated: switchControls.some((control) => isDescendantOrSelf(control, surface)),
+      contributors: deepestUsageCreditsContributors(surface, candidates)
+    }))
+    .filter(({ surface }) => !surface.closest?.(CONVERSATION_CONTENT_SELECTOR))
+    .filter(({ surface }) => !surface.querySelector?.(CONVERSATION_CONTENT_SELECTOR))
+    .filter(({ surface }) => isStrictlyVisibleBannerElement(root, surface))
+    .filter(({ contributors }) => contributors.some((element) => isStrictlyVisibleBannerElement(root, element)))
+    .map(({ surface, controlCorroborated }) => ({
+      surface,
+      controlCorroborated,
+      text: normalizeText(surface.innerText)
+    }))
+    .filter(({ text, controlCorroborated }) => isUsageCreditsMessage(text, { controlCorroborated }))
     .sort((left, right) => left.text.length - right.text.length);
   const match = surfaces.at(0);
   if (!match) {
@@ -454,6 +466,11 @@ export async function clickSend(root, options = {}) {
     side_effect_started: true,
     send_committed: false
   });
+  throwIfBlockingState(root, {
+    phase: "send",
+    side_effect_started: true,
+    send_committed: false
+  }, { forceScan: true });
   send.click();
   return true;
 }
@@ -781,8 +798,30 @@ function visibleElements(root, selector) {
     .filter((element) => element.getClientRects().length > 0);
 }
 
-function isUsageCreditsMessage(text) {
+function hasUsageCreditsCore(text) {
   return USAGE_CREDITS_TEXT_PATTERN.test(text);
+}
+
+function isUsageCreditsMessage(text, { controlCorroborated = false } = {}) {
+  if (!hasUsageCreditsCore(text)) {
+    return false;
+  }
+  if (controlCorroborated) {
+    return true;
+  }
+  const matchIndex = text.toLowerCase().indexOf("out of usage credits");
+  const precedingWindow = text.slice(Math.max(0, matchIndex - 80), matchIndex);
+  const sentenceBoundary = Math.max(
+    precedingWindow.lastIndexOf("."),
+    precedingWindow.lastIndexOf("!"),
+    precedingWindow.lastIndexOf("?")
+  );
+  const precedingText = precedingWindow.slice(sentenceBoundary + 1);
+  if (/\b(?:almost|nearly|not|no longer|isn't|aren't|about to|running low)\b/i.test(precedingText)) {
+    return false;
+  }
+  return /\b(?:your|this)\s+org(?:anization)?\s+is\s+out of usage credits\b/i.test(text)
+    || /\byou(?:'re| are)\s+out of usage credits\b/i.test(text);
 }
 
 function notificationSurfaceFor(element, root) {
@@ -815,13 +854,26 @@ function controlBackedSurfaceFor(element, controls, root) {
         continue;
       }
       const text = normalizeText(node.innerText);
-      if (text.length <= MAX_CONTROL_SURFACE_TEXT_CHARS && isUsageCreditsMessage(text)) {
+      if (text.length <= MAX_CONTROL_SURFACE_TEXT_CHARS && hasUsageCreditsCore(text)) {
         return node;
       }
       break;
     }
   }
   return null;
+}
+
+function deepestUsageCreditsContributors(surface, candidates) {
+  const matching = candidates.filter((element) => (
+    isDescendantOrSelf(element, surface)
+    && hasUsageCreditsCore(normalizeText(element.textContent))
+  ));
+  // A phrase split across sibling inline elements can leave the surface itself
+  // as the deepest contributor. We knowingly accept that paint edge until a
+  // real provider DOM capture justifies text-node range machinery.
+  return matching.filter((element) => !matching.some((other) => (
+    other !== element && isDescendantOrSelf(other, element)
+  )));
 }
 
 function isDescendantOrSelf(element, ancestor) {
@@ -861,8 +913,6 @@ function isStrictlyVisibleBannerElement(root, element) {
       || style.visibility === "collapse"
       || (style.opacity !== "" && Number(style.opacity) === 0)
       || style.contentVisibility === "hidden"
-      || (style.clipPath && style.clipPath !== "none")
-      || (style.clip && style.clip !== "auto" && style.clip !== "none")
     )) {
       return false;
     }
@@ -891,7 +941,7 @@ function isStrictlyVisibleBannerElement(root, element) {
         style.overflow,
         style.overflowX,
         style.overflowY
-      ].some((value) => value === "hidden" || value === "clip");
+      ].some((value) => ["auto", "scroll", "hidden", "clip"].includes(value));
       if (node === element || clipsOverflow) {
         paintedIntersection = {
           left: Math.max(paintedIntersection.left, left),

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -25,7 +25,7 @@ async function handleMessage(message) {
     case "yoetz_send_prompt":
       return sendPrompt(message.job, message.prompt);
     case "yoetz_extract_response":
-      return extractJobResponse(message.job);
+      return extractJobResponse(message.job, message.blocking_context);
     case "yoetz_fetch_conversation":
       return fetchSiteConversationAnswer(message.job, message.conversation_id);
     case "yoetz_cancel_send":
@@ -69,6 +69,7 @@ async function cancelSend(job) {
 
 async function prepareJob(job) {
   const {
+    classifyBlockingState,
     classifyManualHandoff,
     ensureConversationLoaded,
     ensureFreshChat,
@@ -93,6 +94,11 @@ async function prepareJob(job) {
     ? await ensureFreshChat(document, job)
     : null;
   if (!handoff) {
+    assertNoBlockingState(classifyBlockingState, {
+      phase: "upload",
+      side_effect_started: false,
+      send_committed: false
+    });
     if (conversationId) {
       assertUrlRunMarker(job);
     }
@@ -132,15 +138,27 @@ async function uploadJobFile(job, filePayload) {
 }
 
 async function configureModel(job) {
-  const { configureModelState, parseOwnedWindowName } = await domHelpers(job);
+  const { classifyBlockingState, configureModelState, parseOwnedWindowName } = await domHelpers(job);
   const adapter = await siteAdapter(job);
   assertJobOwnership(job, parseOwnedWindowName, ownershipOptionsForJob(job, "model_selection", adapter));
-  return configureModelState(document, job);
+  assertNoBlockingState(classifyBlockingState, {
+    phase: "model_selection",
+    side_effect_started: false,
+    send_committed: false
+  });
+  const selection = await configureModelState(document, job);
+  assertNoBlockingState(classifyBlockingState, {
+    phase: "model_selection",
+    side_effect_started: false,
+    send_committed: false
+  });
+  return selection;
 }
 
 async function sendPrompt(job, prompt) {
   const adapter = await siteAdapter(job);
   const {
+    classifyBlockingState,
     clickSend,
     insertPrompt,
     parseOwnedWindowName,
@@ -148,9 +166,19 @@ async function sendPrompt(job, prompt) {
     waitForSendAccepted
   } = await domHelpers(job);
   assertJobOwnership(job, parseOwnedWindowName, ownershipOptionsForJob(job, "send", adapter));
+  assertNoBlockingState(classifyBlockingState, {
+    phase: "send",
+    side_effect_started: true,
+    send_committed: false
+  });
   const baseline = sendAcceptanceBaseline(document);
   await insertPrompt(document, prompt, { timeoutMs: 20000 });
   assertJobOwnership(job, parseOwnedWindowName, ownershipOptionsForJob(job, "send", adapter));
+  assertNoBlockingState(classifyBlockingState, {
+    phase: "send",
+    side_effect_started: true,
+    send_committed: false
+  });
   const clickOptions = { timeoutMs: Number(job.send_timeout_ms) || 120000 };
   const expectedConversationId = expectedConversationIdForJob(job);
   if (expectedConversationId) {
@@ -163,6 +191,9 @@ async function sendPrompt(job, prompt) {
       timeoutMs: Number(job.send_timeout_ms) || 120000
     });
   } catch (error) {
+    if (error?.code === "usage_credits_exhausted") {
+      throw error;
+    }
     throw commandError(
       "send_acceptance_unknown",
       `${adapter.displayName} send click was committed, but Yoetz could not confirm ${adapter.displayName} accepted the prompt before timeout. If a response eventually appears, do not rerun automatically: ${String(error?.message ?? error)}`,
@@ -183,14 +214,19 @@ async function sendPrompt(job, prompt) {
   };
 }
 
-async function extractJobResponse(job) {
+async function extractJobResponse(job, blockingContext = null) {
   const adapter = await siteAdapter(job);
   const {
+    classifyBlockingState,
     classifyWaitManualHandoff,
     extractResponse,
     parseOwnedWindowName
   } = await domHelpers(job);
   assertJobOwnership(job, parseOwnedWindowName, { adapter });
+  const blockingDetail = blockingContext === "pre_send_baseline"
+    ? { phase: "send", side_effect_started: true, send_committed: false }
+    : { phase: "wait_response", side_effect_started: true, send_committed: true };
+  assertNoBlockingState(classifyBlockingState, blockingDetail);
   const conversationId = adapter.conversationIdFromUrl(location.href);
   const expectedConversationId = expectedConversationIdForJob(job);
   if (expectedConversationId
@@ -208,6 +244,7 @@ async function extractJobResponse(job) {
     );
   }
   const extraction = extractResponse(document);
+  assertNoBlockingState(classifyBlockingState, blockingDetail);
   // During response wait, page text includes the user prompt and model output.
   // Handoff classification here must stay on transport/page metadata only.
   const handoff = classifyWaitManualHandoff({
@@ -497,6 +534,17 @@ function commandError(code, message, detail = {}) {
   return error;
 }
 
+function assertNoBlockingState(classifyBlockingState, detail) {
+  const blockingState = classifyBlockingState?.(document);
+  if (!blockingState) {
+    return;
+  }
+  throw commandError(blockingState.code, blockingState.message, {
+    ...blockingState,
+    ...detail
+  });
+}
+
 function conversationLocationDetail(code) {
   if (!String(code ?? "").startsWith("conversation_")) {
     return {};
@@ -541,6 +589,10 @@ function errorResponse(error) {
     response.attachment_trace = error.attachment_trace;
   }
   for (const key of [
+    "state",
+    "provider_message",
+    "requested_model",
+    "send_committed",
     "requested_conversation_id",
     "current_conversation_id",
     "current_url",

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -166,6 +166,10 @@ async function sendPrompt(job, prompt) {
     waitForSendAccepted
   } = await domHelpers(job);
   assertJobOwnership(job, parseOwnedWindowName, ownershipOptionsForJob(job, "send", adapter));
+  // side_effect_started tracks provider-visible job effects, not whether prompt
+  // text was inserted. The worker reaches sendPrompt only after bundle upload
+  // committed, so every failure from this point is post-side-effect even when
+  // send_committed remains false.
   assertNoBlockingState(classifyBlockingState, {
     phase: "send",
     side_effect_started: true,
@@ -535,7 +539,7 @@ function commandError(code, message, detail = {}) {
 }
 
 function assertNoBlockingState(classifyBlockingState, detail) {
-  const blockingState = classifyBlockingState?.(document);
+  const blockingState = classifyBlockingState?.(document, { forceScan: true });
   if (!blockingState) {
     return;
   }
@@ -591,6 +595,7 @@ function errorResponse(error) {
   for (const key of [
     "state",
     "provider_message",
+    "provider_dom",
     "requested_model",
     "send_committed",
     "requested_conversation_id",

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -484,7 +484,11 @@ async function runJobWithFile(job, file) {
 
   const prompt = job.prompt ?? "";
   if (prompt) {
-    job.response_baseline = await sendToTab(job.tab_id, { type: "yoetz_extract_response", job });
+    job.response_baseline = await sendToTab(job.tab_id, {
+      type: "yoetz_extract_response",
+      job,
+      blocking_context: "pre_send_baseline"
+    });
     assertJobConnectionCurrent(job);
     job.status = "sending_prompt";
     job.updated_at = Date.now();
@@ -1249,6 +1253,16 @@ function errorContextForJob(job, error = null) {
       ? error.side_effect_started
       : Boolean(job.tab_id)
   };
+  for (const key of [
+    "state",
+    "provider_message",
+    "requested_model",
+    "send_committed"
+  ]) {
+    if (error?.[key] !== undefined) {
+      detail[key] = error[key];
+    }
+  }
   if (job.tab_id != null) {
     detail.tab_id = job.tab_id;
   }
@@ -1545,6 +1559,10 @@ function tabCommandError(response) {
     error.attachment_trace = response.attachment_trace;
   }
   for (const key of [
+    "state",
+    "provider_message",
+    "requested_model",
+    "send_committed",
     "requested_conversation_id",
     "current_conversation_id",
     "current_url",

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -1256,6 +1256,7 @@ function errorContextForJob(job, error = null) {
   for (const key of [
     "state",
     "provider_message",
+    "provider_dom",
     "requested_model",
     "send_committed"
   ]) {
@@ -1561,6 +1562,7 @@ function tabCommandError(response) {
   for (const key of [
     "state",
     "provider_message",
+    "provider_dom",
     "requested_model",
     "send_committed",
     "requested_conversation_id",

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -537,6 +537,7 @@ test("content script rechecks Claude credits after prompt insertion without clic
     assert.equal(response.side_effect_started, true);
     assert.equal(response.send_committed, false);
     assert.equal(response.provider_message, usageCreditsState().provider_message);
+    assert.deepEqual(response.provider_dom, usageCreditsState().provider_dom);
     assert.equal(hooks.clickSendCalls.length, 0);
   } finally {
     restore();
@@ -746,6 +747,10 @@ function usageCreditsState() {
     code: "usage_credits_exhausted",
     requested_model: "fable-5-max",
     provider_message: "Your org is out of usage credits for the month. We let your admin know. Switch models to continue chatting.",
+    provider_dom: {
+      container: { found: true, tag: "div", role: "alert" },
+      switch_models_control: { found: false }
+    },
     message: "Claude cannot run Fable 5 Max because this organization is out of monthly usage credits. Yoetz did not switch models."
   };
 }

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -35,6 +35,10 @@ export function classifyWaitManualHandoff() {
   return hooks.waitManualHandoff ?? null;
 }
 
+export function classifyBlockingState() {
+  return hooks.blockingState ?? null;
+}
+
 export async function ensureFreshChat(_document, job) {
   hooks.ensureFreshChatCalls.push(job);
   if (hooks.failFreshChat) {
@@ -121,6 +125,7 @@ const dom = {
   getPageText,
   classifyManualHandoff,
   classifyWaitManualHandoff,
+  classifyBlockingState,
   ensureFreshChat,
   ensureConversationLoaded,
   markOwnership,
@@ -490,6 +495,79 @@ test("content script resume send rechecks conversation drift after prompt insert
   }
 });
 
+test("content script fails closed on Claude credits before marking prepare complete", async () => {
+  const { send, hooks, restore } = await loadContentScript("claude_credits_prepare", "https://claude.ai/new?_yoetz=run_credits");
+  try {
+    hooks.recipe = "claude";
+    hooks.blockingState = usageCreditsState();
+    const response = await send({
+      type: "yoetz_prepare_job",
+      job: { job_id: "job_credits", run_id: "run_credits", recipe: "claude" }
+    });
+
+    assert.equal(response.ok, false);
+    assert.equal(response.code, "usage_credits_exhausted");
+    assert.equal(response.state, "usage_credits_exhausted");
+    assert.equal(response.requested_model, "fable-5-max");
+    assert.equal(response.phase, "upload");
+    assert.equal(response.side_effect_started, false);
+    assert.equal(response.send_committed, false);
+    assert.deepEqual(hooks.markOwnershipCalls, []);
+  } finally {
+    restore();
+  }
+});
+
+test("content script rechecks Claude credits after prompt insertion without clicking send", async () => {
+  const { send, hooks, restore } = await loadContentScript("claude_credits_presend", "https://claude.ai/new?_yoetz=run_credits");
+  try {
+    hooks.recipe = "claude";
+    const job = { job_id: "job_credits", run_id: "run_credits", recipe: "claude" };
+    const prepared = await send({ type: "yoetz_prepare_job", job });
+    assert.equal(prepared.ok, true);
+    hooks.afterInsertPrompt = () => {
+      hooks.blockingState = usageCreditsState();
+    };
+
+    const response = await send({ type: "yoetz_send_prompt", job, prompt: "review" });
+
+    assert.equal(response.ok, false);
+    assert.equal(response.code, "usage_credits_exhausted");
+    assert.equal(response.phase, "send");
+    assert.equal(response.side_effect_started, true);
+    assert.equal(response.send_committed, false);
+    assert.equal(response.provider_message, usageCreditsState().provider_message);
+    assert.equal(hooks.clickSendCalls.length, 0);
+  } finally {
+    restore();
+  }
+});
+
+test("content script classifies a credit banner during baseline extraction as pre-send", async () => {
+  const { send, hooks, restore } = await loadContentScript("claude_credits_baseline", "https://claude.ai/new?_yoetz=run_credits");
+  try {
+    hooks.recipe = "claude";
+    const job = { job_id: "job_credits", run_id: "run_credits", recipe: "claude" };
+    const prepared = await send({ type: "yoetz_prepare_job", job });
+    assert.equal(prepared.ok, true);
+    hooks.blockingState = usageCreditsState();
+
+    const response = await send({
+      type: "yoetz_extract_response",
+      job,
+      blocking_context: "pre_send_baseline"
+    });
+
+    assert.equal(response.ok, false);
+    assert.equal(response.code, "usage_credits_exhausted");
+    assert.equal(response.phase, "send");
+    assert.equal(response.side_effect_started, true);
+    assert.equal(response.send_committed, false);
+  } finally {
+    restore();
+  }
+});
+
 test("content script fresh path still requires a fresh page after prepare", async () => {
   const { send, hooks, restore, location } = await loadContentScript("fresh_guard", "https://chatgpt.com/?_yoetz=run_fresh");
   try {
@@ -659,6 +737,16 @@ function resumeJob() {
     expected_conversation_id: "conv-123",
     upload_timeout_ms: 1000,
     send_timeout_ms: 1000
+  };
+}
+
+function usageCreditsState() {
+  return {
+    state: "usage_credits_exhausted",
+    code: "usage_credits_exhausted",
+    requested_model: "fable-5-max",
+    provider_message: "Your org is out of usage credits for the month. We let your admin know. Switch models to continue chatting.",
+    message: "Claude cannot run Fable 5 Max because this organization is out of monthly usage credits. Yoetz did not switch models."
   };
 }
 

--- a/extensions/chatgpt-native/tests/fake-claude.test.js
+++ b/extensions/chatgpt-native/tests/fake-claude.test.js
@@ -25,7 +25,8 @@ function fakeCreditBanner({
   style = {},
   rect = null,
   conversationDescendant = false,
-  hiddenAncestor = false
+  hiddenAncestor = false,
+  switchControlQueryable = true
 } = {}) {
   const shell = {
     innerText: text,
@@ -33,6 +34,9 @@ function fakeCreditBanner({
     parentElement: null,
     getAttribute() {
       return null;
+    },
+    closest() {
+      return excluded ? {} : null;
     },
     querySelector() {
       return conversationDescendant ? {} : null;
@@ -54,6 +58,9 @@ function fakeCreditBanner({
     },
     getBoundingClientRect() {
       return rect;
+    },
+    closest() {
+      return excluded ? {} : null;
     },
     querySelector() {
       return conversationDescendant ? {} : null;
@@ -112,7 +119,10 @@ function fakeCreditBanner({
         ...style
       })
     },
-    querySelectorAll: (selector) => selector.includes("button") ? [switchModels] : []
+    querySelectorAll(selector) {
+      if (selector === "body *") return [banner, switchModels];
+      return switchControlQueryable && selector.includes("button") ? [switchModels] : [];
+    }
   };
   return { root, shell, banner, switchModels };
 }
@@ -125,19 +135,45 @@ test("classifyBlockingState detects the visible organization credit banner", () 
     code: "usage_credits_exhausted",
     requested_model: "fable-5-max",
     provider_message: "Your org is out of usage credits for the month. We let your admin know. Switch models to continue chatting.",
+    provider_dom: {
+      container: {
+        found: true,
+        tag: null,
+        role: "alert",
+        testid: null,
+        class_fragment: null
+      },
+      switch_models_control: {
+        found: true,
+        tag: null,
+        role: "button",
+        testid: null,
+        class_fragment: null
+      }
+    },
     message: "Claude cannot run Fable 5 Max because this organization is out of monthly usage credits. Yoetz did not switch models."
   });
   assert.equal(banner.switchModels.clickCount, 0);
 });
 
-test("classifyBlockingState ignores quoted, hidden, and incomplete credit text", () => {
+test("classifyBlockingState survives unknown Switch models markup and records diagnostics", () => {
+  const banner = fakeCreditBanner({ switchControlQueryable: false });
+
+  const blockingState = classifyBlockingState(banner.root);
+
+  assert.equal(blockingState?.code, "usage_credits_exhausted");
+  assert.deepEqual(blockingState?.provider_dom.switch_models_control, { found: false });
+  assert.equal(banner.switchModels.clickCount, 0);
+});
+
+test("classifyBlockingState accepts wording drift but rejects structural false positives", () => {
   const quoted = fakeCreditBanner({ excluded: true });
   const hidden = fakeCreditBanner({ visible: false });
   const transparent = fakeCreditBanner({ style: { opacity: "0" } });
   const offscreen = fakeCreditBanner({
     rect: { left: 0, top: 900, right: 500, bottom: 1000, width: 500, height: 100 }
   });
-  const incomplete = fakeCreditBanner({
+  const shortened = fakeCreditBanner({
     text: "Your org is out of usage credits for the month. Switch models to continue chatting."
   });
   const reordered = fakeCreditBanner({
@@ -148,16 +184,36 @@ test("classifyBlockingState ignores quoted, hidden, and incomplete credit text",
   });
   const conversationCompleted = fakeCreditBanner({ conversationDescendant: true });
   const ancestorHidden = fakeCreditBanner({ hiddenAncestor: true });
+  const unrelated = fakeCreditBanner({
+    text: "Your organization has a billing notice. Switch models to continue chatting."
+  });
 
   assert.equal(classifyBlockingState(quoted.root), null);
   assert.equal(classifyBlockingState(hidden.root), null);
   assert.equal(classifyBlockingState(transparent.root), null);
   assert.equal(classifyBlockingState(offscreen.root), null);
-  assert.equal(classifyBlockingState(incomplete.root), null);
-  assert.equal(classifyBlockingState(reordered.root), null);
-  assert.equal(classifyBlockingState(extra.root), null);
+  assert.equal(classifyBlockingState(shortened.root)?.code, "usage_credits_exhausted");
+  assert.equal(classifyBlockingState(reordered.root)?.code, "usage_credits_exhausted");
+  assert.equal(classifyBlockingState(extra.root)?.code, "usage_credits_exhausted");
   assert.equal(classifyBlockingState(conversationCompleted.root), null);
   assert.equal(classifyBlockingState(ancestorHidden.root), null);
+  assert.equal(classifyBlockingState(unrelated.root), null);
+});
+
+test("classifyBlockingState throttles repeated full-DOM scans for quoted credit text", () => {
+  const quoted = fakeCreditBanner({ excluded: true });
+  const querySelectorAll = quoted.root.querySelectorAll.bind(quoted.root);
+  let bodyScans = 0;
+  quoted.root.querySelectorAll = (selector) => {
+    if (selector === "body *") bodyScans += 1;
+    return querySelectorAll(selector);
+  };
+
+  assert.equal(classifyBlockingState(quoted.root), null);
+  assert.equal(classifyBlockingState(quoted.root), null);
+  assert.equal(bodyScans, 1);
+  assert.equal(classifyBlockingState(quoted.root, { forceScan: true }), null);
+  assert.equal(bodyScans, 2);
 });
 
 test("Claude waits reclassify a persistent credit banner instead of timing out", async () => {
@@ -184,6 +240,7 @@ test("Claude waits reclassify a persistent credit banner instead of timing out",
 test("waitForSendAccepted fails with typed credit state without switching models", async () => {
   const banner = fakeCreditBanner();
   banner.root.querySelectorAll = (selector) => {
+    if (selector === "body *") return [banner.banner, banner.switchModels];
     if (selector.includes("button") || selector.includes("[role=")) return [banner.switchModels];
     if (selector === "[data-testid='user-message']") return [];
     if (selector === "[data-is-streaming]") return [];
@@ -621,6 +678,25 @@ test("fake Claude model picker drives hover-only Max then closes", async () => {
   }
 });
 
+test("fake Claude model picker keeps shared menu visibility semantics for offscreen Fable", async () => {
+  const fixture = makeClaudeModelFixture({ offscreenFable: true });
+  const previousPointerEvent = globalThis.PointerEvent;
+  const previousMouseEvent = globalThis.MouseEvent;
+  const previousKeyboardEvent = globalThis.KeyboardEvent;
+  globalThis.PointerEvent = FakePointerEvent;
+  globalThis.MouseEvent = FakeMouseEvent;
+  globalThis.KeyboardEvent = FakeKeyboardEvent;
+  try {
+    const result = await configureModelState(fixture.root, { model_selection_timeout_ms: 250 });
+    assert.equal(result.status, "selected");
+    assert.equal(fixture.fableClicks, 1);
+  } finally {
+    globalThis.PointerEvent = previousPointerEvent;
+    globalThis.MouseEvent = previousMouseEvent;
+    globalThis.KeyboardEvent = previousKeyboardEvent;
+  }
+});
+
 test("fake Claude model picker reclassifies credits immediately after Fable selection", async () => {
   const fixture = makeClaudeModelFixture();
   const credits = fakeCreditBanner();
@@ -630,9 +706,11 @@ test("fake Claude model picker reclassifies credits immediately after Fable sele
     ...credits.root.defaultView
   };
   fixture.root.querySelectorAll = (selector) => (
-    fixture.modelButton.innerText === "Fable 5 High" && selector.includes("button")
-      ? [credits.switchModels]
-      : originalQuerySelectorAll(selector)
+    fixture.modelButton.innerText === "Fable 5 High" && selector === "body *"
+      ? [credits.banner, credits.switchModels]
+      : fixture.modelButton.innerText === "Fable 5 High" && selector.includes("button")
+        ? [credits.switchModels]
+        : originalQuerySelectorAll(selector)
   );
   const previousPointerEvent = globalThis.PointerEvent;
   const previousMouseEvent = globalThis.MouseEvent;
@@ -1227,7 +1305,8 @@ function makeClaudeModelFixture({
   includeMax = true,
   delayedSelectionClose = false,
   ignoreEscape = false,
-  initiallyConfigured = false
+  initiallyConfigured = false,
+  offscreenFable = false
 } = {}) {
   let menuOpen = false;
   let effortHovered = false;
@@ -1306,6 +1385,16 @@ function makeClaudeModelFixture({
     modelButton.textContent = modelButton.innerText;
     closeAfterSelection();
   });
+  if (offscreenFable) {
+    fable.getBoundingClientRect = () => ({
+      left: 10,
+      top: 900,
+      right: 50,
+      bottom: 920,
+      width: 40,
+      height: 20
+    });
+  }
   const sonnet = control({ role: "menuitemradio", "aria-checked": includeFable ? "false" : "true" }, "Sonnet 5");
   const effort = control({ "data-testid": "effort-menu-trigger" }, "Effort");
   const max = control({ role: "menuitemradio", "data-testid": "effort-option-max", "aria-checked": initiallyConfigured ? "true" : "false" }, "Max", (element) => {

--- a/extensions/chatgpt-native/tests/fake-claude.test.js
+++ b/extensions/chatgpt-native/tests/fake-claude.test.js
@@ -2,16 +2,209 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 import {
+  classifyBlockingState,
+  clickSend,
   configureModelState,
   ensureConversationLoaded,
+  ensureFreshChat,
   extractResponse,
   insertPrompt,
   isResponseGenerating,
-  uploadFile
+  uploadFile,
+  waitForSendAccepted
 } from "../src/claude-dom.js";
 import { claudeSiteAdapter } from "../src/sites/claude.js";
 
 const claudeDomSource = await readFile(new URL("../src/claude-dom.js", import.meta.url), "utf8");
+
+function fakeCreditBanner({
+  excluded = false,
+  visible = true,
+  text = "Your org is out of usage credits for the month. We let your admin know. Switch models to continue chatting.",
+  depth = 8,
+  style = {},
+  rect = null,
+  conversationDescendant = false,
+  hiddenAncestor = false
+} = {}) {
+  const shell = {
+    innerText: text,
+    textContent: text,
+    parentElement: null,
+    getAttribute() {
+      return null;
+    },
+    querySelector() {
+      return conversationDescendant ? {} : null;
+    },
+    getClientRects() {
+      return [{}];
+    }
+  };
+  const banner = {
+    attrs: { role: "alert" },
+    innerText: text,
+    textContent: text,
+    parentElement: shell,
+    getAttribute(name) {
+      return this.attrs[name] ?? null;
+    },
+    getClientRects() {
+      return visible ? [{}] : [];
+    },
+    getBoundingClientRect() {
+      return rect;
+    },
+    querySelector() {
+      return conversationDescendant ? {} : null;
+    }
+  };
+  const switchModels = {
+    attrs: { role: "button" },
+    innerText: "Switch models",
+    textContent: "Switch models",
+    parentElement: null,
+    clickCount: 0,
+    click() {
+      this.clickCount += 1;
+    },
+    closest() {
+      return excluded ? {} : null;
+    },
+    getAttribute(name) {
+      return this.attrs[name] ?? null;
+    },
+    getClientRects() {
+      return visible ? [{}] : [];
+    },
+    getBoundingClientRect() {
+      return rect;
+    }
+  };
+  let parent = banner;
+  for (let index = 0; index < depth; index += 1) {
+    parent = {
+      innerText: "Switch models",
+      textContent: "Switch models",
+      parentElement: parent,
+      getAttribute() {
+        return null;
+      },
+      getClientRects() {
+        return visible ? [{}] : [];
+      },
+      getBoundingClientRect() {
+        return rect;
+      }
+    };
+  }
+  switchModels.parentElement = parent;
+  const root = {
+    body: shell,
+    documentElement: shell,
+    defaultView: {
+      innerWidth: 1200,
+      innerHeight: 800,
+      getComputedStyle: (element) => ({
+        display: visible ? "block" : "none",
+        visibility: visible ? "visible" : "hidden",
+        opacity: hiddenAncestor && element === shell ? "0" : (visible ? "1" : "0"),
+        ...style
+      })
+    },
+    querySelectorAll: (selector) => selector.includes("button") ? [switchModels] : []
+  };
+  return { root, shell, banner, switchModels };
+}
+
+test("classifyBlockingState detects the visible organization credit banner", () => {
+  const banner = fakeCreditBanner();
+
+  assert.deepEqual(classifyBlockingState(banner.root), {
+    state: "usage_credits_exhausted",
+    code: "usage_credits_exhausted",
+    requested_model: "fable-5-max",
+    provider_message: "Your org is out of usage credits for the month. We let your admin know. Switch models to continue chatting.",
+    message: "Claude cannot run Fable 5 Max because this organization is out of monthly usage credits. Yoetz did not switch models."
+  });
+  assert.equal(banner.switchModels.clickCount, 0);
+});
+
+test("classifyBlockingState ignores quoted, hidden, and incomplete credit text", () => {
+  const quoted = fakeCreditBanner({ excluded: true });
+  const hidden = fakeCreditBanner({ visible: false });
+  const transparent = fakeCreditBanner({ style: { opacity: "0" } });
+  const offscreen = fakeCreditBanner({
+    rect: { left: 0, top: 900, right: 500, bottom: 1000, width: 500, height: 100 }
+  });
+  const incomplete = fakeCreditBanner({
+    text: "Your org is out of usage credits for the month. Switch models to continue chatting."
+  });
+  const reordered = fakeCreditBanner({
+    text: "Switch models to continue chatting. We let your admin know. Your org is out of usage credits for the month."
+  });
+  const extra = fakeCreditBanner({
+    text: "Your org is out of usage credits for the month. We let your admin know. Prompt quoted this notice. Switch models to continue chatting."
+  });
+  const conversationCompleted = fakeCreditBanner({ conversationDescendant: true });
+  const ancestorHidden = fakeCreditBanner({ hiddenAncestor: true });
+
+  assert.equal(classifyBlockingState(quoted.root), null);
+  assert.equal(classifyBlockingState(hidden.root), null);
+  assert.equal(classifyBlockingState(transparent.root), null);
+  assert.equal(classifyBlockingState(offscreen.root), null);
+  assert.equal(classifyBlockingState(incomplete.root), null);
+  assert.equal(classifyBlockingState(reordered.root), null);
+  assert.equal(classifyBlockingState(extra.root), null);
+  assert.equal(classifyBlockingState(conversationCompleted.root), null);
+  assert.equal(classifyBlockingState(ancestorHidden.root), null);
+});
+
+test("Claude waits reclassify a persistent credit banner instead of timing out", async () => {
+  const composerWait = fakeCreditBanner();
+  composerWait.root.querySelector = () => null;
+  await assert.rejects(
+    ensureFreshChat(composerWait.root, {}, { timeoutMs: 1 }),
+    (error) => error?.code === "usage_credits_exhausted"
+      && error?.phase === "upload"
+      && error?.send_committed === false
+  );
+
+  const sendWait = fakeCreditBanner();
+  sendWait.root.querySelector = () => null;
+  await assert.rejects(
+    clickSend(sendWait.root, { timeoutMs: 1 }),
+    (error) => error?.code === "usage_credits_exhausted"
+      && error?.phase === "send"
+      && error?.send_committed === false
+  );
+  assert.equal(sendWait.switchModels.clickCount, 0);
+});
+
+test("waitForSendAccepted fails with typed credit state without switching models", async () => {
+  const banner = fakeCreditBanner();
+  banner.root.querySelectorAll = (selector) => {
+    if (selector.includes("button") || selector.includes("[role=")) return [banner.switchModels];
+    if (selector === "[data-testid='user-message']") return [];
+    if (selector === "[data-is-streaming]") return [];
+    return [];
+  };
+
+  await assert.rejects(
+    waitForSendAccepted(banner.root, { user_count: 0, assistant_count: 0 }, {
+      timeoutMs: 20,
+      intervalMs: 1
+    }),
+    (error) => {
+      assert.equal(error.code, "usage_credits_exhausted");
+      assert.equal(error.state, "usage_credits_exhausted");
+      assert.equal(error.requested_model, "fable-5-max");
+      assert.equal(error.send_committed, true);
+      return true;
+    }
+  );
+  assert.equal(banner.switchModels.clickCount, 0);
+});
 
 test("Claude upload uses the native files setter for page-world visibility", () => {
   assert.doesNotMatch(
@@ -421,6 +614,42 @@ test("fake Claude model picker drives hover-only Max then closes", async () => {
     assert.ok(fixture.hoverEvents >= 3, "effort submenu must be re-hovered for Max and verification");
     assert.equal(fixture.sawMousePointer, true);
     assert.equal(fixture.modelButton.getAttribute("aria-expanded"), "false");
+  } finally {
+    globalThis.PointerEvent = previousPointerEvent;
+    globalThis.MouseEvent = previousMouseEvent;
+    globalThis.KeyboardEvent = previousKeyboardEvent;
+  }
+});
+
+test("fake Claude model picker reclassifies credits immediately after Fable selection", async () => {
+  const fixture = makeClaudeModelFixture();
+  const credits = fakeCreditBanner();
+  const originalQuerySelectorAll = fixture.root.querySelectorAll.bind(fixture.root);
+  fixture.root.defaultView = {
+    ...fixture.root.defaultView,
+    ...credits.root.defaultView
+  };
+  fixture.root.querySelectorAll = (selector) => (
+    fixture.modelButton.innerText === "Fable 5 High" && selector.includes("button")
+      ? [credits.switchModels]
+      : originalQuerySelectorAll(selector)
+  );
+  const previousPointerEvent = globalThis.PointerEvent;
+  const previousMouseEvent = globalThis.MouseEvent;
+  const previousKeyboardEvent = globalThis.KeyboardEvent;
+  globalThis.PointerEvent = FakePointerEvent;
+  globalThis.MouseEvent = FakeMouseEvent;
+  globalThis.KeyboardEvent = FakeKeyboardEvent;
+  try {
+    await assert.rejects(
+      configureModelState(fixture.root, { model_selection_timeout_ms: 250 }),
+      (error) => error?.code === "usage_credits_exhausted"
+        && error?.phase === "model_selection"
+        && error?.send_committed === false
+    );
+    assert.equal(fixture.fableClicks, 1);
+    assert.equal(fixture.maxClicks, 0);
+    assert.equal(credits.switchModels.clickCount, 0);
   } finally {
     globalThis.PointerEvent = previousPointerEvent;
     globalThis.MouseEvent = previousMouseEvent;

--- a/extensions/chatgpt-native/tests/fake-claude.test.js
+++ b/extensions/chatgpt-native/tests/fake-claude.test.js
@@ -34,6 +34,8 @@ function fakeCreditBanner({
   nestedMessage = false,
   renderedText = text,
   messageHidden = false,
+  messageRect = rect,
+  messageStyle = {},
   displayContentsAncestor = false,
   shellStyle = {}
 } = {}) {
@@ -71,7 +73,7 @@ function fakeCreditBanner({
       return visible ? [{}] : [];
     },
     getBoundingClientRect() {
-      return rect;
+      return messageRect;
     },
     closest() {
       return excluded ? {} : null;
@@ -155,6 +157,7 @@ function fakeCreditBanner({
         visibility: messageHidden && element === message ? "hidden" : (visible ? "visible" : "hidden"),
         opacity: hiddenAncestor && element === shell ? "0" : (visible ? "1" : "0"),
         ...(element === banner ? style : {}),
+        ...(element === message ? messageStyle : {}),
         ...(element === shell ? shellStyle : {})
       })
     },
@@ -236,18 +239,42 @@ test("classifyBlockingState matches rendered notice text and painted visibility"
   const zeroArea = fakeCreditBanner({
     rect: { left: 10, top: 10, right: 10, bottom: 10, width: 0, height: 0 }
   });
-  const fullyClipped = fakeCreditBanner({ style: { clipPath: "inset(50%)" } });
-  const overflowClipped = fakeCreditBanner({
+  const transparentMatchingChild = fakeCreditBanner({
+    nestedMessage: true,
+    messageStyle: { opacity: "0" },
+    switchControlQueryable: false
+  });
+  const offscreenMatchingChild = fakeCreditBanner({
+    nestedMessage: true,
+    messageRect: { left: 0, top: 900, right: 500, bottom: 1000, width: 500, height: 100 },
+    switchControlQueryable: false
+  });
+  const zeroAreaMatchingChild = fakeCreditBanner({
+    nestedMessage: true,
+    messageRect: { left: 10, top: 10, right: 10, bottom: 10, width: 0, height: 0 },
+    switchControlQueryable: false
+  });
+  const visibleClipPath = fakeCreditBanner({ style: { clipPath: "inset(0)" } });
+  const overflowAutoClipped = fakeCreditBanner({
     rect: { left: 200, top: 200, right: 300, bottom: 300, width: 100, height: 100 },
     ancestorRect: { left: 0, top: 0, right: 100, bottom: 100, width: 100, height: 100 },
-    shellStyle: { overflow: "hidden" }
+    shellStyle: { overflow: "auto" }
+  });
+  const overflowScrollClipped = fakeCreditBanner({
+    rect: { left: 200, top: 200, right: 300, bottom: 300, width: 100, height: 100 },
+    ancestorRect: { left: 0, top: 0, right: 100, bottom: 100, width: 100, height: 100 },
+    shellStyle: { overflow: "scroll" }
   });
   const displayContentsAncestor = fakeCreditBanner({ displayContentsAncestor: true });
 
   assert.equal(classifyBlockingState(hiddenMatchingChild.root), null);
   assert.equal(classifyBlockingState(zeroArea.root), null);
-  assert.equal(classifyBlockingState(fullyClipped.root), null);
-  assert.equal(classifyBlockingState(overflowClipped.root), null);
+  assert.equal(classifyBlockingState(transparentMatchingChild.root), null);
+  assert.equal(classifyBlockingState(offscreenMatchingChild.root), null);
+  assert.equal(classifyBlockingState(zeroAreaMatchingChild.root), null);
+  assert.equal(classifyBlockingState(visibleClipPath.root)?.code, "usage_credits_exhausted");
+  assert.equal(classifyBlockingState(overflowAutoClipped.root), null);
+  assert.equal(classifyBlockingState(overflowScrollClipped.root), null);
   assert.equal(classifyBlockingState(displayContentsAncestor.root)?.code, "usage_credits_exhausted");
 });
 
@@ -289,6 +316,40 @@ test("classifyBlockingState accepts wording drift but rejects structural false p
   assert.equal(classifyBlockingState(unrelated.root), null);
 });
 
+test("classifyBlockingState distinguishes terminal semantic notices from warnings", () => {
+  const terminal = fakeCreditBanner({
+    text: "You're out of usage credits.",
+    switchControlQueryable: false
+  });
+  const terminalAfterUnrelatedNegation = fakeCreditBanner({
+    text: "We could not verify your billing. Your org is out of usage credits.",
+    switchControlQueryable: false
+  });
+  const warnings = [
+    "You're almost out of usage credits.",
+    "You're nearly out of usage credits.",
+    "Your org is not out of usage credits.",
+    "You are no longer out of usage credits.",
+    "Your org isn't out of usage credits.",
+    "You aren't out of usage credits.",
+    "You're about to be out of usage credits.",
+    "You're running low, not out of usage credits."
+  ].map((text) => fakeCreditBanner({ text, switchControlQueryable: false }));
+  const controlCorroborated = fakeCreditBanner({
+    role: null,
+    nestedMessage: true,
+    depth: 1,
+    text: "You're almost out of usage credits. Switch models."
+  });
+
+  assert.equal(classifyBlockingState(terminal.root)?.code, "usage_credits_exhausted");
+  assert.equal(classifyBlockingState(terminalAfterUnrelatedNegation.root)?.code, "usage_credits_exhausted");
+  for (const warning of warnings) {
+    assert.equal(classifyBlockingState(warning.root), null);
+  }
+  assert.equal(classifyBlockingState(controlCorroborated.root)?.code, "usage_credits_exhausted");
+});
+
 test("classifyBlockingState throttles repeated full-DOM scans for quoted credit text", () => {
   const quoted = fakeCreditBanner({ excluded: true });
   const querySelectorAll = quoted.root.querySelectorAll.bind(quoted.root);
@@ -303,6 +364,44 @@ test("classifyBlockingState throttles repeated full-DOM scans for quoted credit 
   assert.equal(bodyScans, 1);
   assert.equal(classifyBlockingState(quoted.root, { forceScan: true }), null);
   assert.equal(bodyScans, 2);
+});
+
+test("clickSend force-scans after a cached negative before clicking", async () => {
+  const banner = fakeCreditBanner();
+  const querySelectorAll = banner.root.querySelectorAll.bind(banner.root);
+  let mounted = false;
+  banner.root.querySelectorAll = (selector) => {
+    if (selector === "body *") {
+      return mounted ? [banner.banner, banner.switchModels] : [];
+    }
+    if (selector.includes("button")) {
+      return mounted ? [banner.switchModels] : [];
+    }
+    return querySelectorAll(selector);
+  };
+  const send = {
+    disabled: false,
+    clickCount: 0,
+    getAttribute() {
+      return null;
+    },
+    click() {
+      this.clickCount += 1;
+    }
+  };
+  banner.root.querySelector = (selector) => (
+    selector === "button[aria-label='Send message']" ? send : null
+  );
+
+  assert.equal(classifyBlockingState(banner.root), null);
+  mounted = true;
+  await assert.rejects(
+    clickSend(banner.root, { timeoutMs: 1 }),
+    (error) => error?.code === "usage_credits_exhausted"
+      && error?.phase === "send"
+      && error?.send_committed === false
+  );
+  assert.equal(send.clickCount, 0);
 });
 
 test("Claude waits reclassify a persistent credit banner instead of timing out", async () => {

--- a/extensions/chatgpt-native/tests/fake-claude.test.js
+++ b/extensions/chatgpt-native/tests/fake-claude.test.js
@@ -24,13 +24,23 @@ function fakeCreditBanner({
   depth = 8,
   style = {},
   rect = null,
+  ancestorRect = null,
   conversationDescendant = false,
   hiddenAncestor = false,
-  switchControlQueryable = true
+  switchControlQueryable = true,
+  role = "alert",
+  ariaLive = null,
+  tagName = null,
+  nestedMessage = false,
+  renderedText = text,
+  messageHidden = false,
+  displayContentsAncestor = false,
+  shellStyle = {}
 } = {}) {
   const shell = {
-    innerText: text,
+    innerText: renderedText,
     textContent: text,
+    tagName: "BODY",
     parentElement: null,
     getAttribute() {
       return null;
@@ -42,13 +52,17 @@ function fakeCreditBanner({
       return conversationDescendant ? {} : null;
     },
     getClientRects() {
-      return [{}];
+      return displayContentsAncestor ? [] : [{}];
+    },
+    getBoundingClientRect() {
+      return ancestorRect;
     }
   };
   const banner = {
-    attrs: { role: "alert" },
-    innerText: text,
+    attrs: { role, "aria-live": ariaLive },
+    innerText: renderedText,
     textContent: text,
+    tagName,
     parentElement: shell,
     getAttribute(name) {
       return this.attrs[name] ?? null;
@@ -66,6 +80,28 @@ function fakeCreditBanner({
       return conversationDescendant ? {} : null;
     }
   };
+  const message = nestedMessage || messageHidden ? {
+    attrs: {},
+    innerText: text,
+    textContent: text,
+    tagName: "P",
+    parentElement: banner,
+    getAttribute(name) {
+      return this.attrs[name] ?? null;
+    },
+    getClientRects() {
+      return messageHidden ? [] : [{}];
+    },
+    getBoundingClientRect() {
+      return rect;
+    },
+    closest() {
+      return excluded ? {} : null;
+    },
+    querySelector() {
+      return null;
+    }
+  } : null;
   const switchModels = {
     attrs: { role: "button" },
     innerText: "Switch models",
@@ -113,18 +149,21 @@ function fakeCreditBanner({
       innerWidth: 1200,
       innerHeight: 800,
       getComputedStyle: (element) => ({
-        display: visible ? "block" : "none",
-        visibility: visible ? "visible" : "hidden",
+        display: messageHidden && element === message
+          ? "none"
+          : (displayContentsAncestor && element === shell ? "contents" : (visible ? "block" : "none")),
+        visibility: messageHidden && element === message ? "hidden" : (visible ? "visible" : "hidden"),
         opacity: hiddenAncestor && element === shell ? "0" : (visible ? "1" : "0"),
-        ...style
+        ...(element === banner ? style : {}),
+        ...(element === shell ? shellStyle : {})
       })
     },
     querySelectorAll(selector) {
-      if (selector === "body *") return [banner, switchModels];
+      if (selector === "body *") return [message, banner, switchModels].filter(Boolean);
       return switchControlQueryable && selector.includes("button") ? [switchModels] : [];
     }
   };
-  return { root, shell, banner, switchModels };
+  return { root, shell, banner, message, switchModels };
 }
 
 test("classifyBlockingState detects the visible organization credit banner", () => {
@@ -166,6 +205,52 @@ test("classifyBlockingState survives unknown Switch models markup and records di
   assert.equal(banner.switchModels.clickCount, 0);
 });
 
+test("classifyBlockingState bounds credit text to a provider notice surface", () => {
+  const sidebarTitle = fakeCreditBanner({
+    role: null,
+    tagName: "ASIDE",
+    switchControlQueryable: false
+  });
+  const ordinaryPageText = fakeCreditBanner({
+    role: null,
+    text: "Your org is out of usage credits for the month.",
+    switchControlQueryable: false
+  });
+  const alertWithoutControl = fakeCreditBanner({ switchControlQueryable: false });
+  const nestedAlert = fakeCreditBanner({ nestedMessage: true, depth: 1 });
+  const controlBackedNotice = fakeCreditBanner({ role: null, nestedMessage: true, depth: 1 });
+
+  assert.equal(classifyBlockingState(sidebarTitle.root), null);
+  assert.equal(classifyBlockingState(ordinaryPageText.root), null);
+  assert.equal(classifyBlockingState(alertWithoutControl.root)?.code, "usage_credits_exhausted");
+  assert.equal(classifyBlockingState(nestedAlert.root)?.provider_dom.switch_models_control.found, true);
+  assert.equal(classifyBlockingState(controlBackedNotice.root)?.code, "usage_credits_exhausted");
+});
+
+test("classifyBlockingState matches rendered notice text and painted visibility", () => {
+  const hiddenMatchingChild = fakeCreditBanner({
+    renderedText: "A different visible notification.",
+    messageHidden: true,
+    switchControlQueryable: false
+  });
+  const zeroArea = fakeCreditBanner({
+    rect: { left: 10, top: 10, right: 10, bottom: 10, width: 0, height: 0 }
+  });
+  const fullyClipped = fakeCreditBanner({ style: { clipPath: "inset(50%)" } });
+  const overflowClipped = fakeCreditBanner({
+    rect: { left: 200, top: 200, right: 300, bottom: 300, width: 100, height: 100 },
+    ancestorRect: { left: 0, top: 0, right: 100, bottom: 100, width: 100, height: 100 },
+    shellStyle: { overflow: "hidden" }
+  });
+  const displayContentsAncestor = fakeCreditBanner({ displayContentsAncestor: true });
+
+  assert.equal(classifyBlockingState(hiddenMatchingChild.root), null);
+  assert.equal(classifyBlockingState(zeroArea.root), null);
+  assert.equal(classifyBlockingState(fullyClipped.root), null);
+  assert.equal(classifyBlockingState(overflowClipped.root), null);
+  assert.equal(classifyBlockingState(displayContentsAncestor.root)?.code, "usage_credits_exhausted");
+});
+
 test("classifyBlockingState accepts wording drift but rejects structural false positives", () => {
   const quoted = fakeCreditBanner({ excluded: true });
   const hidden = fakeCreditBanner({ visible: false });
@@ -182,6 +267,9 @@ test("classifyBlockingState accepts wording drift but rejects structural false p
   const extra = fakeCreditBanner({
     text: "Your org is out of usage credits for the month. We let your admin know. Prompt quoted this notice. Switch models to continue chatting."
   });
+  const drifted = fakeCreditBanner({
+    text: "You're out of usage credits. Switch models to continue."
+  });
   const conversationCompleted = fakeCreditBanner({ conversationDescendant: true });
   const ancestorHidden = fakeCreditBanner({ hiddenAncestor: true });
   const unrelated = fakeCreditBanner({
@@ -195,6 +283,7 @@ test("classifyBlockingState accepts wording drift but rejects structural false p
   assert.equal(classifyBlockingState(shortened.root)?.code, "usage_credits_exhausted");
   assert.equal(classifyBlockingState(reordered.root)?.code, "usage_credits_exhausted");
   assert.equal(classifyBlockingState(extra.root)?.code, "usage_credits_exhausted");
+  assert.equal(classifyBlockingState(drifted.root)?.code, "usage_credits_exhausted");
   assert.equal(classifyBlockingState(conversationCompleted.root), null);
   assert.equal(classifyBlockingState(ancestorHidden.root), null);
   assert.equal(classifyBlockingState(unrelated.root), null);

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -5971,6 +5971,10 @@ test("service worker preserves content-script committed-send error metadata", as
               code: "send_acceptance_unknown",
               state: "usage_credits_exhausted",
               provider_message: "Your org is out of usage credits for the month.",
+              provider_dom: {
+                container: { found: true, tag: "div", role: "alert" },
+                switch_models_control: { found: false }
+              },
               requested_model: "fable-5-max",
               send_committed: true,
               phase: "send",
@@ -6005,6 +6009,10 @@ test("service worker preserves content-script committed-send error metadata", as
     assert.equal(error.payload.side_effect_started, true);
     assert.equal(error.payload.state, "usage_credits_exhausted");
     assert.equal(error.payload.provider_message, "Your org is out of usage credits for the month.");
+    assert.deepEqual(error.payload.provider_dom, {
+      container: { found: true, tag: "div", role: "alert" },
+      switch_models_control: { found: false }
+    });
     assert.equal(error.payload.requested_model, "fable-5-max");
     assert.equal(error.payload.send_committed, true);
     assert.equal(port.messages.some((message) => message.type === "job_complete"), false);

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -5969,6 +5969,10 @@ test("service worker preserves content-script committed-send error metadata", as
             return {
               ok: false,
               code: "send_acceptance_unknown",
+              state: "usage_credits_exhausted",
+              provider_message: "Your org is out of usage credits for the month.",
+              requested_model: "fable-5-max",
+              send_committed: true,
               phase: "send",
               side_effect_started: true,
               error: "send click committed; acceptance unknown"
@@ -5999,6 +6003,95 @@ test("service worker preserves content-script committed-send error metadata", as
     const error = port.messages.find((message) => message.type === "job_error" && message.payload.code === "send_acceptance_unknown");
     assert.equal(error.payload.phase, "send");
     assert.equal(error.payload.side_effect_started, true);
+    assert.equal(error.payload.state, "usage_credits_exhausted");
+    assert.equal(error.payload.provider_message, "Your org is out of usage credits for the month.");
+    assert.equal(error.payload.requested_model, "fable-5-max");
+    assert.equal(error.payload.send_committed, true);
+    assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker reports Claude credits at baseline extraction as pre-send", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  let tabId = 0;
+  let sendPromptCalls = 0;
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://claude.ai/new" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return {
+              ok: true,
+              payload: {
+                status: "selected",
+                requested_model: "fable-5-max",
+                model_used: "Fable 5 Max",
+                modelVerified: true,
+                maxVerified: true
+              }
+            };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_extract_response":
+            assert.equal(message.blocking_context, "pre_send_baseline");
+            return {
+              ok: false,
+              code: "usage_credits_exhausted",
+              state: "usage_credits_exhausted",
+              provider_message: "Your org is out of usage credits for the month. We let your admin know. Switch models to continue chatting.",
+              requested_model: "fable-5-max",
+              phase: "send",
+              side_effect_started: true,
+              send_committed: false,
+              error: "Claude cannot run Fable 5 Max because this organization is out of monthly usage credits. Yoetz did not switch models."
+            };
+          case "yoetz_send_prompt":
+            sendPromptCalls += 1;
+            throw new Error("prompt must not be sent after credit exhaustion");
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?claude_credits_baseline=${Date.now()}`);
+    port.emit(envelope("job_start", "job_claude_credits_baseline", {
+      recipe: "claude",
+      prompt: "prompt"
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_claude_credits_baseline", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_claude_credits_baseline.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) => (
+      message.type === "job_error" && message.payload.code === "usage_credits_exhausted"
+    )));
+    const error = port.messages.find((message) => (
+      message.type === "job_error" && message.payload.code === "usage_credits_exhausted"
+    ));
+    assert.equal(error.payload.phase, "send");
+    assert.equal(error.payload.side_effect_started, true);
+    assert.equal(error.payload.send_committed, false);
+    assert.equal(error.payload.requested_model, "fable-5-max");
+    assert.equal(sendPromptCalls, 0);
     assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
   } finally {
     globalThis.chrome = originalChrome;


### PR DESCRIPTION
## Summary
- detect Claude's exact visible organization usage-credit banner without scanning conversation content
- fail terminally as `usage_credits_exhausted` at prepare, model selection, send, and response checkpoints
- preserve pre/post-send side-effect metadata and never click Switch models or silently downgrade Fable

## Verification
- `npm test` in `extensions/chatgpt-native`: 296/296 passing
- `./scripts/build-chatgpt-native-extension.sh --check`: 19 package files verified
- `git diff --check`: clean
- ChatGPT Pro exact-tree review: PASS after three review/fix rounds

The Claude 90-second stable-idle finality floor is intentionally unchanged.