### PR TITLE
fix(chatgpt): pin Sol Extra High and harden terminal recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- OpenAI removed the Pro tier from the composer picker for this account class
+  on 2026-08-12. Live probes exhausted the effort maximum, Standard/Fast speed
+  toggle, and family menu (Sol, Terra, Luna, and legacy 5.5) without finding a
+  Pro control. The ChatGPT recipe now pins GPT-5.6 Sol with the maximum available
+  `Extra High` effort tier and still fails closed on every unverified leg. Drift
+  diagnostics recognize volatile tier grammar, probe and restore controls, and
+  report the available surfaces without weakening the exact target label.
+- Deep-review findings hardened native-extension completion delivery: repeated
+  content-script disconnects can recover per incident, Chrome's current
+  message-channel errors are reconnectable, terminal races emit exactly one
+  outcome, and bounded persisted terminal envelopes replay once after a native
+  reconnect without risking Chrome session-storage quota failures.
 
 ## [0.5.50] - 2026-08-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - OpenAI removed the Pro tier from the composer picker for this account class
   on 2026-08-12. Live probes exhausted the effort maximum, Standard/Fast speed
   toggle, and family menu (Sol, Terra, Luna, and legacy 5.5) without finding a
-  Pro control. The ChatGPT recipe now pins GPT-5.6 Sol with the maximum available
-  `Extra High` effort tier and still fails closed on every unverified leg. Drift
+  Pro control. Enterprise and personal profiles use different picker variants,
+  so the ChatGPT recipe now pins GPT-5.6 Sol at the account's maximum tier
+  (`Pro` or `Extra High`) and fails closed on unknown top tiers or any unverified leg. Drift
   diagnostics recognize volatile tier grammar, probe and restore controls, and
   report the available surfaces without weakening the exact target label.
 - Deep-review findings hardened native-extension completion delivery: repeated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,11 @@ recipe flows, treat `dev-browser` as a QuickJS/WASM runner, not Node.js:
 
 ## Browser Architecture
 
+- The built-in ChatGPT recipe pins GPT-5.6 Sol with the exact `Extra High`
+  maximum effort tier. OpenAI removed the prior Pro picker tier for the
+  validated account class on 2026-08-12; selection remains fail-closed on the
+  family, exact effort label, and numeric maximum proofs. Speed stays at the
+  user's default and is never toggled by selection.
 - Treat yoetz as a thin wrapper over the underlying browser transport unless
   yoetz must own behavior for correctness or UX.
 - Extension-free by default. Preferred live-Chrome transport order:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,11 +84,12 @@ recipe flows, treat `dev-browser` as a QuickJS/WASM runner, not Node.js:
 
 ## Browser Architecture
 
-- The built-in ChatGPT recipe pins GPT-5.6 Sol with the exact `Extra High`
-  maximum effort tier. OpenAI removed the prior Pro picker tier for the
-  validated account class on 2026-08-12; selection remains fail-closed on the
-  family, exact effort label, and numeric maximum proofs. Speed stays at the
-  user's default and is never toggled by selection.
+- The built-in ChatGPT recipe pins GPT-5.6 Sol at the account's verified maximum
+  effort tier: `Pro` for the known Enterprise picker or `Extra High` for the
+  validated personal picker observed on 2026-08-12. Selection remains
+  fail-closed on the family, one of those two exact labels, and numeric maximum
+  proofs; unknown top tiers are rejected. Speed stays at the user's default and
+  is never toggled by selection.
 - Treat yoetz as a thin wrapper over the underlying browser transport unless
   yoetz must own behavior for correctness or UX.
 - Extension-free by default. Preferred live-Chrome transport order:

--- a/README.md
+++ b/README.md
@@ -273,8 +273,8 @@ Agent skill installation options are listed in [Agent Skills](#agent-skills).
 ## Browser Recipes: ChatGPT Pro And Claude
 
 Browser recipes let Yoetz use web-only model surfaces from the terminal. The
-built-in ChatGPT recipe targets GPT-5.6 Sol with the maximum available Extra
-High effort tier and is fail-closed: if Yoetz cannot prove the requested
+built-in ChatGPT recipe targets GPT-5.6 Sol at the account's known top tier
+(`Pro` or `Extra High`) and is fail-closed: if Yoetz cannot prove the requested
 surface is available, it stops
 instead of silently downgrading. The built-in Claude recipe applies the same
 contract to claude.ai with exactly Fable 5 and Effort Max.

--- a/README.md
+++ b/README.md
@@ -273,8 +273,9 @@ Agent skill installation options are listed in [Agent Skills](#agent-skills).
 ## Browser Recipes: ChatGPT Pro And Claude
 
 Browser recipes let Yoetz use web-only model surfaces from the terminal. The
-built-in ChatGPT recipe targets GPT-5.6 Sol with Pro intelligence and is
-fail-closed: if Yoetz cannot prove the requested surface is available, it stops
+built-in ChatGPT recipe targets GPT-5.6 Sol with the maximum available Extra
+High effort tier and is fail-closed: if Yoetz cannot prove the requested
+surface is available, it stops
 instead of silently downgrading. The built-in Claude recipe applies the same
 contract to claude.ai with exactly Fable 5 and Effort Max.
 

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -1959,7 +1959,7 @@ fn run_chatgpt_select_model(
     use_stealth: bool,
     headed: bool,
 ) -> Result<String> {
-    let requested_model = crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL;
+    let requested_model = crate::chatgpt_recipe::CHATGPT_SOL_EXTRA_HIGH_MODEL;
     let function = chatgpt_web::build_model_selection_function(
         requested_model,
         chatgpt_recipe::ChatgptModelStrategy::Select,
@@ -1995,7 +1995,7 @@ fn run_chatgpt_select_model(
             .to_string())
         }
         "selected" => Err(anyhow!(
-            "ChatGPT reported selected without verified GPT-5.6 Sol + Pro proof"
+            "ChatGPT reported selected without verified GPT-5.6 Sol + Extra High proof"
         )),
         "missing-selector" => Err(anyhow!(
             "ChatGPT model selector button not found. url={:?}, title={:?}",
@@ -5945,7 +5945,7 @@ mod tests {
             warnings: Vec::new(),
             vars: BTreeMap::from([(
                 "model".to_string(),
-                crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL.to_string(),
+                crate::chatgpt_recipe::CHATGPT_SOL_EXTRA_HIGH_MODEL.to_string(),
             )]),
         }
     }
@@ -6093,7 +6093,7 @@ case "$*" in
     count=$((count + 1))
     printf '%s' "$count" > "$EVAL_COUNT_PATH"
     if [ "$count" = "1" ]; then
-      printf '{"status":"selected","requested":"gpt-5-6-sol-pro","modelUsed":"GPT-5.6 Sol Pro","familyStatus":"verified","effortStatus":"verified"}'
+      printf '{"status":"selected","requested":"gpt-5-6-sol-extra-high","modelUsed":"GPT-5.6 Sol Extra High","familyStatus":"verified","effortStatus":"verified"}'
     elif [ "$count" = "2" ]; then
       printf '{"status":"marked"}'
     else
@@ -6124,7 +6124,7 @@ if %errorlevel%==0 (
   set /a count=count+1
   > "%EVAL_COUNT_PATH%" echo !count!
   if "!count!"=="1" (
-    echo {"status":"selected","requested":"gpt-5-6-sol-pro","modelUsed":"GPT-5.6 Sol Pro","familyStatus":"verified","effortStatus":"verified"}
+    echo {"status":"selected","requested":"gpt-5-6-sol-extra-high","modelUsed":"GPT-5.6 Sol Extra High","familyStatus":"verified","effortStatus":"verified"}
   ) else if "!count!"=="2" (
     echo {"status":"marked"}
   ) else (
@@ -7007,7 +7007,7 @@ browser_cdp = "http://evil.example.com:9222"
     fn interpolate_replaces_bundle_and_recipe_vars() {
         let ctx = recipe_context();
         let value = interpolate("open {{bundle_path}} {{model}}", &ctx, Some("ignored")).unwrap();
-        assert_eq!(value, "open /tmp/bundle.md gpt-5-6-sol-pro");
+        assert_eq!(value, "open /tmp/bundle.md gpt-5-6-sol-extra-high");
     }
 
     #[test]
@@ -7952,7 +7952,7 @@ steps:
                 "action": CHATGPT_SELECT_MODEL_ACTION,
                 "stdout": {
                     "status": "ok",
-                    "model_used": "GPT-5.6 Sol Pro",
+                    "model_used": "GPT-5.6 Sol Extra High",
                     "model_selection_status": "selected"
                 }
             }),
@@ -7971,7 +7971,7 @@ steps:
         assert_eq!(payload["transport"], "agent-browser");
         assert_eq!(payload["backend"], "agent-browser");
         assert_eq!(payload["response"], "final answer");
-        assert_eq!(payload["model_used"], "GPT-5.6 Sol Pro");
+        assert_eq!(payload["model_used"], "GPT-5.6 Sol Extra High");
         assert_eq!(payload["model_selection_status"], "selected");
         assert_eq!(payload["fallback_used"], true);
         assert_eq!(payload["warnings"], json!(["used paste fallback"]));

--- a/crates/yoetz-cli/src/browser.rs
+++ b/crates/yoetz-cli/src/browser.rs
@@ -1995,7 +1995,7 @@ fn run_chatgpt_select_model(
             .to_string())
         }
         "selected" => Err(anyhow!(
-            "ChatGPT reported selected without verified GPT-5.6 Sol + Extra High proof"
+            "ChatGPT reported selected without verified GPT-5.6 Sol maximum-tier proof"
         )),
         "missing-selector" => Err(anyhow!(
             "ChatGPT model selector button not found. url={:?}, title={:?}",

--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -1559,7 +1559,7 @@ pub fn canary(
         BuiltinWebRecipe::Chatgpt => run_chatgpt_recipe(
             &ChatgptRecipeSpec {
                 bundle_path: Some(bundle_path),
-                model: crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL.to_string(),
+                model: crate::chatgpt_recipe::CHATGPT_SOL_EXTRA_HIGH_MODEL.to_string(),
                 model_strategy: crate::chatgpt_recipe::ChatgptModelStrategy::Select,
                 prompt: "Reply with exactly OK.".to_string(),
                 browser_context_id: None,
@@ -4387,7 +4387,7 @@ mod tests {
         };
         let spec = ChatgptRecipeSpec {
             bundle_path: Some(bundle.path.clone()),
-            model: crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL.to_string(),
+            model: crate::chatgpt_recipe::CHATGPT_SOL_EXTRA_HIGH_MODEL.to_string(),
             model_strategy: crate::chatgpt_recipe::ChatgptModelStrategy::Select,
             prompt: "continue".to_string(),
             browser_context_id: None,
@@ -4533,7 +4533,7 @@ mod tests {
             Some("run_1".to_string()),
             json!({
                 "response": "done",
-                "model_used": "GPT-5.6 Sol Pro",
+                "model_used": "GPT-5.6 Sol Extra High",
                 "model_selection_status": "selected",
                 "warnings": [
                     "kept current",
@@ -4557,7 +4557,7 @@ mod tests {
         let result = parse_recipe_result(envelope).unwrap();
 
         assert_eq!(result.response, "done");
-        assert_eq!(result.model_used.as_deref(), Some("GPT-5.6 Sol Pro"));
+        assert_eq!(result.model_used.as_deref(), Some("GPT-5.6 Sol Extra High"));
         assert_eq!(
             result.model_selection_status,
             ChatgptModelSelectionStatus::Selected

--- a/crates/yoetz-cli/src/chatgpt_recipe.rs
+++ b/crates/yoetz-cli/src/chatgpt_recipe.rs
@@ -10,7 +10,7 @@ pub type ChatgptTransportPhase = web_recipe::WebRecipeTransportPhase;
 pub type ChatgptModelStrategy = web_recipe::WebModelStrategy;
 pub type ChatgptModelSelectionStatus = web_recipe::WebModelSelectionStatus;
 
-pub const CHATGPT_SOL_PRO_MODEL: &str = "gpt-5-6-sol-pro";
+pub const CHATGPT_SOL_EXTRA_HIGH_MODEL: &str = "gpt-5-6-sol-extra-high";
 
 pub(crate) trait AnyhowResultExt<T> {
     fn with_chatgpt_phase(self, phase: ChatgptTransportPhase) -> Result<T, AnyhowError>;
@@ -216,7 +216,7 @@ mod tests {
             backend: "dev-browser".to_string(),
             response: "ok".to_string(),
             model_strategy: ChatgptModelStrategy::Select,
-            model_used: Some("GPT-5.6 Sol Pro".to_string()),
+            model_used: Some("GPT-5.6 Sol Extra High".to_string()),
             model_selection_status: ChatgptModelSelectionStatus::Selected,
             warnings: vec!["fallback".to_string()],
             fallback_used: true,
@@ -240,7 +240,7 @@ mod tests {
         assert_eq!(payload["backend"], "dev-browser");
         assert_eq!(payload["response"], "ok");
         assert_eq!(payload["model_strategy"], "select");
-        assert_eq!(payload["model_used"], "GPT-5.6 Sol Pro");
+        assert_eq!(payload["model_used"], "GPT-5.6 Sol Extra High");
         assert_eq!(payload["model_selection_status"], "selected");
         assert_eq!(payload["warnings"], json!(["fallback"]));
         assert_eq!(payload["fallback_used"], true);

--- a/crates/yoetz-cli/src/chatgpt_web.rs
+++ b/crates/yoetz-cli/src/chatgpt_web.rs
@@ -397,8 +397,15 @@ fn is_verified_sol_extra_high_selection(
         .get("modelUsed")
         .and_then(serde_json::Value::as_str)
         .unwrap_or_default();
-    canonical_chatgpt_model_slug(model_used).as_deref()
-        == Some(crate::chatgpt_recipe::CHATGPT_SOL_EXTRA_HIGH_MODEL)
+    matches!(
+        model_used
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+            .to_ascii_lowercase()
+            .as_str(),
+        "gpt-5.6 sol pro" | "gpt-5.6 sol extra high"
+    )
 }
 
 pub fn model_selector_button_selector_json() -> String {
@@ -637,15 +644,16 @@ async () => {{
   }}
 
   function effortVerified(state) {{
-    return state?.effortItems?.some((item) => fold(textOf(item)) === "extra high" && isChecked(item)) || false;
+    return state?.effortItems?.some((item) => ["pro", "extra high"].includes(fold(textOf(item))) && isChecked(item)) || false;
   }}
 
   function result(status, pill, state, families, warning = null) {{
     const familyIsVerified = familyVerified(state);
     const effortIsVerified = effortVerified(state);
+    const verifiedEffort = state?.effortItems?.find((item) => ["pro", "extra high"].includes(fold(textOf(item))) && isChecked(item));
     const modelUsed = status === "current"
       ? (pill ? textOf(pill) : "")
-      : (familyIsVerified && effortIsVerified ? "GPT-5.6 Sol Extra High" : null);
+      : (familyIsVerified && effortIsVerified ? `GPT-5.6 Sol ${{textOf(verifiedEffort)}}` : null);
     return {{
       requested,
       status,
@@ -681,7 +689,7 @@ async () => {{
   }}
 
   if (requested !== supported) {{
-    return result("not-found", null, null, [], "this recipe supports only GPT-5.6 Sol + Extra High effort");
+    return result("not-found", null, null, [], "this recipe supports only GPT-5.6 Sol at the account maximum tier (Pro or Extra High)");
   }}
   const legacy = legacyPickerMarkers();
   if (legacy.length > 0) {{
@@ -725,25 +733,26 @@ async () => {{
   }}
 
   if (!effortVerified(state)) {{
-    const maxTier = state.effortItems.find((item) => fold(textOf(item)) === "extra high") || null;
+    const maxTier = state.effortItems.find((item) => fold(textOf(item)) === "extra high")
+      || state.effortItems.find((item) => fold(textOf(item)) === "pro") || null;
     if (!maxTier) {{
       await closeMenus(pill);
-      return result("not-found", pill, state, families, "Extra High effort was not visible for GPT-5.6 Sol");
+      return result("not-found", pill, state, families, "Neither Pro nor Extra High was visible as the GPT-5.6 Sol maximum tier");
     }}
     realClick(maxTier);
     await wait(250);
     pill = await waitForPill();
-    if (!pill) return result("selection-mismatch", null, null, families, "ChatGPT composer model pill did not remount after selecting Extra High effort");
+    if (!pill) return result("selection-mismatch", null, null, families, "ChatGPT composer model pill did not remount after selecting the maximum effort tier");
     menu = await openMain(pill);
     state = menu ? readState(menu) : null;
-    if (!state) return result("selection-mismatch", pill, null, families, "picker did not reopen after selecting Extra High effort");
+    if (!state) return result("selection-mismatch", pill, null, families, "picker did not reopen after selecting the maximum effort tier");
   }}
 
   const familyIsVerified = familyVerified(state);
   const effortIsVerified = effortVerified(state);
   if (!familyIsVerified || !effortIsVerified) {{
     await closeMenus(pill);
-    return result("selection-mismatch", pill, state, families, "GPT-5.6 Sol + Extra High could not be verified in one picker pass");
+    return result("selection-mismatch", pill, state, families, "GPT-5.6 Sol at a verified maximum tier (Pro or Extra High) could not be confirmed in one picker pass");
   }}
   if (!await closeMenus(pill)) {{
     return result("selection-mismatch", pill, state, families, "ChatGPT model picker remained open after verification");
@@ -1288,6 +1297,30 @@ mod tests {
             select_reported_chatgpt_model(&selection, "gpt-5-6-sol-extra-high"),
             Some("GPT-5.6 Sol Extra High".to_string())
         );
+
+        let enterprise_selection = serde_json::json!({
+            "status": "selected",
+            "requested": "gpt-5-6-sol-extra-high",
+            "modelUsed": "GPT-5.6 Sol Pro",
+            "familyStatus": "verified",
+            "effortStatus": "verified"
+        });
+        assert_eq!(
+            select_reported_chatgpt_model(&enterprise_selection, "gpt-5-6-sol-extra-high"),
+            Some("GPT-5.6 Sol Pro".to_string())
+        );
+
+        let unknown_selection = serde_json::json!({
+            "status": "selected",
+            "requested": "gpt-5-6-sol-extra-high",
+            "modelUsed": "GPT-5.6 Sol Expert",
+            "familyStatus": "verified",
+            "effortStatus": "verified"
+        });
+        assert_eq!(
+            select_reported_chatgpt_model(&unknown_selection, "gpt-5-6-sol-extra-high"),
+            None
+        );
     }
 
     #[test]
@@ -1399,7 +1432,7 @@ mod tests {
     }
 
     #[test]
-    fn model_selection_function_requires_verified_sol_family_and_extra_high_effort() {
+    fn model_selection_function_requires_verified_sol_family_and_known_maximum_effort() {
         let script =
             build_model_selection_function("gpt-5-6-sol-extra-high", ChatgptModelStrategy::Select);
         assert!(script.contains(r#"const requested = "gpt-5-6-sol-extra-high";"#));
@@ -1410,7 +1443,7 @@ mod tests {
         assert!(script.contains(r#"familyStatus: familyIsVerified ? "verified" : "unverified""#));
         assert!(script.contains(r#"effortStatus: effortIsVerified ? "verified" : "unverified""#));
         assert!(script.contains(r#"fold(textOf(item)) === "gpt-5.6 sol""#));
-        assert!(script.contains(r#"fold(textOf(item)) === "extra high""#));
+        assert!(script.contains(r#"["pro", "extra high"].includes(fold(textOf(item)))"#));
         assert!(script.contains(r#"/^(?:gpt|o\d)\b/i.test(textOf(item))"#));
         assert!(script.contains("await openFamilyMenu"));
         assert!(script.contains("async function waitForPill()"));
@@ -1418,7 +1451,7 @@ mod tests {
         assert!(script
             .contains("ChatGPT composer model pill did not remount after selecting GPT-5.6 Sol"));
         assert!(script.contains(
-            "ChatGPT composer model pill did not remount after selecting Extra High effort"
+            "ChatGPT composer model pill did not remount after selecting the maximum effort tier"
         ));
         assert!(script.contains("return visibleMenus().length === 0;"));
         assert!(script.contains("if (!await closeMenus(pill))"));

--- a/crates/yoetz-cli/src/chatgpt_web.rs
+++ b/crates/yoetz-cli/src/chatgpt_web.rs
@@ -255,15 +255,15 @@ pub fn build_set_window_name_js(run_id: &str) -> String {
 
 pub fn model_alias_map() -> BTreeMap<&'static str, &'static str> {
     BTreeMap::from([
-        ("gpt-5-6-sol-pro", "gpt-5-6-sol-pro"),
-        ("sol-pro", "gpt-5-6-sol-pro"),
+        ("gpt-5-6-sol-extra-high", "gpt-5-6-sol-extra-high"),
+        ("sol-extra-high", "gpt-5-6-sol-extra-high"),
     ])
 }
 
 pub fn model_candidate_map() -> BTreeMap<&'static str, Vec<&'static str>> {
     BTreeMap::from([
-        ("gpt-5-6-sol-pro", vec!["gpt-5-6-sol-pro"]),
-        ("sol-pro", vec!["gpt-5-6-sol-pro"]),
+        ("gpt-5-6-sol-extra-high", vec!["gpt-5-6-sol-extra-high"]),
+        ("sol-extra-high", vec!["gpt-5-6-sol-extra-high"]),
     ])
 }
 
@@ -323,7 +323,7 @@ pub fn select_reported_chatgpt_model(
     requested_model: &str,
 ) -> Option<String> {
     if is_current_model_selection(selection, requested_model)
-        || is_verified_sol_pro_selection(selection, requested_model)
+        || is_verified_sol_extra_high_selection(selection, requested_model)
     {
         return selection
             .get("modelUsed")
@@ -342,7 +342,7 @@ pub(crate) fn chatgpt_model_selection_status(
         .and_then(serde_json::Value::as_str)
         .unwrap_or("unknown");
     match status {
-        "selected" if is_verified_sol_pro_selection(selection, requested_model) => {
+        "selected" if is_verified_sol_extra_high_selection(selection, requested_model) => {
             ChatgptModelSelectionStatus::Selected
         }
         "selected" | "selection-mismatch" => ChatgptModelSelectionStatus::Mismatch,
@@ -372,13 +372,16 @@ fn is_current_model_selection(selection: &serde_json::Value, requested_model: &s
             == Some("skipped")
 }
 
-fn is_verified_sol_pro_selection(selection: &serde_json::Value, requested_model: &str) -> bool {
+fn is_verified_sol_extra_high_selection(
+    selection: &serde_json::Value,
+    requested_model: &str,
+) -> bool {
     if selection.get("status").and_then(serde_json::Value::as_str) != Some("selected")
-        || requested_model.trim() != crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL
+        || requested_model.trim() != crate::chatgpt_recipe::CHATGPT_SOL_EXTRA_HIGH_MODEL
         || selection
             .get("requested")
             .and_then(serde_json::Value::as_str)
-            != Some(crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL)
+            != Some(crate::chatgpt_recipe::CHATGPT_SOL_EXTRA_HIGH_MODEL)
         || selection
             .get("familyStatus")
             .and_then(serde_json::Value::as_str)
@@ -395,7 +398,7 @@ fn is_verified_sol_pro_selection(selection: &serde_json::Value, requested_model:
         .and_then(serde_json::Value::as_str)
         .unwrap_or_default();
     canonical_chatgpt_model_slug(model_used).as_deref()
-        == Some(crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL)
+        == Some(crate::chatgpt_recipe::CHATGPT_SOL_EXTRA_HIGH_MODEL)
 }
 
 pub fn model_selector_button_selector_json() -> String {
@@ -442,7 +445,7 @@ pub fn build_model_selection_function(
 async () => {{
   const requested = {requested_model};
   const strategy = {model_strategy};
-  const supported = "gpt-5-6-sol-pro";
+  const supported = "gpt-5-6-sol-extra-high";
   const MODEL_BUTTON_SELECTOR = {model_button_selector};
   const COMPOSER_SELECTOR = {composer_selector};
   const normalize = (value) => String(value || "").replace(/\s+/g, " ").trim();
@@ -634,7 +637,7 @@ async () => {{
   }}
 
   function effortVerified(state) {{
-    return state?.effortItems?.some((item) => fold(textOf(item)) === "pro" && isChecked(item)) || false;
+    return state?.effortItems?.some((item) => fold(textOf(item)) === "extra high" && isChecked(item)) || false;
   }}
 
   function result(status, pill, state, families, warning = null) {{
@@ -642,7 +645,7 @@ async () => {{
     const effortIsVerified = effortVerified(state);
     const modelUsed = status === "current"
       ? (pill ? textOf(pill) : "")
-      : (familyIsVerified && effortIsVerified ? "GPT-5.6 Sol Pro" : null);
+      : (familyIsVerified && effortIsVerified ? "GPT-5.6 Sol Extra High" : null);
     return {{
       requested,
       status,
@@ -678,7 +681,7 @@ async () => {{
   }}
 
   if (requested !== supported) {{
-    return result("not-found", null, null, [], "this recipe supports only GPT-5.6 Sol + Pro intelligence");
+    return result("not-found", null, null, [], "this recipe supports only GPT-5.6 Sol + Extra High effort");
   }}
   const legacy = legacyPickerMarkers();
   if (legacy.length > 0) {{
@@ -722,25 +725,25 @@ async () => {{
   }}
 
   if (!effortVerified(state)) {{
-    const pro = state.effortItems.find((item) => fold(textOf(item)) === "pro") || null;
-    if (!pro) {{
+    const maxTier = state.effortItems.find((item) => fold(textOf(item)) === "extra high") || null;
+    if (!maxTier) {{
       await closeMenus(pill);
-      return result("not-found", pill, state, families, "Pro intelligence was not visible for GPT-5.6 Sol");
+      return result("not-found", pill, state, families, "Extra High effort was not visible for GPT-5.6 Sol");
     }}
-    realClick(pro);
+    realClick(maxTier);
     await wait(250);
     pill = await waitForPill();
-    if (!pill) return result("selection-mismatch", null, null, families, "ChatGPT composer model pill did not remount after selecting Pro intelligence");
+    if (!pill) return result("selection-mismatch", null, null, families, "ChatGPT composer model pill did not remount after selecting Extra High effort");
     menu = await openMain(pill);
     state = menu ? readState(menu) : null;
-    if (!state) return result("selection-mismatch", pill, null, families, "picker did not reopen after selecting Pro intelligence");
+    if (!state) return result("selection-mismatch", pill, null, families, "picker did not reopen after selecting Extra High effort");
   }}
 
   const familyIsVerified = familyVerified(state);
   const effortIsVerified = effortVerified(state);
   if (!familyIsVerified || !effortIsVerified) {{
     await closeMenus(pill);
-    return result("selection-mismatch", pill, state, families, "GPT-5.6 Sol + Pro could not be verified in one picker pass");
+    return result("selection-mismatch", pill, state, families, "GPT-5.6 Sol + Extra High could not be verified in one picker pass");
   }}
   if (!await closeMenus(pill)) {{
     return result("selection-mismatch", pill, state, families, "ChatGPT model picker remained open after verification");
@@ -1243,13 +1246,19 @@ mod tests {
     #[test]
     fn model_aliases_cover_shortcuts() {
         let aliases = model_alias_map();
-        assert_eq!(aliases.get("gpt-5-6-sol-pro"), Some(&"gpt-5-6-sol-pro"));
-        assert_eq!(aliases.get("sol-pro"), Some(&"gpt-5-6-sol-pro"));
+        assert_eq!(
+            aliases.get("gpt-5-6-sol-extra-high"),
+            Some(&"gpt-5-6-sol-extra-high")
+        );
+        assert_eq!(
+            aliases.get("sol-extra-high"),
+            Some(&"gpt-5-6-sol-extra-high")
+        );
         assert_eq!(aliases.get("gpt-5-4-pro"), None);
         let candidates = model_candidate_map();
         assert_eq!(
-            candidates.get("gpt-5-6-sol-pro"),
-            Some(&vec!["gpt-5-6-sol-pro"])
+            candidates.get("gpt-5-6-sol-extra-high"),
+            Some(&vec!["gpt-5-6-sol-extra-high"])
         );
         assert_eq!(candidates.get("gpt-5-4-pro"), None);
     }
@@ -1261,23 +1270,23 @@ mod tests {
         assert_eq!(canonical_chatgpt_model_slug("Pro"), None);
         assert_eq!(canonical_chatgpt_model_slug("Extended Pro"), None);
         assert_eq!(
-            canonical_chatgpt_model_slug("GPT-5.6 Sol Pro"),
-            Some("gpt-5-6-sol-pro".to_string())
+            canonical_chatgpt_model_slug("GPT-5.6 Sol Extra High"),
+            Some("gpt-5-6-sol-extra-high".to_string())
         );
     }
 
     #[test]
-    fn reported_chatgpt_model_requires_verified_sol_and_pro_proofs() {
+    fn reported_chatgpt_model_requires_verified_sol_and_extra_high_proofs() {
         let selection = serde_json::json!({
             "status": "selected",
-            "requested": "gpt-5-6-sol-pro",
-            "modelUsed": "GPT-5.6 Sol Pro",
+            "requested": "gpt-5-6-sol-extra-high",
+            "modelUsed": "GPT-5.6 Sol Extra High",
             "familyStatus": "verified",
             "effortStatus": "verified"
         });
         assert_eq!(
-            select_reported_chatgpt_model(&selection, "gpt-5-6-sol-pro"),
-            Some("GPT-5.6 Sol Pro".to_string())
+            select_reported_chatgpt_model(&selection, "gpt-5-6-sol-extra-high"),
+            Some("GPT-5.6 Sol Extra High".to_string())
         );
     }
 
@@ -1285,12 +1294,12 @@ mod tests {
     fn reported_chatgpt_model_never_echoes_an_unverified_request() {
         let selection = serde_json::json!({
             "status": "selected",
-            "requested": "gpt-5-6-sol-pro",
+            "requested": "gpt-5-6-sol-extra-high",
             "modelUsed": "Pro Extended",
             "extendedStatus": "required"
         });
         assert_eq!(
-            select_reported_chatgpt_model(&selection, "gpt-5-6-sol-pro"),
+            select_reported_chatgpt_model(&selection, "gpt-5-6-sol-extra-high"),
             None
         );
     }
@@ -1316,12 +1325,12 @@ mod tests {
             chatgpt_model_selection_status(
                 &serde_json::json!({
                     "status": "selected",
-                    "requested": "gpt-5-6-sol-pro",
-                    "modelUsed": "GPT-5.6 Sol Pro",
+                    "requested": "gpt-5-6-sol-extra-high",
+                    "modelUsed": "GPT-5.6 Sol Extra High",
                     "familyStatus": "verified",
                     "effortStatus": "verified"
                 }),
-                "gpt-5-6-sol-pro"
+                "gpt-5-6-sol-extra-high"
             ),
             ChatgptModelSelectionStatus::Selected
         );
@@ -1346,7 +1355,7 @@ mod tests {
                     "modelUsed": "Pro Extended",
                     "extendedStatus": "required"
                 }),
-                "gpt-5-6-sol-pro"
+                "gpt-5-6-sol-extra-high"
             ),
             ChatgptModelSelectionStatus::Mismatch
         );
@@ -1360,7 +1369,7 @@ mod tests {
         assert_eq!(
             chatgpt_model_selection_status(
                 &serde_json::json!({"status": "selection-mismatch"}),
-                "gpt-5-6-sol-pro"
+                "gpt-5-6-sol-extra-high"
             ),
             ChatgptModelSelectionStatus::Mismatch
         );
@@ -1390,10 +1399,10 @@ mod tests {
     }
 
     #[test]
-    fn model_selection_function_requires_verified_sol_family_and_pro_effort() {
+    fn model_selection_function_requires_verified_sol_family_and_extra_high_effort() {
         let script =
-            build_model_selection_function("gpt-5-6-sol-pro", ChatgptModelStrategy::Select);
-        assert!(script.contains(r#"const requested = "gpt-5-6-sol-pro";"#));
+            build_model_selection_function("gpt-5-6-sol-extra-high", ChatgptModelStrategy::Select);
+        assert!(script.contains(r#"const requested = "gpt-5-6-sol-extra-high";"#));
         assert!(script.contains("classList.contains(\"__composer-pill\")"));
         assert!(script.contains(
             "legacy ChatGPT picker detected; this yoetz version requires the GPT-5.6 UI"
@@ -1401,7 +1410,7 @@ mod tests {
         assert!(script.contains(r#"familyStatus: familyIsVerified ? "verified" : "unverified""#));
         assert!(script.contains(r#"effortStatus: effortIsVerified ? "verified" : "unverified""#));
         assert!(script.contains(r#"fold(textOf(item)) === "gpt-5.6 sol""#));
-        assert!(script.contains(r#"fold(textOf(item)) === "pro""#));
+        assert!(script.contains(r#"fold(textOf(item)) === "extra high""#));
         assert!(script.contains(r#"/^(?:gpt|o\d)\b/i.test(textOf(item))"#));
         assert!(script.contains("await openFamilyMenu"));
         assert!(script.contains("async function waitForPill()"));
@@ -1409,7 +1418,7 @@ mod tests {
         assert!(script
             .contains("ChatGPT composer model pill did not remount after selecting GPT-5.6 Sol"));
         assert!(script.contains(
-            "ChatGPT composer model pill did not remount after selecting Pro intelligence"
+            "ChatGPT composer model pill did not remount after selecting Extra High effort"
         ));
         assert!(script.contains("return visibleMenus().length === 0;"));
         assert!(script.contains("if (!await closeMenus(pill))"));

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
@@ -334,7 +334,7 @@ async fn run_attached_recipe_inner(
         .await
         .context("mark yoetz-owned ChatGPT tab with window.name")?;
 
-    // Step 2: wait for the composer to mount, then verify GPT-5.6 Sol + Pro
+    // Step 2: wait for the composer to mount, then verify GPT-5.6 Sol + Extra High
     // before any upload/send side effects.
     wait_for_composer_ready(client, /* focus_composer */ true).await?;
     let model_selection = maybe_select_model(client, &ctx.model).await?;
@@ -758,7 +758,7 @@ async fn maybe_select_model(
             })
         }
         "selected" => Err(anyhow!(
-            "ChatGPT reported selected without verified GPT-5.6 Sol + Pro proof.{} {}",
+            "ChatGPT reported selected without verified GPT-5.6 Sol + Extra High proof.{} {}",
             format_model_selection_diagnostics(&selection),
             format_page_probe_summary(&selection)
         )),
@@ -2097,10 +2097,10 @@ mod tests {
     }
 
     #[test]
-    fn model_selection_script_requires_verified_sol_pro_contract() {
+    fn model_selection_script_requires_verified_sol_extra_high_contract() {
         let explicit_script =
-            build_model_selection_script(crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL);
-        assert!(explicit_script.contains(r#"const requested = "gpt-5-6-sol-pro";"#));
+            build_model_selection_script(crate::chatgpt_recipe::CHATGPT_SOL_EXTRA_HIGH_MODEL);
+        assert!(explicit_script.contains(r#"const requested = "gpt-5-6-sol-extra-high";"#));
         assert!(explicit_script.contains("classList.contains(\"__composer-pill\")"));
         assert!(explicit_script.contains("familyStatus"));
         assert!(explicit_script.contains("effortStatus"));

--- a/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
+++ b/crates/yoetz-cli/src/chrome_devtools_mcp/chatgpt.rs
@@ -334,7 +334,7 @@ async fn run_attached_recipe_inner(
         .await
         .context("mark yoetz-owned ChatGPT tab with window.name")?;
 
-    // Step 2: wait for the composer to mount, then verify GPT-5.6 Sol + Extra High
+    // Step 2: wait for the composer to mount, then verify GPT-5.6 Sol at a known maximum tier.
     // before any upload/send side effects.
     wait_for_composer_ready(client, /* focus_composer */ true).await?;
     let model_selection = maybe_select_model(client, &ctx.model).await?;
@@ -758,7 +758,7 @@ async fn maybe_select_model(
             })
         }
         "selected" => Err(anyhow!(
-            "ChatGPT reported selected without verified GPT-5.6 Sol + Extra High proof.{} {}",
+            "ChatGPT reported selected without verified GPT-5.6 Sol maximum-tier proof.{} {}",
             format_model_selection_diagnostics(&selection),
             format_page_probe_summary(&selection)
         )),

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -1922,7 +1922,7 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<ChatgptRecipe
         }
         if model_selection_status != chatgpt_recipe::ChatgptModelSelectionStatus::Selected {
             return Err(anyhow!(
-                "ChatGPT did not provide verified GPT-5.6 Sol + Extra High selection proof: {}",
+                "ChatGPT did not provide verified GPT-5.6 Sol maximum-tier selection proof: {}",
                 model_selection
             ));
         }

--- a/crates/yoetz-cli/src/dev_browser.rs
+++ b/crates/yoetz-cli/src/dev_browser.rs
@@ -1922,7 +1922,7 @@ pub fn run_chatgpt_recipe(ctx: &DevBrowserRecipeContext) -> Result<ChatgptRecipe
         }
         if model_selection_status != chatgpt_recipe::ChatgptModelSelectionStatus::Selected {
             return Err(anyhow!(
-                "ChatGPT did not provide verified GPT-5.6 Sol + Pro selection proof: {}",
+                "ChatGPT did not provide verified GPT-5.6 Sol + Extra High selection proof: {}",
                 model_selection
             ));
         }
@@ -2595,13 +2595,13 @@ mod tests {
     fn build_chatgpt_prepare_script_uses_named_page_and_login_check() {
         let script = build_chatgpt_prepare_script(
             "yoetz-chatgpt-test",
-            crate::chatgpt_recipe::CHATGPT_SOL_PRO_MODEL,
+            crate::chatgpt_recipe::CHATGPT_SOL_EXTRA_HIGH_MODEL,
             crate::chatgpt_recipe::ChatgptModelStrategy::Select,
             "run-123",
         );
 
         assert!(script.contains("const PAGE_NAME = \"yoetz-chatgpt-test\";"));
-        assert!(script.contains("const MODEL = \"gpt-5-6-sol-pro\";"));
+        assert!(script.contains("const MODEL = \"gpt-5-6-sol-extra-high\";"));
         assert!(script.contains("const MODEL_STRATEGY = \"select\";"));
         assert!(script.contains("const MARKED_URL = \"https://chatgpt.com/?_yoetz=run-123\";"));
         assert!(script.contains("const WINDOW_NAME = \"yoetz:run-123\";"));
@@ -2806,7 +2806,7 @@ mod tests {
     fn parse_script_json_reads_prepare_result() {
         let result: ChatgptPrepareResult = parse_script_json(
             "prepare",
-            r#"{"status":"ready","loggedIn":true,"composerReady":true,"modelUsed":"GPT-5.6 Sol Pro","modelSelection":{"status":"selected","requested":"gpt-5-6-sol-pro","modelUsed":"GPT-5.6 Sol Pro","familyStatus":"verified","effortStatus":"verified"},"url":"https://chatgpt.com/","title":"ChatGPT","bodyText":"Send a message"}"#,
+            r#"{"status":"ready","loggedIn":true,"composerReady":true,"modelUsed":"GPT-5.6 Sol Extra High","modelSelection":{"status":"selected","requested":"gpt-5-6-sol-extra-high","modelUsed":"GPT-5.6 Sol Extra High","familyStatus":"verified","effortStatus":"verified"},"url":"https://chatgpt.com/","title":"ChatGPT","bodyText":"Send a message"}"#,
         )
         .unwrap();
 
@@ -2827,7 +2827,7 @@ mod tests {
                 .as_ref()
                 .and_then(|selection| selection.get("modelUsed"))
                 .and_then(Value::as_str),
-            Some("GPT-5.6 Sol Pro")
+            Some("GPT-5.6 Sol Extra High")
         );
         assert_eq!(result.title, "ChatGPT");
     }

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -2651,7 +2651,7 @@ fn ensure_chatgpt_sol_extra_high_only_vars(recipe_vars: &BTreeMap<String, String
         return Ok(());
     }
     bail!(
-        "ChatGPT recipe supports only GPT-5.6 Sol + Extra High effort; remove unsupported var(s): {}",
+        "ChatGPT recipe supports only GPT-5.6 Sol at the account maximum tier (Pro or Extra High); remove unsupported var(s): {}",
         unsupported.join(", ")
     )
 }
@@ -8016,7 +8016,7 @@ mod tests {
 
         let err = build_chatgpt_recipe_spec(&recipe_args, &recipe_vars).unwrap_err();
         let message = format!("{err:#}");
-        assert!(message.contains("only GPT-5.6 Sol + Extra High effort"));
+        assert!(message.contains("only GPT-5.6 Sol at the account maximum tier"));
         assert!(message.contains("model"));
         assert!(message.contains("extended"));
     }

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -2487,7 +2487,7 @@ fn build_chatgpt_recipe_spec(
     recipe_args: &BrowserRecipeArgs,
     recipe_vars: &BTreeMap<String, String>,
 ) -> Result<chatgpt_recipe::ChatgptRecipeSpec> {
-    ensure_chatgpt_sol_pro_only_vars(recipe_vars)?;
+    ensure_chatgpt_sol_extra_high_only_vars(recipe_vars)?;
     let poll_settings = dev_browser::resolve_chatgpt_poll_settings(recipe_vars)?;
     let upload_timeout_ms =
         dev_browser::resolve_chatgpt_upload_timeout_ms(recipe_vars, recipe_args.bundle.as_deref())?;
@@ -2501,7 +2501,7 @@ fn build_chatgpt_recipe_spec(
         bundle_path: recipe_args.bundle.clone(),
         model: match recipe_args.model_strategy {
             chatgpt_recipe::ChatgptModelStrategy::Select => {
-                chatgpt_recipe::CHATGPT_SOL_PRO_MODEL.to_string()
+                chatgpt_recipe::CHATGPT_SOL_EXTRA_HIGH_MODEL.to_string()
             }
             chatgpt_recipe::ChatgptModelStrategy::Current => "current".to_string(),
         },
@@ -2642,7 +2642,7 @@ fn claude_inline_warn_tokens(recipe_vars: &BTreeMap<String, String>) -> Result<u
         .context("inline_warn_tokens must be a non-negative integer")
 }
 
-fn ensure_chatgpt_sol_pro_only_vars(recipe_vars: &BTreeMap<String, String>) -> Result<()> {
+fn ensure_chatgpt_sol_extra_high_only_vars(recipe_vars: &BTreeMap<String, String>) -> Result<()> {
     let unsupported = ["model", "extended"]
         .into_iter()
         .filter(|key| recipe_vars.contains_key(*key))
@@ -2651,7 +2651,7 @@ fn ensure_chatgpt_sol_pro_only_vars(recipe_vars: &BTreeMap<String, String>) -> R
         return Ok(());
     }
     bail!(
-        "ChatGPT recipe supports only GPT-5.6 Sol + Pro intelligence; remove unsupported var(s): {}",
+        "ChatGPT recipe supports only GPT-5.6 Sol + Extra High effort; remove unsupported var(s): {}",
         unsupported.join(", ")
     )
 }
@@ -6114,7 +6114,7 @@ mod tests {
                 "conversation_id": "final-conversation"
             }),
             json!({"status": "ok"}),
-            "GPT-5.6 Sol Pro",
+            "GPT-5.6 Sol Extra High",
             Instant::now(),
             OutputFormat::Text,
             Some(&prepared_thread),
@@ -7975,7 +7975,7 @@ mod tests {
 
         let spec = build_chatgpt_recipe_spec(&recipe_args, &recipe_vars).unwrap();
         assert_eq!(spec.bundle_path, Some(PathBuf::from("/tmp/bundle.md")));
-        assert_eq!(spec.model, chatgpt_recipe::CHATGPT_SOL_PRO_MODEL);
+        assert_eq!(spec.model, chatgpt_recipe::CHATGPT_SOL_EXTRA_HIGH_MODEL);
         assert_eq!(spec.prompt, "Review this repo");
         assert_eq!(spec.browser_context_id.as_deref(), Some("ctx-123"));
         assert_eq!(spec.profile_email.as_deref(), Some("user@example.com"));
@@ -8016,7 +8016,7 @@ mod tests {
 
         let err = build_chatgpt_recipe_spec(&recipe_args, &recipe_vars).unwrap_err();
         let message = format!("{err:#}");
-        assert!(message.contains("only GPT-5.6 Sol + Pro intelligence"));
+        assert!(message.contains("only GPT-5.6 Sol + Extra High effort"));
         assert!(message.contains("model"));
         assert!(message.contains("extended"));
     }
@@ -8206,7 +8206,7 @@ mod tests {
     }
 
     #[test]
-    fn builtin_chatgpt_recipe_defaults_flow_into_shared_sol_pro_spec() {
+    fn builtin_chatgpt_recipe_defaults_flow_into_shared_sol_extra_high_spec() {
         let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../recipes/chatgpt.yaml");
         let content = fs::read_to_string(&path).expect("read recipes/chatgpt.yaml");
         let recipe: browser::Recipe =
@@ -8234,7 +8234,7 @@ mod tests {
             .expect("build recipe vars");
         let spec = build_chatgpt_recipe_spec(&recipe_args, &recipe_vars).unwrap();
 
-        assert_eq!(spec.model, chatgpt_recipe::CHATGPT_SOL_PRO_MODEL);
+        assert_eq!(spec.model, chatgpt_recipe::CHATGPT_SOL_EXTRA_HIGH_MODEL);
         assert!(!recipe_vars.contains_key("model"));
         assert!(!recipe_vars.contains_key("extended"));
     }
@@ -8501,7 +8501,7 @@ mod tests {
             backend: "dev-browser".to_string(),
             response: "ok".to_string(),
             model_strategy: crate::chatgpt_recipe::ChatgptModelStrategy::Select,
-            model_used: Some("GPT-5.6 Sol Pro".to_string()),
+            model_used: Some("GPT-5.6 Sol Extra High".to_string()),
             model_selection_status: crate::chatgpt_recipe::ChatgptModelSelectionStatus::Selected,
             warnings: vec!["clipboard fallback".to_string()],
             fallback_used: true,

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -5,7 +5,7 @@ const DEFAULT_WAIT_INTERVAL_MS = 250;
 const DEFAULT_SEND_MIN_TIMEOUT_MS = 120000;
 const CHATGPT_SOL_EXTRA_HIGH_MODEL = "gpt-5-6-sol-extra-high";
 const CHATGPT_SOL_FAMILY_LABEL = "GPT-5.6 Sol";
-const CHATGPT_MAX_EFFORT_LABEL = "Extra High";
+const CHATGPT_MAX_EFFORT_LABELS = new Set(["pro", "extra high"]);
 const MANUAL_HANDOFF_SHELL_SELECTORS = Object.freeze([
   "nav",
   "aside",
@@ -587,23 +587,24 @@ async function selectSolMaxTierModel(root, options = {}) {
       state.effort_move_method = moved.method;
       if (!moved.ok) {
         await closeModelPicker(root, modelButton);
-        return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol effort slider did not move to Extra High", "effort_slider_move_failed");
+        return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol effort slider did not move to a verified maximum tier", "effort_slider_move_failed");
       }
     } else {
-      const maxOption = state.effort_items.find((item) => foldedModelText(textOf(item)) === foldedModelText(CHATGPT_MAX_EFFORT_LABEL));
+      const maxOption = state.effort_items.find((item) => foldedModelText(textOf(item)) === "extra high")
+        ?? state.effort_items.find((item) => foldedModelText(textOf(item)) === "pro");
       if (!maxOption) {
         await closeModelPicker(root, modelButton);
-        return selectionFailure(base, modelButton, state, availableFamilies, "Extra High effort was not visible for GPT-5.6 Sol", "effort_control_not_found");
+        return selectionFailure(base, modelButton, state, availableFamilies, "Neither Pro nor Extra High was visible as the GPT-5.6 Sol maximum tier", "effort_control_not_found");
       }
       realClick(maxOption);
       await sleep(Number(options.actionSettleMs ?? 250));
       modelButton = await waitForModelButton(root, options);
       if (!modelButton) {
-        return selectionFailure(base, null, null, availableFamilies, "ChatGPT composer model pill did not remount after selecting Extra High effort", "effort_control_remount_failed");
+        return selectionFailure(base, null, null, availableFamilies, "ChatGPT composer model pill did not remount after selecting the maximum effort tier", "effort_control_remount_failed");
       }
       state = await openAndReadModelPicker(root, modelButton, options);
       if (!state) {
-        return selectionFailure(base, modelButton, null, availableFamilies, "ChatGPT picker did not reopen after selecting Extra High effort", "model_picker_reopen_failed");
+        return selectionFailure(base, modelButton, null, availableFamilies, "ChatGPT picker did not reopen after selecting the maximum effort tier", "model_picker_reopen_failed");
       }
     }
   }
@@ -612,19 +613,19 @@ async function selectSolMaxTierModel(root, options = {}) {
   const effortVerified = effortIsMaxTier(state);
   if (!familyVerified || !effortVerified) {
     await closeModelPicker(root, modelButton);
-    return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol + Extra High could not be verified in one picker pass", "model_selection_verification_failed");
+    return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol at a verified maximum tier (Pro or Extra High) could not be confirmed in one picker pass", "model_selection_verification_failed");
   }
   if (!await closeModelPicker(root, modelButton)) {
     return selectionFailure(base, modelButton, state, availableFamilies, "ChatGPT model picker remained open after verification", "model_picker_close_failed");
   }
   modelButton = await waitForModelButton(root, options);
   const pillText = modelControlLabel(modelButton);
-  if (state.shape === "slider" && !/\bextra\s+high\b/i.test(pillText)) {
-    return selectionFailure(base, modelButton, state, availableFamilies, "ChatGPT composer model pill did not confirm Extra High after closing the slider picker", "effort_composer_pill_unverified");
-  }
   const verifiedEffortLabel = state.shape === "slider"
     ? sliderEffortSnapshot(state.effort_slider, state.surface)?.display_label
     : normalizeText(textOf(state.effort_items.find((item) => itemIsChecked(item))));
+  if (state.shape === "slider" && !pillConfirmsEffortLabel(pillText, verifiedEffortLabel)) {
+    return selectionFailure(base, modelButton, state, availableFamilies, "ChatGPT composer model pill did not confirm the verified maximum tier after closing the slider picker", "effort_composer_pill_unverified");
+  }
 
   return {
     status: "selected",
@@ -999,9 +1000,15 @@ function familyMenuRadios(menu, structurallyTrusted = false) {
 function effortIsMaxTier(state) {
   if (state?.shape === "slider") {
     const snapshot = sliderEffortSnapshot(state.effort_slider, state.surface);
-    return Boolean(snapshot && snapshot.label === "extra high" && snapshot.now === snapshot.max);
+    return Boolean(snapshot && CHATGPT_MAX_EFFORT_LABELS.has(snapshot.label) && snapshot.now === snapshot.max);
   }
-  return state?.effort_items?.some((item) => foldedModelText(textOf(item)) === "extra high" && itemIsChecked(item)) ?? false;
+  return state?.effort_items?.some((item) => CHATGPT_MAX_EFFORT_LABELS.has(foldedModelText(textOf(item))) && itemIsChecked(item)) ?? false;
+}
+
+function pillConfirmsEffortLabel(pillText, effortLabel) {
+  const foldedPill = foldedModelText(pillText);
+  const foldedEffort = foldedModelText(effortLabel);
+  return foldedPill === foldedEffort || foldedPill.endsWith(` ${foldedEffort}`);
 }
 
 function sliderEffortSnapshot(slider, surface = null) {

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -3,9 +3,9 @@ export const OWNERSHIP_ATTR = "data-yoetz-chatgpt-native-job";
 const DEFAULT_WAIT_TIMEOUT_MS = 15000;
 const DEFAULT_WAIT_INTERVAL_MS = 250;
 const DEFAULT_SEND_MIN_TIMEOUT_MS = 120000;
-const CHATGPT_SOL_PRO_MODEL = "gpt-5-6-sol-pro";
+const CHATGPT_SOL_EXTRA_HIGH_MODEL = "gpt-5-6-sol-extra-high";
 const CHATGPT_SOL_FAMILY_LABEL = "GPT-5.6 Sol";
-const CHATGPT_PRO_EFFORT_LABEL = "Pro";
+const CHATGPT_MAX_EFFORT_LABEL = "Extra High";
 const MANUAL_HANDOFF_SHELL_SELECTORS = Object.freeze([
   "nav",
   "aside",
@@ -380,6 +380,10 @@ export async function configureModelState(root, job = {}) {
       picker_shape: null,
       surface_trust: null,
       surface_descendants: [],
+      max_effort_label: null,
+      advanced_rows: [],
+      checkbox_probe: null,
+      family_menu_probe: null,
       effort_control: null,
       effort_move_method: null,
       pill_text: pillText ?? "",
@@ -390,12 +394,12 @@ export async function configureModelState(root, job = {}) {
     };
   }
 
-  const selection = await selectSolProModel(root, modelSelectionOptionsForJob(job));
+  const selection = await selectSolMaxTierModel(root, modelSelectionOptionsForJob(job));
   const warnings = selection.warning ? [selection.warning] : [];
   return {
     status: selection.status,
     model_used: selection.model_used,
-    requested_model: CHATGPT_SOL_PRO_MODEL,
+    requested_model: CHATGPT_SOL_EXTRA_HIGH_MODEL,
     available_options: selection.available_options ?? [],
     available_families: selection.available_families ?? [],
     family_status: selection.family_status ?? "unverified",
@@ -404,6 +408,10 @@ export async function configureModelState(root, job = {}) {
     picker_shape: selection.picker_shape ?? null,
     surface_trust: selection.surface_trust ?? null,
     surface_descendants: selection.surface_descendants ?? [],
+    max_effort_label: selection.max_effort_label ?? null,
+    advanced_rows: selection.advanced_rows ?? [],
+    checkbox_probe: selection.checkbox_probe ?? null,
+    family_menu_probe: selection.family_menu_probe ?? null,
     effort_control: selection.effort_control ?? null,
     effort_move_method: selection.effort_move_method ?? null,
     pill_text: selection.pill_text ?? null,
@@ -493,7 +501,7 @@ function modelControlLabel(node) {
   ].filter(Boolean).join(" "));
 }
 
-async function selectSolProModel(root, options = {}) {
+async function selectSolMaxTierModel(root, options = {}) {
   const base = {
     status: "unavailable",
     model_used: null,
@@ -568,56 +576,59 @@ async function selectSolProModel(root, options = {}) {
     }
   }
 
-  if (!effortIsPro(state)) {
+  if (!effortIsMaxTier(state)) {
     if (state.shape === "slider") {
       if (!state.effort_slider) {
         await closeModelPicker(root, modelButton);
         return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol effort slider was not found in the Advanced picker", "effort_control_not_found");
       }
-      const moved = await moveEffortSliderToPro(root, state, options);
+      const moved = await moveEffortSliderToMaxTier(root, state, options);
       state = moved.state ?? state;
       state.effort_move_method = moved.method;
       if (!moved.ok) {
         await closeModelPicker(root, modelButton);
-        return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol effort slider did not move to Pro", "effort_slider_move_failed");
+        return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol effort slider did not move to Extra High", "effort_slider_move_failed");
       }
     } else {
-      const proOption = state.effort_items.find((item) => foldedModelText(textOf(item)) === foldedModelText(CHATGPT_PRO_EFFORT_LABEL));
-      if (!proOption) {
+      const maxOption = state.effort_items.find((item) => foldedModelText(textOf(item)) === foldedModelText(CHATGPT_MAX_EFFORT_LABEL));
+      if (!maxOption) {
         await closeModelPicker(root, modelButton);
-        return selectionFailure(base, modelButton, state, availableFamilies, "Pro intelligence was not visible for GPT-5.6 Sol", "effort_control_not_found");
+        return selectionFailure(base, modelButton, state, availableFamilies, "Extra High effort was not visible for GPT-5.6 Sol", "effort_control_not_found");
       }
-      realClick(proOption);
+      realClick(maxOption);
       await sleep(Number(options.actionSettleMs ?? 250));
       modelButton = await waitForModelButton(root, options);
       if (!modelButton) {
-        return selectionFailure(base, null, null, availableFamilies, "ChatGPT composer model pill did not remount after selecting Pro intelligence", "effort_control_remount_failed");
+        return selectionFailure(base, null, null, availableFamilies, "ChatGPT composer model pill did not remount after selecting Extra High effort", "effort_control_remount_failed");
       }
       state = await openAndReadModelPicker(root, modelButton, options);
       if (!state) {
-        return selectionFailure(base, modelButton, null, availableFamilies, "ChatGPT picker did not reopen after selecting Pro intelligence", "model_picker_reopen_failed");
+        return selectionFailure(base, modelButton, null, availableFamilies, "ChatGPT picker did not reopen after selecting Extra High effort", "model_picker_reopen_failed");
       }
     }
   }
 
   const familyVerified = familyIsSol(state.family_label);
-  const effortVerified = effortIsPro(state);
+  const effortVerified = effortIsMaxTier(state);
   if (!familyVerified || !effortVerified) {
     await closeModelPicker(root, modelButton);
-    return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol + Pro could not be verified in one picker pass", "model_selection_verification_failed");
+    return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol + Extra High could not be verified in one picker pass", "model_selection_verification_failed");
   }
   if (!await closeModelPicker(root, modelButton)) {
     return selectionFailure(base, modelButton, state, availableFamilies, "ChatGPT model picker remained open after verification", "model_picker_close_failed");
   }
   modelButton = await waitForModelButton(root, options);
   const pillText = modelControlLabel(modelButton);
-  if (state.shape === "slider" && !/\bpro\b/i.test(pillText)) {
-    return selectionFailure(base, modelButton, state, availableFamilies, "ChatGPT composer model pill did not confirm Pro after closing the slider picker", "effort_composer_pill_unverified");
+  if (state.shape === "slider" && !/\bextra\s+high\b/i.test(pillText)) {
+    return selectionFailure(base, modelButton, state, availableFamilies, "ChatGPT composer model pill did not confirm Extra High after closing the slider picker", "effort_composer_pill_unverified");
   }
+  const verifiedEffortLabel = state.shape === "slider"
+    ? sliderEffortSnapshot(state.effort_slider, state.surface)?.display_label
+    : normalizeText(textOf(state.effort_items.find((item) => itemIsChecked(item))));
 
   return {
     status: "selected",
-    model_used: `${CHATGPT_SOL_FAMILY_LABEL} ${CHATGPT_PRO_EFFORT_LABEL}`,
+    model_used: `${normalizeText(state.family_label)} ${verifiedEffortLabel}`,
     failure_reason: null,
     family_status: "verified",
     effort_status: "verified",
@@ -842,8 +853,7 @@ function structurallyOpenControlledSurfaceForTrigger(root, trigger) {
 
 function readStructurallyTrustedPickerState(surface) {
   const labels = menuRadioItems(surface, true).map((item) => foldedModelText(textOf(item)));
-  if (labels.includes("medium") && labels.includes("high")
-    && (labels.includes("pro") || labels.includes("pro extended"))) {
+  if (labels.includes("medium") && labels.includes("high") && labels.includes("extra high")) {
     return readMenuPickerState(surface, true);
   }
   const text = normalizeText(textOf(surface));
@@ -870,8 +880,7 @@ async function waitForFamilyMenu(root, mainMenu, trigger, options = {}) {
 function findMainModelMenu(root) {
   return visibleMenus(root).find((menu) => {
     const labels = menuRadioItems(menu).map((item) => foldedModelText(textOf(item)));
-    return labels.includes("medium") && labels.includes("high")
-      && (labels.includes("pro") || labels.includes("pro extended"));
+    return labels.includes("medium") && labels.includes("high") && labels.includes("extra high");
   }) ?? null;
 }
 
@@ -987,19 +996,19 @@ function familyMenuRadios(menu, structurallyTrusted = false) {
   return menuRadioItems(menu, structurallyTrusted).filter((item) => /^gpt\b|^o3$/i.test(normalizeText(textOf(item))));
 }
 
-function effortIsPro(state) {
+function effortIsMaxTier(state) {
   if (state?.shape === "slider") {
     const snapshot = sliderEffortSnapshot(state.effort_slider, state.surface);
-    return Boolean(snapshot && snapshot.label === "pro" && snapshot.now === snapshot.max);
+    return Boolean(snapshot && snapshot.label === "extra high" && snapshot.now === snapshot.max);
   }
-  return state?.effort_items?.some((item) => foldedModelText(textOf(item)) === "pro" && itemIsChecked(item)) ?? false;
+  return state?.effort_items?.some((item) => foldedModelText(textOf(item)) === "extra high" && itemIsChecked(item)) ?? false;
 }
 
 function sliderEffortSnapshot(slider, surface = null) {
   if (!slider) return null;
   const valueText = normalizeText(slider.getAttribute?.("aria-valuetext") ?? "");
   const nearbyLabel = valueText || effortLabelNearSlider(slider, surface);
-  const match = nearbyLabel.match(/^(Instant|Medium|High|Extra High|Pro)\s*,?\s*(\d+)\s+of\s+(\d+)\s*[.!?]?\s*$/i);
+  const match = nearbyLabel.match(/^([A-Z][A-Za-z ]{1,24}),\s*(\d+)\s+of\s+(\d+)\s*\.?\s*$/);
   const now = Number(slider.getAttribute?.("aria-valuenow"));
   const min = Number(slider.getAttribute?.("aria-valuemin"));
   const max = Number(slider.getAttribute?.("aria-valuemax"));
@@ -1009,7 +1018,7 @@ function sliderEffortSnapshot(slider, surface = null) {
     || max <= min || now < min || now > max || Number(match[2]) !== ordinal || Number(match[3]) !== total) {
     return null;
   }
-  return { label: foldedModelText(match[1]), now, min, max, value_text: nearbyLabel };
+  return { label: foldedModelText(match[1]), display_label: match[1], now, min, max, value_text: nearbyLabel };
 }
 
 function effortLabelNearSlider(slider, surface) {
@@ -1017,7 +1026,7 @@ function effortLabelNearSlider(slider, surface) {
   for (let depth = 0; scope && depth < 8; depth += 1, scope = scope.parentElement) {
     const label = Array.from(scope.querySelectorAll?.("span, div") ?? [])
       .map((node) => normalizeText(textOf(node)))
-      .find((text) => /^(?:Instant|Medium|High|Extra High|Pro)\s*,?\s*\d+\s+of\s+\d+\s*[.!?]?$/i.test(text));
+      .find((text) => /^[A-Z][A-Za-z ]{1,24},\s*\d+\s+of\s+\d+\s*\.?$/.test(text));
     if (label) return label;
     if (scope === surface) break;
   }
@@ -1044,19 +1053,40 @@ function sliderEffortDiagnostics(slider, surface = null) {
   } : null;
 }
 
-async function moveEffortSliderToPro(root, initialState, options = {}) {
+async function moveEffortSliderToMaxTier(root, initialState, options = {}) {
   const settleMs = Number(options.actionSettleMs ?? 250);
   let state = initialState;
+  const originalSnapshot = sliderEffortSnapshot(initialState?.effort_slider, initialState?.surface);
   const attemptKey = async (key, method) => {
     if (state?.shape !== "slider" || !state.effort_slider) return null;
     pressActivationKey(state.effort_slider, key);
     await sleep(settleMs);
     state = findPickerState(root);
-    return effortIsPro(state) ? { ok: true, state, method } : null;
+    return effortIsMaxTier(state) ? { ok: true, state, method } : null;
   };
 
   let result = await attemptKey("End", "keyboard_end");
   if (result) return result;
+
+  const maxSnapshot = sliderEffortSnapshot(state?.effort_slider, state?.surface);
+  if (maxSnapshot && originalSnapshot && maxSnapshot.now === maxSnapshot.max) {
+    state.max_effort_label = maxSnapshot.display_label;
+    const restoreSteps = Math.max(0, maxSnapshot.now - originalSnapshot.now);
+    for (let step = 0; step < restoreSteps; step += 1) {
+      pressActivationKey(state.effort_slider, "ArrowLeft");
+      await sleep(settleMs);
+      state = findPickerState(root) ?? state;
+      state.max_effort_label = maxSnapshot.display_label;
+    }
+    const checkboxProbe = await probeProCheckbox(root, state, options);
+    state = checkboxProbe.state;
+    const familyProbe = await probeFamilyMenu(root, state, options);
+    state = familyProbe.state;
+    state.max_effort_label = maxSnapshot.display_label;
+    state.checkbox_probe = checkboxProbe.diagnostics;
+    state.family_menu_probe = familyProbe.diagnostics;
+    return { ok: false, state, method: familyProbe.diagnostics ? "family_menu_probe" : "keyboard_end_probe" };
+  }
 
   const snapshot = sliderEffortSnapshot(state?.effort_slider, state?.surface);
   const arrowAttempts = Math.min(10, Math.max(1, Math.ceil((snapshot?.max ?? 5) - (snapshot?.min ?? 1)) + 1));
@@ -1070,9 +1100,103 @@ async function moveEffortSliderToPro(root, initialState, options = {}) {
     clickSliderTrackMax(state.effort_slider);
     await sleep(settleMs);
     state = findPickerState(root);
-    if (effortIsPro(state)) return { ok: true, state, method: "pointer_max" };
+    if (effortIsMaxTier(state)) return { ok: true, state, method: "pointer_max" };
   }
   return { ok: false, state, method: null };
+}
+
+async function probeFamilyMenu(root, initialState, options = {}) {
+  if (!initialState?.family_trigger || !initialState?.surface) {
+    return { state: initialState, diagnostics: null };
+  }
+  const menu = await openFamilyPicker(root, initialState.surface, initialState.family_trigger, options);
+  if (!menu) return { state: initialState, diagnostics: null };
+  const structurallyTrusted = menu === structurallyOpenControlledSurfaceForTrigger(root, initialState.family_trigger);
+  const candidates = Array.from(menu.querySelectorAll?.("*") ?? [])
+    .filter((node) => ["menuitem", "menuitemradio"].includes(node.getAttribute?.("role")))
+    .slice(0, 20)
+    .map((node) => ({
+      role: node.getAttribute?.("role") ?? null,
+      label: normalizeText(textOf(node)),
+      checked: node.getAttribute?.("aria-checked") ?? null
+    }));
+  const radioLabels = familyMenuRadios(menu, structurallyTrusted)
+    .map((node) => normalizeText(textOf(node)))
+    .filter(Boolean)
+    .slice(0, 20);
+  pressActivationKey(initialState.family_trigger, "Escape");
+  await sleep(Number(options.actionSettleMs ?? 250));
+  const closed = !findFamilySubmenu(root, initialState.surface)
+    && !structurallyOpenControlledSurfaceForTrigger(root, initialState.family_trigger);
+  const state = findPickerState(root) ?? initialState;
+  return {
+    state,
+    diagnostics: {
+      family_options: candidates,
+      family_radio_labels: radioLabels,
+      close_verified: closed
+    }
+  };
+}
+
+async function probeProCheckbox(root, initialState, options = {}) {
+  const checkbox = Array.from(initialState?.surface?.querySelectorAll?.("*") ?? [])
+    .find((node) => node.getAttribute?.("role") === "menuitemcheckbox");
+  if (!checkbox || checkbox.getAttribute?.("aria-checked") !== "false") {
+    return { state: initialState, diagnostics: null };
+  }
+  const settleMs = Number(options.actionSettleMs ?? 250);
+  const before = checkboxProbeSnapshot(root, initialState, checkbox);
+  pressActivationKey(checkbox, " ");
+  await sleep(settleMs);
+  let state = findPickerState(root) ?? initialState;
+  const enabledCheckbox = Array.from(state.surface?.querySelectorAll?.("*") ?? [])
+    .find((node) => node.getAttribute?.("role") === "menuitemcheckbox");
+  const enabled = checkboxProbeSnapshot(root, state, enabledCheckbox);
+  if (enabledCheckbox) pressActivationKey(enabledCheckbox, " ");
+  await sleep(settleMs);
+  state = findPickerState(root) ?? state;
+  const restoredCheckbox = Array.from(state.surface?.querySelectorAll?.("*") ?? [])
+    .find((node) => node.getAttribute?.("role") === "menuitemcheckbox");
+  const restored = checkboxProbeSnapshot(root, state, restoredCheckbox);
+  return {
+    state,
+    diagnostics: {
+      before,
+      enabled,
+      restored,
+      restore_verified: restoredCheckbox?.getAttribute?.("aria-checked") === "false"
+    }
+  };
+}
+
+function checkboxProbeSnapshot(root, state, checkbox) {
+  const advanced = Array.from(state?.surface?.querySelectorAll?.("*") ?? [])
+    .find((node) => node.getAttribute?.("data-testid") === "composer-model-picker-slider-advanced-view");
+  const speedRowNode = Array.from(advanced?.querySelectorAll?.("*") ?? [])
+    .find((node) => node.getAttribute?.("role") === "menuitem" && /\bSpeed\b/i.test(textOf(node)));
+  const speedOptions = Array.from(speedRowNode?.querySelectorAll?.("*") ?? [])
+    .filter((node) => ["radio", "menuitemradio", "option"].includes(node.getAttribute?.("role")))
+    .map((node) => normalizeText(textOf(node)))
+    .filter(Boolean)
+    .slice(0, 12);
+  const effort = sliderEffortDiagnostics(state?.effort_slider, state?.surface);
+  return {
+    checked: checkbox?.getAttribute?.("aria-checked") ?? null,
+    pill_text: modelControlLabel(findModelButton(root)),
+    advanced_rows: advancedViewRows(state?.surface),
+    speed_options: speedOptions,
+    effort: effort ? {
+      label: effort.label,
+      value_now: effort.value_now,
+      value_min: effort.value_min,
+      value_max: effort.value_max,
+      aria_disabled: state.effort_slider?.getAttribute?.("aria-disabled") ?? null,
+      disabled: Boolean(state.effort_slider?.disabled),
+      aria_hidden: state.effort_slider?.getAttribute?.("aria-hidden") ?? null,
+      hidden: Boolean(state.effort_slider?.hidden)
+    } : null
+  };
 }
 
 function clickSliderTrackMax(slider) {
@@ -1113,12 +1237,16 @@ function selectionFailure(base, modelButton, state, availableFamilies, warning, 
     ...base,
     failure_reason: failureReason,
     family_status: familyIsSol(state?.family_label) ? "verified" : "unverified",
-    effort_status: effortIsPro(state) ? "verified" : "unverified",
+    effort_status: effortIsMaxTier(state) ? "verified" : "unverified",
     picker_shape: state?.shape ?? null,
     surface_trust: state?.surface_trust ?? null,
     surface_descendants: state?.surface_trust === "aria_controls_structural"
       ? structuralSurfaceDescendants(state.surface)
       : [],
+    max_effort_label: state?.max_effort_label ?? null,
+    advanced_rows: advancedViewRows(state?.surface),
+    checkbox_probe: state?.checkbox_probe ?? null,
+    family_menu_probe: state?.family_menu_probe ?? null,
     effort_control: state?.shape === "slider" ? sliderEffortDiagnostics(state.effort_slider, state.surface) : null,
     effort_move_method: state?.effort_move_method ?? null,
     pill_text: modelControlLabel(modelButton),
@@ -1128,6 +1256,26 @@ function selectionFailure(base, modelButton, state, availableFamilies, warning, 
     effort_options: effortDiagnostics(state?.effort_items ?? []),
     warning
   };
+}
+
+function advancedViewRows(surface) {
+  const advanced = Array.from(surface?.querySelectorAll?.("*") ?? [])
+    .find((node) => node.getAttribute?.("data-testid") === "composer-model-picker-slider-advanced-view");
+  return Array.from(advanced?.querySelectorAll?.("*") ?? [])
+    .filter((row) => ["menuitem", "menuitemcheckbox"].includes(row.getAttribute?.("role")))
+    .slice(0, 20)
+    .map((row) => {
+      const parts = Array.from(row.querySelectorAll?.("span, div") ?? [])
+        .map((node) => normalizeText(textOf(node)))
+        .filter((text, index, all) => text && all.indexOf(text) === index)
+        .slice(0, 2);
+      return {
+        role: row.getAttribute?.("role") ?? null,
+        checked: row.getAttribute?.("aria-checked") ?? null,
+        label: parts[0] ?? normalizeText(textOf(row)),
+        value: parts[1] ?? null
+      };
+    });
 }
 
 function structuralSurfaceDescendants(surface) {
@@ -2707,11 +2855,11 @@ export function modelSelectionDiagnostics(root = document) {
   const controlledId = modelButton?.getAttribute?.("aria-controls") ?? null;
   const controlledNode = controlledId ? root.getElementById?.(controlledId) : null;
   return {
-    requested_model: CHATGPT_SOL_PRO_MODEL,
+    requested_model: CHATGPT_SOL_EXTRA_HIGH_MODEL,
     current_model_label: modelControlLabel(modelButton),
-    current_matches_requested: Boolean(familyIsSol(state?.family_label) && effortIsPro(state)),
+    current_matches_requested: Boolean(familyIsSol(state?.family_label) && effortIsMaxTier(state)),
     family_status: familyIsSol(state?.family_label) ? "verified" : "unverified",
-    effort_status: effortIsPro(state) ? "verified" : "unverified",
+    effort_status: effortIsMaxTier(state) ? "verified" : "unverified",
     family_label: state?.family_label ?? null,
     picker_shape: state?.shape ?? null,
     surface_trust: state?.surface_trust ?? null,

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -77,6 +77,7 @@ const MAX_NATIVE_OUTBOUND_BYTES = Math.max(
   1024,
   Number(globalThis.__YOETZ_MAX_NATIVE_OUTBOUND_BYTES ?? 64 * 1024 * 1024) || 64 * 1024 * 1024
 );
+const MAX_PERSISTED_TERMINAL_ENVELOPE_BYTES = 1024 * 1024;
 const WAITING_RESPONSE_PROGRESS_INTERVAL_MS = Math.max(50, Number(globalThis.__YOETZ_WAITING_RESPONSE_PROGRESS_INTERVAL_MS ?? 60000) || 60000);
 const CONTENT_SCRIPT_RECONNECT_ATTEMPTS = Math.max(
   1,
@@ -86,6 +87,7 @@ const CONTENT_SCRIPT_RECONNECT_DELAY_MS = Math.max(
   0,
   Number(globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_DELAY_MS ?? 500) || 500
 );
+const MAX_CONTENT_SCRIPT_RECOVERY_INCIDENTS = 5;
 const BACKEND_API_FETCH_COOLDOWN_MS = Math.max(
   0,
   Number.isFinite(Number(globalThis.__YOETZ_BACKEND_API_FETCH_COOLDOWN_MS))
@@ -127,7 +129,6 @@ const ATTACHMENT_TRACE_PENDING_LEGS = new Set([
 
 const jobs = new Map();
 const terminalJobIds = new Map();
-const terminalFailureJobIds = new Set();
 const contentScriptRecoveries = new Map();
 const chunks = new ChunkAssembler();
 let nativePort = null;
@@ -346,7 +347,7 @@ async function handleNativeMessage(message) {
         jobErrorMessage(job, error, code, detail),
         detail
       );
-    } else if (!job && !terminalFailureJobIds.has(message?.job_id)) {
+    } else if (!job && !terminalJobIds.has(message?.job_id)) {
       postNative(errorEnvelope(message, "extension_error", String(error?.message ?? error), {
         request_id: message?.request_id
       }));
@@ -481,6 +482,10 @@ function modelSelectionFailureDiagnostics(selection) {
     "picker_shape",
     "surface_trust",
     "surface_descendants",
+    "max_effort_label",
+    "advanced_rows",
+    "checkbox_probe",
+    "family_menu_probe",
     "effort_control",
     "effort_move_method",
     "family_status",
@@ -678,7 +683,7 @@ async function completeJobWithExtraction(job, extraction) {
       conversation_id: conversationId,
       conversation_url: conversationUrlForJob(job, conversationId),
       model_strategy: job.model_strategy ?? "select",
-      model_used: job.model_used ?? null,
+      model_used: extraction.model_slug ?? job.model_used ?? null,
       model_selection_status: job.model_selection_status ?? "unavailable",
       warnings: completionWarnings({
         jobWarnings: job.warnings,
@@ -711,16 +716,23 @@ async function completeJobWithExtraction(job, extraction) {
     );
     return;
   }
+  if (TERMINAL_STATUSES.has(job.status)) {
+    return;
+  }
   job.status = "complete";
+  job.terminal_envelope = completeEnvelope;
+  job.terminal_delivered_at = null;
   job.updated_at = Date.now();
-  await persistJob(job);
+  rememberTerminalJob(job.job_id);
+  await persistTerminalJobBestEffort(job);
   const delivered = postNative(completeEnvelope);
   if (!delivered) {
     await recordTerminalDeliveryLost(job, "wait_response");
     return;
   }
+  job.terminal_delivered_at = Date.now();
+  await persistTerminalJobBestEffort(job);
   await closeOwnedTabOnComplete(job);
-  rememberTerminalJob(job.job_id);
   jobs.delete(job.job_id);
   chunks.discard(job.job_id);
 }
@@ -805,11 +817,23 @@ async function continueWaitingResponseJob(job) {
 async function cancelJob(message) {
   const job = requireJob(message.job_id);
   assertJobConnectionCurrent(job);
+  if (TERMINAL_STATUSES.has(job.status)) {
+    postNative(makeEnvelope("job_cancel", {
+      request_id: message.request_id,
+      job_id: job.job_id,
+      run_id: job.run_id,
+      workspace_id: job.workspace_id,
+      capability_token: job.capability_token,
+      payload: { cancelled: false, already_terminal: true }
+    }));
+    return;
+  }
   job.cancelled = true;
   job.status = "cancelled";
+  rememberTerminalJob(job.job_id);
   job.updated_at = Date.now();
   chunks.discard(job.job_id);
-  await persistJob(job);
+  await persistTerminalJobBestEffort(job);
 
   // Best-effort: tell the content script to click the site's stop control AND
   // wait for generation to actually go idle before we tear the tab down — a bare
@@ -866,7 +890,7 @@ async function cancelJob(message) {
     generation_idle: stopConfirmed,
     may_still_be_running: cancelMayStillBeRunning
   }));
-  postNative(makeEnvelope("job_cancel", {
+  const cancelEnvelope = makeEnvelope("job_cancel", {
     request_id: message.request_id,
     job_id: job.job_id,
     run_id: job.run_id,
@@ -880,13 +904,19 @@ async function cancelJob(message) {
       generation_idle: stopConfirmed,
       may_still_be_running: cancelMayStillBeRunning
     }
-  }));
-  // Mark terminal and evict from the in-memory map AFTER the cancel envelope is
-  // posted and the job's terminal status is persisted. Subsequent extract /
-  // send / chunk messages for this job_id will hit requireJob → "unknown job",
-  // and a fresh job_start with the same id will be rejected as duplicate_job
-  // until the terminalJobIds TTL expires.
-  rememberTerminalJob(job.job_id);
+  });
+  job.terminal_envelope = cancelEnvelope;
+  job.terminal_delivered_at = null;
+  await persistTerminalJobBestEffort(job);
+  if (postNative(cancelEnvelope)) {
+    job.terminal_delivered_at = Date.now();
+    await persistTerminalJobBestEffort(job);
+  } else {
+    await recordTerminalDeliveryLost(job, "cancel");
+  }
+  // Evict only after the terminal envelope is posted and its delivery state is
+  // persisted. Late work for this job id is suppressed by terminalJobIds, and a
+  // fresh job_start remains rejected until that entry expires.
   jobs.delete(job.job_id);
 }
 
@@ -1257,6 +1287,15 @@ async function restoreJobsFromStorage({ emitLostState = false } = {}) {
       continue;
     }
     if (TERMINAL_STATUSES.has(job.status)) {
+      rememberTerminalJob(job.job_id);
+      if (job.terminal_envelope && !job.terminal_delivered_at) {
+        if (postNative(job.terminal_envelope)) {
+          job.terminal_delivered_at = Date.now();
+          await persistTerminalJobBestEffort(job);
+        } else {
+          await recordTerminalDeliveryLost(job, job.delivery_lost_phase ?? phaseForStatus(job.status) ?? "upload");
+        }
+      }
       continue;
     }
     if (jobs.has(job.job_id)) {
@@ -2238,7 +2277,10 @@ async function extractDomResponseForJob(job) {
   try {
     return await sendToTab(job.tab_id, { type: "yoetz_extract_response", job });
   } catch (error) {
-    if (!isRecoverableContentScriptError(error) || job.content_script_recovery_attempted) {
+    if (
+      !isRecoverableContentScriptError(error)
+      || Number(job.content_script_recovery_incidents ?? 0) >= MAX_CONTENT_SCRIPT_RECOVERY_INCIDENTS
+    ) {
       throw error;
     }
     await recoverContentScriptJob(job, error);
@@ -2400,7 +2442,8 @@ async function recoverContentScriptJob(job, error, options = {}) {
 }
 
 async function recoverContentScriptJobOnce(job, error, options = {}) {
-  job.content_script_recovery_attempted = true;
+  job.content_script_recovery_incidents = Number(job.content_script_recovery_incidents ?? 0) + 1;
+  job.content_script_recovery_in_progress = true;
   job.content_script_suspended_at = null;
   job.updated_at = Date.now();
   await persistJob(job);
@@ -2411,6 +2454,9 @@ async function recoverContentScriptJobOnce(job, error, options = {}) {
   }));
   await waitForContentScript(job.tab_id, adapterForJob(job));
   const rebound = await sendToTab(job.tab_id, { type: "yoetz_bind_job", job });
+  job.content_script_recovery_in_progress = false;
+  job.updated_at = Date.now();
+  await persistJob(job);
   postNative(progress(job, "content_script_recovered", {
     url: rebound?.url ?? null,
     title: rebound?.title ?? null,
@@ -2421,7 +2467,7 @@ async function recoverContentScriptJobOnce(job, error, options = {}) {
 
 function isRecoverableContentScriptError(error) {
   const message = String(error?.message ?? error);
-  return /Could not establish connection|Receiving end does not exist|Extension context invalidated|message port closed|is not active in this tab/i.test(message);
+  return /Could not establish connection|Receiving end does not exist|Extension context invalidated|message (?:port|channel)(?: is)? closed|A listener indicated an asynchronous response.*channel closed|is not active in this tab/i.test(message);
 }
 
 function isPostSendExtraction(job, extraction) {
@@ -2634,14 +2680,11 @@ function commandError(code, message, detail = {}) {
   return error;
 }
 
-function rememberTerminalJob(jobId, suppressLateErrors = false) {
+function rememberTerminalJob(jobId) {
   if (!jobId) {
     return;
   }
   terminalJobIds.set(jobId, Date.now() + JOB_TTL_MS);
-  if (suppressLateErrors) {
-    terminalFailureJobIds.add(jobId);
-  }
   cleanupTerminalJobIds();
 }
 
@@ -2650,7 +2693,6 @@ function cleanupTerminalJobIds() {
   for (const [jobId, expiresAt] of terminalJobIds.entries()) {
     if (expiresAt <= now) {
       terminalJobIds.delete(jobId);
-      terminalFailureJobIds.delete(jobId);
     }
   }
 }
@@ -2667,14 +2709,18 @@ async function failJob(job, code, message, detail = {}) {
   }
   if (job) {
     job.status = terminalStatus ?? "failed";
+    rememberTerminalJob(job.job_id);
     job.updated_at = Date.now();
     chunks.discard(job.job_id);
-    await persistJob(job);
+    job.terminal_envelope = errorEnvelope(job, code, message, payloadDetail);
+    job.terminal_delivered_at = null;
+    await persistTerminalJobBestEffort(job);
   }
-  const delivered = postNative(errorEnvelope(job, code, message, payloadDetail));
+  const delivered = postNative(job?.terminal_envelope ?? errorEnvelope(job, code, message, payloadDetail));
   if (job) {
     if (delivered) {
-      rememberTerminalJob(job.job_id, true);
+      job.terminal_delivered_at = Date.now();
+      await persistTerminalJobBestEffort(job);
       jobs.delete(job.job_id);
     } else {
       await recordTerminalDeliveryLost(job, payloadDetail.phase ?? phaseForStatus(job.status) ?? "upload");
@@ -2701,6 +2747,16 @@ async function persistJob(job) {
   });
 }
 
+async function persistTerminalJobBestEffort(job) {
+  try {
+    await persistJob(job);
+    return true;
+  } catch (error) {
+    console.warn(`could not persist terminal job ${job?.job_id ?? "unknown"}: ${String(error?.message ?? error)}`);
+    return false;
+  }
+}
+
 function jobsStorageKey(jobId) {
   return `${JOBS_KEY_PREFIX}${jobId}`;
 }
@@ -2715,6 +2771,13 @@ function jobsStorageKey(jobId) {
 // after a restart without bloating storage.
 function strippedJobForStorage(job) {
   const { last_response_progress_text: fullText, ...rest } = job;
+  if (
+    rest.terminal_envelope
+    && nativeEnvelopeByteLength(rest.terminal_envelope) > MAX_PERSISTED_TERMINAL_ENVELOPE_BYTES
+  ) {
+    delete rest.terminal_envelope;
+    rest.terminal_envelope_too_large = true;
+  }
   if (typeof fullText === "string" && fullText.length > 0) {
     rest.last_response_progress_length = fullText.length;
     rest.last_response_progress_tail = fullText.length > RESPONSE_TEXT_PERSIST_TAIL

--- a/extensions/chatgpt-native/src/sites/chatgpt.js
+++ b/extensions/chatgpt-native/src/sites/chatgpt.js
@@ -3,7 +3,7 @@ import { fetchConversationAnswer } from "./chatgpt-backend.js";
 export * from "../chatgpt-dom.js";
 export { fetchConversationAnswer } from "./chatgpt-backend.js";
 
-const CHATGPT_MODEL = "gpt-5-6-sol-pro";
+const CHATGPT_MODEL = "gpt-5-6-sol-extra-high";
 const CHATGPT_ORIGIN = "https://chatgpt.com";
 
 function conversationIdFromUrl(value) {
@@ -52,9 +52,9 @@ function isExpectedConversationIdAssignment(job, expectedConversationId, current
     && normalizeConversationId(current).ok;
 }
 
-function modelUsedLooksLikeSolPro(value) {
+function modelUsedLooksLikeSolExtraHigh(value) {
   const folded = String(value ?? "").toLowerCase();
-  return /\bsol\b/.test(folded) && /\bpro\b/.test(folded);
+  return /\bsol\b/.test(folded) && /\bextra\s+high\b/.test(folded);
 }
 
 function isAcceptableModelSelection(selection) {
@@ -67,7 +67,7 @@ function isAcceptableModelSelection(selection) {
     && selection?.requested_model === CHATGPT_MODEL
     && selection?.family_status === "verified"
     && selection?.effort_status === "verified"
-    && modelUsedLooksLikeSolPro(selection?.model_used);
+    && modelUsedLooksLikeSolExtraHigh(selection?.model_used);
 }
 
 function normalizedResponseText(value) {

--- a/extensions/chatgpt-native/src/sites/chatgpt.js
+++ b/extensions/chatgpt-native/src/sites/chatgpt.js
@@ -52,9 +52,9 @@ function isExpectedConversationIdAssignment(job, expectedConversationId, current
     && normalizeConversationId(current).ok;
 }
 
-function modelUsedLooksLikeSolExtraHigh(value) {
-  const folded = String(value ?? "").toLowerCase();
-  return /\bsol\b/.test(folded) && /\bextra\s+high\b/.test(folded);
+function modelUsedLooksLikeSolMaximum(value) {
+  const folded = String(value ?? "").trim().replace(/\s+/g, " ").toLowerCase();
+  return folded === "gpt-5.6 sol pro" || folded === "gpt-5.6 sol extra high";
 }
 
 function isAcceptableModelSelection(selection) {
@@ -67,7 +67,7 @@ function isAcceptableModelSelection(selection) {
     && selection?.requested_model === CHATGPT_MODEL
     && selection?.family_status === "verified"
     && selection?.effort_status === "verified"
-    && modelUsedLooksLikeSolExtraHigh(selection?.model_used);
+    && modelUsedLooksLikeSolMaximum(selection?.model_used);
 }
 
 function normalizedResponseText(value) {

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -111,7 +111,7 @@ export async function uploadFile(_document, file, options) {
 
 export function configureModelState(_document, job) {
   hooks.configureModelCalls.push(job);
-  return { status: "selected", model_used: "GPT-5.6 Sol Pro", requested_model: "gpt-5-6-sol-pro", family_status: "verified", effort_status: "verified" };
+  return { status: "selected", model_used: "GPT-5.6 Sol Extra High", requested_model: "gpt-5-6-sol-extra-high", family_status: "verified", effort_status: "verified" };
 }
 
 export function sendAcceptanceBaseline() {
@@ -461,7 +461,7 @@ test("content script inspect labels model diagnostics as current chip state", as
   try {
     globalThis.window.name = "yoetz-chatgpt-native:run-inspect:job-inspect";
     hooks.modelSelectionDiagnostics = {
-      modelChip: "GPT-5.6 Sol Pro",
+      modelChip: "GPT-5.6 Sol Extra High",
       modelVerified: true
     };
 

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -2297,6 +2297,19 @@ test("GPT-5.6 Sol picker verifies already-correct state with one menu open", asy
   assert.equal(fixture.menusOpen(), 0);
 });
 
+test("GPT-5.6 Sol picker accepts an Enterprise Pro maximum and reports the actual tier", async () => {
+  const fixture = makeSolPickerFixture({ family: "GPT-5.6 Sol", effort: "Pro" });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "selected");
+  assert.equal(result.model_used, "GPT-5.6 Sol Pro");
+  assert.equal(result.requested_model, "gpt-5-6-sol-extra-high");
+  assert.equal(result.family_status, "verified");
+  assert.equal(result.effort_status, "verified");
+  assert.equal(fixture.effortClicks(), 0);
+});
+
 test("GPT-5.6 Sol menu picker ignores transcript text that describes the Advanced picker", async () => {
   const fixture = makeSolPickerFixture({
     family: "GPT-5.6 Sol",
@@ -2366,6 +2379,21 @@ test("GPT-5.6 Sol Advanced picker moves the scoped effort slider with End", asyn
   assert.equal(result.pill_text, "Extra High");
 });
 
+test("GPT-5.6 Sol Advanced picker accepts Pro at the Enterprise slider maximum", async () => {
+  const fixture = makeSolSliderFixture({
+    keyboardMode: "end",
+    levels: ["Instant", "Medium", "High", "Heavy", "Pro"]
+  });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "selected");
+  assert.equal(result.model_used, "GPT-5.6 Sol Pro");
+  assert.equal(result.requested_model, "gpt-5-6-sol-extra-high");
+  assert.equal(result.effort_control.value_text, "Pro, 5 of 5");
+  assert.equal(result.pill_text, "Pro");
+});
+
 test("GPT-5.6 Sol Advanced picker waits for an expanded Radix surface to finish animating", async () => {
   const fixture = makeSolSliderFixture({ keyboardMode: "end", animatedReveal: true });
 
@@ -2392,7 +2420,7 @@ test("GPT-5.6 Sol structurally trusts its controlled open picker in a frozen bac
   assert.deepEqual(fixture.keyAttempts(), ["End"]);
 });
 
-test("GPT-5.6 Sol fails closed when structural slider max is not Extra High", async () => {
+test("GPT-5.6 Sol fails closed when the structural slider maximum has an unknown label", async () => {
   const fixture = makeSolSliderFixture({
     keyboardMode: "end",
     animatedReveal: true,

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -2225,21 +2225,21 @@ test("GPT-5.6 Sol picker rejects checked GPT-5.5 Pro Extended as stale", async (
   const result = await configureModelState(fixture.doc, {});
 
   assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "GPT-5.6 Sol Pro");
-  assert.equal(result.requested_model, "gpt-5-6-sol-pro");
+  assert.equal(result.model_used, "GPT-5.6 Sol Extra High");
+  assert.equal(result.requested_model, "gpt-5-6-sol-extra-high");
   assert.equal(result.family_status, "verified");
   assert.equal(result.effort_status, "verified");
   assert.equal(fixture.familyClicks(), 1);
-  assert.equal(fixture.effortClicks(), 0, "family switch should preserve the Pro tier");
+  assert.equal(fixture.effortClicks(), 0, "family switch should preserve the Extra High tier");
 });
 
-test("GPT-5.6 Sol picker upgrades High effort to Pro and verifies both proofs", async () => {
+test("GPT-5.6 Sol picker upgrades High effort to Extra High and verifies both proofs", async () => {
   const fixture = makeSolPickerFixture({ family: "GPT-5.6 Sol", effort: "High" });
 
   const result = await configureModelState(fixture.doc, {});
 
   assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "GPT-5.6 Sol Pro");
+  assert.equal(result.model_used, "GPT-5.6 Sol Extra High");
   assert.equal(result.family_status, "verified");
   assert.equal(result.effort_status, "verified");
   assert.equal(fixture.familyClicks(), 0);
@@ -2248,7 +2248,7 @@ test("GPT-5.6 Sol picker upgrades High effort to Pro and verifies both proofs", 
   assert.equal(fixture.menusOpen(), 0, "verification must leave the picker closed");
 });
 
-test("GPT-5.6 Sol picker switches GPT-5.5 Instant to Sol Pro", async () => {
+test("GPT-5.6 Sol picker switches GPT-5.5 Instant to Sol Extra High", async () => {
   const fixture = makeSolPickerFixture({
     family: "GPT-5.5",
     effort: "Instant",
@@ -2258,7 +2258,7 @@ test("GPT-5.6 Sol picker switches GPT-5.5 Instant to Sol Pro", async () => {
   const result = await configureModelState(fixture.doc, {});
 
   assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "GPT-5.6 Sol Pro");
+  assert.equal(result.model_used, "GPT-5.6 Sol Extra High");
   assert.equal(result.family_status, "verified");
   assert.equal(result.effort_status, "verified");
   assert.equal(fixture.familyClicks(), 1);
@@ -2273,7 +2273,7 @@ test("GPT-5.6 Sol picker recovers from the o3 family", async () => {
   const result = await configureModelState(fixture.doc, {});
 
   assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "GPT-5.6 Sol Pro");
+  assert.equal(result.model_used, "GPT-5.6 Sol Extra High");
   assert.equal(result.family_status, "verified");
   assert.equal(result.effort_status, "verified");
   assert.equal(fixture.familyClicks(), 1);
@@ -2282,12 +2282,12 @@ test("GPT-5.6 Sol picker recovers from the o3 family", async () => {
 });
 
 test("GPT-5.6 Sol picker verifies already-correct state with one menu open", async () => {
-  const fixture = makeSolPickerFixture({ family: "GPT-5.6 Sol", effort: "Pro" });
+  const fixture = makeSolPickerFixture({ family: "GPT-5.6 Sol", effort: "Extra High" });
 
   const result = await configureModelState(fixture.doc, {});
 
   assert.equal(result.status, "selected");
-  assert.equal(result.model_used, "GPT-5.6 Sol Pro");
+  assert.equal(result.model_used, "GPT-5.6 Sol Extra High");
   assert.equal(result.family_status, "verified");
   assert.equal(result.effort_status, "verified");
   assert.deepEqual(result.available_families, []);
@@ -2359,11 +2359,11 @@ test("GPT-5.6 Sol Advanced picker moves the scoped effort slider with End", asyn
   assert.equal(result.status, "selected");
   assert.equal(result.picker_shape, "slider");
   assert.equal(result.effort_move_method, "keyboard_end");
-  assert.equal(result.effort_control.value_text, "Pro, 5 of 5");
+  assert.equal(result.effort_control.value_text, "Extra High, 5 of 5");
   assert.deepEqual(fixture.keyAttempts(), ["End"]);
   assert.equal(fixture.pointerAttempts(), 0);
   assert.equal(fixture.pickerOpen(), false);
-  assert.equal(result.pill_text, "Pro");
+  assert.equal(result.pill_text, "Extra High");
 });
 
 test("GPT-5.6 Sol Advanced picker waits for an expanded Radix surface to finish animating", async () => {
@@ -2377,7 +2377,7 @@ test("GPT-5.6 Sol Advanced picker waits for an expanded Radix surface to finish 
   assert.equal(result.status, "selected");
   assert.equal(result.picker_shape, "slider");
   assert.equal(result.effort_move_method, "keyboard_end");
-  assert.equal(result.effort_control.value_text, "Pro, 5 of 5");
+  assert.equal(result.effort_control.value_text, "Extra High, 5 of 5");
   assert.equal(fixture.pickerOpen(), false);
 });
 
@@ -2388,16 +2388,16 @@ test("GPT-5.6 Sol structurally trusts its controlled open picker in a frozen bac
 
   assert.equal(result.status, "selected");
   assert.equal(result.surface_trust, "aria_controls_structural");
-  assert.equal(result.effort_control.value_text, "Pro, 5 of 5");
+  assert.equal(result.effort_control.value_text, "Extra High, 5 of 5");
   assert.deepEqual(fixture.keyAttempts(), ["End"]);
 });
 
-test("GPT-5.6 Sol fails closed when structural slider max is labeled Extra High", async () => {
+test("GPT-5.6 Sol fails closed when structural slider max is not Extra High", async () => {
   const fixture = makeSolSliderFixture({
     keyboardMode: "end",
     animatedReveal: true,
     backgroundFrozen: true,
-    maxLabelOverride: "Extra High",
+    maxLabelOverride: "Expert",
     transcriptEffortDecoy: "Pro, 5 of 5."
   });
 
@@ -2405,8 +2405,40 @@ test("GPT-5.6 Sol fails closed when structural slider max is labeled Extra High"
 
   assert.equal(result.status, "unavailable");
   assert.equal(result.failure_reason, "effort_slider_move_failed");
-  assert.equal(result.effort_control.value_now, 4);
-  assert.equal(result.effort_control.label, "extra high");
+  assert.equal(result.effort_control.value_now, 2);
+  assert.equal(result.max_effort_label, "Expert");
+  assert.deepEqual(fixture.keyAttempts(), ["End", "ArrowLeft", "ArrowLeft"]);
+});
+
+test("GPT-5.6 Sol recognizes volatile effort names, probes max, restores, and fails closed", async () => {
+  const fixture = makeSolSliderFixture({
+    keyboardMode: "end",
+    backgroundFrozen: true,
+    levels: ["Minimal", "Light", "Standard", "Heavy", "Expert"],
+    initialValue: 2,
+    includeSpeedRows: true
+  });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "unavailable");
+  assert.equal(result.failure_reason, "effort_slider_move_failed");
+  assert.equal(result.max_effort_label, "Expert");
+  assert.equal(result.effort_control.label, "light");
+  assert.equal(result.effort_control.value_now, 1);
+  assert.deepEqual(fixture.keyAttempts(), ["End", "ArrowLeft", "ArrowLeft", "ArrowLeft"]);
+  assert.equal(result.effort_move_method, "family_menu_probe");
+  assert.equal(result.checkbox_probe.before.checked, "false");
+  assert.equal(result.checkbox_probe.enabled.checked, "true");
+  assert.equal(result.checkbox_probe.restored.checked, "false");
+  assert.equal(result.checkbox_probe.restore_verified, true);
+  assert.deepEqual(result.family_menu_probe.family_radio_labels, ["GPT-5.6 Sol", "GPT-5.6 Sol Pro", "GPT-5.5"]);
+  assert.equal(result.family_menu_probe.family_options.some((option) => option.label === "GPT-5.6 Sol" && option.checked === "true"), true);
+  assert.equal(result.family_menu_probe.family_options.some((option) => option.label === "GPT-5.6 Sol Pro" && option.checked === "false"), true);
+  assert.equal(result.family_menu_probe.close_verified, true);
+  assert.equal(fixture.familyMenuOpen(), false);
+  assert.equal(result.advanced_rows.some((row) => row.label === "Speed" && row.value === "Standard"), true);
+  assert.equal(result.advanced_rows.some((row) => row.role === "menuitemcheckbox" && row.checked === "false"), true);
 });
 
 test("GPT-5.6 Sol rejects an identical hidden picker without trigger ownership", async () => {
@@ -2445,7 +2477,7 @@ test("structural picker failures capture bounded failure-time descendant topolog
     animatedReveal: true,
     backgroundFrozen: true,
     keyboardMode: "end",
-    maxLabelOverride: "Extra High"
+    maxLabelOverride: "Expert"
   });
 
   const result = await configureModelState(fixture.doc, {});
@@ -2453,7 +2485,7 @@ test("structural picker failures capture bounded failure-time descendant topolog
   assert.equal(result.status, "unavailable");
   assert.equal(result.failure_reason, "effort_slider_move_failed");
   assert.equal(result.surface_trust, "aria_controls_structural");
-  assert.equal(result.surface_descendants.some((node) => node.role === "slider" && node.aria_valuenow === "4"), true);
+  assert.equal(result.surface_descendants.some((node) => node.role === "slider" && node.aria_valuenow === "2"), true);
   assert.equal(result.surface_descendants.some((node) => node.role === "menuitem" && node.aria_haspopup === "menu"), true);
 });
 
@@ -2492,7 +2524,7 @@ test("GPT-5.6 Sol Advanced picker accepts trailing punctuation in aria-valuetext
 
   assert.equal(result.status, "selected");
   assert.equal(result.effort_move_method, "keyboard_end");
-  assert.equal(result.effort_control.value_text, "Pro, 5 of 5.");
+  assert.equal(result.effort_control.value_text, "Extra High, 5 of 5.");
 });
 
 test("GPT-5.6 Sol Advanced picker falls through End to bounded ArrowRight steps", async () => {
@@ -2621,7 +2653,7 @@ function makeSolPickerFixture({
     familyMenu = null;
   };
   const updatePill = (remount = false) => {
-    const pillEffort = currentEffort === "Pro Extended" ? "Pro" : currentEffort;
+    const pillEffort = currentEffort === "Pro Extended" ? "Extra High" : currentEffort;
     const label = currentFamily === "GPT-5.6 Sol" ? pillEffort : `5.5\n${pillEffort}`;
     if (remount && remountPillOnSelection) {
       const previousPill = pill;
@@ -2652,8 +2684,8 @@ function makeSolPickerFixture({
           if (label === "GPT-5.6 Sol" || label === "GPT-5.5") {
             currentFamily = label;
             if (currentFamily === "GPT-5.6 Sol") {
-              currentEffort = currentEffort === "Pro Extended" ? "Pro" : currentEffort === "Instant" ? "Medium" : currentEffort;
-            } else if (currentEffort === "Pro") {
+              currentEffort = currentEffort === "Pro Extended" ? "Extra High" : currentEffort === "Instant" ? "Medium" : currentEffort;
+            } else if (currentEffort === "Extra High") {
               currentEffort = "Pro Extended";
             }
             familyClickCount += 1;
@@ -2734,11 +2766,13 @@ function makeSolSliderFixture({
   backgroundFrozen = false,
   disconnectedTrigger = false,
   maxLabelOverride = null,
+  levels = ["Instant", "Medium", "High", "Heavy", "Extra High"],
+  initialValue = 3,
+  includeSpeedRows = false,
   transcriptEffortDecoy = null,
   familyLabel = "GPT-5.6 Sol"
 } = {}) {
-  const levels = ["Instant", "Medium", "High", "Extra High", "Pro"];
-  let currentValue = 3;
+  let currentValue = initialValue;
   let panel = null;
   let effortSlider = null;
   let effortLabel = null;
@@ -2798,6 +2832,7 @@ function makeSolSliderFixture({
       }
       if (keyboardMode === "end" && event.key === "End") updateValue(5);
       if (keyboardMode === "arrows" && event.key === "ArrowRight") updateValue(currentValue + 1);
+      if (event.key === "ArrowLeft") updateValue(currentValue - 1);
     },
     onPointerDown: () => {
       pointerAttemptCount += 1;
@@ -2824,6 +2859,7 @@ function makeSolSliderFixture({
       family.setAttribute("data-state", "open");
       familyMenu = new FakeElement("div", { id: "family-picker", role: "menu", "data-state": "open", style: "opacity:0" });
       const oldFamily = new FakeElement("div", { role: "menuitemradio", "aria-checked": familyLabel === "GPT-5.5" ? "true" : "false" }, "GPT-5.5");
+      const proFamily = new FakeElement("div", { role: "menuitemradio", "aria-checked": "false" }, "GPT-5.6 Sol Pro");
       const solFamily = new FakeElement("div", {
         role: "menuitemradio",
         "aria-checked": familyLabel === "GPT-5.6 Sol" ? "true" : "false",
@@ -2839,11 +2875,20 @@ function makeSolSliderFixture({
           familyMenu = null;
         }
       }, "GPT-5.6 Sol");
-      familyMenu.append(oldFamily, solFamily);
+      familyMenu.append(solFamily, proFamily, oldFamily);
       body.append(familyMenu);
     };
     const family = backgroundFrozen
-      ? new FakeElement("div", { role: "menuitem", tabindex: "0", "aria-haspopup": "menu", "aria-expanded": "false", "aria-controls": "family-picker", "data-state": "closed", onPointerDown: openFamilyMenu }, `Model\n${familyLabel}`)
+      ? new FakeElement("div", { role: "menuitem", tabindex: "0", "aria-haspopup": "menu", "aria-expanded": "false", "aria-controls": "family-picker", "data-state": "closed", onPointerDown: openFamilyMenu, onKeyDown: (event) => {
+        if (event.key !== "Escape") return;
+        family.setAttribute("aria-expanded", "false");
+        family.setAttribute("data-state", "closed");
+        if (familyMenu) {
+          body.children = body.children.filter((child) => child !== familyMenu);
+          familyMenu.parentElement = null;
+          familyMenu = null;
+        }
+      } }, `Model\n${familyLabel}`)
         .append(new FakeElement("div", {}, "Model"), (familyValueNode = new FakeElement("div", {}, familyLabel)))
       : new FakeElement("button", { "aria-haspopup": "menu" }, "GPT-5.6 Sol");
     if (backgroundFrozen) {
@@ -2860,6 +2905,35 @@ function makeSolSliderFixture({
         simple.append(sliderControl, effortLabel);
       }
       advanced.append(new FakeElement("div", { role: "menuitem", tabindex: "0", "aria-expanded": "false" }, "Advanced"), family);
+      if (includeSpeedRows) {
+        const speedRow = new FakeElement("div", { role: "menuitem" }, "Speed Standard")
+          .append(new FakeElement("span", {}, "Speed"), new FakeElement("span", {}, "Standard"));
+        const tooltip = new FakeElement("div", { id: "pro-speed-tooltip", role: "tooltip" }, "Consumes usage limits faster");
+        let speedMenu = null;
+        const checkbox = new FakeElement("div", {
+          role: "menuitemcheckbox",
+          "aria-checked": "false",
+          "aria-describedby": "pro-speed-tooltip",
+          onKeyDown: (event) => {
+            if (event.key !== " ") return;
+            const enabled = checkbox.getAttribute("aria-checked") !== "true";
+            checkbox.setAttribute("aria-checked", String(enabled));
+            if (enabled) {
+              speedMenu = new FakeElement("div", { role: "menu" })
+                .append(
+                  new FakeElement("div", { role: "menuitemradio", "aria-checked": "true" }, "Standard"),
+                  new FakeElement("div", { role: "menuitemradio", "aria-checked": "false" }, "Extended")
+                );
+              speedRow.append(speedMenu);
+            } else if (speedMenu) {
+              speedRow.children = speedRow.children.filter((child) => child !== speedMenu);
+              speedMenu.parentElement = null;
+              speedMenu = null;
+            }
+          }
+        }, "Faster Smarter").append(new FakeElement("span", {}, "Faster"), new FakeElement("span", {}, "Smarter"));
+        advanced.append(speedRow, checkbox, tooltip);
+      }
       group.append(simple, advanced);
       panel.append(group);
     } else {
@@ -2911,7 +2985,8 @@ function makeSolSliderFixture({
     pointerAttempts: () => pointerAttemptCount,
     pickerOpen: () => Boolean(panel),
     panel: () => panel,
-    familyClicks: () => familyClickCount
+    familyClicks: () => familyClickCount,
+    familyMenuOpen: () => Boolean(familyMenu)
   };
 }
 

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -78,7 +78,7 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
             return {
               ok: true,
               payload: sentJobs.has(message.job.job_id) && releasableJobs.has(message.job.job_id)
-                ? { method: "assistant_dom_fallback", text: `answer ${message.job.job_id}`, is_generating: false, assistant_count: 1, copy_button_count: 1, has_copy_button: true, turn_index: 0, conversation_id: `conv-${message.job.job_id}` }
+                ? { method: "assistant_dom_fallback", text: `answer ${message.job.job_id}`, is_generating: false, assistant_count: 1, copy_button_count: 1, has_copy_button: true, turn_index: 0, conversation_id: `conv-${message.job.job_id}`, model_slug: "gpt-5-6-pro" }
                 : sentJobs.has(message.job.job_id)
                   ? { method: "assistant_dom_fallback", text: `partial ${message.job.job_id}`, is_generating: true, assistant_count: 1, copy_button_count: 0, has_copy_button: false, turn_index: 0, conversation_id: `conv-${message.job.job_id}` }
                   : { method: "none", text: "", is_generating: false, assistant_count: 0, turn_index: -1 }
@@ -162,6 +162,10 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
       port.messages.find((message) => message.type === "job_complete" && message.job_id === "job_a")?.payload.conversation_url,
       "https://chatgpt.com/c/conv-job_a"
     );
+    assert.equal(
+      port.messages.find((message) => message.type === "job_complete" && message.job_id === "job_a")?.payload.model_used,
+      "gpt-5-6-pro"
+    );
     assert.equal(sentToTabs.filter((item) => item.message.type === "yoetz_upload_file").length, 2);
     for (const jobId of jobs) {
       const ownedTabIds = new Set(
@@ -173,7 +177,7 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
     }
     assert.equal(
       sentToTabs.find((item) => item.message.type === "yoetz_configure_model" && item.message.job.job_id === "job_b")?.message.job.model,
-      "gpt-5-6-sol-pro"
+      "gpt-5-6-sol-extra-high"
     );
   } finally {
     globalThis.chrome = originalChrome;
@@ -1641,7 +1645,7 @@ test("service worker fails fast on metadata manual handoff detected while waitin
   }
 });
 
-test("service worker fails closed when GPT-5.6 Sol Pro is unavailable", async () => {
+test("service worker fails closed when GPT-5.6 Sol Extra High is unavailable", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
   const sentToTabs = [];
@@ -1664,7 +1668,7 @@ test("service worker fails closed when GPT-5.6 Sol Pro is unavailable", async ()
               payload: {
                 status: "unavailable",
                 model_used: "Default",
-                requested_model: "gpt-5-6-sol-pro",
+                requested_model: "gpt-5-6-sol-extra-high",
                 available_options: ["Default"],
                 failure_reason: "effort_slider_move_failed",
                 picker_shape: "slider",
@@ -1710,7 +1714,7 @@ test("service worker fails closed when GPT-5.6 Sol Pro is unavailable", async ()
   }
 });
 
-test("service worker fails resumed jobs before upload when GPT-5.6 Sol Pro is unavailable", async () => {
+test("service worker fails resumed jobs before upload when GPT-5.6 Sol Extra High is unavailable", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
   const createdTabs = [];
@@ -1737,7 +1741,7 @@ test("service worker fails resumed jobs before upload when GPT-5.6 Sol Pro is un
               payload: {
                 status: "unavailable",
                 model_used: "Default",
-                requested_model: "gpt-5-6-sol-pro",
+                requested_model: "gpt-5-6-sol-extra-high",
                 family_status: "unverified",
                 effort_status: "unverified",
                 available_options: ["Default"],
@@ -1775,7 +1779,7 @@ test("service worker fails resumed jobs before upload when GPT-5.6 Sol Pro is un
   }
 });
 
-test("service worker fails closed when GPT-5.6 Sol Pro selection is only kept_current", async () => {
+test("service worker fails closed when GPT-5.6 Sol Extra High selection is only kept_current", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
   const sentToTabs = [];
@@ -1903,7 +1907,7 @@ test("service worker keeps the current-model warning to one final payload entry"
   }
 });
 
-test("service worker fails closed when GPT-5.6 Sol Pro selection fails", async () => {
+test("service worker fails closed when GPT-5.6 Sol Extra High selection fails", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
   let tabId = 0;
@@ -1942,7 +1946,7 @@ test("service worker fails closed when GPT-5.6 Sol Pro selection fails", async (
     await eventually(() => port.messages.some((message) => message.type === "job_error"));
     const error = port.messages.find((message) => message.type === "job_error");
     assert.equal(error.payload.code, "model_selection_failed");
-    assert.equal(error.payload.requested_model, "gpt-5-6-sol-pro");
+    assert.equal(error.payload.requested_model, "gpt-5-6-sol-extra-high");
     assert.equal(port.messages.some((message) => message.payload?.phase === "ready_for_file"), false);
   } finally {
     globalThis.chrome = originalChrome;
@@ -2001,7 +2005,7 @@ test("service worker rejects the legacy extended_status selection proof", async 
   }
 });
 
-test("service worker accepts only verified GPT-5.6 Sol Pro selection", async () => {
+test("service worker accepts only verified GPT-5.6 Sol Extra High selection", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
   let tabId = 0;
@@ -2021,8 +2025,8 @@ test("service worker accepts only verified GPT-5.6 Sol Pro selection", async () 
               ok: true,
               payload: {
                 status: "selected",
-                model_used: "GPT-5.6 Sol Pro",
-                requested_model: "gpt-5-6-sol-pro",
+                model_used: "GPT-5.6 Sol Extra High",
+                requested_model: "gpt-5-6-sol-extra-high",
                 family_status: "verified",
                 effort_status: "verified"
               }
@@ -2756,7 +2760,7 @@ test("service worker classifies final affordance without scoped assistant text",
               payload: sent
                 ? {
                     method: "page_text_fallback",
-                    text: "Skip to content\nbundle.md\nFile\nReview the attached file and provide your analysis.\n\nI\n\nGPT-5.6 Sol Pro",
+                    text: "Skip to content\nbundle.md\nFile\nReview the attached file and provide your analysis.\n\nI\n\nGPT-5.6 Sol Extra High",
                     is_generating: false,
                     assistant_count: 1,
                     user_count: 1,
@@ -6232,7 +6236,7 @@ test("service worker idempotently rebinds a persisted bfcache restore without re
             return { ok: true, payload: { rebound: true, url: "https://chatgpt.com/", title: "ChatGPT" } };
           case "yoetz_extract_response":
             if (sent && bindCalls === 0) {
-              throw new Error("Could not establish connection. Receiving end does not exist.");
+              throw new Error("A listener indicated an asynchronous response by returning true, but the message channel closed before a response was received");
             }
             if (sent && !bfcacheRestoreStarted) {
               markInFlightExtractionStarted();
@@ -6287,7 +6291,7 @@ test("service worker idempotently rebinds a persisted bfcache restore without re
     bfcacheRestoreStarted = true;
     const restored = lifecycle("pageshow");
     await lifecycleBindStarted;
-    rejectInFlightExtraction(new Error("Could not establish connection. Receiving end does not exist."));
+    rejectInFlightExtraction(new Error("The message channel closed before a response was received."));
     releaseLifecycleBind();
     assert.equal((await restored).ok, true);
     // A duplicate restore observes the already rebound state without rebinding;
@@ -7129,6 +7133,55 @@ test("service worker preserves terminal_delivery_lost jobs on restore", async ()
   }
 });
 
+test("service worker replays an undelivered persisted terminal envelope once on reconnect", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const storage = makeStorage();
+  const terminalEnvelope = envelope("job_complete", "job_terminal_replay", {
+    is_final: true,
+    response: "persisted answer"
+  });
+  await storage.set({
+    "jobs.job_terminal_replay": {
+      job_id: "job_terminal_replay",
+      run_id: "run_test",
+      workspace_id: "workspace_test",
+      capability_token: "cap_test",
+      status: "complete",
+      terminal_envelope: terminalEnvelope,
+      terminal_delivered_at: null,
+      started_at: Date.now(),
+      updated_at: Date.now()
+    },
+    "jobs.job_terminal_too_large": {
+      job_id: "job_terminal_too_large",
+      status: "complete",
+      terminal_envelope_too_large: true,
+      terminal_delivered_at: null,
+      started_at: Date.now(),
+      updated_at: Date.now()
+    }
+  });
+  globalThis.chrome = chromeStub({ port, storage, tabs: {} });
+
+  try {
+    await import(`../src/service-worker.js?terminal_replay=${Date.now()}`);
+    await eventually(() => port.messages.some((message) => (
+      message.type === "job_complete" && message.job_id === "job_terminal_replay"
+    )));
+    const persisted = (await storage.get("jobs.job_terminal_replay"))["jobs.job_terminal_replay"];
+    assert.ok(persisted.terminal_delivered_at);
+    assert.equal(port.messages.some((message) => message.job_id === "job_terminal_too_large"), false);
+
+    port.messages.length = 0;
+    port.emit(envelope("reconnect", "reconnect_after_terminal"));
+    await eventually(() => port.messages.some((message) => message.type === "reconnect"));
+    assert.equal(port.messages.some((message) => message.job_id === "job_terminal_replay"), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker cancelJob isolates one of two active ChatGPT jobs", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
@@ -7223,6 +7276,9 @@ test("service worker cancelJob isolates one of two active ChatGPT jobs", async (
     assert.equal(cancelEnvelope.payload.cancelled, true);
     assert.equal(cancelEnvelope.payload.stop_clicked, true);
     assert.equal(cancelEnvelope.payload.tab_disposition, "closed");
+    assert.equal(port.messages.filter((m) => (
+      m.job_id === "job_cancel_a" && ["job_cancel", "job_complete", "job_error"].includes(m.type)
+    )).length, 1);
     const cancelledProgress = port.messages.find((m) =>
       m.type === "job_progress"
       && m.job_id === "job_cancel_a"
@@ -7236,8 +7292,8 @@ test("service worker cancelJob isolates one of two active ChatGPT jobs", async (
     assert.equal(survivor.payload.response, "survivor complete");
     assert.notEqual(jobTabs.get("job_cancel_a"), jobTabs.get("job_survivor_b"));
 
-    // Subsequent extract_response for the cancelled job_id must surface
-    // "unknown job" — the in-memory map can no longer carry a cancelled entry.
+    // Late work unwinding after a terminal claim must not emit a second terminal
+    // envelope for the cancelled job.
     port.messages.length = 0;
     port.emit(envelope("job_file_chunk", "job_cancel_a", {
       sequence: 0,
@@ -7247,9 +7303,8 @@ test("service worker cancelJob isolates one of two active ChatGPT jobs", async (
       mime_type: "text/markdown",
       bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
     }));
-    await eventually(() => port.messages.some((m) => m.type === "job_error" && m.job_id === "job_cancel_a"));
-    const followupError = port.messages.find((m) => m.type === "job_error" && m.job_id === "job_cancel_a");
-    assert.match(String(followupError.payload.message ?? ""), /unknown job/);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    assert.equal(port.messages.some((m) => m.job_id === "job_cancel_a"), false);
   } finally {
     globalThis.chrome = originalChrome;
   }
@@ -7646,6 +7701,22 @@ test("service worker preserves legacy success behavior when the close gate is ab
   assert.equal(result.shard.tab_disposition, undefined);
 });
 
+test("service worker delivers a large terminal response live without persisting its envelope", async () => {
+  const responseText = "x".repeat(1024 * 1024 + 4096);
+  const result = await runSuccessfulCompletionCase({
+    jobId: "job_large_terminal_envelope",
+    responseText
+  });
+
+  assert.equal(
+    result.messages.find((message) => message.type === "job_complete")?.payload.response.length,
+    responseText.length
+  );
+  assert.equal(result.shard.status, "complete");
+  assert.equal(result.shard.terminal_envelope, undefined);
+  assert.equal(result.shard.terminal_envelope_too_large, true);
+});
+
 test("service worker keeps the tab when successful completion delivery is lost", async () => {
   const result = await runSuccessfulCompletionCase({
     jobId: "job_close_delivery_lost",
@@ -7917,7 +7988,8 @@ async function runSuccessfulCompletionCase({
   jobId,
   closeTabOnComplete,
   failCompleteDelivery = false,
-  removeError = null
+  removeError = null,
+  responseText = "done"
 }) {
   const originalChrome = globalThis.chrome;
   const port = makePort();
@@ -7973,7 +8045,7 @@ async function runSuccessfulCompletionCase({
               ok: true,
               payload: {
                 method: "backend_api",
-                text: "done",
+                text: responseText,
                 is_generating: false,
                 node_fresh: true,
                 node_id: `answer-${jobId}`,
@@ -7990,7 +8062,7 @@ async function runSuccessfulCompletionCase({
               payload: sent
                 ? {
                     method: "assistant_dom_fallback",
-                    text: "done",
+                    text: responseText,
                     is_generating: false,
                     assistant_count: 1,
                     user_count: 1,
@@ -8066,8 +8138,8 @@ async function runSuccessfulCompletionCase({
 function verifiedSolProSelection() {
   return {
     status: "selected",
-    model_used: "GPT-5.6 Sol Pro",
-    requested_model: "gpt-5-6-sol-pro",
+    model_used: "GPT-5.6 Sol Extra High",
+    requested_model: "gpt-5-6-sol-extra-high",
     family_status: "verified",
     effort_status: "verified"
   };

--- a/extensions/chatgpt-native/tests/sites.test.js
+++ b/extensions/chatgpt-native/tests/sites.test.js
@@ -119,6 +119,20 @@ test("ChatGPT adapter owns conversation and model policy", () => {
     requested_model: "gpt-5-6-sol-extra-high",
     family_status: "verified",
     effort_status: "verified",
+    model_used: "GPT-5.6 Sol Pro"
+  }), true);
+  assert.equal(adapter.isAcceptableModelSelection({
+    status: "selected",
+    requested_model: "gpt-5-6-sol-extra-high",
+    family_status: "verified",
+    effort_status: "verified",
+    model_used: "GPT-5.6 Sol Expert"
+  }), false);
+  assert.equal(adapter.isAcceptableModelSelection({
+    status: "selected",
+    requested_model: "gpt-5-6-sol-extra-high",
+    family_status: "verified",
+    effort_status: "verified",
     model_used: "GPT-5.6 Instant"
   }), false);
   assert.equal(adapter.completion.supportsBackendApiFallback, true);

--- a/extensions/chatgpt-native/tests/sites.test.js
+++ b/extensions/chatgpt-native/tests/sites.test.js
@@ -109,14 +109,14 @@ test("ChatGPT adapter owns conversation and model policy", () => {
   }, provisionalConversationId, assignedConversationId), false);
   assert.equal(adapter.isAcceptableModelSelection({
     status: "selected",
-    requested_model: "gpt-5-6-sol-pro",
+    requested_model: "gpt-5-6-sol-extra-high",
     family_status: "verified",
     effort_status: "verified",
-    model_used: "GPT-5.6 Sol Pro"
+    model_used: "GPT-5.6 Sol Extra High"
   }), true);
   assert.equal(adapter.isAcceptableModelSelection({
     status: "selected",
-    requested_model: "gpt-5-6-sol-pro",
+    requested_model: "gpt-5-6-sol-extra-high",
     family_status: "verified",
     effort_status: "verified",
     model_used: "GPT-5.6 Instant"

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -51,10 +51,10 @@ name: chatgpt
 # transports connect directly to Chrome via CDP.
 #
 # Variables:
-#   This recipe supports exactly one ChatGPT target: GPT-5.6 Sol with Extra High effort.
+#   This recipe supports exactly one ChatGPT target: GPT-5.6 Sol at the account maximum tier.
 #   `model` and `extended` overrides are intentionally unsupported.
 #   Selection is fail-closed unless the picker proves both the GPT-5.6 Sol
-#              family and Extra High max-tier effort in one verification pass. The legacy
+#              family and a known max-tier label (Pro or Extra High) in one verification pass.
 #              model-switcher DOM is rejected with a diagnostic breadcrumb.
 #   prompt   — prompt text to send with the attachment. For Yoetz bundle
 #              sessions, typed ChatGPT transports default this to bundle.json's
@@ -167,7 +167,7 @@ steps:
   # Click send once the typed prompt has enabled the button.
   - action: chatgpt_send
 
-  # Poll for response completion. Default 90min timeout for GPT-5.6 Sol Extra High;
+  # Poll for response completion. Default 90min timeout for GPT-5.6 Sol at maximum effort;
   # override with --var wait_timeout_ms=N or --var wait_interval_ms=N.
   - action: chatgpt_wait_response
     args: ["--interval-ms", "{{wait_interval_ms}}", "--timeout-ms", "{{wait_timeout_ms}}"]

--- a/recipes/chatgpt.yaml
+++ b/recipes/chatgpt.yaml
@@ -51,10 +51,10 @@ name: chatgpt
 # transports connect directly to Chrome via CDP.
 #
 # Variables:
-#   This recipe supports exactly one ChatGPT target: GPT-5.6 Sol with Pro intelligence.
+#   This recipe supports exactly one ChatGPT target: GPT-5.6 Sol with Extra High effort.
 #   `model` and `extended` overrides are intentionally unsupported.
 #   Selection is fail-closed unless the picker proves both the GPT-5.6 Sol
-#              family and Pro effort in one verification pass. The legacy
+#              family and Extra High max-tier effort in one verification pass. The legacy
 #              model-switcher DOM is rejected with a diagnostic breadcrumb.
 #   prompt   — prompt text to send with the attachment. For Yoetz bundle
 #              sessions, typed ChatGPT transports default this to bundle.json's
@@ -167,7 +167,7 @@ steps:
   # Click send once the typed prompt has enabled the button.
   - action: chatgpt_send
 
-  # Poll for response completion. Default 90min timeout for GPT-5.6 Sol Pro;
+  # Poll for response completion. Default 90min timeout for GPT-5.6 Sol Extra High;
   # override with --var wait_timeout_ms=N or --var wait_interval_ms=N.
   - action: chatgpt_wait_response
     args: ["--interval-ms", "{{wait_interval_ms}}", "--timeout-ms", "{{wait_timeout_ms}}"]

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -238,8 +238,8 @@ Chrome remote-debugging approval friction, recommend the opt-in
 flow, load/update the extension in Chrome, run `doctor`, then target the stable
 `extension_instance_id` when multiple profiles are open.
 The recipe requires ChatGPT's GPT-5.6 composer-pill picker. Yoetz targets only
-GPT-5.6 Sol with the maximum available Extra High effort tier and fails closed if that selection cannot be
-proven; Enterprise accounts still on the legacy picker are rejected explicitly.
+GPT-5.6 Sol at the account's maximum effort tier (`Pro` or `Extra High`) and fails closed if that selection
+cannot be proven; unknown maximum labels and Enterprise accounts still on the legacy picker are rejected explicitly.
 
 Do not silently switch transports after upload/send/wait side effects. If the
 extension reports a terminal ChatGPT phase, preserve the manual-recovery tab and
@@ -502,9 +502,9 @@ Requires Node >= 24.4. If macOS shows a Keychain prompt for `Chrome Safe Storage
 
 ### Use ChatGPT Pro via recipe
 
-The built-in ChatGPT recipe always targets GPT-5.6 Sol with the maximum available Extra High effort tier.
+The built-in ChatGPT recipe always targets GPT-5.6 Sol at the account's verified maximum effort tier (`Pro` or `Extra High`).
 Do not pass `model` or `extended` overrides; the CLI rejects them. An unproven
-An unverified GPT-5.6 Sol + Extra High selection is a hard failure before upload/send, including
+GPT-5.6 Sol maximum-tier selection is a hard failure before upload/send, including
 Enterprise accounts that still expose the legacy picker.
 
 ```bash

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -238,7 +238,7 @@ Chrome remote-debugging approval friction, recommend the opt-in
 flow, load/update the extension in Chrome, run `doctor`, then target the stable
 `extension_instance_id` when multiple profiles are open.
 The recipe requires ChatGPT's GPT-5.6 composer-pill picker. Yoetz targets only
-GPT-5.6 Sol with Pro intelligence and fails closed if that selection cannot be
+GPT-5.6 Sol with the maximum available Extra High effort tier and fails closed if that selection cannot be
 proven; Enterprise accounts still on the legacy picker are rejected explicitly.
 
 Do not silently switch transports after upload/send/wait side effects. If the
@@ -502,9 +502,9 @@ Requires Node >= 24.4. If macOS shows a Keychain prompt for `Chrome Safe Storage
 
 ### Use ChatGPT Pro via recipe
 
-The built-in ChatGPT recipe always targets GPT-5.6 Sol with Pro intelligence.
+The built-in ChatGPT recipe always targets GPT-5.6 Sol with the maximum available Extra High effort tier.
 Do not pass `model` or `extended` overrides; the CLI rejects them. An unproven
-GPT-5.6 Sol + Pro selection is a hard failure before upload/send, including
+An unverified GPT-5.6 Sol + Extra High selection is a hard failure before upload/send, including
 Enterprise accounts that still expose the legacy picker.
 
 ```bash


### PR DESCRIPTION
## Summary

Two connected changes, both evidence-driven from live probes and the post-release deep review.

### Re-pin: GPT-5.6 Sol + Extra High (closes #400)

OpenAI removed the Pro tier from the composer picker for this account class on 2026-08-12. Four capture-and-restore probes exhausted every surface: effort slider maxes at "Extra High" (5 slots), the Faster/Smarter checkbox is a Standard/Fast speed toggle, and the family submenu offers Sol / Terra / Luna / 5.5 Legacy — no Pro anywhere. The recipe now pins the maximum available tier: family GPT-5.6 Sol + effort "Extra High" (exact label at max position, fail-closed on any rename), speed untouched. `requested_model=gpt-5-6-sol-extra-high`; `model_used` prefers the assistant's `data-message-model-slug` (live ground truth: `gpt-5.6-sol-wm`). Effort-label recognition is grammar-based ("X, N of M" + numeric-ARIA ordinal agreement) so tier renames self-diagnose; all probe machinery stays wired to the failure path.

### Tier-1 hardening from the ChatGPT deep review (4 confirmed blockers)

- Recoverable-error classifier now matches Chrome's actual bfcache rejection wording ("message channel closed" + listener variant) — previously only "message port closed", letting the core bfcache scenario bypass recovery and terminally fail a submitted job.
- Per-incident recovery tracking (cap 5) replaces the sticky one-shot flag: multiple bfcache cycles in one long job all recover.
- Cancellation terminal-claim: synchronous claim before the first await, `already_terminal` cancel response, and late-error suppression extended to all terminal ids — exactly one terminal envelope per job.
- Terminal-envelope durability: persisted (size-gated at 1MiB, best-effort so persistence failure never blocks live delivery) and replayed once on worker restart; restore seeds the idempotency ledger for every terminal shard.

Tier-2 findings (suspension-aware parking, poller-lease ownership) land next as their own reviewed change; backlog issues follow.

## Validation

- Extension suite 346/346; cargo workspace green; hybrid must-fail proofs for the pin and each Tier-1 counterexample.
- Live acceptance on the staged build: verified Sol+Extra-High selection, 310KB upload, real mid-run bfcache suspend/rebind with no replay, clean `copy_button` completion (run 20260812T073649Z_b99f1a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbMozs4Nt8Thd5zWRkuNQr