### PR TITLE
ci: compile dev-deps in MSRV check (--all-targets)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,9 @@ jobs:
         with:
           shared-key: rust-msrv-1.88-${{ runner.os }}
           cache-bin: false
-      - run: cargo check --workspace
+      # --all-targets compiles dev-dependencies too; without it a dev-dep with
+      # rust-version above the MSRV passes this job while `cargo test` breaks.
+      - run: cargo check --workspace --all-targets
 
   doc:
     name: Documentation


### PR DESCRIPTION
## Summary

The MSRV (1.88) job runs `cargo check --workspace`, which never compiles dev-dependencies. That made dependabot #389 (serial_test 3.5.0 → 4.0.1, MSRV 1.93.1) come out green while `cargo test` on 1.88 would fail — a false pass. `--all-targets` compiles tests/benches/examples in check mode, so a dev-dep whose `rust-version` exceeds the MSRV now fails this job.

#389 was closed via `@dependabot ignore this major version`; this closes the CI hole that let it look mergeable.

## Validation

- One-line workflow change; the MSRV job on this PR itself exercises the new flag against the current lock (serial_test 3.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbMozs4Nt8Thd5zWRkuNQr