### PR TITLE
fix: fail closed on ambiguous Claude finality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Claude browser jobs now fail with `response_finality_stalled` after five
+  continuously unchanged minutes without positive finality proof, preserving
+  the owned tab for inspection instead of waiting until the general timeout.
 - Browser recipes now poll every two seconds after post-send assistant activity
   becomes visible and emit `awaiting_final_affordance` on transition, while
   preserving the configured cadence for outward response-progress events.

--- a/extensions/chatgpt-native/src/claude-dom.js
+++ b/extensions/chatgpt-native/src/claude-dom.js
@@ -17,6 +17,10 @@ const MAX_CONTROL_SURFACE_DEPTH = 8;
 // A provider notice is short; this rejects broad page/sidebar wrappers when the
 // control-backed fallback is needed because no semantic live region exists.
 const MAX_CONTROL_SURFACE_TEXT_CHARS = 1000;
+const CONTENT_SCRIPT_INSTANCE_ID = globalThis.crypto?.randomUUID?.()
+  ?? `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+const assistantIdentityCache = new WeakMap();
+let nextAssistantIdentity = 0;
 const CONVERSATION_CONTENT_SELECTOR = [
   COMPOSER_SELECTOR,
   "[data-testid='user-message']",
@@ -522,15 +526,21 @@ export function extractResponse(root = document) {
   };
   const globalCopyButtons = root.querySelectorAll(COPY_ACTION_SELECTOR).length;
   const scopedCopyButtons = turn?.querySelectorAll?.(COPY_ACTION_SELECTOR)?.length ?? 0;
+  const lastTurnStreaming = last?.getAttribute?.("data-is-streaming") ?? null;
+  const assistantIdentity = last ? assistantIdentityFor(last) : null;
   const isGenerating = isResponseGenerating(root);
   const precedingUserCount = last ? precedingUserTurnCount(root, last) : 0;
   const diagnostics = {
     counts: {
       assistant_turns: assistants.length,
       copy_buttons: globalCopyButtons,
+      scoped_copy_buttons: scopedCopyButtons,
       stop_controls: root.querySelectorAll("button[aria-label='Stop response']").length,
       thinking_rows: root.querySelectorAll("button[class*='group/status']").length,
       artifact_blocks: artifactBlocks.count
+    },
+    finality: {
+      last_turn_streaming: lastTurnStreaming
     },
     assistant_turn_snippets: assistants.slice(-3).map((element) => elementSummary(element)),
     page_text_chars: String(root.body?.innerText ?? "").length,
@@ -542,6 +552,7 @@ export function extractResponse(root = document) {
       text: "",
       is_generating: isGenerating,
       assistant_count: assistants.length,
+      assistant_identity: assistantIdentity,
       turn_index: assistants.length - 1,
       preceding_user_count: precedingUserCount,
       copy_button_count: globalCopyButtons,
@@ -555,6 +566,7 @@ export function extractResponse(root = document) {
     text,
     is_generating: isGenerating,
     assistant_count: assistants.length,
+    assistant_identity: assistantIdentity,
     turn_index: assistants.length - 1,
     preceding_user_count: precedingUserCount,
     copy_button_count: globalCopyButtons,
@@ -665,11 +677,35 @@ function userTurnCount(root) {
 
 function precedingUserTurnCount(root, target) {
   const users = Array.from(root.querySelectorAll("[data-testid='user-message']"));
-  return users.filter((element) => {
-    const position = element.compareDocumentPosition?.(target) ?? 0;
-    const following = globalThis.Node?.DOCUMENT_POSITION_FOLLOWING ?? 4;
-    return Boolean(position & following);
-  }).length;
+  return users.filter((element) => isStrictlyFollowing(element, target)).length;
+}
+
+function isStrictlyFollowing(source, target) {
+  const position = source?.compareDocumentPosition?.(target) ?? 0;
+  const following = globalThis.Node?.DOCUMENT_POSITION_FOLLOWING ?? 4;
+  const disconnected = globalThis.Node?.DOCUMENT_POSITION_DISCONNECTED ?? 1;
+  const implementationSpecific = globalThis.Node?.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC ?? 32;
+  return !(position & (disconnected | implementationSpecific))
+    && Boolean(position & following);
+}
+
+function assistantIdentityFor(element) {
+  const providerIdentity = [
+    element.getAttribute?.("data-message-id"),
+    element.getAttribute?.("data-turn-id"),
+    element.getAttribute?.("id"),
+    element.id
+  ].find((value) => typeof value === "string" && value.trim());
+  if (providerIdentity) {
+    return `provider:${providerIdentity.trim()}`;
+  }
+  let identity = assistantIdentityCache.get(element);
+  if (!identity) {
+    nextAssistantIdentity += 1;
+    identity = `dom:${CONTENT_SCRIPT_INSTANCE_ID}:${nextAssistantIdentity}`;
+    assistantIdentityCache.set(element, identity);
+  }
+  return identity;
 }
 
 function conversationIdFromLocation() {

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -67,6 +67,12 @@ const POST_SEND_ASSISTANT_ACTIVITY_POLL_MS = Math.max(
   250,
   Number(globalThis.__YOETZ_POST_SEND_ASSISTANT_ACTIVITY_POLL_MS ?? 2000) || 2000
 );
+const RESPONSE_FINALITY_STALL_MS = Math.max(
+  0,
+  Number.isFinite(Number(globalThis.__YOETZ_RESPONSE_FINALITY_STALL_MS))
+    ? Number(globalThis.__YOETZ_RESPONSE_FINALITY_STALL_MS)
+    : 5 * 60 * 1000
+);
 const MAX_NATIVE_OUTBOUND_BYTES = Math.max(
   1024,
   Number(globalThis.__YOETZ_MAX_NATIVE_OUTBOUND_BYTES ?? 64 * 1024 * 1024) || 64 * 1024 * 1024
@@ -1618,6 +1624,8 @@ async function waitForResponse(job) {
   let renderRefreshCandidate = null;
   let renderRefreshCandidateSinceMs = 0;
   let extractionFailureSinceMs = 0;
+  let finalityStallSignature = null;
+  let finalityStallCandidateSinceMs = 0;
   let lastResponseProgressAt = 0;
   let lastResponseProgressGenerating = null;
   let lastResponseProgressInterimTurn = false;
@@ -1648,6 +1656,49 @@ async function waitForResponse(job) {
     last = extraction ?? last;
     const postSend = isPostSendExtraction(job, extraction);
     const postSendAssistantActivity = isPostSendAssistantActivity(job, extraction, true);
+    const currentFinalityStallSignature = isClaudeFinalityConflict(job, extraction)
+      ? responseFinalityStallSignature(extraction)
+      : null;
+    if (currentFinalityStallSignature === null) {
+      finalityStallSignature = null;
+      finalityStallCandidateSinceMs = 0;
+    } else if (currentFinalityStallSignature !== finalityStallSignature) {
+      finalityStallSignature = currentFinalityStallSignature;
+      finalityStallCandidateSinceMs = Date.now();
+    } else if (!finalityStallCandidateSinceMs) {
+      finalityStallCandidateSinceMs = Date.now();
+    }
+    const finalityStalledForMs = finalityStallCandidateSinceMs
+      ? Date.now() - finalityStallCandidateSinceMs
+      : 0;
+    if (currentFinalityStallSignature !== null
+        && finalityStalledForMs >= RESPONSE_FINALITY_STALL_MS) {
+      const inspectCommand = inspectCommandForJob(job);
+      const adapter = adapterForJob(job);
+      await failJob(
+        job,
+        "response_finality_stalled",
+        `${adapter.displayName} response content remained unchanged for ${formatDurationForMessage(finalityStalledForMs)} without positive finality proof. The owned ${adapter.displayName} tab is left open; inspect it before rerunning with: ${inspectCommand}. Do not rerun until inspection because the prompt was already submitted.`,
+        {
+          phase: "wait_response",
+          side_effect_started: true,
+          completion_reason: "non_streaming_turn_with_persistent_stop",
+          send_committed: true,
+          stable_for_ms: finalityStalledForMs,
+          stall_timeout_ms: RESPONSE_FINALITY_STALL_MS,
+          extraction_method: extraction.method,
+          response_length: extraction.text.length,
+          assistant_count: extraction.assistant_count ?? 0,
+          assistant_identity: extraction.assistant_identity,
+          turn_index: extraction.turn_index ?? -1,
+          copy_button_count: extraction.copy_button_count ?? 0,
+          has_copy_button: Boolean(extraction.has_copy_button),
+          inspect_command: inspectCommand,
+          diagnostics: diagnosticPayload(extraction.diagnostics)
+        }
+      );
+      return null;
+    }
     if (postSend && extraction?.text && extraction.text.length >= best.text.length) {
       best = extraction;
     }
@@ -2040,6 +2091,7 @@ function diagnosticPayload(diagnostics) {
     page_text_chars: diagnostics.page_text_chars ?? null,
     page_text_content_chars: diagnostics.page_text_content_chars ?? null,
     counts: diagnostics.counts ?? {},
+    finality: diagnostics.finality ?? {},
     assistant_turn_snippets: (diagnostics.assistant_turn_snippets ?? []).slice(-3),
     article_snippets: (diagnostics.article_snippets ?? []).slice(-3),
     markdown_snippets: (diagnostics.markdown_snippets ?? []).slice(-3),
@@ -2226,6 +2278,28 @@ function isPostSendExtraction(job, extraction) {
     return true;
   }
   return isPostSendAssistantActivity(job, extraction);
+}
+
+function responseFinalityStallSignature(extraction) {
+  return JSON.stringify([
+    extraction.text,
+    extraction.assistant_count,
+    extraction.turn_index,
+    extraction.method,
+    extraction.assistant_identity
+  ]);
+}
+
+function isClaudeFinalityConflict(job, extraction) {
+  return adapterForJob(job).recipe === "claude"
+    && isPostSendExtraction(job, extraction)
+    && extraction.method === "assistant_dom"
+    && Boolean(extraction.text)
+    && typeof extraction.assistant_identity === "string"
+    && Boolean(extraction.assistant_identity.trim())
+    && extraction.is_generating === true
+    && extraction.diagnostics?.finality?.last_turn_streaming === "false"
+    && Number(extraction.diagnostics?.counts?.stop_controls ?? 0) > 0;
 }
 
 function isPostSendAssistantActivity(job, extraction, allowUnknownTurnIndex = false) {

--- a/extensions/chatgpt-native/src/sites/claude.js
+++ b/extensions/chatgpt-native/src/sites/claude.js
@@ -66,11 +66,9 @@ function selectFinalAffordanceCandidate(candidate, extraction) {
   const candidateText = normalizedResponseText(candidate?.text);
   const nextText = normalizedResponseText(extraction?.text);
   if (!candidate) return { candidate: extraction, resetTimer: true };
-  if (nextText === candidateText) {
+  if (extraction.assistant_identity === candidate.assistant_identity
+      && nextText === candidateText) {
     return { candidate: extraction, resetTimer: false };
-  }
-  if (nextText.length < candidateText.length) {
-    return { candidate, resetTimer: false };
   }
   return { candidate: extraction, resetTimer: true };
 }

--- a/extensions/chatgpt-native/tests/fake-claude.test.js
+++ b/extensions/chatgpt-native/tests/fake-claude.test.js
@@ -1224,6 +1224,35 @@ test("fake Claude completed scoped answer does not require a hover-only copy but
   assert.equal(claudeSiteAdapter.completion.finalAffordanceRequiresStableIdle, true);
 });
 
+test("fake Claude reports a non-streaming last turn while a global stop keeps extraction fail-closed", () => {
+  const page = fakeClaudePage({
+    text: "complete-looking response with a persistent stop control",
+    streaming: false,
+    copy: false,
+    stop: true
+  });
+
+  const extraction = extractResponse(page.root);
+
+  assert.equal(extraction.has_copy_button, false);
+  assert.equal(extraction.is_generating, true);
+  assert.deepEqual(extraction.diagnostics.finality, {
+    last_turn_streaming: "false"
+  });
+  assert.equal(extraction.diagnostics.counts.scoped_copy_buttons, 0);
+  assert.equal(extraction.diagnostics.counts.stop_controls, 1);
+  assert.equal(claudeSiteAdapter.completion.hasFinalAssistantAffordance(extraction), false);
+});
+
+test("fake Claude rejects disconnected user nodes for assistant freshness", () => {
+  const page = fakeClaudePage({ text: "answer", streaming: false, copy: false });
+  page.user.compareDocumentPosition = () => 37;
+
+  const extraction = extractResponse(page.root);
+
+  assert.equal(extraction.preceding_user_count, 0);
+});
+
 test("fake Claude extraction reports artifact cards from only the final assistant root", () => {
   const finalArtifact = fakeArtifactCard("Release plan / Document · MD / Download");
   const finalPage = fakeClaudePage({
@@ -1341,7 +1370,14 @@ test("fake Claude model acceptance requires Fable 5 and Max together", () => {
   }
 });
 
-function fakeClaudePage({ text, streaming, copy, thinking = false, artifacts = [] }) {
+function fakeClaudePage({
+  text,
+  streaming,
+  copy,
+  thinking = false,
+  artifacts = [],
+  stop = false
+}) {
   const body = { innerText: text, textContent: text };
   const copyButton = {};
   const page = {
@@ -1354,20 +1390,22 @@ function fakeClaudePage({ text, streaming, copy, thinking = false, artifacts = [
   };
   const assistant = fakeClaudeAssistant({ text, streaming, thinking, artifacts, body, turn });
   const user = {
-    compareDocumentPosition() {
-      return 4;
+    compareDocumentPosition(target) {
+      return target === assistant ? 4 : 0;
     }
   };
   const root = {
     body: { innerText: text, textContent: text },
     querySelector(selector) {
-      if (selector === "button[aria-label='Stop response']") return null;
+      if (selector === "button[aria-label='Stop response']") return stop ? {} : null;
       return null;
     },
     querySelectorAll(selector) {
-      if (selector === "[data-is-streaming]") return [assistant];
+      if (selector === "[data-is-streaming]") {
+        return [assistant];
+      }
       if (selector === "[data-testid='action-bar-copy']") return page.globalCopy;
-      if (selector === "button[aria-label='Stop response']") return [];
+      if (selector === "button[aria-label='Stop response']") return stop ? [{}] : [];
       if (selector === "button[class*='group/status']") return thinking ? [{}] : [];
       if (selector === "[data-testid='user-message']") return [user];
       return [];
@@ -1375,6 +1413,7 @@ function fakeClaudePage({ text, streaming, copy, thinking = false, artifacts = [
   };
   page.root = root;
   page.assistant = assistant;
+  page.user = user;
   page.body = body;
   return page;
 }

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -493,21 +493,23 @@ test("service worker runs a Claude job through its adapter and probes the select
             };
           case "yoetz_extract_response":
             if (sent) postSendExtractCount += 1;
+            const latestAssistant = postSendExtractCount >= 2;
             return {
               ok: true,
               payload: sent
                   ? {
                     method: "assistant_dom",
-                    text: "Claude answer",
+                    text: latestAssistant ? "Short answer" : "Claude answer that is longer",
                     is_generating: false,
                     assistant_count: 1,
+                    assistant_identity: latestAssistant ? "assistant-a2" : "assistant-a1",
                     copy_button_count: 0,
                     has_copy_button: false,
                     turn_index: 0,
                     conversation_id: conversationId,
                     artifact_blocks: {
-                      count: postSendExtractCount >= 2 ? 1 : 0,
-                      titles: postSendExtractCount >= 2 ? ["Release plan"] : []
+                      count: postSendExtractCount >= 3 ? 1 : 0,
+                      titles: postSendExtractCount >= 3 ? ["Release plan"] : []
                     }
                   }
                 : { method: "none", text: "", is_generating: false, assistant_count: 0, turn_index: -1 }
@@ -562,7 +564,7 @@ test("service worker runs a Claude job through its adapter and probes the select
     const complete = port.messages.find((message) =>
       message.type === "job_complete" && message.job_id === "job_claude"
     );
-    assert.equal(complete.payload.response, "Claude answer");
+    assert.equal(complete.payload.response, "Short answer");
     assert.equal(complete.payload.model_used, "Fable 5 Max");
     assert.equal(complete.payload.completion_reason, "stable_idle");
     assert.equal(complete.payload.conversation_id, conversationId);
@@ -572,7 +574,7 @@ test("service worker runs a Claude job through its adapter and probes the select
       count: 1,
       titles: ["Release plan"]
     }]);
-    assert.equal(postSendExtractCount, 2);
+    assert.equal(postSendExtractCount, 3);
   } finally {
     globalThis.chrome = originalChrome;
   }
@@ -3462,6 +3464,222 @@ test("service worker keeps stable-idle finality tied to the configured interval 
       delete globalThis.__YOETZ_STABLE_IDLE_INTERVAL_MULTIPLIER;
     } else {
       globalThis.__YOETZ_STABLE_IDLE_INTERVAL_MULTIPLIER = previousStableIdleMultiplier;
+    }
+  }
+});
+
+test("service worker fails a continuously unchanged post-send response as response_finality_stalled", async () => {
+  const originalChrome = globalThis.chrome;
+  const previousFinalityStallMs = globalThis.__YOETZ_RESPONSE_FINALITY_STALL_MS;
+  globalThis.__YOETZ_RESPONSE_FINALITY_STALL_MS = 600;
+  const port = makePort();
+  let tabId = 0;
+  let sent = false;
+  let extractionCount = 0;
+  let removedTabs = 0;
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://claude.ai/" }),
+      remove: async () => {
+        removedTabs += 1;
+      },
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: verifiedFableMaxSelection() };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return {
+              ok: true,
+              payload: {
+                sent: true,
+                submitted_assistant_count: 0,
+                submitted_user_count: 1
+              }
+            };
+          case "yoetz_extract_response":
+            if (!sent) {
+              return { ok: true, payload: { method: "none", text: "", is_generating: false, assistant_count: 0, turn_index: -1 } };
+            }
+            extractionCount += 1;
+            return {
+              ok: true,
+              payload: {
+                method: "assistant_dom",
+                text: "Complete-looking body blocked by an unowned global stop control.",
+                is_generating: true,
+                assistant_count: 1,
+                assistant_identity: "stalled-assistant",
+                preceding_user_count: 1,
+                turn_index: 0,
+                diagnostics: {
+                  finality: {
+                    last_turn_streaming: "false"
+                  },
+                  counts: { stop_controls: 1 }
+                }
+              }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?response_finality_stalled=${Date.now()}`);
+    port.emit(envelope("job_start", "job_response_finality_stalled", {
+      recipe: "claude",
+      prompt: "prompt",
+      wait_interval_ms: 500,
+      wait_timeout_ms: 4000
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_response_finality_stalled", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_response_finality_stalled.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) =>
+      message.type === "job_error" && message.payload.code === "response_finality_stalled"
+    ), 3000);
+    const error = port.messages.find((message) =>
+      message.type === "job_error" && message.payload.code === "response_finality_stalled"
+    );
+    assert.ok(extractionCount >= 3);
+    assert.equal(error.payload.tab_disposition, "kept");
+    assert.equal(error.payload.extraction_method, "assistant_dom");
+    assert.equal(error.payload.assistant_count, 1);
+    assert.equal(error.payload.assistant_identity, "stalled-assistant");
+    assert.equal(error.payload.turn_index, 0);
+    assert.equal(error.payload.response_length, 64);
+    assert.equal(error.payload.completion_reason, "non_streaming_turn_with_persistent_stop");
+    assert.equal(error.payload.send_committed, true);
+    assert.equal(error.payload.copy_button_count, 0);
+    assert.equal(error.payload.has_copy_button, false);
+    assert.equal(error.payload.diagnostics.finality.last_turn_streaming, "false");
+    assert.equal(error.payload.diagnostics.counts.stop_controls, 1);
+    assert.match(error.payload.message, /inspect it before rerunning/i);
+    assert.match(error.payload.message, /Do not rerun until inspection/i);
+    assert.equal(removedTabs, 0, "terminal finality failures must preserve the owned tab");
+    assert.equal(port.messages.some((message) => message.type === "job_complete"), false);
+
+    port.emit(envelope("job_start", "job_response_finality_stalled", {
+      recipe: "claude",
+      prompt: "must not resubmit"
+    }));
+    await eventually(() => port.messages.some((message) =>
+      message.type === "job_error" && message.payload.code === "duplicate_job"
+    ));
+    assert.equal(removedTabs, 0);
+  } finally {
+    globalThis.chrome = originalChrome;
+    if (previousFinalityStallMs === undefined) {
+      delete globalThis.__YOETZ_RESPONSE_FINALITY_STALL_MS;
+    } else {
+      globalThis.__YOETZ_RESPONSE_FINALITY_STALL_MS = previousFinalityStallMs;
+    }
+  }
+});
+
+test("service worker resets the finality-stall timer on signature changes and disappearance", async () => {
+  const originalChrome = globalThis.chrome;
+  const previousFinalityStallMs = globalThis.__YOETZ_RESPONSE_FINALITY_STALL_MS;
+  globalThis.__YOETZ_RESPONSE_FINALITY_STALL_MS = 600;
+  const port = makePort();
+  let tabId = 0;
+  let sent = false;
+  let extractionCount = 0;
+  const postSendExtractions = [
+    { method: "assistant_dom", text: "A", is_generating: true, assistant_count: 1, assistant_identity: "a1", preceding_user_count: 1, turn_index: 0, diagnostics: { finality: { last_turn_streaming: "false" }, counts: { stop_controls: 1 } } },
+    { method: "assistant_dom", text: "A", is_generating: true, assistant_count: 1, assistant_identity: "a2", preceding_user_count: 1, turn_index: 0, diagnostics: { finality: { last_turn_streaming: "false" }, counts: { stop_controls: 1 } } },
+    { method: "assistant_dom", text: "A", is_generating: true, assistant_count: 1, assistant_identity: "a2", preceding_user_count: 1, turn_index: 0, diagnostics: { finality: { last_turn_streaming: "false" }, counts: { stop_controls: 1 } } },
+    { method: "assistant_dom", text: "B", is_generating: true, assistant_count: 1, assistant_identity: "a2", preceding_user_count: 1, turn_index: 0, diagnostics: { finality: { last_turn_streaming: "false" }, counts: { stop_controls: 1 } } },
+    { method: "none", text: "", is_generating: true, assistant_count: 0, turn_index: -1 },
+    { method: "assistant_dom", text: "A", is_generating: true, assistant_count: 1, assistant_identity: "a3", preceding_user_count: 1, turn_index: 0, diagnostics: { finality: { last_turn_streaming: "true" }, counts: { stop_controls: 1 } } },
+    { method: "assistant_dom", text: "A", is_generating: true, assistant_count: 1, preceding_user_count: 1, turn_index: 0, diagnostics: { finality: { last_turn_streaming: "false" }, counts: { stop_controls: 1 } } },
+    { method: "assistant_dom", text: "A", is_generating: true, assistant_count: 1, preceding_user_count: 1, turn_index: 0, diagnostics: { finality: { last_turn_streaming: "false" }, counts: { stop_controls: 1 } } },
+    { method: "assistant_dom", text: "A", is_generating: true, assistant_count: 1, preceding_user_count: 1, turn_index: 0, diagnostics: { finality: { last_turn_streaming: "false" }, counts: { stop_controls: 1 } } },
+    { method: "assistant_dom", text: "A", is_generating: true, assistant_count: 1, assistant_identity: "a4", preceding_user_count: 1, turn_index: 0, diagnostics: { finality: { last_turn_streaming: "false" }, counts: { stop_controls: 1 } } }
+  ];
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://claude.ai/" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: verifiedFableMaxSelection() };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true, submitted_assistant_count: 0, submitted_user_count: 1 } };
+          case "yoetz_extract_response":
+            if (!sent) {
+              return { ok: true, payload: { method: "none", text: "", is_generating: false, assistant_count: 0, turn_index: -1 } };
+            }
+            extractionCount += 1;
+            return {
+              ok: true,
+              payload: postSendExtractions[Math.min(extractionCount - 1, postSendExtractions.length - 1)]
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?response_finality_stall_resets=${Date.now()}`);
+    port.emit(envelope("job_start", "job_response_finality_stall_resets", {
+      recipe: "claude",
+      prompt: "prompt",
+      wait_interval_ms: 500,
+      wait_timeout_ms: 7000
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_response_finality_stall_resets", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_response_finality_stall_resets.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+
+    await eventually(() => port.messages.some((message) =>
+      message.type === "job_error" && message.payload.code === "response_finality_stalled"
+    ), 7000);
+    assert.ok(
+      extractionCount >= 12,
+      `timer must restart after signature changes and ignore missing identity; observed ${extractionCount} extractions`
+    );
+  } finally {
+    globalThis.chrome = originalChrome;
+    if (previousFinalityStallMs === undefined) {
+      delete globalThis.__YOETZ_RESPONSE_FINALITY_STALL_MS;
+    } else {
+      globalThis.__YOETZ_RESPONSE_FINALITY_STALL_MS = previousFinalityStallMs;
     }
   }
 });


### PR DESCRIPTION
## Summary
- fail Claude runs with a typed `response_finality_stalled` error after five continuously unchanged minutes when the latest assistant reports non-streaming but a global Stop control persists
- preserve the owned tab and require inspection before any rerun
- bind stable-idle candidates to assistant identity and reset on any text/identity change, including shrinkage

## Verification
- `node --test extensions/chatgpt-native/tests/*.test.js` (307/307)
- `./scripts/build-chatgpt-native-extension.sh --check` (19 files)
- `git diff --check`

Live Claude canary not run: provider was unavailable. Deterministic DOM/service-worker fixtures are the release gate for this change.

Closes #350