### PR TITLE
docs: record unreleased browser fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Browser recipes now poll every two seconds after post-send assistant activity
+  becomes visible and emit `awaiting_final_affordance` on transition, while
+  preserving the configured cadence for outward response-progress events.
+- Claude browser recipes now detect the visible organization usage-credit
+  exhaustion banner, stop before clicking Send, and return structured provider
+  diagnostics without switching models.
+
 ## [0.5.46] - 2026-07-27
 ### Changed
 


### PR DESCRIPTION
## Summary

- document the shared browser response-loop behavior merged in #367
- document Claude usage-credit exhaustion handling merged in #368
- state the safety property that Yoetz does not switch models

## Verification

- git diff --check
- peer review PASS on the corrected one-file scope

## Release status

0.5.47 remains explicitly held. This PR updates only the Unreleased section; it does not bump versions, tag, or publish artifacts.