### PR TITLE
feat(ask): add session opt-out and retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Added
+
+- `yoetz ask --no-session` (and a trusted-config `[sessions] no_session = true`
+  key) skips creating `~/.yoetz/sessions/<id>/` entirely for headless callers;
+  stdout output is unchanged apart from empty artifact paths.
+- Session retention: optional `[sessions] max_age_days` / `max_count` config
+  keys prune old or excess session directories opportunistically on startup.
+  Disabled by default; `[sessions]` is ignored (with a warning) from untrusted
+  repo-local configs because it controls data deletion.
 
 ## [0.5.36] - 2026-07-19
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,6 +3176,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror 2.0.18",
  "time",
  "toml",

--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ shape.
 The default `models frontier` lab list is configurable with
 `[frontier].families`; `--all` and `--family` continue to bypass that list.
 
+`yoetz ask` writes artifacts to `~/.yoetz/sessions/<id>/` by default. Headless
+callers can skip that entirely with `yoetz ask --no-session` (or
+`[sessions] no_session = true`), and `[sessions] max_age_days` /
+`[sessions] max_count` prune old or excess session dirs on startup. Both are
+off by default, and `[sessions]` is only honored from trusted config
+locations, never from repo-local `./yoetz.toml`.
+
 Resolve live model IDs before putting them in scripts:
 
 ```bash

--- a/crates/yoetz-cli/src/commands/ask.rs
+++ b/crates/yoetz-cli/src/commands/ask.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 use crate::{budget, providers, registry};
 use std::env;
-use std::path::PathBuf;
 use std::time::Instant;
 use yoetz_core::bundle::{build_bundle, estimate_tokens, BundleOptions};
 use yoetz_core::media::MediaType;
@@ -95,13 +94,28 @@ pub(crate) async fn handle_ask(
         Some(build_bundle(&prompt, options)?)
     };
 
-    let session = create_session_dir()?;
+    // --no-session (or `[sessions] no_session = true` from trusted config)
+    // skips the session directory and every artifact write; stdout output is
+    // unchanged apart from the empty artifact paths.
+    let no_session = args.no_session || config.sessions.no_session.unwrap_or(false);
+    let session = if no_session {
+        None
+    } else {
+        Some(create_session_dir()?)
+    };
+    let run_id = session
+        .as_ref()
+        .map(|s| s.id.clone())
+        .unwrap_or_else(yoetz_core::session::new_session_id);
     let mut artifacts = ArtifactPaths {
-        session_dir: session.path.to_string_lossy().to_string(),
+        session_dir: session
+            .as_ref()
+            .map(|s| s.path.to_string_lossy().to_string())
+            .unwrap_or_default(),
         ..Default::default()
     };
 
-    if let Some(bundle_ref) = &bundle {
+    if let (Some(session), Some(bundle_ref)) = (&session, &bundle) {
         let bundle_json = session.path.join("bundle.json");
         let bundle_md = session.path.join("bundle.md");
         write_json_file(&bundle_json, bundle_ref)?;
@@ -245,8 +259,10 @@ pub(crate) async fn handle_ask(
                 )
                 .await?;
                 if ctx.debug || env::var("YOETZ_GEMINI_DEBUG").ok().as_deref() == Some("1") {
-                    let raw_path = session.path.join("gemini_response.json");
-                    let _ = write_json_file(&raw_path, &result.raw);
+                    if let Some(session) = &session {
+                        let raw_path = session.path.join("gemini_response.json");
+                        let _ = write_json_file(&raw_path, &result.raw);
+                    }
                 }
                 (result.content, result.usage, None, None)
             }
@@ -348,7 +364,7 @@ pub(crate) async fn handle_ask(
     }
 
     let mut result = RunResult {
-        id: session.id,
+        id: run_id,
         model: model_id,
         provider: provider_id,
         bundle,
@@ -358,9 +374,11 @@ pub(crate) async fn handle_ask(
         artifacts,
     };
 
-    let response_json = PathBuf::from(&result.artifacts.session_dir).join("response.json");
-    result.artifacts.response_json = Some(response_json.to_string_lossy().to_string());
-    write_json_file(&response_json, &result)?;
+    if let Some(session) = &session {
+        let response_json = session.path.join("response.json");
+        result.artifacts.response_json = Some(response_json.to_string_lossy().to_string());
+        write_json_file(&response_json, &result)?;
+    }
 
     maybe_write_output(ctx, &result)?;
     notifications::maybe_notify_completion(

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -191,6 +191,12 @@ struct AskArgs {
     /// Suppress native completion notifications for this run.
     #[arg(long)]
     no_notify: bool,
+
+    /// Skip creating a session directory under ~/.yoetz/sessions/ (no
+    /// bundle/response artifacts are written; stdout output is unchanged).
+    /// Can also be enabled via `[sessions] no_session = true` in config.
+    #[arg(long)]
+    no_session: bool,
 }
 
 #[derive(Args)]
@@ -1055,6 +1061,17 @@ async fn main() -> Result<()> {
         // (review finding #9).
         env::set_var(chrome_devtools_mcp::client::YOETZ_DEBUG_CDP_ENV, "1");
     }
+    // Opportunistic session retention: only when the user configured limits,
+    // and never fatal — a prune failure must not block the actual command.
+    if config.sessions.retention_enabled() {
+        if let Err(e) = yoetz_core::session::prune_sessions(
+            config.sessions.max_age_days,
+            config.sessions.max_count,
+        ) {
+            eprintln!("warning: session pruning failed: {e}");
+        }
+    }
+
     let client = build_client(cli.timeout_secs)?;
     let litellm = std::sync::Arc::new(build_litellm(&config, client.clone())?);
     let ctx = AppContext {

--- a/crates/yoetz-cli/tests/cli.rs
+++ b/crates/yoetz-cli/tests/cli.rs
@@ -903,6 +903,89 @@ fn retention_disabled_by_default_keeps_all_sessions() {
 }
 
 #[test]
+fn ask_no_session_via_trusted_config_profile_overlay() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = dir.path().join("state");
+    let config_path = session_test_config(&dir, "");
+    // Trusted profile overlay under an isolated $HOME:
+    // ~/.config/yoetz/profiles/quiet.toml
+    let home = dir.path().join("home");
+    let profiles = home.join(".config/yoetz/profiles");
+    fs::create_dir_all(&profiles).unwrap();
+    fs::write(
+        profiles.join("quiet.toml"),
+        "[sessions]\nno_session = true\n",
+    )
+    .unwrap();
+
+    ask_dry_run(&state, &config_path)
+        .env("HOME", &home)
+        .env_remove("XDG_CONFIG_HOME")
+        .args([
+            "--config-profile",
+            "quiet",
+            "--format",
+            "json",
+            "ask",
+            "--prompt",
+            "hi",
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"session_dir\": \"\""));
+
+    assert!(!state.join("sessions").exists());
+}
+
+/// Strip the volatile per-run fields (random id, session-dependent artifact
+/// paths) so the rest of the payload can be compared exactly.
+fn normalized_run_json(stdout: &[u8]) -> serde_json::Value {
+    let mut value: serde_json::Value = serde_json::from_slice(stdout).unwrap();
+    let obj = value.as_object_mut().unwrap();
+    obj.remove("id");
+    obj.remove("artifacts");
+    value
+}
+
+#[test]
+fn ask_no_session_json_payload_matches_default_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = session_test_config(&dir, "");
+
+    let default_out = ask_dry_run(&dir.path().join("state-default"), &config_path)
+        .args(["--format", "json", "ask", "--prompt", "hi", "--dry-run"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let no_session_out = ask_dry_run(&dir.path().join("state-nosession"), &config_path)
+        .args([
+            "--format",
+            "json",
+            "ask",
+            "--prompt",
+            "hi",
+            "--dry-run",
+            "--no-session",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let default_json = normalized_run_json(&default_out);
+    let no_session_json = normalized_run_json(&no_session_out);
+    assert_eq!(default_json, no_session_json);
+    assert_eq!(
+        no_session_json["content"],
+        serde_json::json!("(dry-run) no provider call executed")
+    );
+}
+
+#[test]
 fn ask_help_documents_no_session() {
     yoetz()
         .args(["ask", "--help"])

--- a/crates/yoetz-cli/tests/cli.rs
+++ b/crates/yoetz-cli/tests/cli.rs
@@ -751,3 +751,162 @@ fn allow_unknown_flag_accepted() {
         .success()
         .stdout(predicate::str::contains("--allow-unknown"));
 }
+
+// ---- issue #391: session opt-out and retention ----
+
+/// Trusted config (via YOETZ_CONFIG_PATH) with registry auto-sync disabled so
+/// dry-run asks never touch the network, plus optional extra sections.
+fn session_test_config(dir: &TempDir, extra: &str) -> PathBuf {
+    let config_path = dir.path().join("config.toml");
+    fs::write(
+        &config_path,
+        format!("[registry]\nauto_sync_secs = 0\n{extra}"),
+    )
+    .unwrap();
+    config_path
+}
+
+fn ask_dry_run(state: &PathBuf, config_path: &PathBuf) -> Command {
+    let mut cmd = yoetz();
+    cmd.env("YOETZ_DIR", state)
+        .env("YOETZ_CONFIG_PATH", config_path)
+        .env_remove("OPENAI_API_KEY")
+        .env_remove("ANTHROPIC_API_KEY")
+        .env_remove("GEMINI_API_KEY")
+        .env_remove("OPENROUTER_API_KEY")
+        .env_remove("XAI_API_KEY");
+    cmd
+}
+
+#[test]
+fn ask_dry_run_creates_session_dir_by_default() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = dir.path().join("state");
+    let config_path = session_test_config(&dir, "");
+
+    ask_dry_run(&state, &config_path)
+        .args(["--format", "json", "ask", "--prompt", "hi", "--dry-run"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "(dry-run) no provider call executed",
+        ))
+        .stdout(predicate::str::contains("response.json"));
+
+    let sessions = state.join("sessions");
+    assert!(sessions.exists());
+    let entries: Vec<_> = fs::read_dir(&sessions).unwrap().collect();
+    assert_eq!(entries.len(), 1);
+    let session_dir = entries[0].as_ref().unwrap().path();
+    assert!(session_dir.join("response.json").exists());
+}
+
+#[test]
+fn ask_no_session_flag_leaves_sessions_untouched() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = dir.path().join("state");
+    let config_path = session_test_config(&dir, "");
+
+    ask_dry_run(&state, &config_path)
+        .args([
+            "--format",
+            "json",
+            "ask",
+            "--prompt",
+            "hi",
+            "--dry-run",
+            "--no-session",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "(dry-run) no provider call executed",
+        ))
+        .stdout(predicate::str::contains("\"session_dir\": \"\""))
+        .stdout(predicate::str::contains("\"response_json\": null"));
+
+    assert!(!state.join("sessions").exists());
+}
+
+#[test]
+fn ask_no_session_via_trusted_config_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = dir.path().join("state");
+    let config_path = session_test_config(&dir, "[sessions]\nno_session = true\n");
+
+    ask_dry_run(&state, &config_path)
+        .args(["--format", "json", "ask", "--prompt", "hi", "--dry-run"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"session_dir\": \"\""));
+
+    assert!(!state.join("sessions").exists());
+}
+
+#[test]
+fn sessions_config_ignored_from_untrusted_repo_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = dir.path().join("state");
+    let config_path = session_test_config(&dir, "");
+    let cwd = dir.path().join("repo");
+    fs::create_dir_all(&cwd).unwrap();
+    // Repo-local config is untrusted: its [sessions] must be ignored with a
+    // warning, so the session dir is still created.
+    fs::write(cwd.join("yoetz.toml"), "[sessions]\nno_session = true\n").unwrap();
+
+    ask_dry_run(&state, &config_path)
+        .current_dir(&cwd)
+        .args(["--format", "json", "ask", "--prompt", "hi", "--dry-run"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("ignoring [sessions]"));
+
+    assert!(state.join("sessions").exists());
+}
+
+#[test]
+fn retention_prunes_excess_sessions_on_startup() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = dir.path().join("state");
+    let sessions = state.join("sessions");
+    // The "2020" dir is created first (older-or-equal mtime) and has the
+    // lexically smaller id, so it loses under both orderings deterministically.
+    fs::create_dir_all(sessions.join("20200101_000000_aaaaaa")).unwrap();
+    fs::create_dir_all(sessions.join("20990101_000000_bbbbbb")).unwrap();
+    let config_path = session_test_config(&dir, "[sessions]\nmax_count = 1\n");
+
+    ask_dry_run(&state, &config_path)
+        .args(["--format", "json", "status"])
+        .assert()
+        .success();
+
+    assert!(!sessions.join("20200101_000000_aaaaaa").exists());
+    assert!(sessions.join("20990101_000000_bbbbbb").exists());
+}
+
+#[test]
+fn retention_disabled_by_default_keeps_all_sessions() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = dir.path().join("state");
+    let sessions = state.join("sessions");
+    fs::create_dir_all(sessions.join("20200101_000000_aaaaaa")).unwrap();
+    fs::create_dir_all(sessions.join("20990101_000000_bbbbbb")).unwrap();
+    let config_path = session_test_config(&dir, "");
+
+    ask_dry_run(&state, &config_path)
+        .args(["--format", "json", "status"])
+        .assert()
+        .success();
+
+    assert!(sessions.join("20200101_000000_aaaaaa").exists());
+    assert!(sessions.join("20990101_000000_bbbbbb").exists());
+}
+
+#[test]
+fn ask_help_documents_no_session() {
+    yoetz()
+        .args(["ask", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--no-session"));
+}

--- a/crates/yoetz-core/Cargo.toml
+++ b/crates/yoetz-core/Cargo.toml
@@ -27,3 +27,6 @@ sha2.workspace = true
 hex.workspace = true
 base64.workspace = true
 mime_guess.workspace = true
+
+[dev-dependencies]
+tempfile = "3.27"

--- a/crates/yoetz-core/src/config.rs
+++ b/crates/yoetz-core/src/config.rs
@@ -15,6 +15,7 @@ pub struct Config {
     pub registry: RegistryConfig,
     pub frontier: FrontierConfig,
     pub notifications: NotificationsConfig,
+    pub sessions: SessionsConfig,
     #[serde(default)]
     pub aliases: HashMap<String, String>,
 }
@@ -58,6 +59,26 @@ pub struct NotificationsConfig {
     pub notify_threshold_secs: Option<u64>,
 }
 
+/// Session artifact lifecycle: opt-out of session writes and retention limits.
+/// Only honored from trusted config sources: retention deletes user data and
+/// `no_session` suppresses audit artifacts, so repo-local configs must not
+/// control it.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SessionsConfig {
+    /// Skip creating session directories for `yoetz ask` (like `--no-session`).
+    pub no_session: Option<bool>,
+    /// Prune session dirs whose mtime is older than this many days.
+    pub max_age_days: Option<u64>,
+    /// Keep at most this many newest session dirs.
+    pub max_count: Option<usize>,
+}
+
+impl SessionsConfig {
+    pub fn retention_enabled(&self) -> bool {
+        self.max_age_days.is_some() || self.max_count.is_some()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct ConfigFile {
     pub defaults: Option<Defaults>,
@@ -65,6 +86,7 @@ struct ConfigFile {
     pub registry: Option<RegistryConfig>,
     pub frontier: Option<FrontierConfig>,
     pub notifications: Option<NotificationsConfig>,
+    pub sessions: Option<SessionsConfig>,
     pub aliases: Option<HashMap<String, String>>,
 }
 
@@ -132,6 +154,16 @@ impl Config {
         }
         if let Some(notifications) = other.notifications {
             merge_notifications(&mut self.notifications, notifications);
+        }
+        if let Some(sessions) = other.sessions {
+            if trusted {
+                merge_sessions(&mut self.sessions, sessions);
+            } else {
+                eprintln!(
+                    "warning: ignoring [sessions] from untrusted config {}",
+                    source.display()
+                );
+            }
         }
         if let Some(aliases) = other.aliases {
             if trusted {
@@ -271,6 +303,11 @@ model = "gpt-5-4-pro"
                 families: Some(vec!["evil".to_string()]),
             }),
             notifications: None,
+            sessions: Some(SessionsConfig {
+                no_session: Some(true),
+                max_age_days: Some(1),
+                max_count: Some(1),
+            }),
             aliases: Some(HashMap::from([(
                 "fast".to_string(),
                 "gpt-5-4-pro".to_string(),
@@ -287,6 +324,12 @@ model = "gpt-5-4-pro"
         assert!(config.registry.openrouter_models_url.is_none());
         assert!(config.frontier.families.is_none());
         assert!(config.notifications.enabled.is_none());
+        // [sessions] controls data deletion and artifact suppression; untrusted
+        // repo-local configs must not set it.
+        assert!(config.sessions.no_session.is_none());
+        assert!(config.sessions.max_age_days.is_none());
+        assert!(config.sessions.max_count.is_none());
+        assert!(!config.sessions.retention_enabled());
     }
 
     #[test]
@@ -308,6 +351,7 @@ model = "gpt-5-4-pro"
             }),
             frontier: None,
             notifications: None,
+            sessions: None,
             aliases: None,
         };
         config.merge(
@@ -331,6 +375,7 @@ model = "gpt-5-4-pro"
                 enabled: Some(false),
                 notify_threshold_secs: Some(90),
             }),
+            sessions: None,
             aliases: None,
         };
         config.merge(file, false, Path::new("./yoetz.toml"));
@@ -349,6 +394,7 @@ model = "gpt-5-4-pro"
                 families: Some(vec!["openai".to_string(), "z-ai".to_string()]),
             }),
             notifications: None,
+            sessions: None,
             aliases: None,
         };
 
@@ -362,6 +408,50 @@ model = "gpt-5-4-pro"
             config.frontier.families,
             Some(vec!["openai".to_string(), "z-ai".to_string()])
         );
+    }
+
+    #[test]
+    fn trusted_config_applies_sessions() {
+        let mut config = Config::default();
+        let file = ConfigFile {
+            defaults: None,
+            providers: None,
+            registry: None,
+            frontier: None,
+            notifications: None,
+            sessions: Some(SessionsConfig {
+                no_session: Some(true),
+                max_age_days: Some(30),
+                max_count: Some(100),
+            }),
+            aliases: None,
+        };
+
+        config.merge(
+            file,
+            true,
+            Path::new("/home/user/.config/yoetz/config.toml"),
+        );
+
+        assert_eq!(config.sessions.no_session, Some(true));
+        assert_eq!(config.sessions.max_age_days, Some(30));
+        assert_eq!(config.sessions.max_count, Some(100));
+        assert!(config.sessions.retention_enabled());
+    }
+
+    #[test]
+    fn parse_sessions_from_toml() {
+        let toml_str = r#"
+[sessions]
+no_session = true
+max_age_days = 14
+max_count = 50
+"#;
+        let file: ConfigFile = toml::from_str(toml_str).unwrap();
+        let sessions = file.sessions.unwrap();
+        assert_eq!(sessions.no_session, Some(true));
+        assert_eq!(sessions.max_age_days, Some(14));
+        assert_eq!(sessions.max_count, Some(50));
     }
 }
 
@@ -404,5 +494,17 @@ fn merge_notifications(target: &mut NotificationsConfig, other: NotificationsCon
     }
     if other.notify_threshold_secs.is_some() {
         target.notify_threshold_secs = other.notify_threshold_secs;
+    }
+}
+
+fn merge_sessions(target: &mut SessionsConfig, other: SessionsConfig) {
+    if other.no_session.is_some() {
+        target.no_session = other.no_session;
+    }
+    if other.max_age_days.is_some() {
+        target.max_age_days = other.max_age_days;
+    }
+    if other.max_count.is_some() {
+        target.max_count = other.max_count;
     }
 }

--- a/crates/yoetz-core/src/session.rs
+++ b/crates/yoetz-core/src/session.rs
@@ -66,8 +66,18 @@ pub fn prune_sessions_in(
     if max_age_days.is_none() && max_count.is_none() {
         return Ok(0);
     }
-    if !base.exists() {
-        return Ok(0);
+    // Refuse to prune through a symlinked (or non-directory) sessions root:
+    // read_dir would follow the link and remove_dir_all could then delete
+    // real directories outside the yoetz root.
+    let base_meta = match fs::symlink_metadata(base) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        other => other.with_context(|| format!("stat sessions base {}", base.display()))?,
+    };
+    if !base_meta.is_dir() {
+        anyhow::bail!(
+            "refusing to prune sessions: {} is not a real directory",
+            base.display()
+        );
     }
 
     // (path, id, mtime) for real directories only; symlinks and files are
@@ -83,7 +93,11 @@ pub fn prune_sessions_in(
         let meta = entry
             .metadata()
             .with_context(|| format!("stat {}", entry.path().display()))?;
-        let mtime = meta.modified().unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        // An unknown mtime must never look "infinitely old" (guaranteed
+        // deletion); surface the error instead.
+        let mtime = meta
+            .modified()
+            .with_context(|| format!("read mtime of {}", entry.path().display()))?;
         let id = entry.file_name().to_string_lossy().to_string();
         dirs.push((entry.path(), id, mtime));
     }
@@ -184,10 +198,14 @@ mod tests {
     }
 
     #[cfg(unix)]
-    fn set_mtime(path: &Path, age_secs: u64) {
-        let when = SystemTime::now() - Duration::from_secs(age_secs);
+    fn set_mtime_to(path: &Path, when: SystemTime) {
         let file = fs::File::open(path).unwrap();
         file.set_modified(when).unwrap();
+    }
+
+    #[cfg(unix)]
+    fn set_mtime(path: &Path, age_secs: u64) {
+        set_mtime_to(path, SystemTime::now() - Duration::from_secs(age_secs));
     }
 
     #[test]
@@ -218,6 +236,33 @@ mod tests {
         let removed = prune_sessions_in(&base, None, Some(0)).unwrap();
         assert_eq!(removed, 0);
         assert!(base.join("stray.txt").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prune_refuses_symlinked_base() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Real directory outside the yoetz root, with a child session-like dir.
+        let external = mkdir(tmp.path(), "external");
+        let victim = mkdir(&external, "20200101_000000_victim");
+        let base = tmp.path().join("sessions");
+        std::os::unix::fs::symlink(&external, &base).unwrap();
+
+        let err = prune_sessions_in(&base, None, Some(0)).unwrap_err();
+        assert!(err.to_string().contains("not a real directory"));
+        // The external target and its child are untouched.
+        assert!(external.exists());
+        assert!(victim.exists());
+    }
+
+    #[test]
+    fn prune_refuses_file_base() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("sessions");
+        fs::write(&base, "not a dir").unwrap();
+        let err = prune_sessions_in(&base, Some(1), None).unwrap_err();
+        assert!(err.to_string().contains("not a real directory"));
+        assert!(base.exists());
     }
 
     #[cfg(unix)]
@@ -275,8 +320,9 @@ mod tests {
         let a = mkdir(&base, "20250101_000000_aaaaaa");
         let b = mkdir(&base, "20250102_000000_bbbbbb");
         // Identical mtimes: the lexically larger (newer-looking) id survives.
-        set_mtime(&a, 100);
-        set_mtime(&b, 100);
+        let when = SystemTime::now() - Duration::from_secs(100);
+        set_mtime_to(&a, when);
+        set_mtime_to(&b, when);
         let removed = prune_sessions_in(&base, None, Some(1)).unwrap();
         assert_eq!(removed, 1);
         assert!(!a.exists());

--- a/crates/yoetz-core/src/session.rs
+++ b/crates/yoetz-core/src/session.rs
@@ -24,6 +24,17 @@ pub fn create_session_dir_in(root: &Path) -> Result<SessionInfo> {
     fs::create_dir_all(&base).with_context(|| format!("create sessions dir {}", base.display()))?;
     chmod_owner_only_dir(&base)?;
 
+    let id = new_session_id();
+    let path = base.join(&id);
+    fs::create_dir_all(&path).with_context(|| format!("create session {}", path.display()))?;
+    chmod_owner_only_dir(&path)?;
+
+    Ok(SessionInfo { id, path })
+}
+
+/// Generate a run id in the same `YYYYMMDD_HHMMSS_xxxxxx` format used for
+/// session directories, without creating anything on disk.
+pub fn new_session_id() -> String {
     let ts = OffsetDateTime::now_utc()
         .format(TS_FORMAT)
         .unwrap_or_else(|_| "unknown".to_string());
@@ -32,16 +43,76 @@ pub fn create_session_dir_in(root: &Path) -> Result<SessionInfo> {
         .take(6)
         .map(char::from)
         .collect();
-    let id = format!("{ts}_{rand}");
-    let path = base.join(&id);
-    fs::create_dir_all(&path).with_context(|| format!("create session {}", path.display()))?;
-    chmod_owner_only_dir(&path)?;
-
-    Ok(SessionInfo { id, path })
+    format!("{ts}_{rand}")
 }
 
 pub fn session_base_dir() -> PathBuf {
     yoetz_root_dir().join("sessions")
+}
+
+/// Prune old/excess session directories under `~/.yoetz/sessions/`.
+///
+/// No-op when both limits are `None`. Never creates the root or sessions
+/// directory. Returns the number of session directories removed.
+pub fn prune_sessions(max_age_days: Option<u64>, max_count: Option<usize>) -> Result<usize> {
+    prune_sessions_in(&session_base_dir(), max_age_days, max_count)
+}
+
+pub fn prune_sessions_in(
+    base: &Path,
+    max_age_days: Option<u64>,
+    max_count: Option<usize>,
+) -> Result<usize> {
+    if max_age_days.is_none() && max_count.is_none() {
+        return Ok(0);
+    }
+    if !base.exists() {
+        return Ok(0);
+    }
+
+    // (path, id, mtime) for real directories only; symlinks and files are
+    // never followed or removed.
+    let mut dirs: Vec<(PathBuf, String, std::time::SystemTime)> = Vec::new();
+    for entry in fs::read_dir(base).with_context(|| format!("read {}", base.display()))? {
+        let entry = entry?;
+        // DirEntry::file_type does not follow symlinks, so a symlink to a
+        // directory is excluded here.
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let meta = entry
+            .metadata()
+            .with_context(|| format!("stat {}", entry.path().display()))?;
+        let mtime = meta.modified().unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        let id = entry.file_name().to_string_lossy().to_string();
+        dirs.push((entry.path(), id, mtime));
+    }
+
+    let mut doomed: Vec<PathBuf> = Vec::new();
+
+    if let Some(days) = max_age_days {
+        let cutoff = std::time::SystemTime::now()
+            .checked_sub(std::time::Duration::from_secs(days.saturating_mul(86_400)))
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        let (old, kept): (Vec<_>, Vec<_>) = dirs.into_iter().partition(|(_, _, m)| *m < cutoff);
+        doomed.extend(old.into_iter().map(|(p, _, _)| p));
+        dirs = kept;
+    }
+
+    if let Some(count) = max_count {
+        if dirs.len() > count {
+            // Newest first by mtime, id as a stable tie-break.
+            dirs.sort_by(|a, b| b.2.cmp(&a.2).then_with(|| b.1.cmp(&a.1)));
+            doomed.extend(dirs.split_off(count).into_iter().map(|(p, _, _)| p));
+        }
+    }
+
+    let mut removed = 0usize;
+    for path in doomed {
+        fs::remove_dir_all(&path).with_context(|| format!("prune session {}", path.display()))?;
+        removed += 1;
+    }
+    Ok(removed)
 }
 
 fn yoetz_root_dir() -> PathBuf {
@@ -99,4 +170,148 @@ pub fn list_sessions_in(base: &Path) -> Result<Vec<SessionInfo>> {
     }
     items.sort_by(|a, b| b.id.cmp(&a.id));
     Ok(items)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, SystemTime};
+
+    fn mkdir(base: &Path, name: &str) -> PathBuf {
+        let path = base.join(name);
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[cfg(unix)]
+    fn set_mtime(path: &Path, age_secs: u64) {
+        let when = SystemTime::now() - Duration::from_secs(age_secs);
+        let file = fs::File::open(path).unwrap();
+        file.set_modified(when).unwrap();
+    }
+
+    #[test]
+    fn prune_is_noop_when_unset() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("sessions");
+        mkdir(&base, "20200101_000000_aaaaaa");
+        let removed = prune_sessions_in(&base, None, None).unwrap();
+        assert_eq!(removed, 0);
+        assert!(base.join("20200101_000000_aaaaaa").exists());
+    }
+
+    #[test]
+    fn prune_does_not_create_missing_base() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("sessions");
+        let removed = prune_sessions_in(&base, Some(1), Some(1)).unwrap();
+        assert_eq!(removed, 0);
+        assert!(!base.exists());
+    }
+
+    #[test]
+    fn prune_skips_plain_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("sessions");
+        fs::create_dir_all(&base).unwrap();
+        fs::write(base.join("stray.txt"), "keep me").unwrap();
+        let removed = prune_sessions_in(&base, None, Some(0)).unwrap();
+        assert_eq!(removed, 0);
+        assert!(base.join("stray.txt").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prune_skips_symlinked_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("sessions");
+        fs::create_dir_all(&base).unwrap();
+        let target = mkdir(tmp.path(), "outside");
+        std::os::unix::fs::symlink(&target, base.join("linked")).unwrap();
+        let removed = prune_sessions_in(&base, None, Some(0)).unwrap();
+        assert_eq!(removed, 0);
+        assert!(base.join("linked").exists());
+        assert!(target.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prune_by_age_keeps_recent_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("sessions");
+        let old = mkdir(&base, "20200101_000000_oldddd");
+        let fresh = mkdir(&base, "20990101_000000_freshh");
+        set_mtime(&old, 10 * 86_400);
+        set_mtime(&fresh, 60);
+        let removed = prune_sessions_in(&base, Some(7), None).unwrap();
+        assert_eq!(removed, 1);
+        assert!(!old.exists());
+        assert!(fresh.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prune_by_count_keeps_newest_by_mtime() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("sessions");
+        let a = mkdir(&base, "a");
+        let b = mkdir(&base, "b");
+        let c = mkdir(&base, "c");
+        set_mtime(&a, 300);
+        set_mtime(&b, 200);
+        set_mtime(&c, 100);
+        let removed = prune_sessions_in(&base, None, Some(2)).unwrap();
+        assert_eq!(removed, 1);
+        assert!(!a.exists());
+        assert!(b.exists());
+        assert!(c.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prune_count_tie_breaks_on_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("sessions");
+        let a = mkdir(&base, "20250101_000000_aaaaaa");
+        let b = mkdir(&base, "20250102_000000_bbbbbb");
+        // Identical mtimes: the lexically larger (newer-looking) id survives.
+        set_mtime(&a, 100);
+        set_mtime(&b, 100);
+        let removed = prune_sessions_in(&base, None, Some(1)).unwrap();
+        assert_eq!(removed, 1);
+        assert!(!a.exists());
+        assert!(b.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prune_applies_age_then_count_to_survivors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("sessions");
+        let ancient = mkdir(&base, "w");
+        let old = mkdir(&base, "x");
+        let mid = mkdir(&base, "y");
+        let fresh = mkdir(&base, "z");
+        set_mtime(&ancient, 30 * 86_400);
+        set_mtime(&old, 10 * 86_400);
+        set_mtime(&mid, 3_600);
+        set_mtime(&fresh, 60);
+        // Age prunes ancient+old; count=1 then prunes mid from the survivors.
+        let removed = prune_sessions_in(&base, Some(7), Some(1)).unwrap();
+        assert_eq!(removed, 3);
+        assert!(!ancient.exists());
+        assert!(!old.exists());
+        assert!(!mid.exists());
+        assert!(fresh.exists());
+    }
+
+    #[test]
+    fn new_session_id_has_expected_shape() {
+        let id = new_session_id();
+        let parts: Vec<&str> = id.split('_').collect();
+        assert_eq!(parts.len(), 3);
+        assert_eq!(parts[0].len(), 8);
+        assert_eq!(parts[1].len(), 6);
+        assert_eq!(parts[2].len(), 6);
+    }
 }

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -25,3 +25,15 @@ org_registry_path = "./registry.json"
 
 [frontier]
 families = ["openai", "anthropic", "google", "x-ai", "z-ai", "meta-llama", "deepseek", "mistralai", "qwen", "moonshotai"]
+
+# Session artifact lifecycle for `yoetz ask`. All keys optional; when unset,
+# sessions are always written and never pruned (previous behavior).
+# Only honored from trusted config locations (home/XDG/YOETZ_CONFIG_PATH and
+# config profiles); repo-local ./yoetz.toml cannot set these.
+[sessions]
+# Skip writing ~/.yoetz/sessions/<id>/ for `yoetz ask` (same as --no-session).
+# no_session = true
+# Prune session dirs older than N days on startup.
+# max_age_days = 30
+# Keep at most N newest session dirs on startup.
+# max_count = 200


### PR DESCRIPTION
## Summary

- Add `yoetz ask --no-session` and trusted `[sessions] no_session = true` configuration.
- Add disabled-by-default `max_age_days` and `max_count` session retention.
- Make pruning safe around untrusted configuration and symlinked session roots.
- Add CLI and core tests, documentation, help text, and changelog coverage.

## Impact

Headless callers can avoid session artifacts entirely, while interactive users can bound retained sessions without changing default behavior.

## Validation

- `cargo test --workspace`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets`
- CTO exact-head review at `49f40fe7738ebc49971de7c0ab1d3c639e2a8e6e`

Closes #391