### PR TITLE
feat(ask): session opt-out and retention with live-session leases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Session retention: optional `[sessions] max_age_days` / `max_count` config
   keys prune old or excess session directories opportunistically on startup.
   Disabled by default; `[sessions]` is ignored (with a warning) from untrusted
-  repo-local configs because it controls data deletion.
+  repo-local configs because it controls data deletion. Active session writers
+  are lease-protected from pruning, including browser recipes that reuse a
+  managed bundle session. Mixed old/new binaries are not lease-compatible:
+  the new pruner cannot see an old binary's `.browser-recipe.lock`.
 
 ## [0.5.49] - 2026-08-07
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Added
+
+- `yoetz ask --no-session` (and a trusted-config `[sessions] no_session = true`
+  key) skips creating `~/.yoetz/sessions/<id>/` entirely for headless callers;
+  stdout output is unchanged apart from empty artifact paths.
+- Session retention: optional `[sessions] max_age_days` / `max_count` config
+  keys prune old or excess session directories opportunistically on startup.
+  Disabled by default; `[sessions]` is ignored (with a warning) from untrusted
+  repo-local configs because it controls data deletion.
 
 ## [0.5.36] - 2026-07-19
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3250,6 +3250,7 @@ version = "0.5.49"
 dependencies = [
  "anyhow",
  "base64 0.23.0",
+ "fs2",
  "hex",
  "ignore",
  "mime_guess",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,6 +3176,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "thiserror 2.0.18",
  "time",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ hex = "0.4"
 base64 = "0.23"
 mime_guess = "2.0"
 dotenvy = "0.15"
+fs2 = "0.4"
 
 [workspace.lints.rust]
 unsafe_code = "warn"

--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ shape.
 The default `models frontier` lab list is configurable with
 `[frontier].families`; `--all` and `--family` continue to bypass that list.
 
+`yoetz ask` writes artifacts to `~/.yoetz/sessions/<id>/` by default. Headless
+callers can skip that entirely with `yoetz ask --no-session` (or
+`[sessions] no_session = true`), and `[sessions] max_age_days` /
+`[sessions] max_count` prune old or excess session dirs on startup. Both are
+off by default, and `[sessions]` is only honored from trusted config
+locations, never from repo-local `./yoetz.toml`.
+
 Resolve live model IDs before putting them in scripts:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -150,7 +150,12 @@ callers can skip that entirely with `yoetz ask --no-session` (or
 `[sessions] no_session = true`), and `[sessions] max_age_days` /
 `[sessions] max_count` prune old or excess session dirs on startup. Both are
 off by default, and `[sessions]` is only honored from trusted config
-locations, never from repo-local `./yoetz.toml`.
+locations, never from repo-local `./yoetz.toml`. A `max_count` of `0` removes
+all completed sessions while preserving active writers. A legacy session with
+no lease file is left alone for its first five minutes to avoid racing a writer
+that has just created the directory. In JSON output,
+`--no-session` emits `session_dir: ""` and `response_json: null`; artifact
+consumers must handle those values without constructing a path.
 
 Resolve live model IDs before putting them in scripts:
 

--- a/crates/yoetz-cli/Cargo.toml
+++ b/crates/yoetz-cli/Cargo.toml
@@ -46,7 +46,7 @@ tokio = { version = "1.52", features = ["rt-multi-thread", "macros", "time"] }
 serde_yaml_ng = "0.10.0"
 tempfile = "3.27"
 jsonschema = "0.49"
-fs2 = "0.4"
+fs2.workspace = true
 headless_chrome = "1.0.21"
 futures-util = "0.3"
 libc = "0.2"

--- a/crates/yoetz-cli/src/commands/ask.rs
+++ b/crates/yoetz-cli/src/commands/ask.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 use crate::{budget, providers, registry};
 use std::env;
-use std::path::PathBuf;
 use std::time::Instant;
 use yoetz_core::bundle::{build_bundle, estimate_tokens, BundleOptions};
 use yoetz_core::media::MediaType;
@@ -95,13 +94,28 @@ pub(crate) async fn handle_ask(
         Some(build_bundle(&prompt, options)?)
     };
 
-    let session = create_session_dir()?;
+    // --no-session (or `[sessions] no_session = true` from trusted config)
+    // skips the session directory and every artifact write; stdout output is
+    // unchanged apart from the empty artifact paths.
+    let no_session = args.no_session || config.sessions.no_session.unwrap_or(false);
+    let session = if no_session {
+        None
+    } else {
+        Some(create_session_dir()?)
+    };
+    let run_id = session
+        .as_ref()
+        .map(|s| s.id.clone())
+        .unwrap_or_else(yoetz_core::session::new_session_id);
     let mut artifacts = ArtifactPaths {
-        session_dir: session.path.to_string_lossy().to_string(),
+        session_dir: session
+            .as_ref()
+            .map(|s| s.path.to_string_lossy().to_string())
+            .unwrap_or_default(),
         ..Default::default()
     };
 
-    if let Some(bundle_ref) = &bundle {
+    if let (Some(session), Some(bundle_ref)) = (&session, &bundle) {
         let bundle_json = session.path.join("bundle.json");
         let bundle_md = session.path.join("bundle.md");
         write_json_file(&bundle_json, bundle_ref)?;
@@ -245,8 +259,10 @@ pub(crate) async fn handle_ask(
                 )
                 .await?;
                 if ctx.debug || env::var("YOETZ_GEMINI_DEBUG").ok().as_deref() == Some("1") {
-                    let raw_path = session.path.join("gemini_response.json");
-                    let _ = write_json_file(&raw_path, &result.raw);
+                    if let Some(session) = &session {
+                        let raw_path = session.path.join("gemini_response.json");
+                        let _ = write_json_file(&raw_path, &result.raw);
+                    }
                 }
                 (result.content, result.usage, None, None)
             }
@@ -348,7 +364,7 @@ pub(crate) async fn handle_ask(
     }
 
     let mut result = RunResult {
-        id: session.id,
+        id: run_id,
         model: model_id,
         provider: provider_id,
         bundle,
@@ -358,9 +374,11 @@ pub(crate) async fn handle_ask(
         artifacts,
     };
 
-    let response_json = PathBuf::from(&result.artifacts.session_dir).join("response.json");
-    result.artifacts.response_json = Some(response_json.to_string_lossy().to_string());
-    write_json_file(&response_json, &result)?;
+    if let Some(session) = &session {
+        let response_json = session.path.join("response.json");
+        result.artifacts.response_json = Some(response_json.to_string_lossy().to_string());
+        write_json_file(&response_json, &result)?;
+    }
 
     maybe_write_output(ctx, &result)?;
     notifications::maybe_notify_completion(

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -191,6 +191,12 @@ struct AskArgs {
     /// Suppress native completion notifications for this run.
     #[arg(long)]
     no_notify: bool,
+
+    /// Skip creating a session directory under ~/.yoetz/sessions/ (no
+    /// bundle/response artifacts are written; stdout output is unchanged).
+    /// Can also be enabled via `[sessions] no_session = true` in config.
+    #[arg(long)]
+    no_session: bool,
 }
 
 #[derive(Args)]
@@ -1055,6 +1061,17 @@ async fn main() -> Result<()> {
         // (review finding #9).
         env::set_var(chrome_devtools_mcp::client::YOETZ_DEBUG_CDP_ENV, "1");
     }
+    // Opportunistic session retention: only when the user configured limits,
+    // and never fatal — a prune failure must not block the actual command.
+    if config.sessions.retention_enabled() {
+        if let Err(e) = yoetz_core::session::prune_sessions(
+            config.sessions.max_age_days,
+            config.sessions.max_count,
+        ) {
+            eprintln!("warning: session pruning failed: {e}");
+        }
+    }
+
     let client = build_client(cli.timeout_secs)?;
     let litellm = std::sync::Arc::new(build_litellm(&config, client.clone())?);
     let ctx = AppContext {

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -1,7 +1,6 @@
 use anyhow::{anyhow, bail, Context, Result};
 use base64::{engine::general_purpose, Engine as _};
 use clap::{Args, Parser, Subcommand, ValueEnum};
-use fs2::FileExt;
 use jsonschema::Validator;
 use litellm_rust::{
     ChatContentPart, ChatContentPartFile, ChatContentPartImageUrl, ChatContentPartText, ChatFile,
@@ -12,7 +11,7 @@ use serde::Serialize;
 use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use std::env;
-use std::fs::{self, File, OpenOptions};
+use std::fs;
 use std::io::{self, IsTerminal, Read};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -86,7 +85,6 @@ use http::send_json;
 /// simple queries when no explicit --max-output-tokens is provided.
 const REGISTRY_OUTPUT_TOKENS_CAP: usize = 16384;
 const DEFAULT_CHATGPT_RECIPE_PROMPT: &str = "Review the attached file and provide your analysis.";
-const BROWSER_RECIPE_SESSION_LOCK_FILENAME: &str = ".browser-recipe.lock";
 
 #[derive(Parser)]
 #[command(
@@ -3109,47 +3107,26 @@ fn ensure_regular_file(path: &Path, name: &str, thread_label: &str) -> Result<()
     Ok(())
 }
 
-#[derive(Debug)]
-struct BrowserRecipeSessionLease {
-    _file: File,
-}
-
-impl Drop for BrowserRecipeSessionLease {
-    fn drop(&mut self) {
-        let _ = FileExt::unlock(&self._file);
-    }
-}
-
 fn acquire_browser_recipe_session_lease(
     bundle_path: Option<&Path>,
-) -> Result<Option<BrowserRecipeSessionLease>> {
+) -> Result<Option<yoetz_core::session::SessionLease>> {
     let Some(artifacts) = browser_recipe_artifact_paths(bundle_path) else {
         return Ok(None);
     };
     let session_dir = PathBuf::from(artifacts.session_dir);
-    let lock_path = session_dir.join(BROWSER_RECIPE_SESSION_LOCK_FILENAME);
-    let file = OpenOptions::new()
-        .create(true)
-        .read(true)
-        .write(true)
-        .truncate(false)
-        .open(&lock_path)
-        .with_context(|| format!("open browser recipe session lock {}", lock_path.display()))?;
-    match FileExt::try_lock_exclusive(&file) {
-        Ok(()) => Ok(Some(BrowserRecipeSessionLease { _file: file })),
-        Err(err) if err.kind() == io::ErrorKind::WouldBlock => bail!(
+    match yoetz_core::session::try_acquire_session_lease(&session_dir)? {
+        Some(lease) => Ok(Some(lease)),
+        None => bail!(
             "session_busy: browser recipe session {} already has an active writer; use one session directory per parallel run",
             session_dir.display()
         ),
-        Err(err) => Err(err)
-            .with_context(|| format!("lock browser recipe session {}", lock_path.display())),
     }
 }
 
 fn acquire_browser_recipe_session_lease_in(
     recipe_args: &BrowserRecipeArgs,
     sessions_base: &Path,
-) -> Result<Option<BrowserRecipeSessionLease>> {
+) -> Result<Option<yoetz_core::session::SessionLease>> {
     validate_thread_persistence_preflight_in(recipe_args, sessions_base)?;
     acquire_browser_recipe_session_lease(recipe_args.bundle.as_deref())
 }
@@ -5914,6 +5891,33 @@ mod tests {
     }
 
     #[test]
+    fn browser_recipe_session_lease_blocks_retention_pruning() {
+        let dir = TempDir::new().unwrap();
+        let sessions = dir.path().join("sessions");
+        let session = sessions.join("20250101_000000_active");
+        fs::create_dir_all(&session).unwrap();
+        let bundle_md = session.join("bundle.md");
+        fs::write(&bundle_md, "# bundle").unwrap();
+        fs::write(session.join("bundle.json"), "{}").unwrap();
+        let lease = acquire_browser_recipe_session_lease(Some(&bundle_md))
+            .unwrap()
+            .expect("managed bundle session should be locked");
+
+        assert_eq!(
+            yoetz_core::session::prune_sessions_in(&sessions, None, Some(0)).unwrap(),
+            0
+        );
+        assert!(session.exists());
+
+        drop(lease);
+        assert_eq!(
+            yoetz_core::session::prune_sessions_in(&sessions, None, Some(0)).unwrap(),
+            1
+        );
+        assert!(!session.exists());
+    }
+
+    #[test]
     #[cfg(unix)]
     fn browser_recipe_session_lease_releases_a_fork_inherited_descriptor() {
         let dir = TempDir::new().unwrap();
@@ -6950,7 +6954,7 @@ mod tests {
             .to_string()
             .contains("direct child of the managed sessions directory"));
         assert!(!external_session
-            .join(BROWSER_RECIPE_SESSION_LOCK_FILENAME)
+            .join(yoetz_core::session::SESSION_LEASE_FILENAME)
             .exists());
     }
 

--- a/crates/yoetz-cli/tests/cli.rs
+++ b/crates/yoetz-cli/tests/cli.rs
@@ -903,6 +903,89 @@ fn retention_disabled_by_default_keeps_all_sessions() {
 }
 
 #[test]
+fn ask_no_session_via_trusted_config_profile_overlay() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = dir.path().join("state");
+    let config_path = session_test_config(&dir, "");
+    // Trusted profile overlay under an isolated $HOME:
+    // ~/.config/yoetz/profiles/quiet.toml
+    let home = dir.path().join("home");
+    let profiles = home.join(".config/yoetz/profiles");
+    fs::create_dir_all(&profiles).unwrap();
+    fs::write(
+        profiles.join("quiet.toml"),
+        "[sessions]\nno_session = true\n",
+    )
+    .unwrap();
+
+    ask_dry_run(&state, &config_path)
+        .env("HOME", &home)
+        .env_remove("XDG_CONFIG_HOME")
+        .args([
+            "--config-profile",
+            "quiet",
+            "--format",
+            "json",
+            "ask",
+            "--prompt",
+            "hi",
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"session_dir\": \"\""));
+
+    assert!(!state.join("sessions").exists());
+}
+
+/// Strip the volatile per-run fields (random id, session-dependent artifact
+/// paths) so the rest of the payload can be compared exactly.
+fn normalized_run_json(stdout: &[u8]) -> serde_json::Value {
+    let mut value: serde_json::Value = serde_json::from_slice(stdout).unwrap();
+    let obj = value.as_object_mut().unwrap();
+    obj.remove("id");
+    obj.remove("artifacts");
+    value
+}
+
+#[test]
+fn ask_no_session_json_payload_matches_default_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = session_test_config(&dir, "");
+
+    let default_out = ask_dry_run(&dir.path().join("state-default"), &config_path)
+        .args(["--format", "json", "ask", "--prompt", "hi", "--dry-run"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let no_session_out = ask_dry_run(&dir.path().join("state-nosession"), &config_path)
+        .args([
+            "--format",
+            "json",
+            "ask",
+            "--prompt",
+            "hi",
+            "--dry-run",
+            "--no-session",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let default_json = normalized_run_json(&default_out);
+    let no_session_json = normalized_run_json(&no_session_out);
+    assert_eq!(default_json, no_session_json);
+    assert_eq!(
+        no_session_json["content"],
+        serde_json::json!("(dry-run) no provider call executed")
+    );
+}
+
+#[test]
 fn ask_help_documents_no_session() {
     yoetz()
         .args(["ask", "--help"])

--- a/crates/yoetz-cli/tests/cli.rs
+++ b/crates/yoetz-cli/tests/cli.rs
@@ -751,3 +751,162 @@ fn allow_unknown_flag_accepted() {
         .success()
         .stdout(predicate::str::contains("--allow-unknown"));
 }
+
+// ---- issue #391: session opt-out and retention ----
+
+/// Trusted config (via YOETZ_CONFIG_PATH) with registry auto-sync disabled so
+/// dry-run asks never touch the network, plus optional extra sections.
+fn session_test_config(dir: &TempDir, extra: &str) -> PathBuf {
+    let config_path = dir.path().join("config.toml");
+    fs::write(
+        &config_path,
+        format!("[registry]\nauto_sync_secs = 0\n{extra}"),
+    )
+    .unwrap();
+    config_path
+}
+
+fn ask_dry_run(state: &PathBuf, config_path: &PathBuf) -> Command {
+    let mut cmd = yoetz();
+    cmd.env("YOETZ_DIR", state)
+        .env("YOETZ_CONFIG_PATH", config_path)
+        .env_remove("OPENAI_API_KEY")
+        .env_remove("ANTHROPIC_API_KEY")
+        .env_remove("GEMINI_API_KEY")
+        .env_remove("OPENROUTER_API_KEY")
+        .env_remove("XAI_API_KEY");
+    cmd
+}
+
+#[test]
+fn ask_dry_run_creates_session_dir_by_default() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = dir.path().join("state");
+    let config_path = session_test_config(&dir, "");
+
+    ask_dry_run(&state, &config_path)
+        .args(["--format", "json", "ask", "--prompt", "hi", "--dry-run"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "(dry-run) no provider call executed",
+        ))
+        .stdout(predicate::str::contains("response.json"));
+
+    let sessions = state.join("sessions");
+    assert!(sessions.exists());
+    let entries: Vec<_> = fs::read_dir(&sessions).unwrap().collect();
+    assert_eq!(entries.len(), 1);
+    let session_dir = entries[0].as_ref().unwrap().path();
+    assert!(session_dir.join("response.json").exists());
+}
+
+#[test]
+fn ask_no_session_flag_leaves_sessions_untouched() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = dir.path().join("state");
+    let config_path = session_test_config(&dir, "");
+
+    ask_dry_run(&state, &config_path)
+        .args([
+            "--format",
+            "json",
+            "ask",
+            "--prompt",
+            "hi",
+            "--dry-run",
+            "--no-session",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "(dry-run) no provider call executed",
+        ))
+        .stdout(predicate::str::contains("\"session_dir\": \"\""))
+        .stdout(predicate::str::contains("\"response_json\": null"));
+
+    assert!(!state.join("sessions").exists());
+}
+
+#[test]
+fn ask_no_session_via_trusted_config_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = dir.path().join("state");
+    let config_path = session_test_config(&dir, "[sessions]\nno_session = true\n");
+
+    ask_dry_run(&state, &config_path)
+        .args(["--format", "json", "ask", "--prompt", "hi", "--dry-run"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"session_dir\": \"\""));
+
+    assert!(!state.join("sessions").exists());
+}
+
+#[test]
+fn sessions_config_ignored_from_untrusted_repo_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = dir.path().join("state");
+    let config_path = session_test_config(&dir, "");
+    let cwd = dir.path().join("repo");
+    fs::create_dir_all(&cwd).unwrap();
+    // Repo-local config is untrusted: its [sessions] must be ignored with a
+    // warning, so the session dir is still created.
+    fs::write(cwd.join("yoetz.toml"), "[sessions]\nno_session = true\n").unwrap();
+
+    ask_dry_run(&state, &config_path)
+        .current_dir(&cwd)
+        .args(["--format", "json", "ask", "--prompt", "hi", "--dry-run"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("ignoring [sessions]"));
+
+    assert!(state.join("sessions").exists());
+}
+
+#[test]
+fn retention_prunes_excess_sessions_on_startup() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = dir.path().join("state");
+    let sessions = state.join("sessions");
+    // The "2020" dir is created first (older-or-equal mtime) and has the
+    // lexically smaller id, so it loses under both orderings deterministically.
+    fs::create_dir_all(sessions.join("20200101_000000_aaaaaa")).unwrap();
+    fs::create_dir_all(sessions.join("20990101_000000_bbbbbb")).unwrap();
+    let config_path = session_test_config(&dir, "[sessions]\nmax_count = 1\n");
+
+    ask_dry_run(&state, &config_path)
+        .args(["--format", "json", "status"])
+        .assert()
+        .success();
+
+    assert!(!sessions.join("20200101_000000_aaaaaa").exists());
+    assert!(sessions.join("20990101_000000_bbbbbb").exists());
+}
+
+#[test]
+fn retention_disabled_by_default_keeps_all_sessions() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = dir.path().join("state");
+    let sessions = state.join("sessions");
+    fs::create_dir_all(sessions.join("20200101_000000_aaaaaa")).unwrap();
+    fs::create_dir_all(sessions.join("20990101_000000_bbbbbb")).unwrap();
+    let config_path = session_test_config(&dir, "");
+
+    ask_dry_run(&state, &config_path)
+        .args(["--format", "json", "status"])
+        .assert()
+        .success();
+
+    assert!(sessions.join("20200101_000000_aaaaaa").exists());
+    assert!(sessions.join("20990101_000000_bbbbbb").exists());
+}
+
+#[test]
+fn ask_help_documents_no_session() {
+    yoetz()
+        .args(["ask", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--no-session"));
+}

--- a/crates/yoetz-cli/tests/cli.rs
+++ b/crates/yoetz-cli/tests/cli.rs
@@ -873,6 +873,20 @@ fn retention_prunes_excess_sessions_on_startup() {
     // lexically smaller id, so it loses under both orderings deterministically.
     fs::create_dir_all(sessions.join("20200101_000000_aaaaaa")).unwrap();
     fs::create_dir_all(sessions.join("20990101_000000_bbbbbb")).unwrap();
+    fs::write(
+        sessions
+            .join("20200101_000000_aaaaaa")
+            .join(yoetz_core::session::SESSION_LEASE_FILENAME),
+        "",
+    )
+    .unwrap();
+    fs::write(
+        sessions
+            .join("20990101_000000_bbbbbb")
+            .join(yoetz_core::session::SESSION_LEASE_FILENAME),
+        "",
+    )
+    .unwrap();
     let config_path = session_test_config(&dir, "[sessions]\nmax_count = 1\n");
 
     ask_dry_run(&state, &config_path)

--- a/crates/yoetz-core/Cargo.toml
+++ b/crates/yoetz-core/Cargo.toml
@@ -27,6 +27,7 @@ sha2.workspace = true
 hex.workspace = true
 base64.workspace = true
 mime_guess.workspace = true
+fs2.workspace = true
 
 [dev-dependencies]
 tempfile = "3.27"

--- a/crates/yoetz-core/Cargo.toml
+++ b/crates/yoetz-core/Cargo.toml
@@ -27,3 +27,6 @@ sha2.workspace = true
 hex.workspace = true
 base64.workspace = true
 mime_guess.workspace = true
+
+[dev-dependencies]
+tempfile = "3.27"

--- a/crates/yoetz-core/src/config.rs
+++ b/crates/yoetz-core/src/config.rs
@@ -15,6 +15,7 @@ pub struct Config {
     pub registry: RegistryConfig,
     pub frontier: FrontierConfig,
     pub notifications: NotificationsConfig,
+    pub sessions: SessionsConfig,
     #[serde(default)]
     pub aliases: HashMap<String, String>,
 }
@@ -58,6 +59,26 @@ pub struct NotificationsConfig {
     pub notify_threshold_secs: Option<u64>,
 }
 
+/// Session artifact lifecycle: opt-out of session writes and retention limits.
+/// Only honored from trusted config sources: retention deletes user data and
+/// `no_session` suppresses audit artifacts, so repo-local configs must not
+/// control it.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SessionsConfig {
+    /// Skip creating session directories for `yoetz ask` (like `--no-session`).
+    pub no_session: Option<bool>,
+    /// Prune session dirs whose mtime is older than this many days.
+    pub max_age_days: Option<u64>,
+    /// Keep at most this many newest session dirs.
+    pub max_count: Option<usize>,
+}
+
+impl SessionsConfig {
+    pub fn retention_enabled(&self) -> bool {
+        self.max_age_days.is_some() || self.max_count.is_some()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct ConfigFile {
     pub defaults: Option<Defaults>,
@@ -65,6 +86,7 @@ struct ConfigFile {
     pub registry: Option<RegistryConfig>,
     pub frontier: Option<FrontierConfig>,
     pub notifications: Option<NotificationsConfig>,
+    pub sessions: Option<SessionsConfig>,
     pub aliases: Option<HashMap<String, String>>,
 }
 
@@ -132,6 +154,16 @@ impl Config {
         }
         if let Some(notifications) = other.notifications {
             merge_notifications(&mut self.notifications, notifications);
+        }
+        if let Some(sessions) = other.sessions {
+            if trusted {
+                merge_sessions(&mut self.sessions, sessions);
+            } else {
+                eprintln!(
+                    "warning: ignoring [sessions] from untrusted config {}",
+                    source.display()
+                );
+            }
         }
         if let Some(aliases) = other.aliases {
             if trusted {
@@ -271,6 +303,11 @@ model = "gpt-5-4-pro"
                 families: Some(vec!["evil".to_string()]),
             }),
             notifications: None,
+            sessions: Some(SessionsConfig {
+                no_session: Some(true),
+                max_age_days: Some(1),
+                max_count: Some(1),
+            }),
             aliases: Some(HashMap::from([(
                 "fast".to_string(),
                 "gpt-5-4-pro".to_string(),
@@ -287,6 +324,12 @@ model = "gpt-5-4-pro"
         assert!(config.registry.openrouter_models_url.is_none());
         assert!(config.frontier.families.is_none());
         assert!(config.notifications.enabled.is_none());
+        // [sessions] controls data deletion and artifact suppression; untrusted
+        // repo-local configs must not set it.
+        assert!(config.sessions.no_session.is_none());
+        assert!(config.sessions.max_age_days.is_none());
+        assert!(config.sessions.max_count.is_none());
+        assert!(!config.sessions.retention_enabled());
     }
 
     #[test]
@@ -308,6 +351,7 @@ model = "gpt-5-4-pro"
             }),
             frontier: None,
             notifications: None,
+            sessions: None,
             aliases: None,
         };
         config.merge(
@@ -331,6 +375,7 @@ model = "gpt-5-4-pro"
                 enabled: Some(false),
                 notify_threshold_secs: Some(90),
             }),
+            sessions: None,
             aliases: None,
         };
         config.merge(file, false, Path::new("./yoetz.toml"));
@@ -349,6 +394,7 @@ model = "gpt-5-4-pro"
                 families: Some(vec!["openai".to_string(), "z-ai".to_string()]),
             }),
             notifications: None,
+            sessions: None,
             aliases: None,
         };
 
@@ -362,6 +408,50 @@ model = "gpt-5-4-pro"
             config.frontier.families,
             Some(vec!["openai".to_string(), "z-ai".to_string()])
         );
+    }
+
+    #[test]
+    fn trusted_config_applies_sessions() {
+        let mut config = Config::default();
+        let file = ConfigFile {
+            defaults: None,
+            providers: None,
+            registry: None,
+            frontier: None,
+            notifications: None,
+            sessions: Some(SessionsConfig {
+                no_session: Some(true),
+                max_age_days: Some(30),
+                max_count: Some(100),
+            }),
+            aliases: None,
+        };
+
+        config.merge(
+            file,
+            true,
+            Path::new("/home/user/.config/yoetz/config.toml"),
+        );
+
+        assert_eq!(config.sessions.no_session, Some(true));
+        assert_eq!(config.sessions.max_age_days, Some(30));
+        assert_eq!(config.sessions.max_count, Some(100));
+        assert!(config.sessions.retention_enabled());
+    }
+
+    #[test]
+    fn parse_sessions_from_toml() {
+        let toml_str = r#"
+[sessions]
+no_session = true
+max_age_days = 14
+max_count = 50
+"#;
+        let file: ConfigFile = toml::from_str(toml_str).unwrap();
+        let sessions = file.sessions.unwrap();
+        assert_eq!(sessions.no_session, Some(true));
+        assert_eq!(sessions.max_age_days, Some(14));
+        assert_eq!(sessions.max_count, Some(50));
     }
 }
 
@@ -404,5 +494,17 @@ fn merge_notifications(target: &mut NotificationsConfig, other: NotificationsCon
     }
     if other.notify_threshold_secs.is_some() {
         target.notify_threshold_secs = other.notify_threshold_secs;
+    }
+}
+
+fn merge_sessions(target: &mut SessionsConfig, other: SessionsConfig) {
+    if other.no_session.is_some() {
+        target.no_session = other.no_session;
+    }
+    if other.max_age_days.is_some() {
+        target.max_age_days = other.max_age_days;
+    }
+    if other.max_count.is_some() {
+        target.max_count = other.max_count;
     }
 }

--- a/crates/yoetz-core/src/session.rs
+++ b/crates/yoetz-core/src/session.rs
@@ -66,8 +66,18 @@ pub fn prune_sessions_in(
     if max_age_days.is_none() && max_count.is_none() {
         return Ok(0);
     }
-    if !base.exists() {
-        return Ok(0);
+    // Refuse to prune through a symlinked (or non-directory) sessions root:
+    // read_dir would follow the link and remove_dir_all could then delete
+    // real directories outside the yoetz root.
+    let base_meta = match fs::symlink_metadata(base) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        other => other.with_context(|| format!("stat sessions base {}", base.display()))?,
+    };
+    if !base_meta.is_dir() {
+        anyhow::bail!(
+            "refusing to prune sessions: {} is not a real directory",
+            base.display()
+        );
     }
 
     // (path, id, mtime) for real directories only; symlinks and files are
@@ -83,7 +93,11 @@ pub fn prune_sessions_in(
         let meta = entry
             .metadata()
             .with_context(|| format!("stat {}", entry.path().display()))?;
-        let mtime = meta.modified().unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        // An unknown mtime must never look "infinitely old" (guaranteed
+        // deletion); surface the error instead.
+        let mtime = meta
+            .modified()
+            .with_context(|| format!("read mtime of {}", entry.path().display()))?;
         let id = entry.file_name().to_string_lossy().to_string();
         dirs.push((entry.path(), id, mtime));
     }
@@ -184,10 +198,14 @@ mod tests {
     }
 
     #[cfg(unix)]
-    fn set_mtime(path: &Path, age_secs: u64) {
-        let when = SystemTime::now() - Duration::from_secs(age_secs);
+    fn set_mtime_to(path: &Path, when: SystemTime) {
         let file = fs::File::open(path).unwrap();
         file.set_modified(when).unwrap();
+    }
+
+    #[cfg(unix)]
+    fn set_mtime(path: &Path, age_secs: u64) {
+        set_mtime_to(path, SystemTime::now() - Duration::from_secs(age_secs));
     }
 
     #[test]
@@ -218,6 +236,33 @@ mod tests {
         let removed = prune_sessions_in(&base, None, Some(0)).unwrap();
         assert_eq!(removed, 0);
         assert!(base.join("stray.txt").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prune_refuses_symlinked_base() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Real directory outside the yoetz root, with a child session-like dir.
+        let external = mkdir(tmp.path(), "external");
+        let victim = mkdir(&external, "20200101_000000_victim");
+        let base = tmp.path().join("sessions");
+        std::os::unix::fs::symlink(&external, &base).unwrap();
+
+        let err = prune_sessions_in(&base, None, Some(0)).unwrap_err();
+        assert!(err.to_string().contains("not a real directory"));
+        // The external target and its child are untouched.
+        assert!(external.exists());
+        assert!(victim.exists());
+    }
+
+    #[test]
+    fn prune_refuses_file_base() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("sessions");
+        fs::write(&base, "not a dir").unwrap();
+        let err = prune_sessions_in(&base, Some(1), None).unwrap_err();
+        assert!(err.to_string().contains("not a real directory"));
+        assert!(base.exists());
     }
 
     #[cfg(unix)]
@@ -275,8 +320,9 @@ mod tests {
         let a = mkdir(&base, "20250101_000000_aaaaaa");
         let b = mkdir(&base, "20250102_000000_bbbbbb");
         // Identical mtimes: the lexically larger (newer-looking) id survives.
-        set_mtime(&a, 100);
-        set_mtime(&b, 100);
+        let when = SystemTime::now() - Duration::from_secs(100);
+        set_mtime_to(&a, when);
+        set_mtime_to(&b, when);
         let removed = prune_sessions_in(&base, None, Some(1)).unwrap();
         assert_eq!(removed, 1);
         assert!(!a.exists());

--- a/crates/yoetz-core/src/session.rs
+++ b/crates/yoetz-core/src/session.rs
@@ -24,6 +24,17 @@ pub fn create_session_dir_in(root: &Path) -> Result<SessionInfo> {
     fs::create_dir_all(&base).with_context(|| format!("create sessions dir {}", base.display()))?;
     chmod_owner_only_dir(&base)?;
 
+    let id = new_session_id();
+    let path = base.join(&id);
+    fs::create_dir_all(&path).with_context(|| format!("create session {}", path.display()))?;
+    chmod_owner_only_dir(&path)?;
+
+    Ok(SessionInfo { id, path })
+}
+
+/// Generate a run id in the same `YYYYMMDD_HHMMSS_xxxxxx` format used for
+/// session directories, without creating anything on disk.
+pub fn new_session_id() -> String {
     let ts = OffsetDateTime::now_utc()
         .format(TS_FORMAT)
         .unwrap_or_else(|_| "unknown".to_string());
@@ -32,16 +43,76 @@ pub fn create_session_dir_in(root: &Path) -> Result<SessionInfo> {
         .take(6)
         .map(char::from)
         .collect();
-    let id = format!("{ts}_{rand}");
-    let path = base.join(&id);
-    fs::create_dir_all(&path).with_context(|| format!("create session {}", path.display()))?;
-    chmod_owner_only_dir(&path)?;
-
-    Ok(SessionInfo { id, path })
+    format!("{ts}_{rand}")
 }
 
 pub fn session_base_dir() -> PathBuf {
     yoetz_root_dir().join("sessions")
+}
+
+/// Prune old/excess session directories under `~/.yoetz/sessions/`.
+///
+/// No-op when both limits are `None`. Never creates the root or sessions
+/// directory. Returns the number of session directories removed.
+pub fn prune_sessions(max_age_days: Option<u64>, max_count: Option<usize>) -> Result<usize> {
+    prune_sessions_in(&session_base_dir(), max_age_days, max_count)
+}
+
+pub fn prune_sessions_in(
+    base: &Path,
+    max_age_days: Option<u64>,
+    max_count: Option<usize>,
+) -> Result<usize> {
+    if max_age_days.is_none() && max_count.is_none() {
+        return Ok(0);
+    }
+    if !base.exists() {
+        return Ok(0);
+    }
+
+    // (path, id, mtime) for real directories only; symlinks and files are
+    // never followed or removed.
+    let mut dirs: Vec<(PathBuf, String, std::time::SystemTime)> = Vec::new();
+    for entry in fs::read_dir(base).with_context(|| format!("read {}", base.display()))? {
+        let entry = entry?;
+        // DirEntry::file_type does not follow symlinks, so a symlink to a
+        // directory is excluded here.
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let meta = entry
+            .metadata()
+            .with_context(|| format!("stat {}", entry.path().display()))?;
+        let mtime = meta.modified().unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        let id = entry.file_name().to_string_lossy().to_string();
+        dirs.push((entry.path(), id, mtime));
+    }
+
+    let mut doomed: Vec<PathBuf> = Vec::new();
+
+    if let Some(days) = max_age_days {
+        let cutoff = std::time::SystemTime::now()
+            .checked_sub(std::time::Duration::from_secs(days.saturating_mul(86_400)))
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        let (old, kept): (Vec<_>, Vec<_>) = dirs.into_iter().partition(|(_, _, m)| *m < cutoff);
+        doomed.extend(old.into_iter().map(|(p, _, _)| p));
+        dirs = kept;
+    }
+
+    if let Some(count) = max_count {
+        if dirs.len() > count {
+            // Newest first by mtime, id as a stable tie-break.
+            dirs.sort_by(|a, b| b.2.cmp(&a.2).then_with(|| b.1.cmp(&a.1)));
+            doomed.extend(dirs.split_off(count).into_iter().map(|(p, _, _)| p));
+        }
+    }
+
+    let mut removed = 0usize;
+    for path in doomed {
+        fs::remove_dir_all(&path).with_context(|| format!("prune session {}", path.display()))?;
+        removed += 1;
+    }
+    Ok(removed)
 }
 
 fn yoetz_root_dir() -> PathBuf {
@@ -99,4 +170,148 @@ pub fn list_sessions_in(base: &Path) -> Result<Vec<SessionInfo>> {
     }
     items.sort_by(|a, b| b.id.cmp(&a.id));
     Ok(items)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, SystemTime};
+
+    fn mkdir(base: &Path, name: &str) -> PathBuf {
+        let path = base.join(name);
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[cfg(unix)]
+    fn set_mtime(path: &Path, age_secs: u64) {
+        let when = SystemTime::now() - Duration::from_secs(age_secs);
+        let file = fs::File::open(path).unwrap();
+        file.set_modified(when).unwrap();
+    }
+
+    #[test]
+    fn prune_is_noop_when_unset() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("sessions");
+        mkdir(&base, "20200101_000000_aaaaaa");
+        let removed = prune_sessions_in(&base, None, None).unwrap();
+        assert_eq!(removed, 0);
+        assert!(base.join("20200101_000000_aaaaaa").exists());
+    }
+
+    #[test]
+    fn prune_does_not_create_missing_base() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("sessions");
+        let removed = prune_sessions_in(&base, Some(1), Some(1)).unwrap();
+        assert_eq!(removed, 0);
+        assert!(!base.exists());
+    }
+
+    #[test]
+    fn prune_skips_plain_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("sessions");
+        fs::create_dir_all(&base).unwrap();
+        fs::write(base.join("stray.txt"), "keep me").unwrap();
+        let removed = prune_sessions_in(&base, None, Some(0)).unwrap();
+        assert_eq!(removed, 0);
+        assert!(base.join("stray.txt").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prune_skips_symlinked_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("sessions");
+        fs::create_dir_all(&base).unwrap();
+        let target = mkdir(tmp.path(), "outside");
+        std::os::unix::fs::symlink(&target, base.join("linked")).unwrap();
+        let removed = prune_sessions_in(&base, None, Some(0)).unwrap();
+        assert_eq!(removed, 0);
+        assert!(base.join("linked").exists());
+        assert!(target.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prune_by_age_keeps_recent_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("sessions");
+        let old = mkdir(&base, "20200101_000000_oldddd");
+        let fresh = mkdir(&base, "20990101_000000_freshh");
+        set_mtime(&old, 10 * 86_400);
+        set_mtime(&fresh, 60);
+        let removed = prune_sessions_in(&base, Some(7), None).unwrap();
+        assert_eq!(removed, 1);
+        assert!(!old.exists());
+        assert!(fresh.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prune_by_count_keeps_newest_by_mtime() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("sessions");
+        let a = mkdir(&base, "a");
+        let b = mkdir(&base, "b");
+        let c = mkdir(&base, "c");
+        set_mtime(&a, 300);
+        set_mtime(&b, 200);
+        set_mtime(&c, 100);
+        let removed = prune_sessions_in(&base, None, Some(2)).unwrap();
+        assert_eq!(removed, 1);
+        assert!(!a.exists());
+        assert!(b.exists());
+        assert!(c.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prune_count_tie_breaks_on_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("sessions");
+        let a = mkdir(&base, "20250101_000000_aaaaaa");
+        let b = mkdir(&base, "20250102_000000_bbbbbb");
+        // Identical mtimes: the lexically larger (newer-looking) id survives.
+        set_mtime(&a, 100);
+        set_mtime(&b, 100);
+        let removed = prune_sessions_in(&base, None, Some(1)).unwrap();
+        assert_eq!(removed, 1);
+        assert!(!a.exists());
+        assert!(b.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prune_applies_age_then_count_to_survivors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("sessions");
+        let ancient = mkdir(&base, "w");
+        let old = mkdir(&base, "x");
+        let mid = mkdir(&base, "y");
+        let fresh = mkdir(&base, "z");
+        set_mtime(&ancient, 30 * 86_400);
+        set_mtime(&old, 10 * 86_400);
+        set_mtime(&mid, 3_600);
+        set_mtime(&fresh, 60);
+        // Age prunes ancient+old; count=1 then prunes mid from the survivors.
+        let removed = prune_sessions_in(&base, Some(7), Some(1)).unwrap();
+        assert_eq!(removed, 3);
+        assert!(!ancient.exists());
+        assert!(!old.exists());
+        assert!(!mid.exists());
+        assert!(fresh.exists());
+    }
+
+    #[test]
+    fn new_session_id_has_expected_shape() {
+        let id = new_session_id();
+        let parts: Vec<&str> = id.split('_').collect();
+        assert_eq!(parts.len(), 3);
+        assert_eq!(parts[0].len(), 8);
+        assert_eq!(parts[1].len(), 6);
+        assert_eq!(parts[2].len(), 6);
+    }
 }

--- a/crates/yoetz-core/src/session.rs
+++ b/crates/yoetz-core/src/session.rs
@@ -3,12 +3,27 @@ use crate::types::SessionInfo;
 use anyhow::{Context, Result};
 use rand::{distr::Alphanumeric, RngExt};
 use std::env;
-use std::fs;
+use std::fs::{self, File, OpenOptions};
+use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use time::{format_description::FormatItem, macros::format_description, OffsetDateTime};
 
 static TS_FORMAT: &[FormatItem<'static>] =
     format_description!("[year][month][day]_[hour][minute][second]");
+pub const SESSION_LEASE_FILENAME: &str = ".session.lock";
+const LEGACY_SESSION_ADOPTION_FLOOR: std::time::Duration = std::time::Duration::from_secs(300);
+
+#[derive(Debug)]
+pub struct SessionLease {
+    file: File,
+}
+
+impl Drop for SessionLease {
+    fn drop(&mut self) {
+        let _ = fs2::FileExt::unlock(&self.file);
+    }
+}
 
 /// Create a new timestamped session directory under `~/.yoetz/sessions/`.
 pub fn create_session_dir() -> Result<SessionInfo> {
@@ -28,8 +43,67 @@ pub fn create_session_dir_in(root: &Path) -> Result<SessionInfo> {
     let path = base.join(&id);
     fs::create_dir_all(&path).with_context(|| format!("create session {}", path.display()))?;
     chmod_owner_only_dir(&path)?;
+    let lease = try_acquire_session_lease(&path)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "new session {} unexpectedly already has an active writer",
+            path.display()
+        )
+    })?;
 
-    Ok(SessionInfo { id, path })
+    Ok(SessionInfo {
+        id,
+        path,
+        _lease: Some(Arc::new(lease)),
+    })
+}
+
+/// Try to hold the writer lease for an existing session directory.
+///
+/// `Ok(None)` means another process is actively writing that session. The
+/// lease file is created for legacy sessions that predate this mechanism.
+pub fn try_acquire_session_lease(session_dir: &Path) -> Result<Option<SessionLease>> {
+    let lock_path = session_dir.join(SESSION_LEASE_FILENAME);
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .with_context(|| format!("open session lease {}", lock_path.display()))?;
+    match fs2::FileExt::try_lock_exclusive(&file) {
+        Ok(()) => Ok(Some(SessionLease { file })),
+        Err(err) if is_lock_contended(&err) => Ok(None),
+        Err(err) => Err(err).with_context(|| format!("lock session lease {}", lock_path.display())),
+    }
+}
+
+enum ExistingSessionLease {
+    Acquired(SessionLease),
+    Busy,
+    Missing,
+}
+
+fn probe_existing_session_lease(session_dir: &Path) -> Result<ExistingSessionLease> {
+    let lock_path = session_dir.join(SESSION_LEASE_FILENAME);
+    let file = match OpenOptions::new().read(true).write(true).open(&lock_path) {
+        Ok(file) => file,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            return Ok(ExistingSessionLease::Missing)
+        }
+        Err(err) => {
+            return Err(err).with_context(|| format!("open session lease {}", lock_path.display()))
+        }
+    };
+    match fs2::FileExt::try_lock_exclusive(&file) {
+        Ok(()) => Ok(ExistingSessionLease::Acquired(SessionLease { file })),
+        Err(err) if is_lock_contended(&err) => Ok(ExistingSessionLease::Busy),
+        Err(err) => Err(err).with_context(|| format!("lock session lease {}", lock_path.display())),
+    }
+}
+
+fn is_lock_contended(err: &io::Error) -> bool {
+    err.kind() == io::ErrorKind::WouldBlock
+        || err.raw_os_error() == fs2::lock_contended_error().raw_os_error()
 }
 
 /// Generate a run id in the same `YYYYMMDD_HHMMSS_xxxxxx` format used for
@@ -80,36 +154,70 @@ pub fn prune_sessions_in(
         );
     }
 
-    // (path, id, mtime) for real directories only; symlinks and files are
-    // never followed or removed.
-    let mut dirs: Vec<(PathBuf, String, std::time::SystemTime)> = Vec::new();
+    // (path, id, mtime, existing lease) for removable directories only. The
+    // first phase never creates lease files, because doing so would refresh a
+    // legacy directory's mtime and defeat age retention.
+    let now = std::time::SystemTime::now();
+    let mut dirs: Vec<(PathBuf, String, std::time::SystemTime, Option<SessionLease>)> = Vec::new();
     for entry in fs::read_dir(base).with_context(|| format!("read {}", base.display()))? {
-        let entry = entry?;
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+            Err(err) => {
+                return Err(err).with_context(|| format!("read entry in {}", base.display()))
+            }
+        };
         // DirEntry::file_type does not follow symlinks, so a symlink to a
         // directory is excluded here.
-        if !entry.file_type()?.is_dir() {
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+            Err(err) => {
+                return Err(err).with_context(|| format!("inspect {}", entry.path().display()))
+            }
+        };
+        if !file_type.is_dir() {
             continue;
         }
-        let meta = entry
-            .metadata()
-            .with_context(|| format!("stat {}", entry.path().display()))?;
+        let path = entry.path();
+        let meta = match entry.metadata() {
+            Ok(meta) => meta,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+            Err(err) => return Err(err).with_context(|| format!("stat {}", path.display())),
+        };
         // An unknown mtime must never look "infinitely old" (guaranteed
         // deletion); surface the error instead.
         let mtime = meta
             .modified()
             .with_context(|| format!("read mtime of {}", entry.path().display()))?;
+        let lease = match probe_existing_session_lease(&path)? {
+            ExistingSessionLease::Acquired(lease) => Some(lease),
+            ExistingSessionLease::Busy => continue,
+            ExistingSessionLease::Missing => {
+                // A writer creates the directory just before its lease file.
+                // Never adopt a fresh missing-lease directory in that window.
+                let old_enough = now
+                    .duration_since(mtime)
+                    .is_ok_and(|age| age >= LEGACY_SESSION_ADOPTION_FLOOR);
+                if !old_enough {
+                    continue;
+                }
+                None
+            }
+        };
         let id = entry.file_name().to_string_lossy().to_string();
-        dirs.push((entry.path(), id, mtime));
+        dirs.push((path, id, mtime, lease));
     }
 
-    let mut doomed: Vec<PathBuf> = Vec::new();
+    let mut doomed: Vec<(PathBuf, String, std::time::SystemTime, Option<SessionLease>)> =
+        Vec::new();
 
     if let Some(days) = max_age_days {
         let cutoff = std::time::SystemTime::now()
             .checked_sub(std::time::Duration::from_secs(days.saturating_mul(86_400)))
             .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-        let (old, kept): (Vec<_>, Vec<_>) = dirs.into_iter().partition(|(_, _, m)| *m < cutoff);
-        doomed.extend(old.into_iter().map(|(p, _, _)| p));
+        let (old, kept): (Vec<_>, Vec<_>) = dirs.into_iter().partition(|(_, _, m, _)| *m < cutoff);
+        doomed.extend(old);
         dirs = kept;
     }
 
@@ -117,13 +225,36 @@ pub fn prune_sessions_in(
         if dirs.len() > count {
             // Newest first by mtime, id as a stable tie-break.
             dirs.sort_by(|a, b| b.2.cmp(&a.2).then_with(|| b.1.cmp(&a.1)));
-            doomed.extend(dirs.split_off(count).into_iter().map(|(p, _, _)| p));
+            doomed.extend(dirs.split_off(count));
         }
     }
 
+    // Release leases for survivors before a potentially long removal pass so
+    // browser recipes can reopen them without a spurious session_busy error.
+    drop(dirs);
+
     let mut removed = 0usize;
-    for path in doomed {
+    for (path, _, _, lease) in doomed {
+        let lease = match lease {
+            Some(lease) => lease,
+            None => match try_acquire_session_lease(&path) {
+                Ok(Some(lease)) => lease,
+                Ok(None) => continue,
+                Err(err)
+                    if err
+                        .downcast_ref::<io::Error>()
+                        .is_some_and(|source| source.kind() == io::ErrorKind::NotFound) =>
+                {
+                    continue
+                }
+                Err(err) => return Err(err),
+            },
+        };
+        // Keep the lease through removal so no writer can enter after
+        // selection. Some older Windows/FAT/SMB combinations may reject
+        // deleting the open lease file; that fails safe with a warning.
         fs::remove_dir_all(&path).with_context(|| format!("prune session {}", path.display()))?;
+        drop(lease);
         removed += 1;
     }
     Ok(removed)
@@ -179,6 +310,7 @@ pub fn list_sessions_in(base: &Path) -> Result<Vec<SessionInfo>> {
             items.push(SessionInfo {
                 id,
                 path: entry.path(),
+                _lease: None,
             });
         }
     }
@@ -194,6 +326,12 @@ mod tests {
     fn mkdir(base: &Path, name: &str) -> PathBuf {
         let path = base.join(name);
         fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn mkdir_completed(base: &Path, name: &str) -> PathBuf {
+        let path = mkdir(base, name);
+        drop(try_acquire_session_lease(&path).unwrap().unwrap());
         path
     }
 
@@ -236,6 +374,55 @@ mod tests {
         let removed = prune_sessions_in(&base, None, Some(0)).unwrap();
         assert_eq!(removed, 0);
         assert!(base.join("stray.txt").exists());
+    }
+
+    #[test]
+    fn created_session_holds_writer_lease_until_dropped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session = create_session_dir_in(tmp.path()).unwrap();
+
+        assert!(try_acquire_session_lease(&session.path).unwrap().is_none());
+
+        let path = session.path.clone();
+        drop(session);
+        assert!(try_acquire_session_lease(&path).unwrap().is_some());
+    }
+
+    #[test]
+    fn fs2_platform_contention_error_is_recognized() {
+        assert!(is_lock_contended(&fs2::lock_contended_error()));
+    }
+
+    #[test]
+    fn prune_count_zero_skips_live_session_and_removes_unlocked_session() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("sessions");
+        let live = mkdir(&base, "20250102_000000_liveee");
+        let unlocked = mkdir_completed(&base, "20250101_000000_doneee");
+        let _live_lease = try_acquire_session_lease(&live).unwrap().unwrap();
+
+        let removed = prune_sessions_in(&base, None, Some(0)).unwrap();
+
+        assert_eq!(removed, 1);
+        assert!(live.exists());
+        assert!(!unlocked.exists());
+    }
+
+    #[test]
+    fn prune_count_limit_applies_only_to_unlocked_sessions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("sessions");
+        let live = mkdir(&base, "20250103_000000_liveee");
+        let older = mkdir_completed(&base, "20250101_000000_olderr");
+        let newer = mkdir_completed(&base, "20250102_000000_newerr");
+        let _live_lease = try_acquire_session_lease(&live).unwrap().unwrap();
+
+        let removed = prune_sessions_in(&base, None, Some(1)).unwrap();
+
+        assert_eq!(removed, 1);
+        assert!(live.exists());
+        assert!(!older.exists());
+        assert!(newer.exists());
     }
 
     #[cfg(unix)]
@@ -284,8 +471,8 @@ mod tests {
     fn prune_by_age_keeps_recent_dirs() {
         let tmp = tempfile::tempdir().unwrap();
         let base = tmp.path().join("sessions");
-        let old = mkdir(&base, "20200101_000000_oldddd");
-        let fresh = mkdir(&base, "20990101_000000_freshh");
+        let old = mkdir_completed(&base, "20200101_000000_oldddd");
+        let fresh = mkdir_completed(&base, "20990101_000000_freshh");
         set_mtime(&old, 10 * 86_400);
         set_mtime(&fresh, 60);
         let removed = prune_sessions_in(&base, Some(7), None).unwrap();
@@ -299,9 +486,9 @@ mod tests {
     fn prune_by_count_keeps_newest_by_mtime() {
         let tmp = tempfile::tempdir().unwrap();
         let base = tmp.path().join("sessions");
-        let a = mkdir(&base, "a");
-        let b = mkdir(&base, "b");
-        let c = mkdir(&base, "c");
+        let a = mkdir_completed(&base, "a");
+        let b = mkdir_completed(&base, "b");
+        let c = mkdir_completed(&base, "c");
         set_mtime(&a, 300);
         set_mtime(&b, 200);
         set_mtime(&c, 100);
@@ -317,8 +504,8 @@ mod tests {
     fn prune_count_tie_breaks_on_id() {
         let tmp = tempfile::tempdir().unwrap();
         let base = tmp.path().join("sessions");
-        let a = mkdir(&base, "20250101_000000_aaaaaa");
-        let b = mkdir(&base, "20250102_000000_bbbbbb");
+        let a = mkdir_completed(&base, "20250101_000000_aaaaaa");
+        let b = mkdir_completed(&base, "20250102_000000_bbbbbb");
         // Identical mtimes: the lexically larger (newer-looking) id survives.
         let when = SystemTime::now() - Duration::from_secs(100);
         set_mtime_to(&a, when);
@@ -334,10 +521,10 @@ mod tests {
     fn prune_applies_age_then_count_to_survivors() {
         let tmp = tempfile::tempdir().unwrap();
         let base = tmp.path().join("sessions");
-        let ancient = mkdir(&base, "w");
-        let old = mkdir(&base, "x");
-        let mid = mkdir(&base, "y");
-        let fresh = mkdir(&base, "z");
+        let ancient = mkdir_completed(&base, "w");
+        let old = mkdir_completed(&base, "x");
+        let mid = mkdir_completed(&base, "y");
+        let fresh = mkdir_completed(&base, "z");
         set_mtime(&ancient, 30 * 86_400);
         set_mtime(&old, 10 * 86_400);
         set_mtime(&mid, 3_600);
@@ -349,6 +536,37 @@ mod tests {
         assert!(!old.exists());
         assert!(!mid.exists());
         assert!(fresh.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn count_scan_does_not_refresh_legacy_mtime_before_age_prune() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("sessions");
+        let legacy = mkdir(&base, "20200101_000000_legacy");
+        let old_mtime = SystemTime::now() - Duration::from_secs(10 * 86_400);
+        set_mtime_to(&legacy, old_mtime);
+
+        assert_eq!(prune_sessions_in(&base, None, Some(10)).unwrap(), 0);
+        assert!(!legacy.join(SESSION_LEASE_FILENAME).exists());
+        assert_eq!(
+            fs::metadata(&legacy).unwrap().modified().unwrap(),
+            old_mtime
+        );
+
+        assert_eq!(prune_sessions_in(&base, Some(7), None).unwrap(), 1);
+        assert!(!legacy.exists());
+    }
+
+    #[test]
+    fn prune_does_not_adopt_fresh_directory_without_lease() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("sessions");
+        let fresh = mkdir(&base, "20250101_000000_starting");
+
+        assert_eq!(prune_sessions_in(&base, None, Some(0)).unwrap(), 0);
+        assert!(fresh.exists());
+        assert!(!fresh.join(SESSION_LEASE_FILENAME).exists());
     }
 
     #[test]

--- a/crates/yoetz-core/src/types.rs
+++ b/crates/yoetz-core/src/types.rs
@@ -122,4 +122,8 @@ pub struct BundleResult {
 pub struct SessionInfo {
     pub id: String,
     pub path: PathBuf,
+    /// Held for the lifetime of a session writer so retention cannot remove
+    /// the directory while artifacts are still being produced.
+    #[serde(skip)]
+    pub(crate) _lease: Option<std::sync::Arc<crate::session::SessionLease>>,
 }

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -25,3 +25,15 @@ org_registry_path = "./registry.json"
 
 [frontier]
 families = ["openai", "anthropic", "google", "x-ai", "z-ai", "meta-llama", "deepseek", "mistralai", "qwen", "moonshotai"]
+
+# Session artifact lifecycle for `yoetz ask`. All keys optional; when unset,
+# sessions are always written and never pruned (previous behavior).
+# Only honored from trusted config locations (home/XDG/YOETZ_CONFIG_PATH and
+# config profiles); repo-local ./yoetz.toml cannot set these.
+[sessions]
+# Skip writing ~/.yoetz/sessions/<id>/ for `yoetz ask` (same as --no-session).
+# no_session = true
+# Prune session dirs older than N days on startup.
+# max_age_days = 30
+# Keep at most N newest session dirs on startup.
+# max_count = 200

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -32,8 +32,11 @@ families = ["openai", "anthropic", "google", "x-ai", "z-ai", "meta-llama", "deep
 # config profiles); repo-local ./yoetz.toml cannot set these.
 [sessions]
 # Skip writing ~/.yoetz/sessions/<id>/ for `yoetz ask` (same as --no-session).
+# JSON artifact fields then use session_dir = "" and response_json = null.
 # no_session = true
 # Prune session dirs older than N days on startup.
 # max_age_days = 30
-# Keep at most N newest session dirs on startup.
+# Keep at most N newest completed session dirs on startup. Active writers are
+# always preserved; max_count = 0 removes every completed session. Legacy dirs
+# without a lease file receive a five-minute grace period before adoption.
 # max_count = 200


### PR DESCRIPTION
## Summary

Supersedes #392 (thanks @omriariav — your three commits are included as-is; this branch adds the peer-review fix on top). Closes #391.

- `yoetz ask --no-session` and trusted-config `[sessions] no_session = true` skip session artifacts entirely; stdout payload is unchanged apart from empty artifact paths.
- Optional `[sessions] max_age_days` / `max_count` retention, disabled by default, honored only from trusted config locations.
- **Live-session leases** (the review fix): every session writer holds an exclusive `fs2` lease on `.session.lock` inside its session dir for its lifetime; browser recipes reuse the same core lease (replacing `.browser-recipe.lock`, `session_busy` contract preserved). Pruning probes without creating lease files (a creating probe would refresh dir mtimes and permanently defeat age retention for frequent callers), skips busy dirs, never adopts missing-lease dirs younger than 300s (closes the mkdir-before-lock window), releases survivor leases before the removal pass, and holds doomed leases through `remove_dir_all`. Contention detection matches both `WouldBlock` and the platform `fs2::lock_contended_error` code (Windows).

## Review

Two peer-review rounds (codex + claude): round 1 REQUEST CHANGES on live-session deletion (mtime is not a liveness signal); round 2 REQUEST CHANGES on four findings against the lease implementation (age-retention self-defeat via probe side effects — proven by execution; survivor-lease hold; fresh-dir adoption race; Windows contention mapping). All applied; regression tests cover each.

## Validation

- `cargo test --workspace`: green (637 + suites), including new counterexample tests: held lease + `max_count=0` preserves the live dir and removes unlocked ones; count-only scan leaves legacy mtimes untouched before an age prune; fresh missing-lease dir survives `max_count=0` without lock creation.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbMozs4Nt8Thd5zWRkuNQr