### PR TITLE
fix(extension): support ChatGPT effort slider

### DIFF
--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -3127,6 +3127,16 @@ fn job_error_message(payload: &Value) -> String {
 }
 
 fn append_job_error_detail(payload: &Value, message: &str, detail: &mut Vec<String>) {
+    if let Some(reason) = payload
+        .get("failure_reason")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    {
+        let reason_text = format!("failure_reason={reason}");
+        if !message.contains(reason) {
+            detail.push(reason_text);
+        }
+    }
     if let Some(tab_id) = payload
         .get("tab_id")
         .and_then(Value::as_i64)
@@ -4336,6 +4346,19 @@ mod tests {
         }));
 
         assert!(message.contains("attachment_trace=<omitted:"));
+    }
+
+    #[test]
+    fn job_error_message_surfaces_model_selection_failure_reason() {
+        let message = job_error_message(&json!({
+            "code": "model_selection_failed",
+            "message": "Requested ChatGPT model was not selected",
+            "phase": "model_selection",
+            "failure_reason": "effort_slider_move_failed"
+        }));
+
+        assert!(message.contains("failure_reason=effort_slider_move_failed"));
+        assert!(message.contains("phase model_selection"));
     }
 
     #[test]

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -376,6 +376,10 @@ export async function configureModelState(root, job = {}) {
       available_families: [],
       family_status: "skipped",
       effort_status: "skipped",
+      failure_reason: null,
+      picker_shape: null,
+      effort_control: null,
+      effort_move_method: null,
       pill_text: pillText ?? "",
       family_label: null,
       effort_options: [],
@@ -394,6 +398,10 @@ export async function configureModelState(root, job = {}) {
     available_families: selection.available_families ?? [],
     family_status: selection.family_status ?? "unverified",
     effort_status: selection.effort_status ?? "unverified",
+    failure_reason: selection.failure_reason ?? null,
+    picker_shape: selection.picker_shape ?? null,
+    effort_control: selection.effort_control ?? null,
+    effort_move_method: selection.effort_move_method ?? null,
     pill_text: selection.pill_text ?? null,
     family_label: selection.family_label ?? null,
     effort_options: selection.effort_options ?? [],
@@ -485,8 +493,12 @@ async function selectSolProModel(root, options = {}) {
   const base = {
     status: "unavailable",
     model_used: null,
+    failure_reason: null,
     family_status: "unverified",
     effort_status: "unverified",
+    picker_shape: null,
+    effort_control: null,
+    effort_move_method: null,
     available_options: [],
     available_families: [],
     effort_options: []
@@ -495,6 +507,7 @@ async function selectSolProModel(root, options = {}) {
   if (legacyMarkers.length > 0) {
     return {
       ...base,
+      failure_reason: "legacy_picker_detected",
       warning: "legacy ChatGPT picker detected; this yoetz version requires the GPT-5.6 UI",
       legacy_picker: legacyMarkers.slice(0, 10)
     };
@@ -506,11 +519,16 @@ async function selectSolProModel(root, options = {}) {
     if (lateLegacyMarkers.length > 0) {
       return {
         ...base,
+        failure_reason: "legacy_picker_detected",
         warning: "legacy ChatGPT picker detected; this yoetz version requires the GPT-5.6 UI",
         legacy_picker: lateLegacyMarkers.slice(0, 10)
       };
     }
-    return { ...base, warning: "ChatGPT GPT-5.6 composer model pill not found" };
+    return {
+      ...base,
+      failure_reason: "model_control_not_found",
+      warning: "ChatGPT GPT-5.6 composer model pill not found"
+    };
   }
 
   let availableFamilies = [];
@@ -518,46 +536,61 @@ async function selectSolProModel(root, options = {}) {
   if (!state) {
     return {
       ...base,
+      failure_reason: "model_picker_open_failed",
       pill_text: modelControlLabel(modelButton),
       warning: "ChatGPT GPT-5.6 model picker did not open"
     };
   }
 
   if (!familyIsSol(state.family_label)) {
-    const familyMenu = await openFamilyPicker(root, state.menu, state.family_trigger, options);
+    const familyMenu = await openFamilyPicker(root, state.menu ?? state.surface, state.family_trigger, options);
     availableFamilies = familyMenu ? familyMenuRadios(familyMenu).map((item) => textOf(item)).filter(Boolean) : [];
     const solOption = familyMenuRadios(familyMenu).find((item) => foldedModelText(textOf(item)) === foldedModelText(CHATGPT_SOL_FAMILY_LABEL));
     if (!solOption) {
       await closeModelPicker(root, modelButton);
-      return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol was not visible in the family submenu");
+      return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol was not visible in the family submenu", "model_family_not_found");
     }
     realClick(solOption);
     await sleep(Number(options.actionSettleMs ?? 250));
     modelButton = await waitForModelButton(root, options);
     if (!modelButton) {
-      return selectionFailure(base, null, null, availableFamilies, "ChatGPT composer model pill did not remount after selecting GPT-5.6 Sol");
+      return selectionFailure(base, null, null, availableFamilies, "ChatGPT composer model pill did not remount after selecting GPT-5.6 Sol", "model_family_remount_failed");
     }
     state = await openAndReadModelPicker(root, modelButton, options);
     if (!state) {
-      return selectionFailure(base, modelButton, null, availableFamilies, "ChatGPT picker did not reopen after selecting GPT-5.6 Sol");
+      return selectionFailure(base, modelButton, null, availableFamilies, "ChatGPT picker did not reopen after selecting GPT-5.6 Sol", "model_picker_reopen_failed");
     }
   }
 
   if (!effortIsPro(state)) {
-    const proOption = state.effort_items.find((item) => foldedModelText(textOf(item)) === foldedModelText(CHATGPT_PRO_EFFORT_LABEL));
-    if (!proOption) {
-      await closeModelPicker(root, modelButton);
-      return selectionFailure(base, modelButton, state, availableFamilies, "Pro intelligence was not visible for GPT-5.6 Sol");
-    }
-    realClick(proOption);
-    await sleep(Number(options.actionSettleMs ?? 250));
-    modelButton = await waitForModelButton(root, options);
-    if (!modelButton) {
-      return selectionFailure(base, null, null, availableFamilies, "ChatGPT composer model pill did not remount after selecting Pro intelligence");
-    }
-    state = await openAndReadModelPicker(root, modelButton, options);
-    if (!state) {
-      return selectionFailure(base, modelButton, null, availableFamilies, "ChatGPT picker did not reopen after selecting Pro intelligence");
+    if (state.shape === "slider") {
+      if (!state.effort_slider) {
+        await closeModelPicker(root, modelButton);
+        return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol effort slider was not found in the Advanced picker", "effort_control_not_found");
+      }
+      const moved = await moveEffortSliderToPro(root, state, options);
+      state = moved.state ?? state;
+      state.effort_move_method = moved.method;
+      if (!moved.ok) {
+        await closeModelPicker(root, modelButton);
+        return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol effort slider did not move to Pro", "effort_slider_move_failed");
+      }
+    } else {
+      const proOption = state.effort_items.find((item) => foldedModelText(textOf(item)) === foldedModelText(CHATGPT_PRO_EFFORT_LABEL));
+      if (!proOption) {
+        await closeModelPicker(root, modelButton);
+        return selectionFailure(base, modelButton, state, availableFamilies, "Pro intelligence was not visible for GPT-5.6 Sol", "effort_control_not_found");
+      }
+      realClick(proOption);
+      await sleep(Number(options.actionSettleMs ?? 250));
+      modelButton = await waitForModelButton(root, options);
+      if (!modelButton) {
+        return selectionFailure(base, null, null, availableFamilies, "ChatGPT composer model pill did not remount after selecting Pro intelligence", "effort_control_remount_failed");
+      }
+      state = await openAndReadModelPicker(root, modelButton, options);
+      if (!state) {
+        return selectionFailure(base, modelButton, null, availableFamilies, "ChatGPT picker did not reopen after selecting Pro intelligence", "model_picker_reopen_failed");
+      }
     }
   }
 
@@ -565,18 +598,27 @@ async function selectSolProModel(root, options = {}) {
   const effortVerified = effortIsPro(state);
   if (!familyVerified || !effortVerified) {
     await closeModelPicker(root, modelButton);
-    return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol + Pro could not be verified in one picker pass");
+    return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol + Pro could not be verified in one picker pass", "model_selection_verification_failed");
   }
   if (!await closeModelPicker(root, modelButton)) {
-    return selectionFailure(base, modelButton, state, availableFamilies, "ChatGPT model picker remained open after verification");
+    return selectionFailure(base, modelButton, state, availableFamilies, "ChatGPT model picker remained open after verification", "model_picker_close_failed");
+  }
+  modelButton = await waitForModelButton(root, options);
+  const pillText = modelControlLabel(modelButton);
+  if (state.shape === "slider" && !/\bpro\b/i.test(pillText)) {
+    return selectionFailure(base, modelButton, state, availableFamilies, "ChatGPT composer model pill did not confirm Pro after closing the slider picker", "effort_composer_pill_unverified");
   }
 
   return {
     status: "selected",
     model_used: `${CHATGPT_SOL_FAMILY_LABEL} ${CHATGPT_PRO_EFFORT_LABEL}`,
+    failure_reason: null,
     family_status: "verified",
     effort_status: "verified",
-    pill_text: modelControlLabel(modelButton),
+    picker_shape: state.shape,
+    effort_control: state.shape === "slider" ? sliderEffortDiagnostics(state.effort_slider) : null,
+    effort_move_method: state.effort_move_method ?? null,
+    pill_text: pillText,
     family_label: state.family_label,
     available_options: state.effort_items.map((item) => textOf(item)).filter(Boolean),
     available_families: availableFamilies,
@@ -608,7 +650,7 @@ async function openAndReadModelPicker(root, modelButton, options = {}) {
 
 async function openModelPicker(root, modelButton, options = {}) {
   const settleMs = Number(options.settleMs ?? 150);
-  const opened = () => Boolean(findMainModelMenu(root));
+  const opened = () => Boolean(findPickerState(root));
   if (opened()) {
     return true;
   }
@@ -739,11 +781,11 @@ function pressActivationKey(element, key) {
 }
 
 async function closeModelPicker(root, modelButton) {
-  for (let attempt = 0; attempt < 3 && visibleMenus(root).length > 0; attempt += 1) {
+  for (let attempt = 0; attempt < 3 && findPickerState(root); attempt += 1) {
     pressActivationKey(modelButton, "Escape");
     await sleep(50);
   }
-  return visibleMenus(root).length === 0;
+  return !findPickerState(root);
 }
 
 async function waitForPickerState(root, options = {}) {
@@ -751,11 +793,16 @@ async function waitForPickerState(root, options = {}) {
   const intervalMs = Number(options.intervalMs ?? 100);
   const startedAt = Date.now();
   while (Date.now() - startedAt < timeoutMs) {
-    const menu = findMainModelMenu(root);
-    if (menu) return readPickerState(menu);
+    const state = findPickerState(root);
+    if (state) return state;
     await sleep(intervalMs);
   }
   return null;
+}
+
+function findPickerState(root) {
+  const menu = findMainModelMenu(root);
+  return menu ? readMenuPickerState(menu) : readSliderPickerState(root);
 }
 
 async function waitForFamilyMenu(root, mainMenu, options = {}) {
@@ -786,7 +833,7 @@ function visibleMenus(root) {
   return Array.from(root.querySelectorAll('[role="menu"]')).filter((menu) => isVisible(menu));
 }
 
-function readPickerState(menu) {
+function readMenuPickerState(menu) {
   const effortItems = menuRadioItems(menu);
   const familyTrigger = Array.from(menu.querySelectorAll('[role="menuitem"]'))
     .find((item) => {
@@ -795,11 +842,83 @@ function readPickerState(menu) {
         && /^(?:gpt|o\d)\b/i.test(label);
     });
   return {
+    shape: "menu",
     menu,
+    surface: menu,
     family_trigger: familyTrigger ?? null,
     family_label: textOf(familyTrigger),
-    effort_items: effortItems
+    effort_items: effortItems,
+    effort_slider: null,
+    effort_move_method: null
   };
+}
+
+function readSliderPickerState(root) {
+  const surface = findAdvancedPickerSurface(root);
+  if (!surface) return null;
+  const familyTrigger = Array.from(surface.querySelectorAll('[role="menuitem"], button'))
+    .find((item) => {
+      const label = normalizeText(textOf(item));
+      return /^(?:gpt|o\d)\b/i.test(label) && isVisible(item, { allowDisabled: true });
+    });
+  const effortSlider = Array.from(surface.querySelectorAll('[role="slider"]'))
+    .filter((slider) => isVisible(slider))
+    .find((slider) => sliderIsEffortControl(slider, surface) && Boolean(sliderEffortSnapshot(slider))) ?? null;
+  return {
+    shape: "slider",
+    menu: null,
+    surface,
+    family_trigger: familyTrigger ?? null,
+    family_label: textOf(familyTrigger),
+    effort_items: [],
+    effort_slider: effortSlider,
+    effort_move_method: null
+  };
+}
+
+function sliderIsEffortControl(slider, surface) {
+  const directLabel = normalizeText([
+    slider?.getAttribute?.("aria-label"),
+    slider?.getAttribute?.("title")
+  ].filter(Boolean).join(" "));
+  if (/\beffort\b/i.test(directLabel)) return true;
+
+  const labelledBy = normalizeText(slider?.getAttribute?.("aria-labelledby") ?? "")
+    .split(" ")
+    .map((id) => slider?.ownerDocument?.getElementById?.(id))
+    .filter(Boolean)
+    .map((node) => textOf(node))
+    .join(" ");
+  if (/\beffort\b/i.test(labelledBy)) return true;
+
+  let ancestor = slider?.parentElement;
+  while (ancestor && ancestor !== surface) {
+    const text = normalizeText(textOf(ancestor));
+    if (/\beffort\b/i.test(text) && !/\b(?:faster|smarter)\b/i.test(text)) return true;
+    ancestor = ancestor.parentElement;
+  }
+  return false;
+}
+
+function findAdvancedPickerSurface(root) {
+  const candidates = Array.from(root.querySelectorAll('div, [role="dialog"]'))
+    .filter((node) => {
+      if (!isVisible(node, { allowDisabled: true })) return false;
+      const text = normalizeText(textOf(node));
+      return /\bAdvanced\b/i.test(text)
+        && /\bFaster\b/i.test(text)
+        && /\bSmarter\b/i.test(text)
+        && /\bModel\b/i.test(text)
+        && /\bEffort\b/i.test(text)
+        && /\b(?:GPT|o\d)\b/i.test(text)
+        && Array.from(node.querySelectorAll?.('[role="slider"]') ?? [])
+          .some((slider) => isVisible(slider, { allowDisabled: true }));
+    });
+  return candidates.sort((left, right) => (
+    left.querySelectorAll?.("*")?.length ?? 0
+  ) - (
+    right.querySelectorAll?.("*")?.length ?? 0
+  ))[0] ?? null;
 }
 
 function menuRadioItems(menu) {
@@ -811,7 +930,89 @@ function familyMenuRadios(menu) {
 }
 
 function effortIsPro(state) {
+  if (state?.shape === "slider") {
+    const snapshot = sliderEffortSnapshot(state.effort_slider);
+    return Boolean(snapshot && snapshot.label === "pro" && snapshot.now === snapshot.max);
+  }
   return state?.effort_items?.some((item) => foldedModelText(textOf(item)) === "pro" && itemIsChecked(item)) ?? false;
+}
+
+function sliderEffortSnapshot(slider) {
+  if (!slider) return null;
+  const valueText = normalizeText(slider.getAttribute?.("aria-valuetext") ?? "");
+  const match = valueText.match(/^(Instant|Medium|High|Extra High|Pro)\s*,?\s*(\d+)\s+of\s+(\d+)\s*[.!?]?\s*$/i);
+  const now = Number(slider.getAttribute?.("aria-valuenow"));
+  const min = Number(slider.getAttribute?.("aria-valuemin"));
+  const max = Number(slider.getAttribute?.("aria-valuemax"));
+  if (!match || !Number.isFinite(now) || !Number.isFinite(min) || !Number.isFinite(max)
+    || max <= min || now < min || now > max || Number(match[2]) !== now || Number(match[3]) !== max) {
+    return null;
+  }
+  return { label: foldedModelText(match[1]), now, min, max, value_text: valueText };
+}
+
+function sliderEffortDiagnostics(slider) {
+  const snapshot = sliderEffortSnapshot(slider);
+  return snapshot ? {
+    role: "slider",
+    label: snapshot.label,
+    value_text: snapshot.value_text,
+    value_now: snapshot.now,
+    value_min: snapshot.min,
+    value_max: snapshot.max
+  } : null;
+}
+
+async function moveEffortSliderToPro(root, initialState, options = {}) {
+  const settleMs = Number(options.actionSettleMs ?? 250);
+  let state = initialState;
+  const attemptKey = async (key, method) => {
+    if (state?.shape !== "slider" || !state.effort_slider) return null;
+    pressActivationKey(state.effort_slider, key);
+    await sleep(settleMs);
+    state = findPickerState(root);
+    return effortIsPro(state) ? { ok: true, state, method } : null;
+  };
+
+  let result = await attemptKey("End", "keyboard_end");
+  if (result) return result;
+
+  const snapshot = sliderEffortSnapshot(state?.effort_slider);
+  const arrowAttempts = Math.min(10, Math.max(1, Math.ceil((snapshot?.max ?? 5) - (snapshot?.min ?? 1)) + 1));
+  for (let attempt = 0; attempt < arrowAttempts; attempt += 1) {
+    result = await attemptKey("ArrowRight", "keyboard_arrow_right");
+    if (result) return result;
+    if (state?.shape !== "slider" || !state.effort_slider) break;
+  }
+
+  if (state?.shape === "slider" && state.effort_slider) {
+    clickSliderTrackMax(state.effort_slider);
+    await sleep(settleMs);
+    state = findPickerState(root);
+    if (effortIsPro(state)) return { ok: true, state, method: "pointer_max" };
+  }
+  return { ok: false, state, method: null };
+}
+
+function clickSliderTrackMax(slider) {
+  const rect = slider?.getBoundingClientRect?.();
+  if (!rect || !Number.isFinite(rect.left) || !Number.isFinite(rect.top)
+    || !Number.isFinite(rect.width) || !Number.isFinite(rect.height)
+    || rect.width <= 0 || rect.height <= 0) {
+    return false;
+  }
+  const clientX = rect.left + rect.width - 1;
+  const clientY = rect.top + (rect.height / 2);
+  for (const [type, constructorName, init] of [
+    ["pointerdown", "PointerEvent", { button: 0, buttons: 1, pointerId: 1, pointerType: "mouse", isPrimary: true }],
+    ["mousedown", "MouseEvent", { button: 0, buttons: 1 }],
+    ["pointerup", "PointerEvent", { button: 0, buttons: 0, pointerId: 1, pointerType: "mouse", isPrimary: true }],
+    ["mouseup", "MouseEvent", { button: 0, buttons: 0 }],
+    ["click", "MouseEvent", { button: 0, buttons: 0, detail: 1 }]
+  ]) {
+    dispatchSyntheticEvent(slider, type, constructorName, { ...init, clientX, clientY });
+  }
+  return true;
 }
 
 function familyIsSol(value) {
@@ -826,11 +1027,15 @@ function effortDiagnostics(items) {
   return items.map((item) => ({ label: textOf(item), checked: itemIsChecked(item) }));
 }
 
-function selectionFailure(base, modelButton, state, availableFamilies, warning) {
+function selectionFailure(base, modelButton, state, availableFamilies, warning, failureReason) {
   return {
     ...base,
+    failure_reason: failureReason,
     family_status: familyIsSol(state?.family_label) ? "verified" : "unverified",
     effort_status: effortIsPro(state) ? "verified" : "unverified",
+    picker_shape: state?.shape ?? null,
+    effort_control: state?.shape === "slider" ? sliderEffortDiagnostics(state.effort_slider) : null,
+    effort_move_method: state?.effort_move_method ?? null,
     pill_text: modelControlLabel(modelButton),
     family_label: state?.family_label ?? null,
     available_options: state?.effort_items?.map((item) => textOf(item)).filter(Boolean) ?? [],
@@ -2392,9 +2597,8 @@ function uniqueElements(nodes) {
 
 export function modelSelectionDiagnostics(root = document) {
   const modelButton = findModelButton(root);
-  const mainMenu = findMainModelMenu(root);
-  const state = mainMenu ? readPickerState(mainMenu) : null;
-  const familyMenu = findFamilySubmenu(root, mainMenu);
+  const state = findPickerState(root);
+  const familyMenu = findFamilySubmenu(root, state?.menu ?? state?.surface);
   return {
     requested_model: CHATGPT_SOL_PRO_MODEL,
     current_model_label: modelControlLabel(modelButton),
@@ -2402,6 +2606,8 @@ export function modelSelectionDiagnostics(root = document) {
     family_status: familyIsSol(state?.family_label) ? "verified" : "unverified",
     effort_status: effortIsPro(state) ? "verified" : "unverified",
     family_label: state?.family_label ?? null,
+    picker_shape: state?.shape ?? null,
+    effort_control: state?.shape === "slider" ? sliderEffortDiagnostics(state.effort_slider) : null,
     model_button: modelButton ? elementSummary(modelButton) : null,
     visible_options: state?.effort_items?.map((item) => textOf(item)).filter(Boolean).slice(0, 20) ?? [],
     visible_families: familyMenuRadios(familyMenu).map((item) => textOf(item)).filter(Boolean).slice(0, 20),

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -354,6 +354,7 @@ async function startJob(message) {
     const diagnosticSummary = formatModelSelectionFailureDiagnostics(diagnostics);
     await failJob(job, "model_selection_failed", [
       `Requested ${adapter.displayName} model was not selected: ${modelSelection.status ?? "unknown"}`,
+      modelSelection.failure_reason ? `reason: ${modelSelection.failure_reason}` : null,
       diagnosticSummary ? `diagnostics: ${diagnosticSummary}` : null
     ].filter(Boolean).join(". "), {
       phase: "model_selection",
@@ -362,6 +363,7 @@ async function startJob(message) {
       model_strategy: job.model_strategy,
       model_used: job.model_used,
       model_selection_status: job.model_selection_status,
+      failure_reason: modelSelection.failure_reason ?? null,
       model_selection: modelSelection,
       ...(Object.keys(diagnostics).length > 0 ? { model_selection_diagnostics: diagnostics } : {})
     });
@@ -380,6 +382,13 @@ async function startJob(message) {
 function modelSelectionFailureDiagnostics(selection) {
   const diagnostics = {};
   for (const key of [
+    "failure_reason",
+    "picker_shape",
+    "effort_control",
+    "effort_move_method",
+    "family_status",
+    "effort_status",
+    "family_label",
     "modelVerified",
     "maxVerified",
     "modelChip"

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -45,7 +45,11 @@ class FakeElement {
   append(...children) {
     for (const child of children) {
       child.parentElement = this;
-      child.ownerDocument = this.ownerDocument;
+      if (this.ownerDocument) {
+        setOwner(child, this.ownerDocument);
+      } else {
+        child.ownerDocument = null;
+      }
       this.children.push(child);
     }
     return this;
@@ -95,6 +99,10 @@ class FakeElement {
       return [];
     }
     return [{}];
+  }
+
+  getBoundingClientRect() {
+    return { left: 10, top: 20, width: 200, height: 20, right: 210, bottom: 40 };
   }
 
   checkVisibility(options = {}) {
@@ -2279,6 +2287,22 @@ test("GPT-5.6 Sol picker verifies already-correct state with one menu open", asy
   assert.equal(fixture.menusOpen(), 0);
 });
 
+test("GPT-5.6 Sol menu picker ignores transcript text that describes the Advanced picker", async () => {
+  const fixture = makeSolPickerFixture({
+    family: "GPT-5.6 Sol",
+    effort: "High",
+    transcriptPickerDecoy: true
+  });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "selected");
+  assert.equal(result.picker_shape, "menu");
+  assert.equal(fixture.mainOpens(), 2);
+  assert.equal(fixture.effortClicks(), 1);
+  assert.equal(fixture.menusOpen(), 0);
+});
+
 test("GPT-5.6 Sol picker fails closed when Escape cannot close the menu", async () => {
   const fixture = makeSolPickerFixture({
     family: "GPT-5.6 Sol",
@@ -2317,6 +2341,94 @@ test("GPT-5.6 Sol picker fails loudly on the legacy model-switcher DOM", async (
   assert.equal(legacyButton.events.includes("pointerdown"), false);
 });
 
+test("GPT-5.6 Sol Advanced picker moves the scoped effort slider with End", async () => {
+  const fixture = makeSolSliderFixture({ keyboardMode: "end" });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "selected");
+  assert.equal(result.picker_shape, "slider");
+  assert.equal(result.effort_move_method, "keyboard_end");
+  assert.equal(result.effort_control.value_text, "Pro, 5 of 5");
+  assert.deepEqual(fixture.keyAttempts(), ["End"]);
+  assert.equal(fixture.pointerAttempts(), 0);
+  assert.equal(fixture.pickerOpen(), false);
+  assert.equal(result.pill_text, "Pro");
+});
+
+test("GPT-5.6 Sol Advanced picker accepts trailing punctuation in aria-valuetext", async () => {
+  const fixture = makeSolSliderFixture({ keyboardMode: "end", valueTextSuffix: "." });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "selected");
+  assert.equal(result.effort_move_method, "keyboard_end");
+  assert.equal(result.effort_control.value_text, "Pro, 5 of 5.");
+});
+
+test("GPT-5.6 Sol Advanced picker falls through End to bounded ArrowRight steps", async () => {
+  const fixture = makeSolSliderFixture({ keyboardMode: "arrows" });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "selected");
+  assert.equal(result.effort_move_method, "keyboard_arrow_right");
+  assert.deepEqual(fixture.keyAttempts(), ["End", "ArrowRight", "ArrowRight"]);
+  assert.equal(fixture.pointerAttempts(), 0);
+});
+
+test("GPT-5.6 Sol Advanced picker uses a max-track pointer fallback after keyboard no-ops", async () => {
+  const fixture = makeSolSliderFixture({ keyboardMode: "none", pointerMoves: true });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "selected");
+  assert.equal(result.effort_move_method, "pointer_max");
+  assert.equal(fixture.keyAttempts()[0], "End");
+  assert.ok(fixture.keyAttempts().includes("ArrowRight"));
+  assert.equal(fixture.pointerAttempts(), 1);
+  assert.equal(result.effort_control.value_now, 5);
+});
+
+test("GPT-5.6 Sol Advanced picker fails closed when neither keyboard nor pointer moves effort", async () => {
+  const fixture = makeSolSliderFixture({ keyboardMode: "none", pointerMoves: false });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "unavailable");
+  assert.equal(result.failure_reason, "effort_slider_move_failed");
+  assert.equal(result.picker_shape, "slider");
+  assert.equal(result.effort_status, "unverified");
+  assert.equal(result.effort_control.value_text, "High, 3 of 5");
+  assert.equal(fixture.pointerAttempts(), 1);
+  assert.equal(fixture.pickerOpen(), false);
+});
+
+test("GPT-5.6 Sol Advanced picker fails closed when the effort slider disappears after End", async () => {
+  const fixture = makeSolSliderFixture({ sliderDisappearsOnEnd: true });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "unavailable");
+  assert.equal(result.failure_reason, "effort_slider_move_failed");
+  assert.deepEqual(fixture.keyAttempts(), ["End"]);
+  assert.equal(fixture.pointerAttempts(), 0);
+  assert.equal(fixture.pickerOpen(), false);
+});
+
+test("GPT-5.6 Sol Advanced picker rejects the Faster/Smarter master slider as effort", async () => {
+  const fixture = makeSolSliderFixture({ includeEffortSlider: false });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "unavailable");
+  assert.equal(result.failure_reason, "effort_control_not_found");
+  assert.equal(result.picker_shape, "slider");
+  assert.equal(result.effort_control, null);
+  assert.equal(fixture.pointerAttempts(), 0);
+  assert.equal(fixture.pickerOpen(), false);
+});
+
 test("current model strategy waits briefly for the pill and reads it without picker clicks", async () => {
   const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
   const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer);
@@ -2345,7 +2457,8 @@ function makeSolPickerFixture({
   family,
   effort,
   escapeCloses = true,
-  remountPillOnSelection = false
+  remountPillOnSelection = false,
+  transcriptPickerDecoy = false
 }) {
   let currentFamily = family;
   let currentEffort = effort;
@@ -2359,6 +2472,13 @@ function makeSolPickerFixture({
   const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
   const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer);
   const body = new FakeElement("body", {}, "Ask anything").append(form);
+  if (transcriptPickerDecoy) {
+    body.append(new FakeElement(
+      "div",
+      { "data-message-author-role": "assistant" },
+      "Advanced Faster Smarter Model GPT-5.6 Sol Effort High, 3 of 5."
+    ));
+  }
 
   const removeMenu = (menu) => {
     if (!menu) return;
@@ -2472,6 +2592,103 @@ function makeSolPickerFixture({
     familyClicks: () => familyClickCount,
     effortClicks: () => effortClickCount,
     menusOpen: () => [mainMenu, familyMenu].filter(Boolean).length
+  };
+}
+
+function makeSolSliderFixture({
+  keyboardMode = "none",
+  pointerMoves = false,
+  includeEffortSlider = true,
+  sliderDisappearsOnEnd = false,
+  valueTextSuffix = ""
+} = {}) {
+  const levels = ["Instant", "Medium", "High", "Extra High", "Pro"];
+  let currentValue = 3;
+  let panel = null;
+  let effortSlider = null;
+  let pointerAttemptCount = 0;
+  const keyAttemptLog = [];
+  const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
+  const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer);
+  const body = new FakeElement("body", {}, "Ask anything").append(form);
+
+  const closePanel = () => {
+    if (!panel) return;
+    body.children = body.children.filter((child) => child !== panel);
+    panel.parentElement = null;
+    panel = null;
+  };
+  const updateValue = (value) => {
+    currentValue = Math.max(1, Math.min(5, value));
+    effortSlider?.setAttribute("aria-valuenow", currentValue);
+    effortSlider?.setAttribute("aria-valuetext", `${levels[currentValue - 1]}, ${currentValue} of 5${valueTextSuffix}`);
+    pill.innerText = levels[currentValue - 1];
+    pill.textContent = levels[currentValue - 1];
+  };
+  const makeEffortSlider = () => new FakeElement("div", {
+    role: "slider",
+    "aria-label": "Effort",
+    "aria-valuemin": "1",
+    "aria-valuemax": "5",
+    "aria-valuenow": String(currentValue),
+    "aria-valuetext": `${levels[currentValue - 1]}, ${currentValue} of 5${valueTextSuffix}`,
+    onKeyDown: (event) => {
+      keyAttemptLog.push(event.key);
+      if (sliderDisappearsOnEnd && event.key === "End") {
+        panel.children = panel.children.filter((child) => child !== effortSlider);
+        effortSlider.parentElement = null;
+        effortSlider = null;
+        return;
+      }
+      if (keyboardMode === "end" && event.key === "End") updateValue(5);
+      if (keyboardMode === "arrows" && event.key === "ArrowRight") updateValue(currentValue + 1);
+    },
+    onPointerDown: () => {
+      pointerAttemptCount += 1;
+      if (pointerMoves) updateValue(5);
+    }
+  });
+  const openPanel = () => {
+    closePanel();
+    panel = new FakeElement(
+      "div",
+      { role: "dialog" },
+      "Advanced Faster Smarter Model GPT-5.6 Sol Effort High 3 of 5"
+    );
+    const masterSlider = new FakeElement("div", {
+      role: "slider",
+      "aria-label": "Faster or smarter",
+      "aria-valuemin": "1",
+      "aria-valuemax": "5",
+      "aria-valuenow": "3",
+      "aria-valuetext": "High, 3 of 5"
+    });
+    const family = new FakeElement("button", { "aria-haspopup": "menu" }, "GPT-5.6 Sol");
+    panel.append(masterSlider, family);
+    if (includeEffortSlider) {
+      effortSlider = makeEffortSlider();
+      panel.append(effortSlider);
+    } else {
+      effortSlider = null;
+    }
+    body.append(panel);
+  };
+  const pill = new FakeElement("button", {
+    class: "__composer-pill __composer-pill--neutral",
+    "aria-haspopup": "menu",
+    onPointerDown: openPanel,
+    onKeyDown: (event) => {
+      if (event.key === "Escape") closePanel();
+    }
+  }, levels[currentValue - 1]);
+  form.append(pill);
+  const doc = new FakeDocument(body);
+
+  return {
+    doc,
+    keyAttempts: () => [...keyAttemptLog],
+    pointerAttempts: () => pointerAttemptCount,
+    pickerOpen: () => Boolean(panel)
   };
 }
 
@@ -2675,6 +2892,12 @@ function matchesSimpleSelector(element, selector) {
   }
   if (selector.includes('[role="menu"]')) {
     return attr("role") === "menu";
+  }
+  if (selector.includes('[role="dialog"]')) {
+    return attr("role") === "dialog";
+  }
+  if (selector.includes('[role="slider"]')) {
+    return attr("role") === "slider";
   }
   if (selector.includes('[role="option"]')) {
     return attr("role") === "option";

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -1666,6 +1666,17 @@ test("service worker fails closed when GPT-5.6 Sol Pro is unavailable", async ()
                 model_used: "Default",
                 requested_model: "gpt-5-6-sol-pro",
                 available_options: ["Default"],
+                failure_reason: "effort_slider_move_failed",
+                picker_shape: "slider",
+                effort_control: {
+                  label: "high",
+                  value_text: "High, 3 of 5",
+                  value_now: 3,
+                  value_min: 1,
+                  value_max: 5
+                },
+                family_status: "verified",
+                effort_status: "unverified",
                 warning: "GPT-5.6 Sol was not visible in the family submenu"
               }
             };
@@ -1687,6 +1698,11 @@ test("service worker fails closed when GPT-5.6 Sol Pro is unavailable", async ()
     assert.equal(error.payload.phase, "model_selection");
     assert.equal(error.payload.side_effect_started, false);
     assert.equal(error.payload.model_selection_status, "unavailable");
+    assert.equal(error.payload.failure_reason, "effort_slider_move_failed");
+    assert.equal(error.payload.model_selection_diagnostics.failure_reason, "effort_slider_move_failed");
+    assert.equal(error.payload.model_selection_diagnostics.picker_shape, "slider");
+    assert.equal(error.payload.model_selection_diagnostics.effort_control.value_text, "High, 3 of 5");
+    assert.match(error.payload.message, /reason: effort_slider_move_failed/);
     assert.equal(sentToTabs.includes("yoetz_upload_file"), false);
     assert.equal(sentToTabs.includes("yoetz_send_prompt"), false);
   } finally {


### PR DESCRIPTION
Closes #381

## Summary
- detect the menu or Advanced-slider picker shape on every open without caching account/session state
- preserve the menu path and scope the effort slider away from the Faster/Smarter master control
- try End, bounded ArrowRight steps, then a max-track pointer fallback, rereading and cross-checking ARIA after each attempt
- fail closed with stable machine-readable reasons propagated through the service worker and CLI
- add negative fixtures for no movement, disappearing controls, same-shaped decoys, transcript keyword decoys, and missing effort controls

## Verification
Local verification binds to feature commit 35c7dc937896776ac10a9c4fa3435063e3496f1b:
- npm test — 333 passed, 0 failed
- cargo fmt --all -- --check
- cargo test -p yoetz job_error_message_surfaces_model_selection_failure_reason — 1 passed
- ./scripts/build-chatgpt-native-extension.sh --check — passed

Current PR head c338c032aca600664f27fdf307b8e857c0825c9c adds only the merged #384 docs base update; hosted CI validates that exact head.

## Live-proof status
Fixture-tested only; live slider proof is pending until the OpenAI A/B serves the slider again. The daily flow remained unbroken today on both personal and Enterprise accounts through the existing menu path, with Pro sticky after selection. This remains P1 because the slider variant is controlled by OpenAI and was not available for an end-to-end run.

Known unknown for the first live re-check: the pointer fallback assumes the role=slider bounding rect spans the track. Some Radix-style controls put that role on the thumb; keyboard remains primary and the implementation fails closed if the pointer verb does not produce verified Pro ARIA.

Follow-up #383 tracks bfcache/background port reconnect behavior separately.