### PR TITLE
fix(browser): terminal-envelope dedup and capability-gated ACK (#406 phase 1)

### DIFF
--- a/crates/yoetz-cli/src/browser_extension_native.rs
+++ b/crates/yoetz-cli/src/browser_extension_native.rs
@@ -3340,7 +3340,7 @@ fn unsupported_socket_error() -> io::Error {
 #[cfg(unix)]
 mod native_host_unix {
     use super::*;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::os::unix::fs::{FileTypeExt, PermissionsExt};
     use std::os::unix::net::{UnixListener, UnixStream};
     use std::thread;
@@ -3381,6 +3381,12 @@ mod native_host_unix {
         native_instance_id: String,
         socket_path: PathBuf,
         instance_path: PathBuf,
+    }
+
+    #[derive(Default)]
+    struct ExtensionSessionState {
+        terminal_ack_capable: bool,
+        terminal_job_ids: HashSet<String>,
     }
 
     impl SocketFileGuard {
@@ -3438,6 +3444,7 @@ mod native_host_unix {
 
         let stdout = Arc::new(Mutex::new(io::stdout()));
         let clients: Clients = Arc::new(Mutex::new(HashMap::new()));
+        let mut extension_session = ExtensionSessionState::default();
         let accept_stdout = Arc::clone(&stdout);
         let accept_clients = Arc::clone(&clients);
         thread::spawn(move || {
@@ -3469,7 +3476,14 @@ mod native_host_unix {
                         record_protocol_mismatch(&paths, &envelope, &err)?;
                         continue;
                     }
-                    route_extension_message(envelope, &clients, &stdout, &paths, &runtime)?;
+                    route_extension_message(
+                        envelope,
+                        &clients,
+                        &stdout,
+                        &paths,
+                        &runtime,
+                        &mut extension_session,
+                    )?;
                 }
                 Err(err) if is_disconnect_error(&err) => {
                     notify_clients_transport_lost(&clients);
@@ -3731,12 +3745,38 @@ mod native_host_unix {
         stdout: &Arc<Mutex<io::Stdout>>,
         paths: &ExtensionPaths,
         runtime: &NativeHostRuntime,
+        extension_session: &mut ExtensionSessionState,
     ) -> Result<()> {
+        if envelope.kind == "hello" {
+            extension_session.terminal_ack_capable = envelope
+                .payload
+                .get("capabilities")
+                .and_then(Value::as_array)
+                .is_some_and(|capabilities| {
+                    capabilities
+                        .iter()
+                        .any(|capability| capability.as_str() == Some("terminal_ack"))
+                });
+        }
+
         let Some(job_id) = envelope.job_id.clone() else {
             record_unrouted_extension_message(paths, &envelope)?;
             record_instance_activity(runtime, &envelope)?;
             return Ok(());
         };
+        let terminal_sequence = terminal_sequence(&envelope)?;
+        if let Some(sequence) = terminal_sequence {
+            if extension_session.terminal_job_ids.contains(&job_id) {
+                eprintln!(
+                    "yoetz chrome native dropped duplicate terminal envelope `{}` for {job_id}",
+                    envelope.kind
+                );
+                acknowledge_terminal(stdout, &envelope, sequence, extension_session)?;
+                record_instance_activity(runtime, &envelope)?;
+                return Ok(());
+            }
+        }
+        let mut delivered_terminal_sequence = None;
         let mut remove_client = matches!(
             envelope.kind.as_str(),
             "job_complete" | "job_error" | "job_cancel" | "pair_complete"
@@ -3808,22 +3848,27 @@ mod native_host_unix {
                     let _ = forward_to_extension(stdout, &cancel);
                 }
                 clients.lock().unwrap().remove(&job_id);
-            } else if let Some(error) = delivery.client_error {
-                let _ = write_json_frame(&mut delivery.stream, &error);
-                remove_client = true;
-            } else if let Some(chunk) = delivery.next_chunk {
-                if let Err(err) = forward_to_extension(stdout, &chunk) {
-                    eprintln!("yoetz chrome native chunk send failed for {job_id}: {err:#}");
-                    let error = client_error_envelope_from_parts(
-                        &delivery.job_id,
-                        delivery.run_id.clone(),
-                        "forward_to_extension_failed",
-                        &format!("native host could not forward file chunk to extension: {err}"),
-                        delivery.fallback_phase,
-                        delivery.side_effect_started,
-                    );
+            } else {
+                delivered_terminal_sequence = terminal_sequence;
+                if let Some(error) = delivery.client_error {
                     let _ = write_json_frame(&mut delivery.stream, &error);
                     remove_client = true;
+                } else if let Some(chunk) = delivery.next_chunk {
+                    if let Err(err) = forward_to_extension(stdout, &chunk) {
+                        eprintln!("yoetz chrome native chunk send failed for {job_id}: {err:#}");
+                        let error = client_error_envelope_from_parts(
+                            &delivery.job_id,
+                            delivery.run_id.clone(),
+                            "forward_to_extension_failed",
+                            &format!(
+                                "native host could not forward file chunk to extension: {err}"
+                            ),
+                            delivery.fallback_phase,
+                            delivery.side_effect_started,
+                        );
+                        let _ = write_json_frame(&mut delivery.stream, &error);
+                        remove_client = true;
+                    }
                 }
             }
 
@@ -3832,11 +3877,49 @@ mod native_host_unix {
             }
         }
 
+        if let Some(sequence) = delivered_terminal_sequence {
+            extension_session.terminal_job_ids.insert(job_id.clone());
+            acknowledge_terminal(stdout, &envelope, sequence, extension_session)?;
+        }
         if is_manual_handoff(&envelope) {
             record_manual_handoff(paths, &envelope)?;
         }
         record_instance_activity(runtime, &envelope)?;
         Ok(())
+    }
+
+    fn terminal_sequence(envelope: &ProtocolEnvelope) -> Result<Option<u64>> {
+        if !matches!(
+            envelope.kind.as_str(),
+            "job_complete" | "job_error" | "job_cancel"
+        ) {
+            return Ok(None);
+        }
+        match envelope.payload.get("sequence") {
+            Some(sequence) => sequence
+                .as_u64()
+                .map(Some)
+                .context("terminal envelope payload.sequence must be a u64"),
+            None => Ok(Some(0)),
+        }
+    }
+
+    fn acknowledge_terminal(
+        stdout: &Arc<Mutex<io::Stdout>>,
+        envelope: &ProtocolEnvelope,
+        sequence: u64,
+        extension_session: &ExtensionSessionState,
+    ) -> Result<()> {
+        if !extension_session.terminal_ack_capable {
+            return Ok(());
+        }
+        let ack = ProtocolEnvelope::new(
+            "terminal_ack",
+            envelope.job_id.clone(),
+            envelope.run_id.clone(),
+            json!({ "sequence": sequence }),
+        );
+        forward_to_extension(stdout, &ack)
     }
 
     fn next_bundle_chunk_envelope(client: &mut ClientJob) -> Result<Option<ProtocolEnvelope>> {

--- a/crates/yoetz-cli/tests/native_extension_host.rs
+++ b/crates/yoetz-cli/tests/native_extension_host.rs
@@ -3,7 +3,7 @@
 use serde_json::{json, Value};
 use std::collections::VecDeque;
 use std::fs;
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, Command, Stdio};
@@ -136,10 +136,147 @@ fn native_host_multiplexes_clients_and_isolates_disconnect_cancellation() {
     assert_eq!(cancel["payload"]["reason"], "local_client_disconnected");
 }
 
+#[test]
+fn native_host_deduplicates_terminals_and_capability_gates_acknowledgements() {
+    let mut host = NativeHost::start();
+    let token = wait_for_token(&host.token_path);
+
+    let legacy_bundle = write_bundle(host.temp.path(), "legacy.md", 4, b'l');
+    let legacy_client =
+        LocalClient::connect(&host.socket_path, "job_legacy", &legacy_bundle, &token);
+    host.output.take("job_start", "job_legacy");
+
+    let legacy_terminal = extension_frame(
+        "job_complete",
+        "job_legacy",
+        json!({"response": "legacy first wins"}),
+    );
+    host.send(legacy_terminal.clone());
+    assert_eq!(
+        legacy_client.take("job_complete")["payload"]["response"],
+        "legacy first wins"
+    );
+    host.output
+        .assert_absent("terminal_ack", "job_legacy", Duration::from_millis(500));
+
+    host.send(legacy_terminal);
+    legacy_client.assert_no_frame();
+    host.output
+        .assert_absent("terminal_ack", "job_legacy", Duration::from_millis(500));
+    host.stderr
+        .take_containing("dropped duplicate terminal envelope `job_complete` for job_legacy");
+
+    host.send(json!({
+        "protocol_version": 1,
+        "transport": "chrome-extension-native",
+        "request_id": "req_hello_unknown_capability",
+        "type": "hello",
+        "payload": {
+            "capabilities": ["unknown_future_capability"]
+        }
+    }));
+    let unknown_bundle = write_bundle(host.temp.path(), "unknown.md", 4, b'u');
+    let unknown_client =
+        LocalClient::connect(&host.socket_path, "job_unknown", &unknown_bundle, &token);
+    host.output.take("job_start", "job_unknown");
+    host.send(extension_frame(
+        "job_complete",
+        "job_unknown",
+        json!({"response": "unknown is not terminal_ack", "sequence": 3}),
+    ));
+    unknown_client.take("job_complete");
+    host.output
+        .assert_absent("terminal_ack", "job_unknown", Duration::from_millis(500));
+
+    host.send(json!({
+        "protocol_version": 1,
+        "transport": "chrome-extension-native",
+        "request_id": "req_hello_terminal_ack",
+        "type": "hello",
+        "payload": {
+            "capabilities": ["unknown_future_capability", "terminal_ack"]
+        }
+    }));
+
+    let unrouted_terminal = extension_frame(
+        "job_complete",
+        "job_unrouted",
+        json!({"response": "retain until routed", "sequence": 6}),
+    );
+    host.send(unrouted_terminal.clone());
+    host.output
+        .assert_absent("terminal_ack", "job_unrouted", Duration::from_millis(500));
+    let unrouted_bundle = write_bundle(host.temp.path(), "unrouted.md", 4, b'r');
+    let unrouted_client =
+        LocalClient::connect(&host.socket_path, "job_unrouted", &unrouted_bundle, &token);
+    host.output.take("job_start", "job_unrouted");
+    host.send(unrouted_terminal);
+    assert_eq!(
+        unrouted_client.take("job_complete")["payload"]["response"],
+        "retain until routed"
+    );
+    assert_eq!(
+        host.output.take("terminal_ack", "job_unrouted")["payload"]["sequence"],
+        6
+    );
+
+    let capable_bundle = write_bundle(host.temp.path(), "capable.md", 4, b'c');
+    let capable_client =
+        LocalClient::connect(&host.socket_path, "job_capable", &capable_bundle, &token);
+    host.output.take("job_start", "job_capable");
+
+    host.send(extension_frame(
+        "job_complete",
+        "job_capable",
+        json!({"response": "capable first wins", "sequence": 7}),
+    ));
+    assert_eq!(
+        capable_client.take("job_complete")["payload"]["response"],
+        "capable first wins"
+    );
+    assert_eq!(
+        host.output.take("terminal_ack", "job_capable")["payload"]["sequence"],
+        7
+    );
+
+    host.send(extension_frame(
+        "job_error",
+        "job_capable",
+        json!({"message": "must be dropped", "sequence": 8}),
+    ));
+    capable_client.assert_no_frame();
+    assert_eq!(
+        host.output.take("terminal_ack", "job_capable")["payload"]["sequence"],
+        8
+    );
+    host.stderr
+        .take_containing("dropped duplicate terminal envelope `job_error` for job_capable");
+
+    let default_bundle = write_bundle(host.temp.path(), "default.md", 4, b'd');
+    let default_client = LocalClient::connect(
+        &host.socket_path,
+        "job_default_sequence",
+        &default_bundle,
+        &token,
+    );
+    host.output.take("job_start", "job_default_sequence");
+    host.send(extension_frame(
+        "job_cancel",
+        "job_default_sequence",
+        json!({"reason": "legacy replay"}),
+    ));
+    default_client.take("job_cancel");
+    assert_eq!(
+        host.output.take("terminal_ack", "job_default_sequence")["payload"]["sequence"],
+        0
+    );
+}
+
 struct NativeHost {
     child: Child,
     stdin: ChildStdin,
     output: FrameInbox,
+    stderr: LineInbox,
     temp: TempDir,
     socket_path: PathBuf,
     token_path: PathBuf,
@@ -163,17 +300,20 @@ impl NativeHost {
             )
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
+            .stderr(Stdio::piped())
             .spawn()
             .unwrap();
         let stdin = child.stdin.take().unwrap();
         let stdout = child.stdout.take().unwrap();
+        let stderr = child.stderr.take().unwrap();
         let output = FrameInbox::from_reader(stdout);
+        let stderr = LineInbox::from_reader(stderr);
         wait_for_path(&socket_path);
         Self {
             child,
             stdin,
             output,
+            stderr,
             temp,
             socket_path,
             token_path,
@@ -237,6 +377,24 @@ impl LocalClient {
         assert_eq!(frame["type"], kind, "client received an unexpected frame");
         frame
     }
+
+    fn assert_no_frame(&self) {
+        self.stream
+            .set_read_timeout(Some(Duration::from_millis(500)))
+            .unwrap();
+        let result = try_read_frame(&mut &self.stream);
+        match result {
+            Ok(frame) => panic!("client received unexpected second terminal frame: {frame}"),
+            Err(err)
+                if matches!(
+                    err.kind(),
+                    std::io::ErrorKind::WouldBlock
+                        | std::io::ErrorKind::TimedOut
+                        | std::io::ErrorKind::UnexpectedEof
+                ) => {}
+            Err(err) => panic!("unexpected client read error: {err}"),
+        }
+    }
 }
 
 struct FrameInbox {
@@ -279,6 +437,59 @@ impl FrameInbox {
                 return frame;
             }
             self.pending.push_back(frame);
+        }
+    }
+
+    fn assert_absent(&mut self, kind: &str, job_id: &str, duration: Duration) {
+        assert!(
+            !self
+                .pending
+                .iter()
+                .any(|frame| frame["type"] == kind && frame["job_id"] == job_id),
+            "found unexpected {kind} for {job_id}"
+        );
+        let deadline = Instant::now() + duration;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            match self.receiver.recv_timeout(remaining) {
+                Ok(frame) if frame["type"] == kind && frame["job_id"] == job_id => {
+                    panic!("found unexpected {kind} for {job_id}: {frame}")
+                }
+                Ok(frame) => self.pending.push_back(frame),
+                Err(mpsc::RecvTimeoutError::Timeout) => return,
+                Err(err) => panic!("native host output closed while checking absence: {err}"),
+            }
+        }
+    }
+}
+
+struct LineInbox {
+    receiver: Receiver<String>,
+}
+
+impl LineInbox {
+    fn from_reader(reader: impl Read + Send + 'static) -> Self {
+        let (sender, receiver) = mpsc::channel();
+        thread::spawn(move || {
+            for line in BufReader::new(reader).lines().map_while(Result::ok) {
+                if sender.send(line).is_err() {
+                    break;
+                }
+            }
+        });
+        Self { receiver }
+    }
+
+    fn take_containing(&self, expected: &str) -> String {
+        let deadline = Instant::now() + FRAME_TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let line = self.receiver.recv_timeout(remaining).unwrap_or_else(|err| {
+                panic!("timed out waiting for stderr containing {expected:?}: {err}")
+            });
+            if line.contains(expected) {
+                return line;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Host-side half of #406 (terminal-envelope durability), backward-compatible:

- **First-wins dedup by `job_id`**: the host keeps a process-local ledger of delivered terminal envelopes (`job_complete`/`job_error`/`job_cancel`); duplicates — including cross-type doubles from older extensions — are logged and dropped before CLI delivery. Exactly one terminal result reaches the client.
- **Capability-gated `terminal_ack`**: after delivering a terminal envelope the host sends `terminal_ack {job_id, payload.sequence}` — only when the extension's hello advertised the `terminal_ack` capability (current extensions do not; the gate prevents `unsupported_type` noise). Duplicate arrivals get an idempotent ACK so a replaying extension can finally mark delivered. Missing `sequence` defaults to 0.
- **Unrouted terminals stay replayable**: no ledger entry and no ACK when no client is attached — the extension's replay can still deliver on the next reconnect.

Schema locked cross-lane (codex + cursor + claude review). Extension-side phase 2 tracked in #406.

## Validation
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (768/0) — verified independently by both agents.
- New `native_extension_host` subprocess suite: dedup exactly-one delivery, cross-type duplicate drop, ACK iff capability advertised, default sequence, unrouted-then-routed replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbMozs4Nt8Thd5zWRkuNQr