### PR TITLE
fix(extension): suspension-aware parking and poller-lease ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- Native-extension ChatGPT/Claude jobs now park on a per-job pageshow gate when
+  a submitted tab is in bfcache instead of burning the 20s content-script probe
+  loop, and both poller catch paths join in-flight or settled recovery under a
+  single poller lease so a restored waiter cannot failJob a live rebound.
 
 ## [0.5.51] - 2026-08-12
 ### Fixed

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -130,6 +130,7 @@ const ATTACHMENT_TRACE_PENDING_LEGS = new Set([
 const jobs = new Map();
 const terminalJobIds = new Map();
 const contentScriptRecoveries = new Map();
+const suspensionGates = new Map();
 const chunks = new ChunkAssembler();
 let nativePort = null;
 let extensionIdentityPromise = null;
@@ -195,10 +196,11 @@ async function handleContentLifecycle(message, sender) {
     if (job.status !== "waiting_response") {
       continue;
     }
-    if (!job.content_script_suspended_at && !contentScriptRecoveries.has(job.job_id)) {
+    if (!job.content_script_suspended_at && contentScriptRecoveries.get(job.job_id)?.settled !== "pending") {
       continue;
     }
     try {
+      openSuspensionGate(job);
       await recoverContentScriptJob(job, new Error("owned tab restored from bfcache"), {
         source: "pageshow",
         restoredFromBfcache: true
@@ -321,33 +323,11 @@ async function handleNativeMessage(message) {
     }
   } catch (error) {
     const job = message?.job_id ? jobs.get(message.job_id) : null;
-    const recovery = job ? contentScriptRecoveries.get(job.job_id) : null;
-    if (recovery) {
-      try {
-        await recovery;
-      } catch {
-        return;
-      }
-      if (
-        jobs.has(job.job_id)
-        && !TERMINAL_STATUSES.has(job.status)
-        && job.status === "waiting_response"
-        && !job.cancelled
-      ) {
-        await continueWaitingResponseJob(job);
-      }
+    if (job) {
+      await handlePollerError(job, error);
       return;
     }
-    if (job && !TERMINAL_STATUSES.has(job.status)) {
-      const code = error?.code ?? "extension_error";
-      const detail = errorContextForJob(job, error);
-      await failJob(
-        job,
-        code,
-        jobErrorMessage(job, error, code, detail),
-        detail
-      );
-    } else if (!job && !terminalJobIds.has(message?.job_id)) {
+    if (!terminalJobIds.has(message?.job_id)) {
       postNative(errorEnvelope(message, "extension_error", String(error?.message ?? error), {
         request_id: message?.request_id
       }));
@@ -720,6 +700,7 @@ async function completeJobWithExtraction(job, extraction) {
     return;
   }
   job.status = "complete";
+  forgetContentScriptRecovery(job.job_id);
   job.terminal_envelope = completeEnvelope;
   job.terminal_delivered_at = null;
   job.updated_at = Date.now();
@@ -773,45 +754,100 @@ async function resumeWaitingResponseJob(job) {
   try {
     const adapter = adapterForJob(job);
     await waitForSiteTab(job.tab_id, adapter);
-    await waitForContentScript(job.tab_id, adapter);
-    const rebound = await sendToTab(job.tab_id, { type: "yoetz_bind_job", job });
-    postNative(progress(job, "content_script_recovered", {
-      restored: true,
-      url: rebound?.url ?? null,
-      title: rebound?.title ?? null
-    }));
-  } catch (error) {
-    if (!jobs.has(job.job_id) || TERMINAL_STATUSES.has(job.status)) {
-      return;
+    if (job.content_script_suspended_at) {
+      await recoverContentScriptJob(job, new Error("owned tab is parked in bfcache after worker restore"), {
+        source: "worker_restore"
+      });
+    } else {
+      await waitForContentScript(job.tab_id, adapter);
+      const rebound = await sendToTab(job.tab_id, { type: "yoetz_bind_job", job });
+      postNative(progress(job, "content_script_recovered", {
+        restored: true,
+        url: rebound?.url ?? null,
+        title: rebound?.title ?? null
+      }));
     }
-    await failJob(
-      job,
-      error?.code ?? "extension_error",
-      String(error?.message ?? error),
-      errorContextForJob(job, error)
-    );
+  } catch (error) {
+    await handlePollerError(job, error);
     return;
   }
   await continueWaitingResponseJob(job);
 }
 
 async function continueWaitingResponseJob(job) {
+  const lease = acquirePollerLease(job);
+  if (lease == null) {
+    return;
+  }
   try {
     const extraction = await waitForResponse(job);
+    if (!holdsPollerLease(job, lease)) {
+      return;
+    }
     assertJobConnectionCurrent(job);
     if (job.cancelled || !extraction) return;
     await completeJobWithExtraction(job, extraction);
   } catch (error) {
-    if (!jobs.has(job.job_id) || TERMINAL_STATUSES.has(job.status)) {
+    if (!holdsPollerLease(job, lease)) {
       return;
     }
-    await failJob(
-      job,
-      error?.code ?? "extension_error",
-      String(error?.message ?? error),
-      errorContextForJob(job, error)
-    );
+    releasePollerLease(job, lease);
+    await handlePollerError(job, error);
+  } finally {
+    releasePollerLease(job, lease);
   }
+}
+
+function acquirePollerLease(job) {
+  if (job.poller_lease != null) {
+    return null;
+  }
+  const lease = Number(job.poller_lease_seq ?? 0) + 1;
+  job.poller_lease_seq = lease;
+  job.poller_lease = lease;
+  return lease;
+}
+
+function holdsPollerLease(job, lease) {
+  return job.poller_lease === lease;
+}
+
+function releasePollerLease(job, lease) {
+  if (job.poller_lease === lease) {
+    job.poller_lease = null;
+  }
+}
+
+function jobCanResumePolling(job) {
+  return Boolean(
+    job
+    && jobs.has(job.job_id)
+    && !TERMINAL_STATUSES.has(job.status)
+    && job.status === "waiting_response"
+    && !job.cancelled
+  );
+}
+
+async function handlePollerError(job, error) {
+  const recovery = contentScriptRecoveries.get(job.job_id);
+  if (recovery) {
+    try {
+      await recovery;
+    } catch {
+      return;
+    }
+    if (!jobCanResumePolling(job)) {
+      return;
+    }
+    await continueWaitingResponseJob(job);
+    return;
+  }
+  if (!jobs.has(job.job_id) || TERMINAL_STATUSES.has(job.status)) {
+    return;
+  }
+  const code = error?.code ?? "extension_error";
+  const detail = errorContextForJob(job, error);
+  await failJob(job, code, jobErrorMessage(job, error, code, detail), detail);
 }
 
 async function cancelJob(message) {
@@ -830,6 +866,7 @@ async function cancelJob(message) {
   }
   job.cancelled = true;
   job.status = "cancelled";
+  forgetContentScriptRecovery(job.job_id);
   rememberTerminalJob(job.job_id);
   job.updated_at = Date.now();
   chunks.discard(job.job_id);
@@ -2275,7 +2312,9 @@ async function extractResponseForJob(job) {
 
 async function extractDomResponseForJob(job) {
   try {
-    return await sendToTab(job.tab_id, { type: "yoetz_extract_response", job });
+    const extraction = await sendToTab(job.tab_id, { type: "yoetz_extract_response", job });
+    forgetSettledSuccessfulRecovery(job.job_id);
+    return extraction;
   } catch (error) {
     if (
       !isRecoverableContentScriptError(error)
@@ -2423,25 +2462,62 @@ function normalizeBackendApiExtraction(backendExtraction, domExtraction, convers
 
 async function recoverContentScriptJob(job, error, options = {}) {
   const existing = contentScriptRecoveries.get(job.job_id);
-  if (existing) {
+  if (existing && existing.settled === "pending") {
     return existing;
   }
-  const recovery = recoverContentScriptJobOnce(job, error, options);
-  contentScriptRecoveries.set(job.job_id, recovery);
-  try {
-    return await recovery;
-  } finally {
-    // Keep the settled recovery discoverable through the next task so an
-    // in-flight command unwinding from the same disconnect can transfer its
-    // response-polling ownership instead of racing the map deletion.
-    await sleep(0);
-    if (contentScriptRecoveries.get(job.job_id) === recovery) {
-      contentScriptRecoveries.delete(job.job_id);
+  if (existing && existing.settled !== "fulfilled") {
+    return existing;
+  }
+  if (existing && existing.settled === "fulfilled" && !options.restoredFromBfcache) {
+    return existing;
+  }
+  return trackContentScriptRecovery(job.job_id, recoverContentScriptJobOnce(job, error, options));
+}
+
+function trackContentScriptRecovery(jobId, promise) {
+  const tracked = promise.then(
+    (value) => {
+      tracked.settled = "fulfilled";
+      return value;
+    },
+    (error) => {
+      tracked.settled = "rejected";
+      throw error;
     }
+  );
+  tracked.settled = "pending";
+  contentScriptRecoveries.set(jobId, tracked);
+  return tracked;
+}
+
+function forgetSettledSuccessfulRecovery(jobId) {
+  const recovery = contentScriptRecoveries.get(jobId);
+  if (recovery?.settled === "fulfilled") {
+    contentScriptRecoveries.delete(jobId);
+  }
+}
+
+function forgetContentScriptRecovery(jobId) {
+  if (!jobId) {
+    return;
+  }
+  contentScriptRecoveries.delete(jobId);
+  const gate = suspensionGates.get(jobId);
+  if (gate) {
+    gate.reject(commandError("extension_error", "job terminated while parked for pageshow", {
+      phase: "wait_response",
+      side_effect_started: true
+    }));
   }
 }
 
 async function recoverContentScriptJobOnce(job, error, options = {}) {
+  if (job.content_script_suspended_at && !options.restoredFromBfcache) {
+    await parkForPageshow(job);
+    if (!jobs.has(job.job_id) || TERMINAL_STATUSES.has(job.status) || job.cancelled) {
+      return;
+    }
+  }
   job.content_script_recovery_incidents = Number(job.content_script_recovery_incidents ?? 0) + 1;
   job.content_script_recovery_in_progress = true;
   job.content_script_suspended_at = null;
@@ -2463,6 +2539,95 @@ async function recoverContentScriptJobOnce(job, error, options = {}) {
     source: options.source ?? "command_error",
     restored_from_bfcache: Boolean(options.restoredFromBfcache)
   }));
+}
+
+function remainingResponseDeadlineMs(job) {
+  const startedAt = Number(job.response_wait_started_at) || Date.now();
+  return Math.max(0, startedAt + responseWaitTimeoutMs(job) - Date.now());
+}
+
+function parkedDeadlineError(job) {
+  return commandError(
+    "response_timeout",
+    "owned tab stayed in bfcache past the response deadline",
+    {
+      phase: "wait_response",
+      side_effect_started: true,
+      inspect_command: inspectCommandForJob(job)
+    }
+  );
+}
+
+async function failParkedJobAtDeadline(job) {
+  if (!jobs.has(job.job_id) || TERMINAL_STATUSES.has(job.status)) {
+    return;
+  }
+  const inspectCommand = inspectCommandForJob(job);
+  const adapter = adapterForJob(job);
+  await failJob(
+    job,
+    "response_timeout",
+    `${adapter.displayName} response wait expired while the owned tab stayed in bfcache with no persisted pageshow. The owned tab is left open; inspect it before rerunning with: ${inspectCommand}`,
+    {
+      phase: "wait_response",
+      side_effect_started: true,
+      completion_reason: "timeout",
+      send_committed: true,
+      inspect_command: inspectCommand
+    }
+  );
+}
+
+async function parkForPageshow(job) {
+  const remainingMs = remainingResponseDeadlineMs(job);
+  postNative(progress(job, "parked_for_pageshow", {
+    inspect_command: inspectCommandForJob(job),
+    remaining_ms: remainingMs,
+    tab_id: job.tab_id,
+    message: "owned background tab is in bfcache; parked until persisted pageshow or response deadline"
+  }));
+  if (remainingMs <= 0) {
+    await failParkedJobAtDeadline(job);
+    throw parkedDeadlineError(job);
+  }
+  await waitForSuspensionGate(job, remainingMs);
+}
+
+function waitForSuspensionGate(job, remainingMs) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      const current = suspensionGates.get(job.job_id);
+      if (current?.timer === timer) {
+        suspensionGates.delete(job.job_id);
+      }
+      failParkedJobAtDeadline(job).then(
+        () => reject(parkedDeadlineError(job)),
+        reject
+      );
+    }, remainingMs);
+    suspensionGates.set(job.job_id, {
+      resolve: () => {
+        clearTimeout(timer);
+        suspensionGates.delete(job.job_id);
+        resolve();
+      },
+      reject: (error) => {
+        clearTimeout(timer);
+        suspensionGates.delete(job.job_id);
+        reject(error);
+      },
+      timer
+    });
+  });
+}
+
+function openSuspensionGate(job) {
+  const gate = suspensionGates.get(job.job_id);
+  if (!gate) {
+    return false;
+  }
+  gate.resolve();
+  return true;
 }
 
 function isRecoverableContentScriptError(error) {
@@ -2709,6 +2874,7 @@ async function failJob(job, code, message, detail = {}) {
   }
   if (job) {
     job.status = terminalStatus ?? "failed";
+    forgetContentScriptRecovery(job.job_id);
     rememberTerminalJob(job.job_id);
     job.updated_at = Date.now();
     chunks.discard(job.job_id);
@@ -2730,6 +2896,7 @@ async function failJob(job, code, message, detail = {}) {
 
 async function recordTerminalDeliveryLost(job, phase) {
   job.status = "terminal_delivery_lost";
+  forgetContentScriptRecovery(job.job_id);
   job.delivery_lost_phase = phase;
   job.updated_at = Date.now();
   await persistJob(job);
@@ -2768,9 +2935,16 @@ function jobsStorageKey(jobId) {
 // transition (or on failJob's error path) would chew through the 10MB session
 // quota and risk masking the real failure with a quota throw. We persist only a
 // bounded tail plus the length, which is enough to reconstruct progress context
-// after a restart without bloating storage.
+// after a restart without bloating storage. Poller leases are process-local
+// coordination and must never be durable: a restored shard that still carries
+// poller_lease would make acquirePollerLease return null and wedge the job.
 function strippedJobForStorage(job) {
-  const { last_response_progress_text: fullText, ...rest } = job;
+  const {
+    last_response_progress_text: fullText,
+    poller_lease: _pollerLease,
+    poller_lease_seq: _pollerLeaseSeq,
+    ...rest
+  } = job;
   if (
     rest.terminal_envelope
     && nativeEnvelopeByteLength(rest.terminal_envelope) > MAX_PERSISTED_TERMINAL_ENVELOPE_BYTES

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -6442,6 +6442,479 @@ test("service worker terminates actionably when persisted bfcache reconnect fail
   }
 });
 
+test("service worker parks a suspended waiting_response job past the reconnect probe window then completes on pageshow", async () => {
+  const originalChrome = globalThis.chrome;
+  const previousAttempts = globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_ATTEMPTS;
+  const previousDelay = globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_DELAY_MS;
+  globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_ATTEMPTS = 2;
+  globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_DELAY_MS = 20;
+  const port = makePort();
+  let runtimeListener = null;
+  let tabId = 0;
+  let sent = false;
+  let hidden = false;
+  let allowProbe = true;
+  let uploadCalls = 0;
+  let sendCalls = 0;
+  let probesWhileHidden = 0;
+  let rejectInFlightExtraction;
+  let markInFlightExtractionStarted;
+  const inFlightExtractionStarted = new Promise((resolve) => {
+    markInFlightExtractionStarted = resolve;
+  });
+  const chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            if (hidden) {
+              probesWhileHidden += 1;
+            }
+            if (!allowProbe) {
+              throw new Error("Could not establish connection. Receiving end does not exist.");
+            }
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: verifiedSolProSelection() };
+          case "yoetz_upload_file":
+            uploadCalls += 1;
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sendCalls += 1;
+            sent = true;
+            return { ok: true, payload: { sent: true } };
+          case "yoetz_bind_job":
+            return { ok: true, payload: { rebound: true, url: "https://chatgpt.com/", title: "ChatGPT" } };
+          case "yoetz_extract_response":
+            if (sent && !hidden) {
+              markInFlightExtractionStarted();
+              return new Promise((_resolve, reject) => {
+                rejectInFlightExtraction = reject;
+              });
+            }
+            return {
+              ok: true,
+              payload: sent && allowProbe
+                ? { method: "copy_scope_dom_fallback", text: "final after long suspension", is_generating: false, assistant_count: 1, copy_button_count: 1, has_copy_button: true, turn_index: 0 }
+                : { method: "none", text: "", is_generating: true, assistant_count: 0, turn_index: -1 }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+  chrome.runtime.onMessage.addListener = (listener) => {
+    runtimeListener = listener;
+  };
+  globalThis.chrome = chrome;
+
+  try {
+    await import(`../src/service-worker.js?park_past_probe=${Date.now()}`);
+    port.emit(envelope("job_start", "job_park_past_probe", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 4000
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_park_past_probe", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_park_past_probe.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+    await eventually(() => sent);
+    await inFlightExtractionStarted;
+
+    const lifecycle = (event) => new Promise((resolve) => {
+      assert.equal(runtimeListener(
+        { type: "yoetz_content_lifecycle", event, persisted: true, job_ids: ["job_park_past_probe"] },
+        { tab: { id: tabId } },
+        resolve
+      ), true);
+    });
+    assert.equal((await lifecycle("pagehide")).ok, true);
+    hidden = true;
+    allowProbe = false;
+    rejectInFlightExtraction(new Error("The message channel closed before a response was received."));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "parked_for_pageshow"));
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    assert.equal(probesWhileHidden, 0, "recovery must not probe while the tab is in bfcache");
+    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
+    allowProbe = true;
+    assert.equal((await lifecycle("pageshow")).ok, true);
+
+    await eventually(() => port.messages.some((message) => message.type === "job_complete"));
+    assert.equal(uploadCalls, 1);
+    assert.equal(sendCalls, 1);
+    assert.equal(
+      port.messages.find((message) => message.type === "job_complete")?.payload.response,
+      "final after long suspension"
+    );
+    const parked = port.messages.find((message) => message.payload?.phase === "parked_for_pageshow");
+    assert.equal(typeof parked?.payload.inspect_command, "string");
+    assert.match(parked.payload.inspect_command, /yoetz browser extension inspect/);
+  } finally {
+    globalThis.chrome = originalChrome;
+    if (previousAttempts === undefined) delete globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_ATTEMPTS;
+    else globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_ATTEMPTS = previousAttempts;
+    if (previousDelay === undefined) delete globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_DELAY_MS;
+    else globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_DELAY_MS = previousDelay;
+  }
+});
+
+test("service worker restored waiting_response poller joins an in-flight pageshow recovery", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const storage = makeStorage();
+  const now = Date.now();
+  let runtimeListener = null;
+  let bindCalls = 0;
+  let rebound = false;
+  let inFlightExtracts = 0;
+  let maxInFlightExtracts = 0;
+  let rejectInFlightExtraction;
+  let markInFlightExtractionStarted;
+  const inFlightExtractionStarted = new Promise((resolve) => {
+    markInFlightExtractionStarted = resolve;
+  });
+  await storage.set({
+    "jobs.job_restore_pageshow_race": {
+      job_id: "job_restore_pageshow_race",
+      run_id: "run_job_restore_pageshow_race",
+      workspace_id: "workspace_test",
+      status: "waiting_response",
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 4000,
+      tab_id: 77,
+      response_baseline: {
+        method: "none",
+        text: "",
+        is_generating: false,
+        assistant_count: 0,
+        turn_index: -1
+      },
+      submitted_user_count: 1,
+      submitted_assistant_count: 0,
+      started_at: now,
+      response_wait_started_at: now,
+      updated_at: now
+    }
+  });
+  const chrome = chromeStub({
+    port,
+    storage,
+    tabs: {
+      create: async () => {
+        throw new Error("restore must reuse the submitted tab");
+      },
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/?_yoetz=run_job_restore_pageshow_race" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_bind_job":
+            bindCalls += 1;
+            rebound = bindCalls >= 2;
+            return { ok: true, payload: { url: "https://chatgpt.com/", title: "ChatGPT" } };
+          case "yoetz_extract_response": {
+            if (bindCalls < 2) {
+              markInFlightExtractionStarted();
+              return new Promise((_resolve, reject) => {
+                rejectInFlightExtraction = reject;
+              });
+            }
+            inFlightExtracts += 1;
+            maxInFlightExtracts = Math.max(maxInFlightExtracts, inFlightExtracts);
+            await new Promise((resolve) => setTimeout(resolve, 20));
+            inFlightExtracts -= 1;
+            return {
+              ok: true,
+              payload: {
+                method: "copy_scope_dom_fallback",
+                text: "restored after pageshow race",
+                is_generating: false,
+                assistant_count: 1,
+                copy_button_count: 1,
+                has_copy_button: true,
+                turn_index: 0,
+                preceding_user_count: 1
+              }
+            };
+          }
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+  chrome.runtime.onMessage.addListener = (listener) => {
+    runtimeListener = listener;
+  };
+  globalThis.chrome = chrome;
+
+  try {
+    await import(`../src/service-worker.js?restore_pageshow_race=${Date.now()}`);
+    await eventually(() => port.messages.some((message) => message.type === "hello"));
+    await inFlightExtractionStarted;
+    const lifecycle = (event) => new Promise((resolve) => {
+      assert.equal(runtimeListener(
+        { type: "yoetz_content_lifecycle", event, persisted: true, job_ids: ["job_restore_pageshow_race"] },
+        { tab: { id: 77 } },
+        resolve
+      ), true);
+    });
+    assert.equal((await lifecycle("pagehide")).ok, true);
+    const restored = lifecycle("pageshow");
+    await eventually(() => bindCalls >= 2 || port.messages.some((message) => message.payload?.phase === "content_script_recovering"));
+    rejectInFlightExtraction(new Error("poller exploded after worker restore"));
+    assert.equal((await restored).ok, true);
+    await eventually(() => port.messages.some((message) => (
+      message.type === "job_complete" && message.job_id === "job_restore_pageshow_race"
+    )));
+    assert.equal(port.messages.some((message) => message.type === "job_error" && message.job_id === "job_restore_pageshow_race"), false);
+    assert.equal(maxInFlightExtracts, 1, "exactly one poller may extract after rebind");
+    assert.equal(
+      port.messages.find((message) => message.type === "job_complete")?.payload.response,
+      "restored after pageshow race"
+    );
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker joins an extraction rejection delivered several tasks after recovery settles", async () => {
+  const originalChrome = globalThis.chrome;
+  const previousAttempts = globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_ATTEMPTS;
+  const previousDelay = globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_DELAY_MS;
+  globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_ATTEMPTS = 1;
+  globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_DELAY_MS = 0;
+  const port = makePort();
+  let runtimeListener = null;
+  let tabId = 0;
+  let sent = false;
+  let recovered = false;
+  let uploadCalls = 0;
+  let sendCalls = 0;
+  let rejectInFlightExtraction;
+  let markInFlightExtractionStarted;
+  const inFlightExtractionStarted = new Promise((resolve) => {
+    markInFlightExtractionStarted = resolve;
+  });
+  const chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            if (recovered) {
+              throw new Error("Could not establish connection. Receiving end does not exist.");
+            }
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: verifiedSolProSelection() };
+          case "yoetz_upload_file":
+            uploadCalls += 1;
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sendCalls += 1;
+            sent = true;
+            return { ok: true, payload: { sent: true } };
+          case "yoetz_bind_job":
+            recovered = true;
+            return { ok: true, payload: { rebound: true, url: "https://chatgpt.com/", title: "ChatGPT" } };
+          case "yoetz_extract_response":
+            if (sent && !recovered) {
+              markInFlightExtractionStarted();
+              return new Promise((_resolve, reject) => {
+                rejectInFlightExtraction = reject;
+              });
+            }
+            return {
+              ok: true,
+              payload: recovered
+                ? { method: "copy_scope_dom_fallback", text: "final after late rejection", is_generating: false, assistant_count: 1, copy_button_count: 1, has_copy_button: true, turn_index: 0 }
+                : { method: "none", text: "", is_generating: true, assistant_count: 0, turn_index: -1 }
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+  chrome.runtime.onMessage.addListener = (listener) => {
+    runtimeListener = listener;
+  };
+  globalThis.chrome = chrome;
+
+  try {
+    await import(`../src/service-worker.js?late_extract_reject=${Date.now()}`);
+    port.emit(envelope("job_start", "job_late_extract_reject", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 4000
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_late_extract_reject", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_late_extract_reject.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+    await eventually(() => sent);
+    await inFlightExtractionStarted;
+    const lifecycle = (event) => new Promise((resolve) => {
+      assert.equal(runtimeListener(
+        { type: "yoetz_content_lifecycle", event, persisted: true, job_ids: ["job_late_extract_reject"] },
+        { tab: { id: tabId } },
+        resolve
+      ), true);
+    });
+    assert.equal((await lifecycle("pagehide")).ok, true);
+    assert.equal((await lifecycle("pageshow")).ok, true);
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "content_script_recovered"));
+    for (let i = 0; i < 5; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    rejectInFlightExtraction(new Error("The message channel closed before a response was received."));
+    await eventually(() => port.messages.some((message) => message.type === "job_complete"));
+    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
+    assert.equal(uploadCalls, 1);
+    assert.equal(sendCalls, 1);
+    assert.equal(
+      port.messages.find((message) => message.type === "job_complete")?.payload.response,
+      "final after late rejection"
+    );
+  } finally {
+    globalThis.chrome = originalChrome;
+    if (previousAttempts === undefined) delete globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_ATTEMPTS;
+    else globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_ATTEMPTS = previousAttempts;
+    if (previousDelay === undefined) delete globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_DELAY_MS;
+    else globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_DELAY_MS = previousDelay;
+  }
+});
+
+test("service worker times out a parked suspension at the response deadline without probing", async () => {
+  const originalChrome = globalThis.chrome;
+  const previousAttempts = globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_ATTEMPTS;
+  const previousDelay = globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_DELAY_MS;
+  globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_ATTEMPTS = 2;
+  globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_DELAY_MS = 20;
+  const port = makePort();
+  let runtimeListener = null;
+  let tabId = 0;
+  let sent = false;
+  let hidden = false;
+  let probesWhileHidden = 0;
+  let rejectInFlightExtraction;
+  let markInFlightExtractionStarted;
+  const inFlightExtractionStarted = new Promise((resolve) => {
+    markInFlightExtractionStarted = resolve;
+  });
+  const chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            if (hidden) {
+              probesWhileHidden += 1;
+              throw new Error("Could not establish connection. Receiving end does not exist.");
+            }
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            return { ok: true, payload: verifiedSolProSelection() };
+          case "yoetz_upload_file":
+            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+          case "yoetz_send_prompt":
+            sent = true;
+            return { ok: true, payload: { sent: true } };
+          case "yoetz_bind_job":
+            return { ok: true, payload: { rebound: true } };
+          case "yoetz_extract_response":
+            if (sent) {
+              markInFlightExtractionStarted();
+              return new Promise((_resolve, reject) => {
+                rejectInFlightExtraction = reject;
+              });
+            }
+            return { ok: true, payload: { method: "none", text: "", is_generating: true, assistant_count: 0, turn_index: -1 } };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+  chrome.runtime.onMessage.addListener = (listener) => {
+    runtimeListener = listener;
+  };
+  globalThis.chrome = chrome;
+
+  try {
+    await import(`../src/service-worker.js?park_deadline=${Date.now()}`);
+    port.emit(envelope("job_start", "job_park_deadline", {
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 250
+    }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    port.emit(envelope("job_file_chunk", "job_park_deadline", {
+      sequence: 0,
+      total_chunks: 1,
+      total_bytes: 4,
+      filename: "job_park_deadline.md",
+      mime_type: "text/markdown",
+      bytes_base64: uint8ArrayToBase64(new TextEncoder().encode("body"))
+    }));
+    await eventually(() => sent);
+    await inFlightExtractionStarted;
+    await new Promise((resolve) => {
+      assert.equal(runtimeListener(
+        { type: "yoetz_content_lifecycle", event: "pagehide", persisted: true, job_ids: ["job_park_deadline"] },
+        { tab: { id: tabId } },
+        resolve
+      ), true);
+    });
+    hidden = true;
+    rejectInFlightExtraction(new Error("The message channel closed before a response was received."));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "parked_for_pageshow"));
+    await eventually(() => port.messages.some((message) => (
+      message.type === "job_error" && message.job_id === "job_park_deadline"
+    )), 2000);
+    const errors = port.messages.filter((message) => (
+      message.type === "job_error" && message.job_id === "job_park_deadline"
+    ));
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].payload.code, "response_timeout");
+    assert.equal(errors[0].payload.message.includes("did not become ready"), false);
+    assert.equal(probesWhileHidden, 0, "deadline expiry must not run the reconnect probe loop");
+  } finally {
+    globalThis.chrome = originalChrome;
+    if (previousAttempts === undefined) delete globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_ATTEMPTS;
+    else globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_ATTEMPTS = previousAttempts;
+    if (previousDelay === undefined) delete globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_DELAY_MS;
+    else globalThis.__YOETZ_CONTENT_SCRIPT_RECONNECT_DELAY_MS = previousDelay;
+  }
+});
+
 test("service worker preserves content-script committed-send error metadata", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();
@@ -7940,6 +8413,168 @@ test("service worker resumes waiting_response jobs after service-worker restart"
     assert.equal(port.messages.filter((message) =>
       message.type === "job_complete" && message.job_id === "job_restore_waiting_response"
     ).length, 1);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker restores a waiting_response shard persisted while a poller lease was held", async () => {
+  const originalChrome = globalThis.chrome;
+  const firstPort = makePort();
+  const firstStorage = makeStorage();
+  const now = Date.now();
+  const provisionalConversationId = "WEB:ca5209ac-2836-440d-b674-ffc54ee5dd2d";
+  const assignedConversationId = "6a5f60dc-8174-8329-949a-1f282d1dccbd";
+  let firstExtractCount = 0;
+  await firstStorage.set({
+    "jobs.job_restore_lease_persist": {
+      job_id: "job_restore_lease_persist",
+      run_id: "run_job_restore_lease_persist",
+      workspace_id: "workspace_test",
+      status: "waiting_response",
+      prompt: "prompt",
+      wait_interval_ms: 50,
+      wait_timeout_ms: 4000,
+      tab_id: 88,
+      submitted_conversation_id: provisionalConversationId,
+      response_baseline: {
+        method: "none",
+        text: "",
+        is_generating: false,
+        assistant_count: 0,
+        turn_index: -1
+      },
+      submitted_user_count: 1,
+      submitted_assistant_count: 0,
+      started_at: now,
+      response_wait_started_at: now,
+      updated_at: now
+    }
+  });
+  globalThis.chrome = chromeStub({
+    port: firstPort,
+    storage: firstStorage,
+    tabs: {
+      create: async () => {
+        throw new Error("restore must reuse the submitted tab");
+      },
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/?_yoetz=run_job_restore_lease_persist" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_bind_job":
+            return { ok: true, payload: { url: "https://chatgpt.com/", title: "ChatGPT" } };
+          case "yoetz_extract_response": {
+            firstExtractCount += 1;
+            if (firstExtractCount === 1) {
+              return {
+                ok: true,
+                payload: {
+                  method: "assistant_dom_fallback",
+                  text: "I",
+                  is_generating: true,
+                  assistant_count: 1,
+                  copy_button_count: 0,
+                  has_copy_button: false,
+                  turn_index: 0,
+                  preceding_user_count: 1,
+                  conversation_id: assignedConversationId
+                }
+              };
+            }
+            return new Promise(() => {});
+          }
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  let persistedShard;
+  try {
+    await import(`../src/service-worker.js?restore_lease_persist_first=${Date.now()}`);
+    await eventually(() => firstPort.messages.some((message) => message.type === "hello"));
+    await eventually(async () => {
+      const shard = (await firstStorage.get("jobs.job_restore_lease_persist"))["jobs.job_restore_lease_persist"];
+      return shard?.submitted_conversation_id === assignedConversationId;
+    });
+    persistedShard = {
+      ...(await firstStorage.get("jobs.job_restore_lease_persist"))["jobs.job_restore_lease_persist"]
+    };
+    assert.equal(persistedShard.poller_lease, undefined, "poller_lease must not be durable");
+    assert.equal(persistedShard.poller_lease_seq, undefined, "poller_lease_seq must not be durable");
+  } catch (error) {
+    globalThis.chrome = originalChrome;
+    throw error;
+  }
+
+  const secondPort = makePort();
+  const secondStorage = makeStorage();
+  await secondStorage.set({
+    "jobs.job_restore_lease_persist": persistedShard
+  });
+  let secondExtractCount = 0;
+  globalThis.chrome = chromeStub({
+    port: secondPort,
+    storage: secondStorage,
+    tabs: {
+      create: async () => {
+        throw new Error("restore must reuse the submitted tab");
+      },
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/?_yoetz=run_job_restore_lease_persist" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_bind_job":
+            return { ok: true, payload: { url: "https://chatgpt.com/", title: "ChatGPT" } };
+          case "yoetz_extract_response": {
+            secondExtractCount += 1;
+            const streaming = {
+              method: "assistant_dom_fallback",
+              text: "I",
+              is_generating: true,
+              assistant_count: 1,
+              copy_button_count: 0,
+              has_copy_button: false,
+              turn_index: 0,
+              preceding_user_count: 1,
+              conversation_id: assignedConversationId
+            };
+            const complete = {
+              method: "assistant_dom_fallback",
+              text: "restored after lease persist",
+              is_generating: false,
+              assistant_count: 1,
+              copy_button_count: 1,
+              has_copy_button: true,
+              turn_index: 0,
+              preceding_user_count: 1,
+              conversation_id: assignedConversationId
+            };
+            return { ok: true, payload: secondExtractCount < 3 ? streaming : complete };
+          }
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?restore_lease_persist_second=${Date.now()}`);
+    await eventually(() => secondPort.messages.some((message) =>
+      message.type === "job_complete" && message.job_id === "job_restore_lease_persist"
+    ));
+    assert.equal(secondPort.messages.some((message) => (
+      message.type === "job_error" && message.job_id === "job_restore_lease_persist"
+    )), false);
+    assert.equal(
+      secondPort.messages.find((message) => message.type === "job_complete")?.payload.response,
+      "restored after lease persist"
+    );
   } finally {
     globalThis.chrome = originalChrome;
   }


### PR DESCRIPTION
## Summary

Closes #404 — the Tier-2 recovery-orchestration rework from the 2026-08-12 ChatGPT deep review (findings B2/B4).

- **B2 — suspension-aware parking**: when `content_script_suspended_at` marks the owned tab as in bfcache, recovery no longer runs the 20-second probe loop it can only lose. It parks on a per-job suspension gate that the persisted `pageshow` opens, bounded by the job's remaining response deadline (expiry is a plain `response_timeout`, tab kept, inspect command included). Parking is the in-map recovery, so concurrent poller errors join the same gate. A worker restart during a park re-parks via the restore path.
- **B4 — poller-lease ownership**: one shared `handlePollerError` now serves every poller catch (native dispatch, continuation, worker-restore). It joins any in-flight or settled-retained recovery and resumes polling only under a single per-job lease (identity-sequenced, process-local — explicitly stripped at persist so restored jobs can always re-acquire). Settled recoveries are retained until overwritten, terminal, or a healthy extraction — the `sleep(0)` macrotask retention is gone.

## Review

Two execution-review rounds (claude). Round-1 finding: the poller lease leaked into `chrome.storage.session` and wedged restored jobs — fixed at `strippedJobForStorage` with a both-directions counterexample (fails pre-strip `1 !== undefined`, restored poller completes post-strip).

## Validation

- Extension suite 353/353; existing X1/X2 race tests untouched and green.
- Hybrid must-fail proof: all four new fixtures (park-then-pageshow completion, restored-poller join, multi-task-late rejection join, parked deadline expiry) fail on released main, pass here — verified independently by both agents.

Implemented by cursor (grok-46).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbMozs4Nt8Thd5zWRkuNQr