### PR TITLE
fix: scope ChatGPT challenge handoffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- ChatGPT native-extension jobs now ignore challenge phrases in authenticated
-  page chrome, and live extension hellos supersede historical manual-handoff
-  records so reconnect restores transport auto-selection.
+- ChatGPT native-extension jobs now scope login, challenge, and rate-limit
+  detection to transcript-free site context so sidebar history and conversation
+  text cannot trigger a false manual handoff, recognize common Cloudflare
+  interstitial metadata, and let live extension hellos supersede historical
+  manual-handoff records so reconnect restores transport auto-selection.
 
 ## [0.5.47] - 2026-07-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- ChatGPT native-extension jobs now ignore challenge phrases in authenticated
+  page chrome, and live extension hellos supersede historical manual-handoff
+  records so reconnect restores transport auto-selection.
+
 ## [0.5.47] - 2026-07-27
 ### Fixed
 

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -1059,10 +1059,10 @@ pub fn status() -> Result<ExtensionStatus> {
         "version_mismatch"
     } else if managed_copy_mismatch.is_some() {
         "managed_copy_mismatch"
-    } else if manual_handoff {
-        "manual_handoff"
     } else if socket_reachable && hello_seen {
         "connected"
+    } else if manual_handoff {
+        "manual_handoff"
     } else if socket_reachable {
         "missing_extension"
     } else if manifest_installed && wrapper_installed && token_present {
@@ -5014,6 +5014,61 @@ mod tests {
             extension_hello.detail,
             "extension_version=0.2.0, extension_instance_id=ext_123, chrome_profile_email=work@example.com"
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    #[serial]
+    fn live_extension_connection_supersedes_historical_manual_handoff() {
+        use std::os::unix::net::UnixListener;
+
+        let dir = TempDir::new().unwrap();
+        let _manifest_guard = EnvGuard::set(
+            "YOETZ_CHROME_NATIVE_MESSAGING_DIR",
+            &dir.path().join("native-hosts"),
+        );
+        let state = dir.path().join("state");
+        let _state_guard = EnvGuard::set("YOETZ_DIR", &state);
+        let extension_version = format!("{YOETZ_CLI_VERSION}.1");
+        write_extension_source_fixture(&state.join("chatgpt-native-extension"), &extension_version);
+        let paths = extension_paths().unwrap();
+        fs::create_dir_all(&paths.instances_dir).unwrap();
+        write_status_file(
+            &paths.status_path,
+            &json!({
+                "last_manual_handoff": {
+                    "job_id": "job_old",
+                    "run_id": "run_old",
+                    "state": "challenge_required",
+                    "message": "old ChatGPT job requires manual handoff",
+                    "seen_at_ms": 1234,
+                }
+            }),
+        )
+        .unwrap();
+        let socket = dir.path().join("work.sock");
+        let _listener = UnixListener::bind(&socket).unwrap();
+        write_instance_fixture(
+            &paths,
+            ExtensionInstanceStatus {
+                native_instance_id: "native_work".to_string(),
+                socket_path: socket,
+                pid: process::id(),
+                extension_instance_id: Some("ext_123".to_string()),
+                extension_version: Some(extension_version),
+                profile_email: Some("work@example.com".to_string()),
+                profile_id: Some("gaia_123".to_string()),
+                recipes: vec!["chatgpt".to_string()],
+                protocol_version: PROTOCOL_VERSION,
+                last_seen_ms: 5678,
+            },
+        );
+
+        let payload = status().unwrap();
+
+        assert_eq!(payload.status, "connected");
+        assert!(payload.socket_reachable);
+        assert!(payload.hello_seen);
     }
 
     #[test]

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -1749,8 +1749,9 @@ fn maybe_print_running_profile_auto_connect_preference(
 /// `connected`. Any other status (`disconnected`, `missing_extension`,
 /// `manual_handoff`, `version_mismatch`, `not_installed`) or I/O error is
 /// treated as not available for auto-selection. The probe is filesystem-local
-/// (status file + Unix socket reachability) and is cheap enough to run on
-/// every `yoetz browser recipe` invocation.
+/// (status file + Unix socket reachability) and is cheap enough to run on every
+/// `yoetz browser recipe` invocation. A live hello supersedes a historical
+/// manual-handoff record.
 fn extension_recipe_ready_for_auto_selection(recipe: Option<web_recipe::BuiltinWebRecipe>) -> bool {
     browser_extension_native::status()
         .map(|status| {

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -6,6 +6,18 @@ const DEFAULT_SEND_MIN_TIMEOUT_MS = 120000;
 const CHATGPT_SOL_PRO_MODEL = "gpt-5-6-sol-pro";
 const CHATGPT_SOL_FAMILY_LABEL = "GPT-5.6 Sol";
 const CHATGPT_PRO_EFFORT_LABEL = "Pro";
+const MANUAL_HANDOFF_SHELL_SELECTORS = Object.freeze([
+  "nav",
+  "aside",
+  "header",
+  "footer",
+  '[role="navigation"]',
+  '[role="complementary"]',
+  '[data-testid*="sidebar"]',
+  '[aria-label*="sidebar"]',
+  '[class~="sidebar"]',
+  '[class~="side-panel"]'
+]);
 
 export function ownedWindowName(job) {
   return `${YOETZ_WINDOW_PREFIX}${job.run_id}:${job.job_id}`;
@@ -38,21 +50,33 @@ export function chatgptConversationJobUrl(conversationId, runId) {
   return url.toString();
 }
 
-export function classifyManualHandoff({ url = "", title = "", text = "", authenticated = false } = {}) {
-  const haystack = `${url}\n${title}\n${text}`.toLowerCase();
-  if (/\/auth\/login|log in|sign in/.test(haystack)) {
-    return {
-      state: "login_required",
-      message: "ChatGPT login required in this Chrome profile"
-    };
-  }
-  if (!authenticated && /captcha|cloudflare|verify you are human|security check/.test(haystack)) {
+export function classifyManualHandoff({ url = "", title = "", text = "" } = {}) {
+  const pathname = manualHandoffPathname(url);
+  const conversationRoute = /^\/c\/[^/]+$/.test(pathname);
+  const normalizedTitle = conversationRoute ? "" : normalizeText(title).toLowerCase();
+  const normalizedText = normalizeText(text).toLowerCase();
+  const challengeRoute = /^\/cdn-cgi\/challenge-platform(?:\/|$)/.test(pathname);
+  const challengeTitle = /^(?:just a moment(?:\.\.\.)?|checking your browser(?:\.\.\.)?)(?:\s*(?:\||[-—])\s*(?:chatgpt|openai))?$/.test(normalizedTitle);
+  if (challengeRoute
+      || challengeTitle
+      || /captcha|cloudflare|checking your browser|attention required|security check|just a moment|verify you are human|cf-chl/.test(normalizedText)) {
     return {
       state: "challenge_required",
       message: "ChatGPT requires manual challenge completion"
     };
   }
-  if (/rate limit|too many requests|try again later/.test(haystack)) {
+  const loginRoute = /^\/(?:auth\/(?:login|oauth)|login|oauth)(?:\/|$)/.test(pathname);
+  const loginTitle = /^(?:log in|login|sign in)(?:\s*(?:\||[-—])\s*(?:chatgpt|openai))?$/.test(normalizedTitle);
+  if (loginRoute
+      || loginTitle
+      || /\blog in\b|\blogin\b|\bsign in\b|\bsign up\b|continue with google/.test(normalizedText)) {
+    return {
+      state: "login_required",
+      message: "ChatGPT login required in this Chrome profile"
+    };
+  }
+  const rateLimitTitle = /^(?:rate limited|too many requests|try again later)(?:\s*(?:\||[-—])\s*(?:chatgpt|openai))?$/.test(normalizedTitle);
+  if (rateLimitTitle || /\brate limits?\b|\btoo many requests\b|\btry again later\b/.test(normalizedText)) {
     return {
       state: "rate_limited",
       message: "ChatGPT is rate limited"
@@ -61,8 +85,8 @@ export function classifyManualHandoff({ url = "", title = "", text = "", authent
   return null;
 }
 
-export function classifyWaitManualHandoff({ url = "", title = "" } = {}) {
-  return classifyManualHandoff({ url, title });
+export function classifyWaitManualHandoff({ url = "", title = "", text = "" } = {}) {
+  return classifyManualHandoff({ url, title, text });
 }
 
 export function findComposer(root = document) {
@@ -74,6 +98,14 @@ export function findComposer(root = document) {
     'textarea',
     'div[contenteditable="true"][data-testid*="composer"]',
     'div[contenteditable="true"]'
+  ]);
+}
+
+export function findAuthenticatedComposer(root = document) {
+  return firstVisible(root, [
+    "#prompt-textarea",
+    'textarea[data-testid*="composer"]',
+    'div[contenteditable="true"][data-testid*="composer"]'
   ]);
 }
 
@@ -111,6 +143,36 @@ export function findModelButton(root = document) {
 
 export function getPageText(root = document) {
   return String(root.body?.innerText ?? root.documentElement?.innerText ?? "");
+}
+
+export function manualHandoffContext(root = document) {
+  if (findAuthenticatedComposer(root)) {
+    return {
+      authenticated: true,
+      title: "",
+      text: ""
+    };
+  }
+
+  const hasTranscript = hasConversationResidue(root);
+  const surfaces = manualHandoffSurfaces(root, { hasTranscript });
+  const chunks = [];
+  for (const surface of surfaces) {
+    collectManualHandoffSurfaceText(surface, chunks);
+  }
+  const hasShell = hasManualHandoffShell(root);
+  if (surfaces.length > 0 || hasShell || hasTranscript) {
+    return {
+      authenticated: false,
+      title: "",
+      text: normalizeText(chunks.join("\n"))
+    };
+  }
+  return {
+    authenticated: false,
+    title: String(root.title ?? ""),
+    text: getPageText(root)
+  };
 }
 
 export function markOwnership(root, job) {
@@ -2085,6 +2147,74 @@ function isConversationTurnSurface(node) {
     '[class*="agent-turn"]',
     '[class*="user-turn"]'
   ].join(",")));
+}
+
+function manualHandoffPathname(url) {
+  try {
+    return new URL(String(url ?? ""), "https://chatgpt.com").pathname.toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+function manualHandoffSurfaces(root, { hasTranscript = false } = {}) {
+  const explicitInterstitialSelectors = [
+    '[role="alert"]',
+    '[role="dialog"]',
+    '[aria-live="assertive"]'
+  ];
+  const selectors = hasTranscript
+    ? explicitInterstitialSelectors
+    : ["main", '[role="main"]', ...explicitInterstitialSelectors];
+  const candidates = uniqueElements(
+    selectors.flatMap((selector) => Array.from(root.querySelectorAll?.(selector) ?? []))
+  )
+    .filter((node) => isVisible(node, { allowDisabled: true }));
+  return candidates.filter((candidate) => !candidates.some(
+    (other) => other !== candidate && containsNode(other, candidate)
+  ));
+}
+
+function hasManualHandoffShell(root) {
+  return MANUAL_HANDOFF_SHELL_SELECTORS.some(
+    (selector) => (root.querySelectorAll?.(selector)?.length ?? 0) > 0
+  );
+}
+
+function collectManualHandoffSurfaceText(node, chunks) {
+  if (!node
+      || isConversationTurnSurface(node)
+      || isManualHandoffShellNode(node)
+      || isManualHandoffEditableNode(node)) {
+    return;
+  }
+  const children = Array.from(node.children ?? []);
+  if (children.length === 0) {
+    if (isVisible(node, { allowDisabled: true })) {
+      const text = textOf(node);
+      if (text) {
+        chunks.push(text);
+      }
+    }
+    return;
+  }
+  for (const child of children) {
+    collectManualHandoffSurfaceText(child, chunks);
+  }
+}
+
+function isManualHandoffShellNode(node) {
+  return Boolean(node?.closest?.(MANUAL_HANDOFF_SHELL_SELECTORS.join(",")));
+}
+
+function isManualHandoffEditableNode(node) {
+  const tag = String(node?.tagName ?? "").toLowerCase();
+  if (tag === "input"
+      || tag === "textarea"
+      || node?.getAttribute?.("contenteditable") === "true") {
+    return true;
+  }
+  return Boolean(node?.closest?.('input, textarea, [contenteditable="true"]'));
 }
 
 function conversationResidue(root) {

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -38,7 +38,7 @@ export function chatgptConversationJobUrl(conversationId, runId) {
   return url.toString();
 }
 
-export function classifyManualHandoff({ url = "", title = "", text = "" } = {}) {
+export function classifyManualHandoff({ url = "", title = "", text = "", authenticated = false } = {}) {
   const haystack = `${url}\n${title}\n${text}`.toLowerCase();
   if (/\/auth\/login|log in|sign in/.test(haystack)) {
     return {
@@ -46,7 +46,7 @@ export function classifyManualHandoff({ url = "", title = "", text = "" } = {}) 
       message: "ChatGPT login required in this Chrome profile"
     };
   }
-  if (/captcha|cloudflare|verify you are human|security check/.test(haystack)) {
+  if (!authenticated && /captcha|cloudflare|verify you are human|security check/.test(haystack)) {
     return {
       state: "challenge_required",
       message: "ChatGPT requires manual challenge completion"

--- a/extensions/chatgpt-native/src/claude-dom.js
+++ b/extensions/chatgpt-native/src/claude-dom.js
@@ -84,6 +84,14 @@ export function classifyWaitManualHandoff({ url = "", title = "" } = {}) {
   return classifyManualHandoff({ url, title, text: "" });
 }
 
+export function manualHandoffContext(root = document) {
+  return {
+    authenticated: Boolean(findComposer(root)),
+    title: String(root.title ?? ""),
+    text: getPageText(root)
+  };
+}
+
 export function classifyBlockingState(root = document, { forceScan = false } = {}) {
   const pageText = normalizeText(root.body?.textContent || root.documentElement?.textContent);
   if (pageText && !USAGE_CREDITS_TEXT_PATTERN.test(pageText)) {

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -73,17 +73,16 @@ async function prepareJob(job) {
     classifyManualHandoff,
     ensureConversationLoaded,
     ensureFreshChat,
-    findComposer,
-    getPageText,
+    manualHandoffContext,
     markOwnership,
     ownedWindowName
   } = await domHelpers(job);
   activeJobs.delete(job.job_id);
+  const handoffContext = manualHandoffContext(document);
   const handoff = classifyManualHandoff({
     url: location.href,
-    title: document.title,
-    text: getPageText(document),
-    authenticated: Boolean(findComposer(document))
+    title: handoffContext.title,
+    text: handoffContext.text
   });
   const conversationId = conversationIdForJob(job);
   if (!handoff && conversationId) {
@@ -226,6 +225,7 @@ async function extractJobResponse(job, blockingContext = null) {
     classifyBlockingState,
     classifyWaitManualHandoff,
     extractResponse,
+    manualHandoffContext,
     parseOwnedWindowName
   } = await domHelpers(job);
   assertJobOwnership(job, parseOwnedWindowName, { adapter });
@@ -251,11 +251,13 @@ async function extractJobResponse(job, blockingContext = null) {
   }
   const extraction = extractResponse(document);
   assertNoBlockingState(classifyBlockingState, blockingDetail);
-  // During response wait, page text includes the user prompt and model output.
-  // Handoff classification here must stay on transport/page metadata only.
+  // During response wait, extraction text includes the user prompt and model output.
+  // Handoff classification stays on route metadata and the adapter's transcript-free context.
+  const handoffContext = manualHandoffContext(document);
   const handoff = classifyWaitManualHandoff({
     url: location.href,
-    title: document.title,
+    title: handoffContext.title,
+    text: handoffContext.text,
     extraction
   });
   return {
@@ -321,22 +323,28 @@ async function inspectPage(runId, options = {}) {
 
 async function authProbe(recipe) {
   const adapter = await siteAdapter(recipe);
-  const { classifyManualHandoff, findComposer, getPageText } = await domHelpers(recipe);
+  const {
+    classifyManualHandoff,
+    getPageText,
+    manualHandoffContext
+  } = await domHelpers(recipe);
   const text = getPageText(document);
+  const handoffContext = manualHandoffContext(document);
   const handoff = classifyManualHandoff({
     url: location.href,
-    title: document.title,
-    text,
-    authenticated: Boolean(findComposer(document))
+    title: handoffContext.title,
+    text: handoffContext.text
   });
-  const authenticated = !handoff;
+  const authenticated = !handoff && handoffContext.authenticated;
+  const status = handoff?.state ?? (authenticated ? "authenticated" : "authentication_unknown");
   return {
-    status: authenticated ? "authenticated" : handoff.state,
+    status,
     authenticated,
     manual_handoff: handoff,
-    message: authenticated
-      ? `${adapter.displayName} authenticated in this Chrome profile`
-      : handoff.message,
+    message: handoff?.message
+      ?? (authenticated
+        ? `${adapter.displayName} authenticated in this Chrome profile`
+        : `${adapter.displayName} authentication could not be confirmed because its composer is not visible`),
     url: location.href,
     title: document.title,
     text_chars: text.length

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -73,6 +73,7 @@ async function prepareJob(job) {
     classifyManualHandoff,
     ensureConversationLoaded,
     ensureFreshChat,
+    findComposer,
     getPageText,
     markOwnership,
     ownedWindowName
@@ -81,7 +82,8 @@ async function prepareJob(job) {
   const handoff = classifyManualHandoff({
     url: location.href,
     title: document.title,
-    text: getPageText(document)
+    text: getPageText(document),
+    authenticated: Boolean(findComposer(document))
   });
   const conversationId = conversationIdForJob(job);
   if (!handoff && conversationId) {
@@ -319,12 +321,13 @@ async function inspectPage(runId, options = {}) {
 
 async function authProbe(recipe) {
   const adapter = await siteAdapter(recipe);
-  const { classifyManualHandoff, getPageText } = await domHelpers(recipe);
+  const { classifyManualHandoff, findComposer, getPageText } = await domHelpers(recipe);
   const text = getPageText(document);
   const handoff = classifyManualHandoff({
     url: location.href,
     title: document.title,
-    text
+    text,
+    authenticated: Boolean(findComposer(document))
   });
   const authenticated = !handoff;
   return {

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -5,7 +5,10 @@ import { uint8ArrayToBase64 } from "../src/chunks.js";
 const chatgptBackendModuleUrl = new URL("../src/sites/chatgpt-backend.js", import.meta.url).href;
 const chatgptDomModuleUrl = new URL("../src/chatgpt-dom.js", import.meta.url).href;
 const helperModule = `import { fetchConversationAnswer } from ${JSON.stringify(chatgptBackendModuleUrl)};
-import { classifyManualHandoff as classifyRealManualHandoff } from ${JSON.stringify(chatgptDomModuleUrl)};
+import {
+  classifyManualHandoff as classifyRealManualHandoff,
+  classifyWaitManualHandoff as classifyRealWaitManualHandoff
+} from ${JSON.stringify(chatgptDomModuleUrl)};
 export { fetchConversationAnswer };
 const hooks = globalThis.__contentScriptTestHooks;
 
@@ -33,6 +36,18 @@ export function findComposer() {
   return hooks.composer ?? null;
 }
 
+export function findAuthenticatedComposer() {
+  return hooks.authenticatedComposer ?? null;
+}
+
+export function manualHandoffContext() {
+  return hooks.manualHandoffContext ?? {
+    authenticated: Boolean(hooks.authenticatedComposer),
+    title: globalThis.document.title,
+    text: hooks.pageText ?? ""
+  };
+}
+
 export function classifyManualHandoff(input) {
   hooks.manualHandoffInputs.push(input);
   return hooks.manualHandoff === undefined
@@ -40,8 +55,11 @@ export function classifyManualHandoff(input) {
     : hooks.manualHandoff;
 }
 
-export function classifyWaitManualHandoff() {
-  return hooks.waitManualHandoff ?? null;
+export function classifyWaitManualHandoff(input) {
+  hooks.waitManualHandoffInputs.push(input);
+  return hooks.waitManualHandoff === undefined
+    ? classifyRealWaitManualHandoff(input)
+    : hooks.waitManualHandoff;
 }
 
 export function classifyBlockingState() {
@@ -133,6 +151,8 @@ const dom = {
   parseOwnedWindowName,
   getPageText,
   findComposer,
+  findAuthenticatedComposer,
+  manualHandoffContext,
   classifyManualHandoff,
   classifyWaitManualHandoff,
   classifyBlockingState,
@@ -330,14 +350,19 @@ test("content script auth probe reports manual handoff without job side effects"
   }
 });
 
-test("content script ignores a sidebar challenge title when the ChatGPT composer is visible", async () => {
+test("content script excludes sidebar challenge text even when authentication is unknown", async () => {
   const { send, hooks, restore } = await loadContentScript(
-    "auth_probe_composer",
+    "auth_probe_scoped_text",
     "https://chatgpt.com/?_yoetz=run_current"
   );
   try {
-    hooks.composer = {};
     hooks.pageText = "New chat\nPre-execution security check\nAsk ChatGPT";
+    hooks.manualHandoffContext = {
+      authenticated: false,
+      title: "",
+      text: "Ask ChatGPT"
+    };
+    globalThis.document.title = "Pre-execution security check";
     const job = {
       job_id: "job_current",
       run_id: "run_current",
@@ -347,19 +372,82 @@ test("content script ignores a sidebar challenge title when the ChatGPT composer
 
     const prepared = await send({ type: "yoetz_prepare_job", job });
     const auth = await send({ type: "yoetz_auth_probe" });
+    const extracted = await send({ type: "yoetz_extract_response", job });
 
     assert.equal(prepared.ok, true);
     assert.equal(prepared.payload.manual_handoff, null);
     assert.equal(prepared.payload.window_name, "yoetz-chatgpt-native:run_current:job_current");
     assert.equal(auth.ok, true);
-    assert.equal(auth.payload.status, "authenticated");
+    assert.equal(auth.payload.status, "authentication_unknown");
+    assert.equal(auth.payload.authenticated, false);
     assert.equal(auth.payload.manual_handoff, null);
+    assert.equal(extracted.ok, true);
+    assert.equal(extracted.payload.manual_handoff, null);
     assert.deepEqual(hooks.markOwnershipCalls, [job]);
-    assert.deepEqual(
-      hooks.manualHandoffInputs.map((input) => input.authenticated),
-      [true, true]
-    );
+    assert.deepEqual(hooks.manualHandoffInputs.map((input) => input.text), ["Ask ChatGPT", "Ask ChatGPT"]);
+    assert.equal(hooks.waitManualHandoffInputs[0].title, "");
+  } finally {
+    restore();
+  }
+});
 
+test("content script does not treat a generic visible editor as authenticated ChatGPT", async () => {
+  const { send, hooks, restore } = await loadContentScript(
+    "auth_probe_generic_editor",
+    "https://chatgpt.com/?_yoetz=run_challenge"
+  );
+  try {
+    hooks.composer = {};
+    hooks.pageText = "Security check";
+    hooks.manualHandoffContext = {
+      authenticated: false,
+      title: "",
+      text: "Security check"
+    };
+    const job = {
+      job_id: "job_challenge",
+      run_id: "run_challenge",
+      upload_timeout_ms: 1000,
+      send_timeout_ms: 1000
+    };
+
+    const prepared = await send({ type: "yoetz_prepare_job", job });
+    const auth = await send({ type: "yoetz_auth_probe" });
+
+    assert.equal(prepared.ok, true);
+    assert.equal(prepared.payload.manual_handoff.state, "challenge_required");
+    assert.equal(auth.ok, true);
+    assert.equal(auth.payload.status, "challenge_required");
+    assert.equal(auth.payload.authenticated, false);
+    assert.deepEqual(hooks.markOwnershipCalls, []);
+    assert.deepEqual(hooks.manualHandoffInputs.map((input) => input.text), ["Security check", "Security check"]);
+  } finally {
+    restore();
+  }
+});
+
+test("content script reports unknown authentication without a strict composer or handoff", async () => {
+  const { send, hooks, restore } = await loadContentScript(
+    "auth_probe_unknown",
+    "https://chatgpt.com/"
+  );
+  try {
+    hooks.composer = {};
+    hooks.pageText = "Welcome";
+    hooks.manualHandoffContext = {
+      authenticated: false,
+      title: "",
+      text: "Welcome"
+    };
+
+    const auth = await send({ type: "yoetz_auth_probe" });
+
+    assert.equal(auth.ok, true);
+    assert.equal(auth.payload.status, "authentication_unknown");
+    assert.equal(auth.payload.authenticated, false);
+    assert.equal(auth.payload.manual_handoff, null);
+    assert.match(auth.payload.message, /composer is not visible/);
+    assert.equal(Object.hasOwn(hooks.manualHandoffInputs[0], "authenticated"), false);
   } finally {
     restore();
   }
@@ -732,7 +820,8 @@ async function loadContentScript(label, href) {
     insertPromptCalls: [],
     clickSendCalls: [],
     sendAcceptanceBaselineCalls: 0,
-    manualHandoffInputs: []
+    manualHandoffInputs: [],
+    waitManualHandoffInputs: []
   };
   globalThis.__contentScriptTestHooks = hooks;
   globalThis.window = { name: "", location };

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -3,7 +3,9 @@ import test from "node:test";
 import { uint8ArrayToBase64 } from "../src/chunks.js";
 
 const chatgptBackendModuleUrl = new URL("../src/sites/chatgpt-backend.js", import.meta.url).href;
+const chatgptDomModuleUrl = new URL("../src/chatgpt-dom.js", import.meta.url).href;
 const helperModule = `import { fetchConversationAnswer } from ${JSON.stringify(chatgptBackendModuleUrl)};
+import { classifyManualHandoff as classifyRealManualHandoff } from ${JSON.stringify(chatgptDomModuleUrl)};
 export { fetchConversationAnswer };
 const hooks = globalThis.__contentScriptTestHooks;
 
@@ -27,8 +29,15 @@ export function getPageText() {
   return hooks.pageText ?? "";
 }
 
-export function classifyManualHandoff() {
-  return hooks.manualHandoff ?? null;
+export function findComposer() {
+  return hooks.composer ?? null;
+}
+
+export function classifyManualHandoff(input) {
+  hooks.manualHandoffInputs.push(input);
+  return hooks.manualHandoff === undefined
+    ? classifyRealManualHandoff(input)
+    : hooks.manualHandoff;
 }
 
 export function classifyWaitManualHandoff() {
@@ -123,6 +132,7 @@ const dom = {
   ownedWindowName,
   parseOwnedWindowName,
   getPageText,
+  findComposer,
   classifyManualHandoff,
   classifyWaitManualHandoff,
   classifyBlockingState,
@@ -315,6 +325,41 @@ test("content script auth probe reports manual handoff without job side effects"
     assert.deepEqual(hooks.ensureFreshChatCalls, []);
     assert.deepEqual(hooks.ensureConversationLoadedCalls, []);
     assert.deepEqual(hooks.markOwnershipCalls, []);
+  } finally {
+    restore();
+  }
+});
+
+test("content script ignores a sidebar challenge title when the ChatGPT composer is visible", async () => {
+  const { send, hooks, restore } = await loadContentScript(
+    "auth_probe_composer",
+    "https://chatgpt.com/?_yoetz=run_current"
+  );
+  try {
+    hooks.composer = {};
+    hooks.pageText = "New chat\nPre-execution security check\nAsk ChatGPT";
+    const job = {
+      job_id: "job_current",
+      run_id: "run_current",
+      upload_timeout_ms: 1000,
+      send_timeout_ms: 1000
+    };
+
+    const prepared = await send({ type: "yoetz_prepare_job", job });
+    const auth = await send({ type: "yoetz_auth_probe" });
+
+    assert.equal(prepared.ok, true);
+    assert.equal(prepared.payload.manual_handoff, null);
+    assert.equal(prepared.payload.window_name, "yoetz-chatgpt-native:run_current:job_current");
+    assert.equal(auth.ok, true);
+    assert.equal(auth.payload.status, "authenticated");
+    assert.equal(auth.payload.manual_handoff, null);
+    assert.deepEqual(hooks.markOwnershipCalls, [job]);
+    assert.deepEqual(
+      hooks.manualHandoffInputs.map((input) => input.authenticated),
+      [true, true]
+    );
+
   } finally {
     restore();
   }
@@ -686,7 +731,8 @@ async function loadContentScript(label, href) {
     configureModelCalls: [],
     insertPromptCalls: [],
     clickSendCalls: [],
-    sendAcceptanceBaselineCalls: 0
+    sendAcceptanceBaselineCalls: 0,
+    manualHandoffInputs: []
   };
   globalThis.__contentScriptTestHooks = hooks;
   globalThis.window = { name: "", location };

--- a/extensions/chatgpt-native/tests/dom.test.js
+++ b/extensions/chatgpt-native/tests/dom.test.js
@@ -5,10 +5,15 @@ import {
   chatgptJobUrl,
   classifyManualHandoff,
   classifyWaitManualHandoff,
+  findAuthenticatedComposer,
+  findComposer,
+  manualHandoffContext,
   normalizeText,
   ownedWindowName,
   parseOwnedWindowName
 } from "../src/chatgpt-dom.js";
+import { chatgptSiteAdapter } from "../src/sites/chatgpt.js";
+import { claudeSiteAdapter } from "../src/sites/claude.js";
 
 test("ownedWindowName round trips run and job ids", () => {
   const job = { run_id: "run_abc", job_id: "job_xyz" };
@@ -34,21 +39,283 @@ test("classifyManualHandoff detects login, challenge, and rate limits", () => {
   assert.equal(classifyManualHandoff({ text: "Message ChatGPT" }), null);
 });
 
-test("classifyManualHandoff ignores challenge words in authenticated ChatGPT chrome", () => {
+test("classifyManualHandoff does not let composer authentication suppress a real handoff", () => {
   assert.equal(
     classifyManualHandoff({
       title: "ChatGPT",
-      text: "New chat\nPre-execution security check\nAsk ChatGPT",
+      text: "Security check",
       authenticated: true
+    }).state,
+    "challenge_required"
+  );
+});
+
+test("classifyManualHandoff does not match login words inside ordinary words", () => {
+  for (const text of [
+    "Design integration plan",
+    "Blog index redesign",
+    "Catalog inventory sync",
+    "Assign inbox owners"
+  ]) {
+    assert.equal(classifyManualHandoff({ text }), null, text);
+  }
+});
+
+test("classifyManualHandoff recognizes common Cloudflare challenge metadata", () => {
+  assert.equal(classifyManualHandoff({ title: "Just a moment..." }).state, "challenge_required");
+  assert.equal(
+    classifyManualHandoff({
+      url: "https://chatgpt.com/cdn-cgi/challenge-platform/h/g/orchestrate/chl_page/v1",
+      authenticated: true
+    }).state,
+    "challenge_required"
+  );
+});
+
+test("classifyManualHandoff parses routes without scanning conversation ids or query text", () => {
+  for (const url of [
+    "https://chatgpt.com/c/login",
+    "https://chatgpt.com/c/cloudflare",
+    "https://chatgpt.com/c/captcha-notes",
+    "https://chatgpt.com/c/opaque-id?_yoetz=security-check"
+  ]) {
+    assert.equal(classifyManualHandoff({ url }), null, url);
+  }
+  assert.equal(classifyManualHandoff({ url: "https://chatgpt.com/auth/login" }).state, "login_required");
+  assert.equal(classifyManualHandoff({ url: "https://chatgpt.com/auth/oauth" }).state, "login_required");
+  assert.equal(
+    classifyManualHandoff({
+      url: "https://chatgpt.com/cdn-cgi/challenge-platform/h/g/orchestrate/chl_page/v1"
+    }).state,
+    "challenge_required"
+  );
+});
+
+test("classifyManualHandoff ignores user-derived conversation titles", () => {
+  for (const title of ["Rate limit design", "Too many requests", "Just a moment..."]) {
+    assert.equal(
+      classifyManualHandoff({
+        url: "https://chatgpt.com/c/opaque-id",
+        title
+      }),
+      null,
+      title
+    );
+  }
+});
+
+test("findAuthenticatedComposer rejects permissive editor fallbacks", () => {
+  const genericEditor = visibleElement({ contenteditable: "true" });
+  const genericTextbox = visibleElement({ contenteditable: "true", role: "textbox" });
+  const genericRoot = selectorRoot(new Map([
+    ['div[contenteditable="true"][role="textbox"]', [genericTextbox]],
+    ['div[contenteditable="true"]', [genericEditor]]
+  ]));
+
+  assert.equal(findComposer(genericRoot), genericTextbox);
+  assert.equal(findAuthenticatedComposer(genericRoot), null);
+
+  const chatgptComposer = visibleElement({ id: "prompt-textarea" });
+  const chatgptRoot = selectorRoot(new Map([
+    ["#prompt-textarea", [chatgptComposer]]
+  ]));
+
+  assert.equal(findAuthenticatedComposer(chatgptRoot), chatgptComposer);
+});
+
+test("manualHandoffContext suppresses all page text when the strict composer is visible", () => {
+  const composer = visibleElement({ id: "prompt-textarea" });
+  const main = visibleElement();
+  main.innerText = "Rate limit design\nSecurity check\nAsk ChatGPT";
+  const root = selectorRoot(new Map([
+    ["#prompt-textarea", [composer]],
+    ["main", [main]]
+  ]));
+  root.body = {
+    innerText: "New chat\nPre-execution security check\nDesign integration plan\nAsk ChatGPT"
+  };
+  root.title = "Pre-execution security check";
+
+  assert.deepEqual(manualHandoffContext(root), {
+    authenticated: true,
+    title: "",
+    text: ""
+  });
+});
+
+test("manualHandoffContext excludes transcript turns and conversation titles", () => {
+  const transcript = visibleElement();
+  transcript.innerText = [
+    "Security check",
+    "Log in rollout",
+    "Rate limit design"
+  ].join("\n");
+  transcript.closest = (selector) => selector.includes("[data-message-author-role]") ? transcript : null;
+  const safeLeaf = visibleElement();
+  safeLeaf.innerText = "Ask ChatGPT";
+  const main = visibleElement();
+  main.children = [transcript, safeLeaf];
+  const root = selectorRoot(new Map([
+    ["main", [main]]
+  ]));
+  root.title = "Rate limit design";
+  root.body = { innerText: "Sidebar\nSecurity check\nRate limit design" };
+
+  const context = manualHandoffContext(root);
+  assert.equal(context.authenticated, false);
+  assert.equal(context.title, "");
+  assert.equal(context.text, "Ask ChatGPT");
+  assert.equal(
+    classifyManualHandoff({
+      url: "https://chatgpt.com/c/opaque-id",
+      title: context.title,
+      text: context.text
     }),
     null
   );
 });
 
+test("manualHandoffContext excludes standalone response text beside an assistant marker", () => {
+  const assistantMarker = visibleElement({ "data-message-author-role": "assistant" });
+  const standaloneAnswer = visibleElement();
+  standaloneAnswer.innerText = "Rate limit design";
+  const main = visibleElement();
+  main.children = [assistantMarker, standaloneAnswer];
+  const root = selectorRoot(new Map([
+    ["main", [main]],
+    ['[data-message-author-role="assistant"]', [assistantMarker]]
+  ]));
+  root.title = "Rate limit design";
+  root.body = {
+    innerText: "Rate limit design",
+    children: [main]
+  };
+
+  assert.deepEqual(manualHandoffContext(root), {
+    authenticated: false,
+    title: "",
+    text: ""
+  });
+});
+
+test("manualHandoffContext excludes user text from an unrecognized editor variant", () => {
+  const genericEditor = visibleElement({ contenteditable: "true" });
+  genericEditor.innerText = "Security check";
+  const safeLeaf = visibleElement();
+  safeLeaf.innerText = "Welcome";
+  const main = visibleElement();
+  main.children = [genericEditor, safeLeaf];
+  const root = selectorRoot(new Map([
+    ["main", [main]],
+    ['div[contenteditable="true"]', [genericEditor]]
+  ]));
+  root.title = "ChatGPT";
+  root.body = { innerText: "Security check\nWelcome", children: [main] };
+
+  assert.deepEqual(manualHandoffContext(root), {
+    authenticated: false,
+    title: "",
+    text: "Welcome"
+  });
+});
+
+test("manualHandoffContext does not fall back to sidebar text while shell chrome exists", () => {
+  const nav = visibleElement();
+  nav.innerText = "Security check\nDesign integration plan";
+  const root = selectorRoot(new Map([
+    ["nav", [nav]]
+  ]));
+  root.title = "Security check";
+  root.body = { innerText: "Security check\nDesign integration plan" };
+
+  assert.deepEqual(manualHandoffContext(root), {
+    authenticated: false,
+    title: "",
+    text: ""
+  });
+});
+
+test("manualHandoffContext does not fall back during header-only shell hydration", () => {
+  const header = visibleElement();
+  header.innerText = "Security check";
+  const root = selectorRoot(new Map([
+    ["header", [header]]
+  ]));
+  root.title = "Security check";
+  root.body = { innerText: "Security check", children: [header] };
+
+  assert.deepEqual(manualHandoffContext(root), {
+    authenticated: false,
+    title: "",
+    text: ""
+  });
+});
+
+test("manualHandoffContext recognizes class-token sidebar shell hydration", () => {
+  const sidebar = visibleElement({ class: "sidebar" });
+  sidebar.innerText = "Security check";
+  const root = selectorRoot(new Map([
+    ['[class~="sidebar"]', [sidebar]]
+  ]));
+  root.title = "Security check";
+  root.body = { innerText: "Security check", children: [sidebar] };
+
+  assert.deepEqual(manualHandoffContext(root), {
+    authenticated: false,
+    title: "",
+    text: ""
+  });
+});
+
+test("manualHandoffContext falls back to a document-only interstitial", () => {
+  const root = selectorRoot(new Map());
+  root.title = "Just a moment...";
+  root.body = { innerText: "Just a moment...\nChecking your browser" };
+
+  assert.deepEqual(manualHandoffContext(root), {
+    authenticated: false,
+    title: "Just a moment...",
+    text: "Just a moment...\nChecking your browser"
+  });
+});
+
+test("every advertised site adapter implements the manual handoff context contract", () => {
+  for (const adapter of [chatgptSiteAdapter, claudeSiteAdapter]) {
+    assert.equal(typeof adapter.dom.manualHandoffContext, "function", adapter.recipe);
+  }
+
+  const claudeComposer = visibleElement({ "data-testid": "chat-input" });
+  const claudeRoot = selectorRoot(new Map([
+    ["[data-testid='chat-input']", [claudeComposer]]
+  ]));
+  claudeRoot.title = "Claude";
+  claudeRoot.body = { innerText: "Welcome to Claude" };
+  assert.deepEqual(claudeSiteAdapter.dom.manualHandoffContext(claudeRoot), {
+    authenticated: true,
+    title: "Claude",
+    text: "Welcome to Claude"
+  });
+});
+
 test("classifyWaitManualHandoff avoids prompt and response text false positives", () => {
   assert.equal(classifyWaitManualHandoff({ url: "https://chatgpt.com/auth/login" }).state, "login_required");
-  assert.equal(classifyWaitManualHandoff({ title: "Security check | ChatGPT" }).state, "challenge_required");
+  assert.equal(classifyWaitManualHandoff({ title: "Just a moment..." }).state, "challenge_required");
   assert.equal(classifyWaitManualHandoff({ title: "Too many requests | ChatGPT" }).state, "rate_limited");
+  assert.equal(
+    classifyWaitManualHandoff({
+      url: "https://chatgpt.com/c/opaque-id",
+      title: "Security check | ChatGPT"
+    }),
+    null
+  );
+  assert.equal(
+    classifyWaitManualHandoff({
+      url: "https://chatgpt.com/c/opaque-id",
+      title: "Just a moment...",
+      text: "Checking your browser"
+    }).state,
+    "challenge_required"
+  );
   assert.equal(
     classifyWaitManualHandoff({
       extraction: {
@@ -87,3 +354,38 @@ test("classifyWaitManualHandoff avoids prompt and response text false positives"
 test("normalizeText trims repeated whitespace conservatively", () => {
   assert.equal(normalizeText(" hello \n\n\n world \r\n"), "hello\n\n world");
 });
+
+function selectorRoot(selectors) {
+  return {
+    querySelector(selector) {
+      return selectors.get(selector)?.[0] ?? null;
+    },
+    querySelectorAll(selector) {
+      return selectors.get(selector) ?? [];
+    }
+  };
+}
+
+function visibleElement(attributes = {}) {
+  return {
+    disabled: false,
+    hidden: false,
+    ownerDocument: {
+      defaultView: {
+        getComputedStyle() {
+          return {};
+        }
+      }
+    },
+    parentElement: null,
+    checkVisibility() {
+      return true;
+    },
+    getAttribute(name) {
+      return attributes[name] ?? null;
+    },
+    getClientRects() {
+      return [{}];
+    }
+  };
+}

--- a/extensions/chatgpt-native/tests/dom.test.js
+++ b/extensions/chatgpt-native/tests/dom.test.js
@@ -34,8 +34,20 @@ test("classifyManualHandoff detects login, challenge, and rate limits", () => {
   assert.equal(classifyManualHandoff({ text: "Message ChatGPT" }), null);
 });
 
+test("classifyManualHandoff ignores challenge words in authenticated ChatGPT chrome", () => {
+  assert.equal(
+    classifyManualHandoff({
+      title: "ChatGPT",
+      text: "New chat\nPre-execution security check\nAsk ChatGPT",
+      authenticated: true
+    }),
+    null
+  );
+});
+
 test("classifyWaitManualHandoff avoids prompt and response text false positives", () => {
   assert.equal(classifyWaitManualHandoff({ url: "https://chatgpt.com/auth/login" }).state, "login_required");
+  assert.equal(classifyWaitManualHandoff({ title: "Security check | ChatGPT" }).state, "challenge_required");
   assert.equal(classifyWaitManualHandoff({ title: "Too many requests | ChatGPT" }).state, "rate_limited");
   assert.equal(
     classifyWaitManualHandoff({


### PR DESCRIPTION
## Summary

- Scope ChatGPT manual-handoff detection to a per-site, transcript-free context instead of whole-page text.
- Parse exact auth, OAuth, and Cloudflare routes without scanning conversation IDs, query text, or user-derived conversation titles.
- Preserve explicit authentication_unknown when a strict ChatGPT composer is absent, while keeping Claude behavior behind the same adapter contract.
- Let a live native socket plus extension hello supersede historical manual-handoff state so reconnect restores transport auto-selection.

## Root cause

The original detector treated all visible page text and the document title as provider metadata. Sidebar history, conversation text, permissive editor selectors, and arbitrary conversation IDs could therefore produce false login, challenge, or rate-limit handoffs.

## Verification

- Focused handoff and content-script tests: 50 passed
- Full extension suite: 325 passed
- Native extension package check: passed
- cargo fmt --all -- --check: passed
- Cached diff hygiene: clean
- Independent exact-tree review and staged simplification review: PASS
- Frozen pre-commit diff-vs-HEAD SHA-256: efd7808ceafdc019150f666d123cc15eaf9f37c9f903b451ae6e676024c34a44
- Exact-head CI run 30576321127: 13 jobs passed, including Real-Browser Smoke
- Final post-reload E2E: managed extension 0.5.47.3, fresh tab run 20260730T195432Z_a8f60b, GPT-5.6 Sol Pro, native transport, no fallback, exact response YOETZ_HANDOFF_CLASSIFIER_OK

Closes #373