### PR TITLE
fix(extension): structural picker trust for background-tab animated surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   managed bundle session. Mixed old/new binaries are not lease-compatible:
   the new pruner cannot see an old binary's `.browser-recipe.lock`.
 
+### Fixed
+
+- ChatGPT native-extension model selection now handles Advanced pickers whose
+  opacity animation is starved in a background recipe tab by structurally
+  trusting only the open surface named by the pill's `aria-controls`, while
+  retaining full ARIA verification and detailed picker visibility diagnostics.
+
 ## [0.5.49] - 2026-08-07
 ### Fixed
 

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -378,6 +378,8 @@ export async function configureModelState(root, job = {}) {
       effort_status: "skipped",
       failure_reason: null,
       picker_shape: null,
+      surface_trust: null,
+      surface_descendants: [],
       effort_control: null,
       effort_move_method: null,
       pill_text: pillText ?? "",
@@ -400,6 +402,8 @@ export async function configureModelState(root, job = {}) {
     effort_status: selection.effort_status ?? "unverified",
     failure_reason: selection.failure_reason ?? null,
     picker_shape: selection.picker_shape ?? null,
+    surface_trust: selection.surface_trust ?? null,
+    surface_descendants: selection.surface_descendants ?? [],
     effort_control: selection.effort_control ?? null,
     effort_move_method: selection.effort_move_method ?? null,
     pill_text: selection.pill_text ?? null,
@@ -544,8 +548,10 @@ async function selectSolProModel(root, options = {}) {
 
   if (!familyIsSol(state.family_label)) {
     const familyMenu = await openFamilyPicker(root, state.menu ?? state.surface, state.family_trigger, options);
-    availableFamilies = familyMenu ? familyMenuRadios(familyMenu).map((item) => textOf(item)).filter(Boolean) : [];
-    const solOption = familyMenuRadios(familyMenu).find((item) => foldedModelText(textOf(item)) === foldedModelText(CHATGPT_SOL_FAMILY_LABEL));
+    const structuralFamilyMenu = familyMenu === structurallyOpenControlledSurfaceForTrigger(root, state.family_trigger);
+    availableFamilies = familyMenu ? familyMenuRadios(familyMenu, structuralFamilyMenu).map((item) => textOf(item)).filter(Boolean) : [];
+    const solOption = familyMenuRadios(familyMenu, structuralFamilyMenu)
+      .find((item) => foldedModelText(textOf(item)) === foldedModelText(CHATGPT_SOL_FAMILY_LABEL));
     if (!solOption) {
       await closeModelPicker(root, modelButton);
       return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol was not visible in the family submenu", "model_family_not_found");
@@ -616,7 +622,8 @@ async function selectSolProModel(root, options = {}) {
     family_status: "verified",
     effort_status: "verified",
     picker_shape: state.shape,
-    effort_control: state.shape === "slider" ? sliderEffortDiagnostics(state.effort_slider) : null,
+    surface_trust: state.surface_trust,
+    effort_control: state.shape === "slider" ? sliderEffortDiagnostics(state.effort_slider, state.surface) : null,
     effort_move_method: state.effort_move_method ?? null,
     pill_text: pillText,
     family_label: state.family_label,
@@ -651,32 +658,40 @@ async function openAndReadModelPicker(root, modelButton, options = {}) {
 async function openModelPicker(root, modelButton, options = {}) {
   const settleMs = Number(options.settleMs ?? 150);
   const opened = () => Boolean(findPickerState(root));
+  const openedOrTriggered = () => opened() || modelPickerTriggerIsOpen(modelButton);
   if (opened()) {
     return true;
   }
   const activators = [openWithPointerEvents, pressEnter, pressSpace];
   for (const activate of activators) {
     try {
-      if (await activate(modelButton, opened, { settleMs })) {
-        return true;
+      if (await activate(modelButton, openedOrTriggered, { settleMs })) {
+        return opened() || Boolean(await waitForPickerState(root, options));
       }
     } catch {
+      recordModelPickerActivationException(root);
       // Try the next activation path; ChatGPT changes this control frequently.
     }
   }
   return false;
 }
 
+function modelPickerTriggerIsOpen(modelButton) {
+  return modelButton?.getAttribute?.("aria-expanded") === "true"
+    || modelButton?.getAttribute?.("data-state") === "open";
+}
+
 async function openFamilyPicker(root, mainMenu, trigger, options = {}) {
   if (!trigger) {
     return null;
   }
-  const opened = () => findFamilySubmenu(root, mainMenu);
+  const opened = () => findFamilySubmenu(root, mainMenu)
+    ?? structurallyOpenControlledSurfaceForTrigger(root, trigger);
   const settleMs = Number(options.settleMs ?? 150);
   for (const activate of [openWithHoverEvents, openWithPointerEvents, pressEnter, pressSpace]) {
     try {
       if (await activate(trigger, opened, { settleMs })) {
-        return waitForFamilyMenu(root, mainMenu, options);
+        return waitForFamilyMenu(root, mainMenu, trigger, options);
       }
     } catch {
       // Try the next Radix activation path.
@@ -724,6 +739,9 @@ async function openWithPointerEvents(element, isOpen, options = {}) {
 async function dispatchActivationPhases(element, isOpen, phases, settleMs) {
   for (const [type, constructorName, init] of phases) {
     dispatchSyntheticEvent(element, type, constructorName, init);
+    // Deliberately abort the synthetic sequence as soon as Radix reports open:
+    // a trailing click on an already-open trigger can toggle it closed again.
+    if (isOpen()) return true;
     await sleep(settleMs);
     if (isOpen()) return true;
   }
@@ -802,15 +820,47 @@ async function waitForPickerState(root, options = {}) {
 
 function findPickerState(root) {
   const menu = findMainModelMenu(root);
-  return menu ? readMenuPickerState(menu) : readSliderPickerState(root);
+  if (menu) return readMenuPickerState(menu, false);
+  const slider = readSliderPickerState(root);
+  if (slider) return slider;
+  const controlledSurface = structurallyOpenControlledSurface(root);
+  return controlledSurface ? readStructurallyTrustedPickerState(controlledSurface) : null;
 }
 
-async function waitForFamilyMenu(root, mainMenu, options = {}) {
+function structurallyOpenControlledSurface(root) {
+  const trigger = findModelButton(root);
+  return structurallyOpenControlledSurfaceForTrigger(root, trigger);
+}
+
+function structurallyOpenControlledSurfaceForTrigger(root, trigger) {
+  if (!modelPickerTriggerIsOpen(trigger)) return null;
+  const controlledId = trigger?.getAttribute?.("aria-controls");
+  if (!controlledId) return null;
+  const surface = root.getElementById?.(controlledId);
+  return surface?.getAttribute?.("data-state") === "open" ? surface : null;
+}
+
+function readStructurallyTrustedPickerState(surface) {
+  const labels = menuRadioItems(surface, true).map((item) => foldedModelText(textOf(item)));
+  if (labels.includes("medium") && labels.includes("high")
+    && (labels.includes("pro") || labels.includes("pro extended"))) {
+    return readMenuPickerState(surface, true);
+  }
+  const text = normalizeText(textOf(surface));
+  if (/\bAdvanced\b/i.test(text) && /\bEffort\b/i.test(text)
+    && surface.querySelectorAll?.('[role="slider"]')?.length > 0) {
+    return readSliderPickerState(surface.ownerDocument, surface);
+  }
+  return null;
+}
+
+async function waitForFamilyMenu(root, mainMenu, trigger, options = {}) {
   const timeoutMs = Number(options.pickerTimeoutMs ?? 3000);
   const intervalMs = Number(options.intervalMs ?? 100);
   const startedAt = Date.now();
   while (Date.now() - startedAt < timeoutMs) {
-    const menu = findFamilySubmenu(root, mainMenu);
+    const menu = findFamilySubmenu(root, mainMenu)
+      ?? structurallyOpenControlledSurfaceForTrigger(root, trigger);
     if (menu) return menu;
     await sleep(intervalMs);
   }
@@ -833,8 +883,8 @@ function visibleMenus(root) {
   return Array.from(root.querySelectorAll('[role="menu"]')).filter((menu) => isVisible(menu));
 }
 
-function readMenuPickerState(menu) {
-  const effortItems = menuRadioItems(menu);
+function readMenuPickerState(menu, structurallyTrusted = false) {
+  const effortItems = menuRadioItems(menu, structurallyTrusted);
   const familyTrigger = Array.from(menu.querySelectorAll('[role="menuitem"]'))
     .find((item) => {
       const label = normalizeText(textOf(item));
@@ -849,30 +899,35 @@ function readMenuPickerState(menu) {
     family_label: textOf(familyTrigger),
     effort_items: effortItems,
     effort_slider: null,
-    effort_move_method: null
+    effort_move_method: null,
+    surface_trust: structurallyTrusted ? "aria_controls_structural" : "visible"
   };
 }
 
-function readSliderPickerState(root) {
-  const surface = findAdvancedPickerSurface(root);
+function readSliderPickerState(root, structurallyTrustedSurface = null) {
+  const surface = structurallyTrustedSurface ?? findAdvancedPickerSurface(root);
   if (!surface) return null;
+  const structurallyTrusted = Boolean(structurallyTrustedSurface);
   const familyTrigger = Array.from(surface.querySelectorAll('[role="menuitem"], button'))
     .find((item) => {
-      const label = normalizeText(textOf(item));
-      return /^(?:gpt|o\d)\b/i.test(label) && isVisible(item, { allowDisabled: true });
+      const label = structurallyTrusted ? structuralFamilyLabel(item) : normalizeText(textOf(item));
+      return Boolean(label)
+        && /^(?:gpt|o\d)\b/i.test(label)
+        && (structurallyTrusted || isVisible(item, { allowDisabled: true }));
     });
   const effortSlider = Array.from(surface.querySelectorAll('[role="slider"]'))
-    .filter((slider) => isVisible(slider))
-    .find((slider) => sliderIsEffortControl(slider, surface) && Boolean(sliderEffortSnapshot(slider))) ?? null;
+    .filter((slider) => structurallyTrusted || isVisible(slider))
+    .find((slider) => sliderIsEffortControl(slider, surface) && Boolean(sliderEffortSnapshot(slider, surface))) ?? null;
   return {
     shape: "slider",
     menu: null,
     surface,
     family_trigger: familyTrigger ?? null,
-    family_label: textOf(familyTrigger),
+    family_label: structurallyTrusted ? structuralFamilyLabel(familyTrigger) : textOf(familyTrigger),
     effort_items: [],
     effort_slider: effortSlider,
-    effort_move_method: null
+    effort_move_method: null,
+    surface_trust: structurallyTrusted ? "aria_controls_structural" : "visible"
   };
 }
 
@@ -881,7 +936,9 @@ function sliderIsEffortControl(slider, surface) {
     slider?.getAttribute?.("aria-label"),
     slider?.getAttribute?.("title")
   ].filter(Boolean).join(" "));
+  if (/\b(?:faster|smarter)\b/i.test(directLabel)) return false;
   if (/\beffort\b/i.test(directLabel)) return true;
+  if (sliderEffortSnapshot(slider, surface)) return true;
 
   const labelledBy = normalizeText(slider?.getAttribute?.("aria-labelledby") ?? "")
     .split(" ")
@@ -921,38 +978,62 @@ function findAdvancedPickerSurface(root) {
   ))[0] ?? null;
 }
 
-function menuRadioItems(menu) {
-  return Array.from(menu?.querySelectorAll?.('[role="menuitemradio"]') ?? []).filter((item) => isVisible(item));
+function menuRadioItems(menu, structurallyTrusted = false) {
+  return Array.from(menu?.querySelectorAll?.('[role="menuitemradio"]') ?? [])
+    .filter((item) => structurallyTrusted || isVisible(item));
 }
 
-function familyMenuRadios(menu) {
-  return menuRadioItems(menu).filter((item) => /^gpt\b|^o3$/i.test(normalizeText(textOf(item))));
+function familyMenuRadios(menu, structurallyTrusted = false) {
+  return menuRadioItems(menu, structurallyTrusted).filter((item) => /^gpt\b|^o3$/i.test(normalizeText(textOf(item))));
 }
 
 function effortIsPro(state) {
   if (state?.shape === "slider") {
-    const snapshot = sliderEffortSnapshot(state.effort_slider);
+    const snapshot = sliderEffortSnapshot(state.effort_slider, state.surface);
     return Boolean(snapshot && snapshot.label === "pro" && snapshot.now === snapshot.max);
   }
   return state?.effort_items?.some((item) => foldedModelText(textOf(item)) === "pro" && itemIsChecked(item)) ?? false;
 }
 
-function sliderEffortSnapshot(slider) {
+function sliderEffortSnapshot(slider, surface = null) {
   if (!slider) return null;
   const valueText = normalizeText(slider.getAttribute?.("aria-valuetext") ?? "");
-  const match = valueText.match(/^(Instant|Medium|High|Extra High|Pro)\s*,?\s*(\d+)\s+of\s+(\d+)\s*[.!?]?\s*$/i);
+  const nearbyLabel = valueText || effortLabelNearSlider(slider, surface);
+  const match = nearbyLabel.match(/^(Instant|Medium|High|Extra High|Pro)\s*,?\s*(\d+)\s+of\s+(\d+)\s*[.!?]?\s*$/i);
   const now = Number(slider.getAttribute?.("aria-valuenow"));
   const min = Number(slider.getAttribute?.("aria-valuemin"));
   const max = Number(slider.getAttribute?.("aria-valuemax"));
+  const ordinal = now - min + 1;
+  const total = max - min + 1;
   if (!match || !Number.isFinite(now) || !Number.isFinite(min) || !Number.isFinite(max)
-    || max <= min || now < min || now > max || Number(match[2]) !== now || Number(match[3]) !== max) {
+    || max <= min || now < min || now > max || Number(match[2]) !== ordinal || Number(match[3]) !== total) {
     return null;
   }
-  return { label: foldedModelText(match[1]), now, min, max, value_text: valueText };
+  return { label: foldedModelText(match[1]), now, min, max, value_text: nearbyLabel };
 }
 
-function sliderEffortDiagnostics(slider) {
-  const snapshot = sliderEffortSnapshot(slider);
+function effortLabelNearSlider(slider, surface) {
+  let scope = slider?.parentElement;
+  for (let depth = 0; scope && depth < 8; depth += 1, scope = scope.parentElement) {
+    const label = Array.from(scope.querySelectorAll?.("span, div") ?? [])
+      .map((node) => normalizeText(textOf(node)))
+      .find((text) => /^(?:Instant|Medium|High|Extra High|Pro)\s*,?\s*\d+\s+of\s+\d+\s*[.!?]?$/i.test(text));
+    if (label) return label;
+    if (scope === surface) break;
+  }
+  return "";
+}
+
+function structuralFamilyLabel(control) {
+  if (!control || control.getAttribute?.("aria-haspopup") !== "menu") return "";
+  if (!/\bModel\b/i.test(textOf(control))) return "";
+  return Array.from(control.querySelectorAll?.("*") ?? [])
+    .map((node) => normalizeText(textOf(node)))
+    .find((text) => /^(?:gpt|o\d)\b/i.test(text)) ?? "";
+}
+
+function sliderEffortDiagnostics(slider, surface = null) {
+  const snapshot = sliderEffortSnapshot(slider, surface);
   return snapshot ? {
     role: "slider",
     label: snapshot.label,
@@ -977,7 +1058,7 @@ async function moveEffortSliderToPro(root, initialState, options = {}) {
   let result = await attemptKey("End", "keyboard_end");
   if (result) return result;
 
-  const snapshot = sliderEffortSnapshot(state?.effort_slider);
+  const snapshot = sliderEffortSnapshot(state?.effort_slider, state?.surface);
   const arrowAttempts = Math.min(10, Math.max(1, Math.ceil((snapshot?.max ?? 5) - (snapshot?.min ?? 1)) + 1));
   for (let attempt = 0; attempt < arrowAttempts; attempt += 1) {
     result = await attemptKey("ArrowRight", "keyboard_arrow_right");
@@ -1034,7 +1115,11 @@ function selectionFailure(base, modelButton, state, availableFamilies, warning, 
     family_status: familyIsSol(state?.family_label) ? "verified" : "unverified",
     effort_status: effortIsPro(state) ? "verified" : "unverified",
     picker_shape: state?.shape ?? null,
-    effort_control: state?.shape === "slider" ? sliderEffortDiagnostics(state.effort_slider) : null,
+    surface_trust: state?.surface_trust ?? null,
+    surface_descendants: state?.surface_trust === "aria_controls_structural"
+      ? structuralSurfaceDescendants(state.surface)
+      : [],
+    effort_control: state?.shape === "slider" ? sliderEffortDiagnostics(state.effort_slider, state.surface) : null,
     effort_move_method: state?.effort_move_method ?? null,
     pill_text: modelControlLabel(modelButton),
     family_label: state?.family_label ?? null,
@@ -1043,6 +1128,26 @@ function selectionFailure(base, modelButton, state, availableFamilies, warning, 
     effort_options: effortDiagnostics(state?.effort_items ?? []),
     warning
   };
+}
+
+function structuralSurfaceDescendants(surface) {
+  return Array.from(surface?.querySelectorAll?.("*") ?? []).slice(0, 40).map((node) => ({
+    tag: node.tagName?.toLowerCase?.() ?? "element",
+    role: node.getAttribute?.("role") ?? null,
+    type: node.getAttribute?.("type") ?? null,
+    tabindex: node.getAttribute?.("tabindex") ?? null,
+    aria_haspopup: node.getAttribute?.("aria-haspopup") ?? null,
+    aria_expanded: node.getAttribute?.("aria-expanded") ?? null,
+    aria_controls: node.getAttribute?.("aria-controls") ?? null,
+    aria_checked: node.getAttribute?.("aria-checked") ?? null,
+    aria_valuetext: node.getAttribute?.("aria-valuetext") ?? null,
+    aria_valuenow: node.getAttribute?.("aria-valuenow") ?? null,
+    aria_valuemin: node.getAttribute?.("aria-valuemin") ?? null,
+    aria_valuemax: node.getAttribute?.("aria-valuemax") ?? null,
+    data_state: node.getAttribute?.("data-state") ?? null,
+    data_testid: node.getAttribute?.("data-testid") ?? null,
+    text: textOf(node).slice(0, 80)
+  }));
 }
 
 function visibleLegacyPickerMarkers(root) {
@@ -2599,6 +2704,8 @@ export function modelSelectionDiagnostics(root = document) {
   const modelButton = findModelButton(root);
   const state = findPickerState(root);
   const familyMenu = findFamilySubmenu(root, state?.menu ?? state?.surface);
+  const controlledId = modelButton?.getAttribute?.("aria-controls") ?? null;
+  const controlledNode = controlledId ? root.getElementById?.(controlledId) : null;
   return {
     requested_model: CHATGPT_SOL_PRO_MODEL,
     current_model_label: modelControlLabel(modelButton),
@@ -2607,14 +2714,99 @@ export function modelSelectionDiagnostics(root = document) {
     effort_status: effortIsPro(state) ? "verified" : "unverified",
     family_label: state?.family_label ?? null,
     picker_shape: state?.shape ?? null,
-    effort_control: state?.shape === "slider" ? sliderEffortDiagnostics(state.effort_slider) : null,
+    surface_trust: state?.surface_trust ?? null,
+    effort_control: state?.shape === "slider" ? sliderEffortDiagnostics(state.effort_slider, state.surface) : null,
     model_button: modelButton ? elementSummary(modelButton) : null,
+    model_button_wiring: modelButton ? {
+      aria_expanded: modelButton.getAttribute?.("aria-expanded") ?? null,
+      data_state: modelButton.getAttribute?.("data-state") ?? null,
+      aria_haspopup: modelButton.getAttribute?.("aria-haspopup") ?? null,
+      aria_controls: controlledId,
+      controlled_node: controlledNode ? pickerNodeDiagnostics(controlledNode) : null
+    } : null,
+    picker_activation_exceptions: modelPickerActivationExceptions.get(root) ?? 0,
+    advanced_picker_candidates: advancedPickerDiagnostics(root),
+    mounted_picker_roles: {
+      sliders: Array.from(root.querySelectorAll('[role="slider"]')).slice(0, 10).map(pickerNodeDiagnostics),
+      menus: Array.from(root.querySelectorAll('[role="menu"]')).slice(0, 10).map(pickerNodeDiagnostics),
+      dialogs: Array.from(root.querySelectorAll('[role="dialog"]')).slice(0, 10).map(pickerNodeDiagnostics)
+    },
     visible_options: state?.effort_items?.map((item) => textOf(item)).filter(Boolean).slice(0, 20) ?? [],
     visible_families: familyMenuRadios(familyMenu).map((item) => textOf(item)).filter(Boolean).slice(0, 20),
     legacy_picker: visibleLegacyPickerMarkers(root).slice(0, 10),
     composer: elementSummary(findComposer(root)),
     model_control_scopes: modelControlScopes(root).slice(0, 5).map(elementSummary)
   };
+}
+
+const modelPickerActivationExceptions = new WeakMap();
+
+function recordModelPickerActivationException(root) {
+  modelPickerActivationExceptions.set(root, (modelPickerActivationExceptions.get(root) ?? 0) + 1);
+}
+
+function advancedPickerDiagnostics(root) {
+  const matches = Array.from(root.querySelectorAll('div, [role="dialog"]'))
+    .filter((node) => /\bAdvanced\b/i.test(textOf(node)) && /\bEffort\b/i.test(textOf(node)));
+  return matches
+    .filter((node) => !matches.some((candidate) => candidate !== node && node.contains?.(candidate)))
+    .slice(0, 10)
+    .map((node) => ({
+      ...pickerNodeDiagnostics(node),
+      sliders: Array.from(node.querySelectorAll('[role="slider"]')).slice(0, 10).map(pickerNodeDiagnostics)
+    }));
+}
+
+function pickerNodeDiagnostics(node) {
+  const ancestors = pickerAncestorDiagnostics(node);
+  const style = node?.ownerDocument?.defaultView?.getComputedStyle?.(node);
+  let checkVisibility = null;
+  try {
+    checkVisibility = typeof node?.checkVisibility === "function"
+      ? node.checkVisibility({ checkOpacity: true, checkVisibilityCSS: true, contentVisibilityAuto: true })
+      : null;
+  } catch {
+    checkVisibility = "threw";
+  }
+  return {
+    tag: node?.tagName?.toLowerCase?.() ?? "element",
+    role: node?.getAttribute?.("role") ?? null,
+    data_state: node?.getAttribute?.("data-state") ?? null,
+    aria_hidden: node?.getAttribute?.("aria-hidden") ?? null,
+    inert: node?.getAttribute?.("inert") != null,
+    opacity: style?.opacity ?? null,
+    pointer_events: style?.pointerEvents ?? null,
+    content_visibility: style?.contentVisibility ?? null,
+    check_visibility: checkVisibility,
+    inner_text_chars: normalizeText(node?.innerText ?? "").length,
+    text_content_chars: normalizeText(node?.textContent ?? "").length,
+    text: textOf(node).slice(0, 240),
+    ancestor_chain: ancestors,
+    first_non_rendered_ancestor: ancestors.find((ancestor) => ancestor.non_rendered) ?? null
+  };
+}
+
+function pickerAncestorDiagnostics(node) {
+  const ancestors = [];
+  let current = node?.parentElement;
+  while (current) {
+    const style = current.ownerDocument?.defaultView?.getComputedStyle?.(current);
+    const display = style?.display ?? null;
+    const visibility = style?.visibility ?? null;
+    const contentVisibility = style?.contentVisibility ?? null;
+    ancestors.push({
+      tag: current.tagName?.toLowerCase?.() ?? "element",
+      id: String(current.getAttribute?.("id") ?? "").slice(0, 120),
+      class: String(current.getAttribute?.("class") ?? "").slice(0, 160),
+      display,
+      visibility,
+      content_visibility: contentVisibility,
+      non_rendered: display === "none" || visibility === "hidden" || contentVisibility === "hidden"
+    });
+    if (current === current.ownerDocument?.body) break;
+    current = current.parentElement;
+  }
+  return ancestors;
 }
 
 function textOf(node) {

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -384,6 +384,8 @@ function modelSelectionFailureDiagnostics(selection) {
   for (const key of [
     "failure_reason",
     "picker_shape",
+    "surface_trust",
+    "surface_descendants",
     "effort_control",
     "effort_move_method",
     "family_status",

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -11,6 +11,7 @@ import {
   findModelButton,
   insertPrompt,
   isResponseGenerating,
+  modelSelectionDiagnostics,
   sendAcceptanceBaseline,
   uploadFile,
   waitForSendAccepted
@@ -133,6 +134,10 @@ class FakeElement {
     }
     return null;
   }
+
+  contains(candidate) {
+    return this === candidate || this.children.some((child) => child.contains?.(candidate));
+  }
 }
 
 class FakeTextNode {
@@ -172,7 +177,8 @@ class FakeDocument {
           display: /display\s*:\s*none/i.test(style) ? "none" : "block",
           visibility: /visibility\s*:\s*hidden/i.test(style) ? "hidden" : "visible",
           opacity: /opacity\s*:\s*0(?:\.0+)?\b/i.test(style) ? "0" : "1",
-          pointerEvents: /pointer-events\s*:\s*none/i.test(style) ? "none" : "auto"
+          pointerEvents: /pointer-events\s*:\s*none/i.test(style) ? "none" : "auto",
+          contentVisibility: /content-visibility\s*:\s*hidden/i.test(style) ? "hidden" : "visible"
         };
       },
       location: {
@@ -184,6 +190,10 @@ class FakeDocument {
 
   querySelectorAll(selector) {
     return this.documentElement.querySelectorAll(selector);
+  }
+
+  getElementById(id) {
+    return flatten(this.documentElement).find((element) => element.getAttribute?.("id") === id) ?? null;
   }
 }
 
@@ -2356,6 +2366,125 @@ test("GPT-5.6 Sol Advanced picker moves the scoped effort slider with End", asyn
   assert.equal(result.pill_text, "Pro");
 });
 
+test("GPT-5.6 Sol Advanced picker waits for an expanded Radix surface to finish animating", async () => {
+  const fixture = makeSolSliderFixture({ keyboardMode: "end", animatedReveal: true });
+
+  const result = await configureModelState(fixture.doc, {
+    pickerTimeoutMs: 1600,
+    intervalMs: 25
+  });
+
+  assert.equal(result.status, "selected");
+  assert.equal(result.picker_shape, "slider");
+  assert.equal(result.effort_move_method, "keyboard_end");
+  assert.equal(result.effort_control.value_text, "Pro, 5 of 5");
+  assert.equal(fixture.pickerOpen(), false);
+});
+
+test("GPT-5.6 Sol structurally trusts its controlled open picker in a frozen background tab", async () => {
+  const fixture = makeSolSliderFixture({ keyboardMode: "end", animatedReveal: true, backgroundFrozen: true });
+
+  const result = await configureModelState(fixture.doc, { pickerTimeoutMs: 200, intervalMs: 25 });
+
+  assert.equal(result.status, "selected");
+  assert.equal(result.surface_trust, "aria_controls_structural");
+  assert.equal(result.effort_control.value_text, "Pro, 5 of 5");
+  assert.deepEqual(fixture.keyAttempts(), ["End"]);
+});
+
+test("GPT-5.6 Sol fails closed when structural slider max is labeled Extra High", async () => {
+  const fixture = makeSolSliderFixture({
+    keyboardMode: "end",
+    animatedReveal: true,
+    backgroundFrozen: true,
+    maxLabelOverride: "Extra High",
+    transcriptEffortDecoy: "Pro, 5 of 5."
+  });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "unavailable");
+  assert.equal(result.failure_reason, "effort_slider_move_failed");
+  assert.equal(result.effort_control.value_now, 4);
+  assert.equal(result.effort_control.label, "extra high");
+});
+
+test("GPT-5.6 Sol rejects an identical hidden picker without trigger ownership", async () => {
+  const fixture = makeSolSliderFixture({
+    keyboardMode: "end",
+    animatedReveal: true,
+    backgroundFrozen: true,
+    disconnectedTrigger: true
+  });
+
+  const result = await configureModelState(fixture.doc, { pickerTimeoutMs: 100, intervalMs: 20 });
+
+  assert.equal(result.status, "unavailable");
+  assert.equal(result.failure_reason, "model_picker_open_failed");
+  assert.deepEqual(fixture.keyAttempts(), []);
+});
+
+test("GPT-5.6 Sol selects a non-Sol family from a structurally controlled submenu", async () => {
+  const fixture = makeSolSliderFixture({
+    familyLabel: "GPT-5.5",
+    keyboardMode: "end",
+    animatedReveal: true,
+    backgroundFrozen: true
+  });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "selected");
+  assert.equal(result.family_label, "GPT-5.6 Sol");
+  assert.equal(result.surface_trust, "aria_controls_structural");
+  assert.equal(fixture.familyClicks(), 1);
+});
+
+test("structural picker failures capture bounded failure-time descendant topology", async () => {
+  const fixture = makeSolSliderFixture({
+    animatedReveal: true,
+    backgroundFrozen: true,
+    keyboardMode: "end",
+    maxLabelOverride: "Extra High"
+  });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "unavailable");
+  assert.equal(result.failure_reason, "effort_slider_move_failed");
+  assert.equal(result.surface_trust, "aria_controls_structural");
+  assert.equal(result.surface_descendants.some((node) => node.role === "slider" && node.aria_valuenow === "4"), true);
+  assert.equal(result.surface_descendants.some((node) => node.role === "menuitem" && node.aria_haspopup === "menu"), true);
+});
+
+test("model selection diagnostics capture an invisible portaled Advanced surface and its sliders", () => {
+  const fixture = makeSolSliderFixture({ animatedReveal: true });
+  fixture.pill.dispatchEvent(new Event("pointerdown"));
+  const panel = fixture.panel();
+  fixture.doc.body.children = fixture.doc.body.children.filter((child) => child !== panel);
+  const ancestor = new FakeElement("div", { style: "display:none" }, "Advanced Effort page wrapper").append(panel);
+  fixture.doc.body.append(ancestor);
+
+  const diagnostics = modelSelectionDiagnostics(fixture.doc);
+
+  assert.equal(diagnostics.picker_shape, null);
+  assert.equal(diagnostics.surface_trust, null);
+  assert.equal(diagnostics.advanced_picker_candidates.length, 1);
+  assert.equal(diagnostics.advanced_picker_candidates[0].role, "dialog");
+  assert.equal(diagnostics.advanced_picker_candidates[0].opacity, "0");
+  assert.equal(diagnostics.advanced_picker_candidates[0].pointer_events, "none");
+  assert.equal(diagnostics.advanced_picker_candidates[0].check_visibility, false);
+  assert.equal(diagnostics.advanced_picker_candidates[0].inner_text_chars > 0, true);
+  assert.equal(diagnostics.advanced_picker_candidates[0].text_content_chars > 0, true);
+  assert.equal(diagnostics.advanced_picker_candidates[0].first_non_rendered_ancestor.display, "none");
+  assert.equal(diagnostics.advanced_picker_candidates[0].sliders.length, 2);
+  assert.equal(diagnostics.advanced_picker_candidates[0].sliders[1].role, "slider");
+  assert.equal(diagnostics.model_button_wiring.aria_controls, "advanced-picker");
+  assert.equal(diagnostics.model_button_wiring.controlled_node.role, "dialog");
+  assert.equal(diagnostics.mounted_picker_roles.sliders.length, 2);
+  assert.equal(diagnostics.mounted_picker_roles.dialogs.length, 1);
+});
+
 test("GPT-5.6 Sol Advanced picker accepts trailing punctuation in aria-valuetext", async () => {
   const fixture = makeSolSliderFixture({ keyboardMode: "end", valueTextSuffix: "." });
 
@@ -2600,38 +2729,65 @@ function makeSolSliderFixture({
   pointerMoves = false,
   includeEffortSlider = true,
   sliderDisappearsOnEnd = false,
-  valueTextSuffix = ""
+  valueTextSuffix = "",
+  animatedReveal = false,
+  backgroundFrozen = false,
+  disconnectedTrigger = false,
+  maxLabelOverride = null,
+  transcriptEffortDecoy = null,
+  familyLabel = "GPT-5.6 Sol"
 } = {}) {
   const levels = ["Instant", "Medium", "High", "Extra High", "Pro"];
   let currentValue = 3;
   let panel = null;
   let effortSlider = null;
+  let effortLabel = null;
   let pointerAttemptCount = 0;
+  let revealGeneration = 0;
+  let familyClickCount = 0;
+  let familyMenu = null;
+  let familyValueNode = null;
   const keyAttemptLog = [];
   const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
   const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer);
   const body = new FakeElement("body", {}, "Ask anything").append(form);
+  if (transcriptEffortDecoy) {
+    body.append(new FakeElement("div", { "data-message-author-role": "user" }, transcriptEffortDecoy));
+  }
 
   const closePanel = () => {
+    revealGeneration += 1;
     if (!panel) return;
     body.children = body.children.filter((child) => child !== panel);
     panel.parentElement = null;
     panel = null;
+    if (familyMenu) {
+      body.children = body.children.filter((child) => child !== familyMenu);
+      familyMenu = null;
+    }
+    pill?.setAttribute("aria-expanded", "false");
+    pill?.setAttribute("data-state", "closed");
   };
   const updateValue = (value) => {
     currentValue = Math.max(1, Math.min(5, value));
-    effortSlider?.setAttribute("aria-valuenow", currentValue);
-    effortSlider?.setAttribute("aria-valuetext", `${levels[currentValue - 1]}, ${currentValue} of 5${valueTextSuffix}`);
-    pill.innerText = levels[currentValue - 1];
-    pill.textContent = levels[currentValue - 1];
+    const label = currentValue === 5 && maxLabelOverride ? maxLabelOverride : levels[currentValue - 1];
+    effortSlider?.setAttribute("aria-valuenow", backgroundFrozen ? currentValue - 1 : currentValue);
+    if (!backgroundFrozen) effortSlider?.setAttribute("aria-valuetext", `${label}, ${currentValue} of 5${valueTextSuffix}`);
+    if (effortLabel) {
+      effortLabel.innerText = `${label}, ${currentValue} of 5${valueTextSuffix}`;
+      effortLabel.textContent = effortLabel.innerText;
+    }
+    pill.innerText = label;
+    pill.textContent = label;
   };
   const makeEffortSlider = () => new FakeElement("div", {
     role: "slider",
+    ...(backgroundFrozen ? { "aria-hidden": "true" } : {}),
     "aria-label": "Effort",
-    "aria-valuemin": "1",
-    "aria-valuemax": "5",
-    "aria-valuenow": String(currentValue),
-    "aria-valuetext": `${levels[currentValue - 1]}, ${currentValue} of 5${valueTextSuffix}`,
+    "aria-valuemin": backgroundFrozen ? "0" : "1",
+    "aria-valuemax": backgroundFrozen ? "4" : "5",
+    "aria-valuenow": String(backgroundFrozen ? currentValue - 1 : currentValue),
+    ...(!backgroundFrozen ? { "aria-valuetext": `${levels[currentValue - 1]}, ${currentValue} of 5${valueTextSuffix}` } : {}),
     onKeyDown: (event) => {
       keyAttemptLog.push(event.key);
       if (sliderDisappearsOnEnd && event.key === "End") {
@@ -2652,7 +2808,7 @@ function makeSolSliderFixture({
     closePanel();
     panel = new FakeElement(
       "div",
-      { role: "dialog" },
+      { id: "advanced-picker", role: "dialog", ...(backgroundFrozen ? { "data-state": "open" } : {}), ...(animatedReveal ? { style: "opacity:0; pointer-events:none" } : {}) },
       "Advanced Faster Smarter Model GPT-5.6 Sol Effort High 3 of 5"
     );
     const masterSlider = new FakeElement("div", {
@@ -2663,22 +2819,86 @@ function makeSolSliderFixture({
       "aria-valuenow": "3",
       "aria-valuetext": "High, 3 of 5"
     });
-    const family = new FakeElement("button", { "aria-haspopup": "menu" }, "GPT-5.6 Sol");
-    panel.append(masterSlider, family);
-    if (includeEffortSlider) {
-      effortSlider = makeEffortSlider();
-      panel.append(effortSlider);
+    const openFamilyMenu = () => {
+      family.setAttribute("aria-expanded", "true");
+      family.setAttribute("data-state", "open");
+      familyMenu = new FakeElement("div", { id: "family-picker", role: "menu", "data-state": "open", style: "opacity:0" });
+      const oldFamily = new FakeElement("div", { role: "menuitemradio", "aria-checked": familyLabel === "GPT-5.5" ? "true" : "false" }, "GPT-5.5");
+      const solFamily = new FakeElement("div", {
+        role: "menuitemradio",
+        "aria-checked": familyLabel === "GPT-5.6 Sol" ? "true" : "false",
+        onClick: () => {
+          familyClickCount += 1;
+          familyValueNode.innerText = "GPT-5.6 Sol";
+          familyValueNode.textContent = "GPT-5.6 Sol";
+          family.innerText = "Model\nGPT-5.6 Sol";
+          family.textContent = family.innerText;
+          family.setAttribute("aria-expanded", "false");
+          family.setAttribute("data-state", "closed");
+          body.children = body.children.filter((child) => child !== familyMenu);
+          familyMenu = null;
+        }
+      }, "GPT-5.6 Sol");
+      familyMenu.append(oldFamily, solFamily);
+      body.append(familyMenu);
+    };
+    const family = backgroundFrozen
+      ? new FakeElement("div", { role: "menuitem", tabindex: "0", "aria-haspopup": "menu", "aria-expanded": "false", "aria-controls": "family-picker", "data-state": "closed", onPointerDown: openFamilyMenu }, `Model\n${familyLabel}`)
+        .append(new FakeElement("div", {}, "Model"), (familyValueNode = new FakeElement("div", {}, familyLabel)))
+      : new FakeElement("button", { "aria-haspopup": "menu" }, "GPT-5.6 Sol");
+    if (backgroundFrozen) {
+      const group = new FakeElement("div", { role: "group", "data-testid": "composer-intelligence-picker-content" });
+      const simple = new FakeElement("div", { "data-testid": "composer-model-picker-slider-simple-view" });
+      const advanced = new FakeElement("div", { "data-testid": "composer-model-picker-slider-advanced-view" });
+      if (includeEffortSlider) {
+        effortSlider = makeEffortSlider();
+        effortLabel = new FakeElement("span", {}, `${levels[currentValue - 1]}, ${currentValue} of 5${valueTextSuffix}`);
+        const sliderControl = new FakeElement("div", { class: "d1BZWq_SliderControl" })
+          .append(new FakeElement("div", { class: "_9wXMRW_Container" })
+            .append(new FakeElement("span", { class: "_9wXMRW_Root" })
+              .append(new FakeElement("span").append(effortSlider))));
+        simple.append(sliderControl, effortLabel);
+      }
+      advanced.append(new FakeElement("div", { role: "menuitem", tabindex: "0", "aria-expanded": "false" }, "Advanced"), family);
+      group.append(simple, advanced);
+      panel.append(group);
     } else {
-      effortSlider = null;
+      panel.append(masterSlider, family);
+      if (includeEffortSlider) {
+        effortSlider = makeEffortSlider();
+        panel.append(effortSlider);
+      } else {
+        effortSlider = null;
+      }
     }
     body.append(panel);
+    pill.setAttribute("aria-expanded", "true");
+    pill.setAttribute("data-state", "open");
+    if (animatedReveal && !backgroundFrozen) {
+      const generation = revealGeneration;
+      const openingPanel = panel;
+      setTimeout(() => {
+        if (generation === revealGeneration && panel === openingPanel) {
+          openingPanel.setAttribute("style", "opacity:1; pointer-events:auto");
+        }
+      }, 900);
+    }
+  };
+  const togglePanel = () => {
+    if (panel) closePanel();
+    else openPanel();
   };
   const pill = new FakeElement("button", {
     class: "__composer-pill __composer-pill--neutral",
     "aria-haspopup": "menu",
-    onPointerDown: openPanel,
+    "aria-expanded": "false",
+    "data-state": "closed",
+    ...(disconnectedTrigger ? {} : { "aria-controls": "advanced-picker" }),
+    onPointerDown: animatedReveal ? togglePanel : openPanel,
+    onClick: animatedReveal ? togglePanel : undefined,
     onKeyDown: (event) => {
       if (event.key === "Escape") closePanel();
+      if (animatedReveal && (event.key === "Enter" || event.key === " ")) togglePanel();
     }
   }, levels[currentValue - 1]);
   form.append(pill);
@@ -2686,9 +2906,12 @@ function makeSolSliderFixture({
 
   return {
     doc,
+    pill,
     keyAttempts: () => [...keyAttemptLog],
     pointerAttempts: () => pointerAttemptCount,
-    pickerOpen: () => Boolean(panel)
+    pickerOpen: () => Boolean(panel),
+    panel: () => panel,
+    familyClicks: () => familyClickCount
   };
 }
 
@@ -2714,6 +2937,8 @@ function matchesSimpleSelector(element, selector) {
   const tag = element.tagName.toLowerCase();
   const attr = (name) => element.attrs[name];
   const text = String(element.innerText ?? element.textContent ?? "");
+
+  if (selector === "*") return true;
 
   if (selector.startsWith("button:has(")) {
     const inner = selector.slice("button:has(".length, -1);
@@ -2742,6 +2967,7 @@ function matchesSimpleSelector(element, selector) {
   if (selector === "#prompt-textarea") return attr("id") === "prompt-textarea";
   if (selector === "button") return tag === "button";
   if (selector === "div") return tag === "div";
+  if (selector === "span") return tag === "span";
   if (selector === "header") return tag === "header";
   if (selector === "article") return tag === "article";
   if (selector === "pre") return tag === "pre";


### PR DESCRIPTION
## Summary

Closes #396. The ChatGPT recipe failed closed at model selection (`model_picker_open_failed`) on the new A/B effort-slider picker. Root cause: yoetz recipe tabs are deliberately background tabs, and browsers freeze rAF/CSS entry animations in non-visible tabs — the picker genuinely opens (`data-state=open`, wired via the trigger's `aria-controls`, laid out) but stays at `opacity:0` forever, so paint-visibility detection honestly reported no picker.

Fix — structural trust anchored on the trigger's own wiring:
- Trigger-state fast path: `aria-expanded`/`data-state` flip synchronously pre-animation; once open, no further activators fire (prevents toggle-close) and detection polls for the surface.
- When paint-visibility fails but the pill's `aria-controls` resolves to a `data-state=open` node, that node (only) is trusted structurally — shape classified from real content, family read from the nested label span, effort driven via focus + End with bounded ArrowRight fallback, verification by re-reading the sibling label text (exact "Pro") and ARIA state. Decoy surfaces without trigger ownership stay rejected; a max slot not labeled Pro still fails closed.
- Failure-time diagnostics now capture candidate surfaces with visibility tuples, ancestor render-chains, innerText/textContent discrimination, pill wiring, and bounded surface-descendant topology — the next drift self-diagnoses from one inspect.

## Review

Four execution-review rounds (claude), each with a hybrid must-fail proof against the pre-fix baseline; fixture topology captured from live failure diagnostics, not invented. Live acceptance passed on a personal Pro account: verified Sol+Pro selection through the structural path, bundle uploaded, prompt sent (run 20260811T094102Z_b73799).

## Validation

- `npm test` (extension): 340/340.
- Hybrid counterexamples: key structural test fails on base/previous-staged code, passes patched.
- Live: selection verified end-to-end pre-send; upload+send completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbMozs4Nt8Thd5zWRkuNQr