### PR TITLE
fix(extension): safe bfcache/port-loss reconnect for owned jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   managed bundle session. Mixed old/new binaries are not lease-compatible:
   the new pruner cannot see an old binary's `.browser-recipe.lock`.
 
+### Fixed
+
+- ChatGPT native-extension jobs now classify persisted background-tab
+  suspension and restore, idempotently rebind the owned job without replaying
+  upload or send, and fail terminally with an actionable inspect command when
+  the content script cannot reconnect after the prompt was submitted.
+
 ## [0.5.49] - 2026-08-07
 ### Fixed
 

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -4,6 +4,8 @@ const siteAdapterModules = Object.freeze({
   chatgpt: "src/sites/chatgpt.js",
   claude: "src/sites/claude.js"
 });
+const LIFECYCLE_RETRY_ATTEMPTS = 3;
+const LIFECYCLE_RETRY_DELAY_MS = 250;
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   handleMessage(message)
@@ -11,6 +13,47 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     .catch((error) => sendResponse(errorResponse(error)));
   return true;
 });
+
+window.addEventListener("pagehide", (event) => {
+  if (event.persisted) {
+    void notifyPersistedLifecycle("pagehide");
+  }
+});
+
+window.addEventListener("pageshow", (event) => {
+  if (event.persisted) {
+    void notifyPersistedLifecycle("pageshow");
+  }
+});
+
+async function notifyPersistedLifecycle(event) {
+  const jobIds = Array.from(activeJobs.keys());
+  if (jobIds.length === 0) {
+    return;
+  }
+  const message = {
+    type: "yoetz_content_lifecycle",
+    event,
+    persisted: true,
+    job_ids: jobIds
+  };
+  const attempts = event === "pageshow" ? LIFECYCLE_RETRY_ATTEMPTS : 1;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const response = await chrome.runtime.sendMessage(message);
+      if (!response?.ok) {
+        throw new Error(response?.error ?? "service worker rejected content lifecycle event");
+      }
+      return;
+    } catch (error) {
+      if (attempt === attempts) {
+        console.warn(`Yoetz ${event} reconnect notification failed: ${String(error?.message ?? error)}`);
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, LIFECYCLE_RETRY_DELAY_MS));
+    }
+  }
+}
 
 async function handleMessage(message) {
   switch (message?.type) {

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -78,6 +78,14 @@ const MAX_NATIVE_OUTBOUND_BYTES = Math.max(
   Number(globalThis.__YOETZ_MAX_NATIVE_OUTBOUND_BYTES ?? 64 * 1024 * 1024) || 64 * 1024 * 1024
 );
 const WAITING_RESPONSE_PROGRESS_INTERVAL_MS = Math.max(50, Number(globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS ?? 60000) || 60000);
+const CONTENT_SCRIPT_RECONNECT_ATTEMPTS = Math.max(
+  1,
+  Number(globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_ATTEMPTS ?? 40) || 40
+);
+const CONTENT_SCRIPT_RECONNECT_DELAY_MS = Math.max(
+  0,
+  Number(globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_DELAY_MS ?? 500) || 500
+);
 const BACKEND_API_FETCH_COOLDOWN_MS = Math.max(
   0,
   Number.isFinite(Number(globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS))
@@ -119,6 +127,8 @@ const ATTACHMENT_TRACE_PENDING_LEGS = new Set([
 
 const jobs = new Map();
 const terminalJobIds = new Map();
+const terminalFailureJobIds = new Set();
+const contentScriptRecoveries = new Map();
 const chunks = new ChunkAssembler();
 let nativePort = null;
 let extensionIdentityPromise = null;
@@ -142,8 +152,76 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     sendResponse({ ok: true });
     return true;
   }
+  if (message?.type === "yoetz_content_lifecycle") {
+    handleContentLifecycle(message, sender)
+      .then((payload) => sendResponse({ ok: true, payload }))
+      .catch((error) => sendResponse({ ok: false, error: String(error?.message ?? error) }));
+    return true;
+  }
   return false;
 });
+
+async function handleContentLifecycle(message, sender) {
+  if (message.persisted !== true || !["pagehide", "pageshow"].includes(message.event)) {
+    throw new Error("invalid persisted content lifecycle event");
+  }
+  const tabId = sender?.tab?.id;
+  if (!Number.isInteger(tabId)) {
+    throw new Error("content lifecycle event is missing its sender tab");
+  }
+  const requestedIds = new Set(Array.isArray(message.job_ids) ? message.job_ids : []);
+  const ownedJobs = Array.from(jobs.values()).filter((job) => (
+    requestedIds.has(job.job_id)
+    && job.tab_id === tabId
+    && !TERMINAL_STATUSES.has(job.status)
+  ));
+  if (message.event === "pagehide") {
+    for (const job of ownedJobs) {
+      job.content_script_suspended_at = Date.now();
+      job.updated_at = Date.now();
+      await persistJob(job);
+      postNative(progress(job, "content_script_suspended", {
+        tab_id: tabId,
+        persisted: true,
+        message: "owned background tab entered bfcache; waiting for a persisted pageshow rebind"
+      }));
+    }
+    return { event: message.event, classified: ownedJobs.length };
+  }
+
+  let rebound = 0;
+  for (const job of ownedJobs) {
+    if (job.status !== "waiting_response") {
+      continue;
+    }
+    if (!job.content_script_suspended_at && !contentScriptRecoveries.has(job.job_id)) {
+      continue;
+    }
+    try {
+      await recoverContentScriptJob(job, new Error("owned tab restored from bfcache"), {
+        source: "pageshow",
+        restoredFromBfcache: true
+      });
+      rebound += 1;
+    } catch (error) {
+      const inspectCommand = inspectCommandForJob(job);
+      await failJob(
+        job,
+        "content_script_reconnect_failed",
+        `${adapterForJob(job).displayName} background tab returned from bfcache, but Yoetz could not reconnect its content script. The prompt was already submitted and the owned tab is left open. Inspect it before rerunning with: ${inspectCommand}. Do not rerun automatically.`,
+        {
+          phase: "wait_response",
+          side_effect_started: true,
+          send_committed: true,
+          persisted: true,
+          reconnect_reason: String(error?.message ?? error),
+          inspect_command: inspectCommand
+        }
+      );
+    }
+  }
+  return { event: message.event, classified: ownedJobs.length, rebound };
+}
 
 chrome.alarms.onAlarm.addListener((alarm) => {
   if (alarm.name === HEARTBEAT_ALARM) {
@@ -242,7 +320,24 @@ async function handleNativeMessage(message) {
     }
   } catch (error) {
     const job = message?.job_id ? jobs.get(message.job_id) : null;
-    if (job) {
+    const recovery = job ? contentScriptRecoveries.get(job.job_id) : null;
+    if (recovery) {
+      try {
+        await recovery;
+      } catch {
+        return;
+      }
+      if (
+        jobs.has(job.job_id)
+        && !TERMINAL_STATUSES.has(job.status)
+        && job.status === "waiting_response"
+        && !job.cancelled
+      ) {
+        await continueWaitingResponseJob(job);
+      }
+      return;
+    }
+    if (job && !TERMINAL_STATUSES.has(job.status)) {
       const code = error?.code ?? "extension_error";
       const detail = errorContextForJob(job, error);
       await failJob(
@@ -251,7 +346,7 @@ async function handleNativeMessage(message) {
         jobErrorMessage(job, error, code, detail),
         detail
       );
-    } else {
+    } else if (!job && !terminalFailureJobIds.has(message?.job_id)) {
       postNative(errorEnvelope(message, "extension_error", String(error?.message ?? error), {
         request_id: message?.request_id
       }));
@@ -671,6 +766,23 @@ async function resumeWaitingResponseJob(job) {
       url: rebound?.url ?? null,
       title: rebound?.title ?? null
     }));
+  } catch (error) {
+    if (!jobs.has(job.job_id) || TERMINAL_STATUSES.has(job.status)) {
+      return;
+    }
+    await failJob(
+      job,
+      error?.code ?? "extension_error",
+      String(error?.message ?? error),
+      errorContextForJob(job, error)
+    );
+    return;
+  }
+  await continueWaitingResponseJob(job);
+}
+
+async function continueWaitingResponseJob(job) {
+  try {
     const extraction = await waitForResponse(job);
     assertJobConnectionCurrent(job);
     if (job.cancelled || !extraction) return;
@@ -1541,12 +1653,12 @@ async function createJobTab(url, adapter) {
 }
 
 async function waitForContentScript(tabId, adapter) {
-  for (let attempt = 0; attempt < 40; attempt += 1) {
+  for (let attempt = 0; attempt < CONTENT_SCRIPT_RECONNECT_ATTEMPTS; attempt += 1) {
     try {
       await sendToTab(tabId, { type: "yoetz_probe", recipe: adapter.recipe });
       return;
     } catch {
-      await sleep(500);
+      await sleep(CONTENT_SCRIPT_RECONNECT_DELAY_MS);
     }
   }
   throw new Error(`Yoetz content script did not become ready in ${adapter.displayName} tab ${tabId}`);
@@ -1642,11 +1754,17 @@ async function waitForResponse(job) {
   let reportedAwaitingFinalAffordance = false;
   const timeoutMs = responseWaitTimeoutMs(job);
   while (Date.now() - startedAt <= timeoutMs) {
+    if (!jobs.has(job.job_id) || TERMINAL_STATUSES.has(job.status)) {
+      return null;
+    }
     assertJobConnectionCurrent(job);
     if (job.cancelled) {
       return null;
     }
     const extraction = await extractResponseForJob(job);
+    if (!jobs.has(job.job_id) || TERMINAL_STATUSES.has(job.status)) {
+      return null;
+    }
     assertJobConnectionCurrent(job);
     if (reconcileJobConversationCurrent(job, extraction)) {
       await persistJob(job);
@@ -2259,18 +2377,43 @@ function normalizeBackendApiExtraction(backendExtraction, domExtraction, convers
   };
 }
 
-async function recoverContentScriptJob(job, error) {
+async function recoverContentScriptJob(job, error, options = {}) {
+  const existing = contentScriptRecoveries.get(job.job_id);
+  if (existing) {
+    return existing;
+  }
+  const recovery = recoverContentScriptJobOnce(job, error, options);
+  contentScriptRecoveries.set(job.job_id, recovery);
+  try {
+    return await recovery;
+  } finally {
+    // Keep the settled recovery discoverable through the next task so an
+    // in-flight command unwinding from the same disconnect can transfer its
+    // response-polling ownership instead of racing the map deletion.
+    await sleep(0);
+    if (contentScriptRecoveries.get(job.job_id) === recovery) {
+      contentScriptRecoveries.delete(job.job_id);
+    }
+  }
+}
+
+async function recoverContentScriptJobOnce(job, error, options = {}) {
   job.content_script_recovery_attempted = true;
+  job.content_script_suspended_at = null;
   job.updated_at = Date.now();
   await persistJob(job);
   postNative(progress(job, "content_script_recovering", {
-    reason: String(error?.message ?? error)
+    reason: String(error?.message ?? error),
+    source: options.source ?? "command_error",
+    restored_from_bfcache: Boolean(options.restoredFromBfcache)
   }));
   await waitForContentScript(job.tab_id, adapterForJob(job));
   const rebound = await sendToTab(job.tab_id, { type: "yoetz_bind_job", job });
   postNative(progress(job, "content_script_recovered", {
     url: rebound?.url ?? null,
-    title: rebound?.title ?? null
+    title: rebound?.title ?? null,
+    source: options.source ?? "command_error",
+    restored_from_bfcache: Boolean(options.restoredFromBfcache)
   }));
 }
 
@@ -2489,11 +2632,14 @@ function commandError(code, message, detail = {}) {
   return error;
 }
 
-function rememberTerminalJob(jobId) {
+function rememberTerminalJob(jobId, suppressLateErrors = false) {
   if (!jobId) {
     return;
   }
   terminalJobIds.set(jobId, Date.now() + JOB_TTL_MS);
+  if (suppressLateErrors) {
+    terminalFailureJobIds.add(jobId);
+  }
   cleanupTerminalJobIds();
 }
 
@@ -2502,11 +2648,15 @@ function cleanupTerminalJobIds() {
   for (const [jobId, expiresAt] of terminalJobIds.entries()) {
     if (expiresAt <= now) {
       terminalJobIds.delete(jobId);
+      terminalFailureJobIds.delete(jobId);
     }
   }
 }
 
 async function failJob(job, code, message, detail = {}) {
+  if (job && TERMINAL_STATUSES.has(job.status)) {
+    return;
+  }
   const { terminal_status: terminalStatus, ...payloadDetail } = detail;
   if (job?.tab_id) {
     // "kept" means Yoetz did not close the tab on this failure path. It does
@@ -2522,7 +2672,7 @@ async function failJob(job, code, message, detail = {}) {
   const delivered = postNative(errorEnvelope(job, code, message, payloadDetail));
   if (job) {
     if (delivered) {
-      rememberTerminalJob(job.job_id);
+      rememberTerminalJob(job.job_id, true);
       jobs.delete(job.job_id);
     } else {
       await recordTerminalDeliveryLost(job, payloadDetail.phase ?? phaseForStatus(job.status) ?? "upload");

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -804,6 +804,35 @@ test("content script requires the surviving window.name marker for conversation 
   }
 });
 
+test("content script reports only persisted pagehide and pageshow for active jobs", async () => {
+  const { send, dispatchLifecycle, runtimeMessages, restore } = await loadContentScript(
+    "persisted_lifecycle",
+    "https://chatgpt.com/?_yoetz=run_lifecycle"
+  );
+  try {
+    const job = {
+      job_id: "job_lifecycle",
+      run_id: "run_lifecycle",
+      upload_timeout_ms: 1000,
+      send_timeout_ms: 1000
+    };
+    assert.equal((await send({ type: "yoetz_prepare_job", job })).ok, true);
+
+    dispatchLifecycle("pagehide", false);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(runtimeMessages.length, 0);
+
+    dispatchLifecycle("pagehide", true);
+    dispatchLifecycle("pageshow", true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.deepEqual(runtimeMessages.map((message) => message.event), ["pagehide", "pageshow"]);
+    assert.deepEqual(runtimeMessages[0].job_ids, ["job_lifecycle"]);
+    assert.deepEqual(runtimeMessages[1].job_ids, ["job_lifecycle"]);
+  } finally {
+    restore();
+  }
+});
+
 async function loadContentScript(label, href) {
   const originalChrome = globalThis.chrome;
   const originalWindow = globalThis.window;
@@ -811,6 +840,8 @@ async function loadContentScript(label, href) {
   const originalLocation = globalThis.location;
   const location = locationState(href);
   let listener = null;
+  const lifecycleListeners = new Map();
+  const runtimeMessages = [];
   const hooks = {
     ensureFreshChatCalls: [],
     ensureConversationLoadedCalls: [],
@@ -824,7 +855,11 @@ async function loadContentScript(label, href) {
     waitManualHandoffInputs: []
   };
   globalThis.__contentScriptTestHooks = hooks;
-  globalThis.window = { name: "", location };
+  globalThis.window = {
+    name: "",
+    location,
+    addEventListener: (type, callback) => lifecycleListeners.set(type, callback)
+  };
   globalThis.document = { title: "ChatGPT", defaultView: globalThis.window };
   globalThis.location = location;
   const helperUrl = `data:text/javascript,${encodeURIComponent(helperModule)}#${label}`;
@@ -832,6 +867,10 @@ async function loadContentScript(label, href) {
     runtime: {
       getURL: () => helperUrl,
       getManifest: () => ({ version: "test" }),
+      sendMessage: async (message) => {
+        runtimeMessages.push(message);
+        return { ok: true };
+      },
       onMessage: {
         addListener: (fn) => {
           listener = fn;
@@ -846,6 +885,8 @@ async function loadContentScript(label, href) {
   return {
     hooks,
     location,
+    runtimeMessages,
+    dispatchLifecycle: (type, persisted) => lifecycleListeners.get(type)?.({ persisted }),
     send: (message) => new Promise((resolve) => listener(message, {}, resolve)),
     restore: () => {
       globalThis.chrome = originalChrome;

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -6178,6 +6178,266 @@ test("service worker rebinds owned tab after content script reload during respon
   }
 });
 
+test("service worker idempotently rebinds a persisted bfcache restore without replaying side effects", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  let runtimeListener = null;
+  let tabId = 0;
+  let sent = false;
+  let rebound = false;
+  let uploadCalls = 0;
+  let sendCalls = 0;
+  let bindCalls = 0;
+  let bfcacheRestoreStarted = false;
+  let rejectInFlightExtraction;
+  let markInFlightExtractionStarted;
+  let markLifecycleBindStarted;
+  let releaseLifecycleBind;
+  const inFlightExtractionStarted = new Promise((resolve) => {
+    markInFlightExtractionStarted = resolve;
+  });
+  const lifecycleBindStarted = new Promise((resolve) => {
+    markLifecycleBindStarted = resolve;
+  });
+  const lifecycleBindReleased = new Promise((resolve) => {
+    releaseLifecycleBind = resolve;
+  });
+  const chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: verifiedSolProSelection() };
+          case "yoetz_upload_file":
+            uploadCalls += 1;
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sendCalls += 1;
+            sent = true;
+            return { ok: true, payload: { sent: true } };
+          case "yoetz_bind_job":
+            bindCalls += 1;
+            rebound = true;
+            if (bfcacheRestoreStarted) {
+              markLifecycleBindStarted();
+              await lifecycleBindReleased;
+            }
+            return { ok: true, payload: { rebound: true, url: "https://chatgpt.com/", title: "ChatGPT" } };
+          case "yoetz_extract_response":
+            if (sent && bindCalls === 0) {
+              throw new Error("Could not establish connection. Receiving end does not exist.");
+            }
+            if (sent && !bfcacheRestoreStarted) {
+              markInFlightExtractionStarted();
+              return new Promise((_resolve, reject) => {
+                rejectInFlightExtraction = reject;
+              });
+            }
+            return {
+              ok: true,
+              payload: sent && rebound
+                ? { method: "copy_scope_dom_fallback", text: "final after bfcache", is_generating: false, assistant_count: 1, copy_button_count: 1, has_copy_button: true, turn_index: 0 }
+                : { method: "none", text: "", is_generating: true, assistant_count: 0, turn_index: -1 }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+  chrome.runtime.onMessage.addListener = (listener) => {
+    runtimeListener = listener;
+  };
+  globalThis.chrome = chrome;
+
+  try {
+    await import(`../src/service-worker.js?bfcache_rebind=${Date.now()}`);
+    port.emit(envelope("job_start", "job_bfcache_rebind", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 1500
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_bfcache_rebind", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_bfcache_rebind.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+    await eventually(() => sent);
+    await inFlightExtractionStarted;
+
+    const lifecycle = (event) => new Promise((resolve) => {
+      assert.equal(runtimeListener(
+        { type: "yoetz_content_lifecycle", event, persisted: true, job_ids: ["job_bfcache_rebind"] },
+        { tab: { id: tabId } },
+        resolve
+      ), true);
+    });
+    assert.equal((await lifecycle("pagehide")).ok, true);
+    bfcacheRestoreStarted = true;
+    const restored = lifecycle("pageshow");
+    await lifecycleBindStarted;
+    rejectInFlightExtraction(new Error("Could not establish connection. Receiving end does not exist."));
+    releaseLifecycleBind();
+    assert.equal((await restored).ok, true);
+    // A duplicate restore observes the already rebound state without rebinding;
+    // provider-visible upload/send steps are never replayed.
+    assert.equal((await lifecycle("pageshow")).ok, true);
+
+    await eventually(() => port.messages.some((message) => message.type === "job_complete"));
+    assert.equal(uploadCalls, 1);
+    assert.equal(sendCalls, 1);
+    assert.equal(bindCalls, 2);
+    assert.equal(
+      port.messages.find((message) => message.type === "job_complete")?.payload.response,
+      "final after bfcache"
+    );
+    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker terminates actionably when persisted bfcache reconnect fails", async () => {
+  const originalChrome = globalThis.chrome;
+  const previousAttempts = globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_ATTEMPTS;
+  const previousDelay = globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_DELAY_MS;
+  globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_ATTEMPTS = 1;
+  globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_DELAY_MS = 0;
+  const port = makePort();
+  let runtimeListener = null;
+  let tabId = 0;
+  let sent = false;
+  let portLost = false;
+  let uploadCalls = 0;
+  let sendCalls = 0;
+  let rejectExtraction;
+  let markExtractionStarted;
+  const extractionStarted = new Promise((resolve) => {
+    markExtractionStarted = resolve;
+  });
+  const storage = makeStorage();
+  const chrome = chromeStub({
+    port,
+    storage,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        if (portLost && ["yoetz_probe", "yoetz_bind_job", "yoetz_extract_response"].includes(message.type)) {
+          throw new Error("Could not establish connection. Receiving end does not exist.");
+        }
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: verifiedSolProSelection() };
+          case "yoetz_upload_file":
+            uploadCalls += 1;
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sendCalls += 1;
+            sent = true;
+            return { ok: true, payload: { sent: true } };
+          case "yoetz_extract_response":
+            if (!sent) {
+              return { ok: true, payload: { method: "none", text: "", is_generating: true, assistant_count: 0, turn_index: -1 } };
+            }
+            markExtractionStarted();
+            return new Promise((_resolve, reject) => {
+              rejectExtraction = reject;
+            });
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+  chrome.runtime.onMessage.addListener = (listener) => {
+    runtimeListener = listener;
+  };
+  globalThis.chrome = chrome;
+
+  try {
+    await import(`../src/service-worker.js?bfcache_rebind_failed=${Date.now()}`);
+    port.emit(envelope("job_start", "job_bfcache_failed", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 5000
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_bfcache_failed", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_bfcache_failed.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+    await eventually(() => sent);
+    await extractionStarted;
+    await new Promise((resolve) => {
+      assert.equal(runtimeListener(
+        { type: "yoetz_content_lifecycle", event: "pagehide", persisted: true, job_ids: ["job_bfcache_failed"] },
+        { tab: { id: tabId } },
+        resolve
+      ), true);
+    });
+    portLost = true;
+
+    const lifecycleResponse = new Promise((resolve) => {
+      assert.equal(runtimeListener(
+        { type: "yoetz_content_lifecycle", event: "pageshow", persisted: true, job_ids: ["job_bfcache_failed"] },
+        { tab: { id: tabId } },
+        resolve
+      ), true);
+    });
+    await eventually(() => port.messages.some((message) => (
+      message.payload?.phase === "content_script_recovering"
+    )));
+    rejectExtraction(new Error("Could not establish connection. Receiving end does not exist."));
+    const response = await lifecycleResponse;
+    assert.equal(response.ok, true);
+    await eventually(() => port.messages.some((message) => (
+      message.type === "job_error" && message.payload.code === "content_script_reconnect_failed"
+    )));
+    const error = port.messages.find((message) => message.payload?.code === "content_script_reconnect_failed");
+    assert.equal(error.payload.phase, "wait_response");
+    assert.equal(error.payload.side_effect_started, true);
+    assert.equal(error.payload.send_committed, true);
+    assert.equal(error.payload.tab_disposition, "kept");
+    assert.match(error.payload.message, /Do not rerun automatically/);
+    assert.equal(uploadCalls, 1);
+    assert.equal(sendCalls, 1);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const jobErrors = port.messages.filter((message) => (
+      message.type === "job_error" && message.job_id === "job_bfcache_failed"
+    ));
+    assert.equal(jobErrors.length, 1);
+    assert.equal(jobErrors[0].payload.code, "content_script_reconnect_failed");
+    const persisted = await storage.get("jobs.job_bfcache_failed");
+    assert.notEqual(persisted["jobs.job_bfcache_failed"]?.status, "terminal_delivery_lost");
+  } finally {
+    globalThis.chrome = originalChrome;
+    if (previousAttempts === undefined) delete globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_ATTEMPTS;
+    else globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_ATTEMPTS = previousAttempts;
+    if (previousDelay === undefined) delete globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_DELAY_MS;
+    else globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_DELAY_MS = previousDelay;
+  }
+});
+
 test("service worker preserves content-script committed-send error metadata", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();


### PR DESCRIPTION
## Summary

Closes #383. ChatGPT native-extension jobs now survive owned background tabs entering and returning from bfcache:

- Content script reports persisted `pagehide`/`pageshow` for active jobs (retry on pageshow to wake the service worker); non-persisted events are ignored.
- Service worker classifies suspension, then rebinds idempotently on restore: single-flight recovery keyed per job, duplicate pageshow is a no-op, and recovery is bind-only — upload and send are never replayed after side effects started.
- Failed post-send reconnect terminates actionably: `content_script_reconnect_failed` with the inspect command, `side_effect_started`/`send_committed` metadata, and the tab kept for manual recovery.
- Two review-round hardenings: the dispatch catch defers to an active recovery and, on success, transfers response-polling ownership to a guarded continuation (no stranded `waiting_response`); a settled recovery stays discoverable through one task to close the map-deletion microtask race; `failJob` is idempotent against concurrent terminal paths, and late job-less errors are suppressed only for failure-terminalized jobs (cancel contract preserved).

## Review

Three execution-review rounds (claude) with counterexample tests for each finding: the bind-only/no-replay property, exactly-one-`job_error` under lifecycle-vs-extract races, and ownership transfer reaching `job_complete` when a concurrent recovery succeeds mid-unwind.

## Validation

- `npm test` (extension): 340/340 on the integrated branch (run twice post-merge with main).
- Targeted race suite: 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbMozs4Nt8Thd5zWRkuNQr