### PR TITLE
fix(extension): terminal_ack delivery receipts with age-bounded replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   a submitted tab is in bfcache instead of burning the 20s content-script probe
   loop, and both poller catch paths join in-flight or settled recovery under a
   single poller lease so a restored waiter cannot failJob a live rebound.
+- Native-extension terminal envelopes advertise `terminal_ack`, stamp
+  `payload.sequence`, and treat a host ACK as the delivery receipt so restore
+  replay stops only after the host confirms it received the envelope. Unacked
+  terminal shards older than the job TTL are purged instead of replayed.
 
 ## [0.5.51] - 2026-08-12
 ### Fixed

--- a/extensions/chatgpt-native/src/protocol.js
+++ b/extensions/chatgpt-native/src/protocol.js
@@ -17,7 +17,8 @@ export const MESSAGE_TYPES = Object.freeze([
   "heartbeat",
   "reconnect",
   "inspect_run",
-  "request_identity_permission"
+  "request_identity_permission",
+  "terminal_ack"
 ]);
 
 export function nowIso() {

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -19,6 +19,8 @@ const RECONNECT_ALARM = "yoetz-reconnect";
 const TERMINAL_STATUSES = new Set(["complete", "cancelled", "failed", "manual_handoff", "state_lost", "terminal_delivery_lost"]);
 const EXTENSION_ID_STORAGE_KEY = "yoetz_extension_instance_id";
 const ADVERTISED_RECIPES = Object.freeze(advertisedRecipes());
+const TERMINAL_ACK_CAPABILITY = "terminal_ack";
+const ADVERTISED_CAPABILITIES = Object.freeze([TERMINAL_ACK_CAPABILITY]);
 const MIN_STABLE_IDLE_MS = Number(globalThis.__YOETZ_MIN_STABLE_IDLE_MS ?? 90000);
 // Require multiple stable polls so final controls cannot win before late text hydration.
 const STABLE_IDLE_INTERVAL_MULTIPLIER = Number(globalThis.__YOETZ_STABLE_IDLE_INTERVAL_MULTIPLIER ?? 3);
@@ -317,6 +319,9 @@ async function handleNativeMessage(message) {
         break;
       case "request_identity_permission":
         await handleRequestIdentityPermission(message);
+        break;
+      case "terminal_ack":
+        await handleTerminalAck(message);
         break;
       default:
         postNative(errorEnvelope(message, "unsupported_type", `unsupported service-worker message ${message.type}`));
@@ -701,18 +706,17 @@ async function completeJobWithExtraction(job, extraction) {
   }
   job.status = "complete";
   forgetContentScriptRecovery(job.job_id);
+  rememberTerminalJob(job.job_id);
+  stampTerminalSequence(job, completeEnvelope);
   job.terminal_envelope = completeEnvelope;
   job.terminal_delivered_at = null;
   job.updated_at = Date.now();
-  rememberTerminalJob(job.job_id);
   await persistTerminalJobBestEffort(job);
-  const delivered = postNative(completeEnvelope);
-  if (!delivered) {
+  const posted = postNative(completeEnvelope);
+  if (!posted) {
     await recordTerminalDeliveryLost(job, "wait_response");
     return;
   }
-  job.terminal_delivered_at = Date.now();
-  await persistTerminalJobBestEffort(job);
   await closeOwnedTabOnComplete(job);
   jobs.delete(job.job_id);
   chunks.discard(job.job_id);
@@ -944,16 +948,13 @@ async function cancelJob(message) {
   });
   job.terminal_envelope = cancelEnvelope;
   job.terminal_delivered_at = null;
+  stampTerminalSequence(job, cancelEnvelope);
   await persistTerminalJobBestEffort(job);
-  if (postNative(cancelEnvelope)) {
-    job.terminal_delivered_at = Date.now();
-    await persistTerminalJobBestEffort(job);
-  } else {
+  if (!postNative(cancelEnvelope)) {
     await recordTerminalDeliveryLost(job, "cancel");
   }
-  // Evict only after the terminal envelope is posted and its delivery state is
-  // persisted. Late work for this job id is suppressed by terminalJobIds, and a
-  // fresh job_start remains rejected until that entry expires.
+  // Evict only after the terminal envelope is posted. Delivery is confirmed by
+  // terminal_ack; Port.postMessage returning is not a receipt.
   jobs.delete(job.job_id);
 }
 
@@ -1320,19 +1321,19 @@ async function restoreJobsFromStorage({ emitLostState = false } = {}) {
     if (!job?.job_id) {
       continue;
     }
-    if (Date.now() - (job.updated_at ?? job.started_at ?? 0) > JOB_TTL_MS) {
+    if (TERMINAL_STATUSES.has(job.status)) {
+      if (isExpiredTerminalJob(job)) {
+        await removeJobShard(job.job_id);
+        continue;
+      }
+      rememberTerminalJob(job.job_id);
+      if (!job.terminal_delivered_at && job.terminal_envelope) {
+        stampTerminalSequence(job, job.terminal_envelope);
+        postNative(job.terminal_envelope);
+      }
       continue;
     }
-    if (TERMINAL_STATUSES.has(job.status)) {
-      rememberTerminalJob(job.job_id);
-      if (job.terminal_envelope && !job.terminal_delivered_at) {
-        if (postNative(job.terminal_envelope)) {
-          job.terminal_delivered_at = Date.now();
-          await persistTerminalJobBestEffort(job);
-        } else {
-          await recordTerminalDeliveryLost(job, job.delivery_lost_phase ?? phaseForStatus(job.status) ?? "upload");
-        }
-      }
+    if (Date.now() - (job.updated_at ?? job.started_at ?? 0) > JOB_TTL_MS) {
       continue;
     }
     if (jobs.has(job.job_id)) {
@@ -1539,7 +1540,8 @@ function postHello() {
         extension_instance_id: identity.extension_instance_id,
         profile_email: identity.profile_email || null,
         profile_id: identity.profile_id || null,
-        recipes: [...ADVERTISED_RECIPES]
+        recipes: [...ADVERTISED_RECIPES],
+        capabilities: [...ADVERTISED_CAPABILITIES]
       }
     }));
   }).catch(async (error) => {
@@ -1561,7 +1563,8 @@ function postHello() {
         extension_instance_id: extensionInstanceId,
         profile_email: null,
         profile_id: null,
-        recipes: [...ADVERTISED_RECIPES]
+        recipes: [...ADVERTISED_RECIPES],
+        capabilities: [...ADVERTISED_CAPABILITIES]
       }
     }));
   });
@@ -2748,7 +2751,7 @@ function nativeEnvelopeByteLength(message) {
 }
 
 function enforceMessageCapability(message) {
-  if (!message?.job_id || message.type === "job_start") {
+  if (!message?.job_id || message.type === "job_start" || message.type === "terminal_ack") {
     return;
   }
   const job = jobs.get(message.job_id);
@@ -2879,17 +2882,16 @@ async function failJob(job, code, message, detail = {}) {
     job.updated_at = Date.now();
     chunks.discard(job.job_id);
     job.terminal_envelope = errorEnvelope(job, code, message, payloadDetail);
+    stampTerminalSequence(job, job.terminal_envelope);
     job.terminal_delivered_at = null;
     await persistTerminalJobBestEffort(job);
   }
-  const delivered = postNative(job?.terminal_envelope ?? errorEnvelope(job, code, message, payloadDetail));
+  const posted = postNative(job?.terminal_envelope ?? errorEnvelope(job, code, message, payloadDetail));
   if (job) {
-    if (delivered) {
-      job.terminal_delivered_at = Date.now();
-      await persistTerminalJobBestEffort(job);
-      jobs.delete(job.job_id);
-    } else {
+    if (!posted) {
       await recordTerminalDeliveryLost(job, payloadDetail.phase ?? phaseForStatus(job.status) ?? "upload");
+    } else {
+      jobs.delete(job.job_id);
     }
   }
 }
@@ -2926,6 +2928,118 @@ async function persistTerminalJobBestEffort(job) {
 
 function jobsStorageKey(jobId) {
   return `${JOBS_KEY_PREFIX}${jobId}`;
+}
+
+function terminalAgeStamp(job) {
+  for (const value of [job?.terminal_at, job?.updated_at, job?.started_at]) {
+    if (Number.isSafeInteger(value) && value > 0) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function isExpiredTerminalJob(job) {
+  const stamp = terminalAgeStamp(job);
+  return stamp != null && Date.now() - stamp > JOB_TTL_MS;
+}
+
+async function removeJobShard(jobId) {
+  if (!jobId || !chrome.storage.session.remove) {
+    return;
+  }
+  try {
+    await chrome.storage.session.remove(jobsStorageKey(jobId));
+  } catch (error) {
+    console.warn(`could not remove expired job ${jobId}: ${String(error?.message ?? error)}`);
+  }
+}
+
+function stampTerminalSequence(job, envelope) {
+  if (!job || !envelope || typeof envelope !== "object") {
+    return envelope;
+  }
+  if (job.terminal_sequence == null) {
+    job.terminal_sequence = 0;
+  }
+  if (job.terminal_at == null) {
+    job.terminal_at = Date.now();
+  }
+  if (!envelope.payload || typeof envelope.payload !== "object" || Array.isArray(envelope.payload)) {
+    envelope.payload = {};
+  }
+  if (envelope.payload.sequence == null) {
+    envelope.payload.sequence = job.terminal_sequence;
+  }
+  return envelope;
+}
+
+function expectedTerminalSequence(job) {
+  if (Number.isSafeInteger(job?.terminal_sequence) && job.terminal_sequence >= 0) {
+    return job.terminal_sequence;
+  }
+  const stamped = job?.terminal_envelope?.payload?.sequence;
+  if (Number.isSafeInteger(stamped) && stamped >= 0) {
+    return stamped;
+  }
+  return 0;
+}
+
+function inboundAckSequence(message) {
+  const sequence = message?.payload?.sequence;
+  if (sequence == null) {
+    return 0;
+  }
+  if (!Number.isSafeInteger(sequence) || sequence < 0) {
+    return null;
+  }
+  return sequence;
+}
+
+async function loadJobForTerminalAck(jobId) {
+  const live = jobs.get(jobId);
+  if (live) {
+    return live;
+  }
+  const key = jobsStorageKey(jobId);
+  const stored = (await chrome.storage.session.get(key))?.[key];
+  if (stored && typeof stored === "object") {
+    return stored;
+  }
+  if (terminalJobIds.has(jobId)) {
+    return {
+      job_id: jobId,
+      status: "complete",
+      terminal_sequence: 0,
+      updated_at: Date.now()
+    };
+  }
+  return null;
+}
+
+async function handleTerminalAck(message) {
+  const jobId = message?.job_id;
+  if (!jobId || typeof jobId !== "string") {
+    return;
+  }
+  const sequence = inboundAckSequence(message);
+  if (sequence == null) {
+    return;
+  }
+  const job = await loadJobForTerminalAck(jobId);
+  if (!job) {
+    return;
+  }
+  if (expectedTerminalSequence(job) !== sequence) {
+    return;
+  }
+  if (job.terminal_delivered_at) {
+    return;
+  }
+  job.terminal_delivered_at = Date.now();
+  job.updated_at = Date.now();
+  rememberTerminalJob(jobId);
+  await persistTerminalJobBestEffort(job);
 }
 
 // Build a JSON-cloneable, size-bounded view of a job for chrome.storage.session.
@@ -2969,8 +3083,10 @@ async function cleanupExpiredJobs() {
     if (!key.startsWith(JOBS_KEY_PREFIX) || !value) {
       continue;
     }
-    const stamp = value.updated_at ?? value.started_at ?? 0;
-    if (stamp < cutoff) {
+    const stamp = TERMINAL_STATUSES.has(value.status)
+      ? terminalAgeStamp(value)
+      : (value.updated_at ?? value.started_at ?? 0);
+    if (stamp != null && stamp < cutoff) {
       expiredKeys.push(key);
     }
   }

--- a/extensions/chatgpt-native/tests/protocol.test.js
+++ b/extensions/chatgpt-native/tests/protocol.test.js
@@ -49,7 +49,8 @@ test("all required native message types are declared", () => {
     "job_complete",
     "job_error",
     "heartbeat",
-    "reconnect"
+    "reconnect",
+    "terminal_ack"
   ]) {
     assert.ok(MESSAGE_TYPES.includes(type), `${type} missing`);
   }

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -101,6 +101,7 @@ test("service worker routes reconnect and multiplexes two native jobs", async ()
     assert.equal(port.messages[0].payload.profile_id, "gaia-work");
     assert.match(port.messages[0].payload.extension_instance_id, /^ext_/);
     assert.deepEqual(port.messages[0].payload.recipes, ["chatgpt", "claude"]);
+    assert.deepEqual(port.messages[0].payload.capabilities, ["terminal_ack"]);
 
     port.emit(envelope("reconnect", "job_reconnect"));
     await eventually(() => port.messages.some((message) => message.type === "reconnect" && message.job_id === "job_reconnect"));
@@ -2389,6 +2390,7 @@ test("service worker hello falls back with instance id when profile identity fai
     assert.equal(hello.payload.profile_email, null);
     assert.equal(hello.payload.profile_id, null);
     assert.deepEqual(hello.payload.recipes, ["chatgpt", "claude"]);
+    assert.deepEqual(hello.payload.capabilities, ["terminal_ack"]);
   } finally {
     globalThis.chrome = originalChrome;
   }
@@ -7642,14 +7644,247 @@ test("service worker replays an undelivered persisted terminal envelope once on 
     await eventually(() => port.messages.some((message) => (
       message.type === "job_complete" && message.job_id === "job_terminal_replay"
     )));
+    const replayed = port.messages.find((message) => (
+      message.type === "job_complete" && message.job_id === "job_terminal_replay"
+    ));
+    assert.equal(replayed.payload.sequence, 0);
     const persisted = (await storage.get("jobs.job_terminal_replay"))["jobs.job_terminal_replay"];
-    assert.ok(persisted.terminal_delivered_at);
+    assert.equal(persisted.terminal_delivered_at, null);
     assert.equal(port.messages.some((message) => message.job_id === "job_terminal_too_large"), false);
+
+    port.emit(envelope("terminal_ack", "job_terminal_replay", { sequence: 0 }));
+    await eventually(async () => {
+      const afterAck = (await storage.get("jobs.job_terminal_replay"))["jobs.job_terminal_replay"];
+      return Boolean(afterAck.terminal_delivered_at);
+    });
 
     port.messages.length = 0;
     port.emit(envelope("reconnect", "reconnect_after_terminal"));
     await eventually(() => port.messages.some((message) => message.type === "reconnect"));
     assert.equal(port.messages.some((message) => message.job_id === "job_terminal_replay"), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker hello advertises the terminal_ack capability", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  globalThis.chrome = chromeStub({ port, tabs: {} });
+
+  try {
+    await import(`../src/service-worker.js?hello_terminal_ack_capability=${Date.now()}`);
+    await eventually(() => port.messages.some((message) => message.type === "hello"));
+    const hello = port.messages.find((message) => message.type === "hello");
+    assert.ok(hello.payload.capabilities.includes("terminal_ack"));
+    assert.deepEqual(hello.payload.recipes, ["chatgpt", "claude"]);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker terminal_ack marks a persisted envelope delivered so restore does not replay", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const storage = makeStorage();
+  const terminalEnvelope = envelope("job_complete", "job_terminal_ack_before_restore", {
+    is_final: true,
+    response: "acked before restore",
+    sequence: 0
+  });
+  globalThis.chrome = chromeStub({ port, storage, tabs: {} });
+
+  try {
+    await import(`../src/service-worker.js?terminal_ack_before_restore=${Date.now()}`);
+    await eventually(() => port.messages.some((message) => message.type === "hello"));
+
+    await storage.set({
+      "jobs.job_terminal_ack_before_restore": {
+        job_id: "job_terminal_ack_before_restore",
+        run_id: "run_test",
+        workspace_id: "workspace_test",
+        capability_token: "cap_test",
+        status: "complete",
+        terminal_envelope: terminalEnvelope,
+        terminal_sequence: 0,
+        terminal_delivered_at: null,
+        started_at: Date.now(),
+        updated_at: Date.now()
+      }
+    });
+    port.emit(envelope("terminal_ack", "job_terminal_ack_before_restore", { sequence: 0 }));
+    await eventually(async () => {
+      const shard = (await storage.get("jobs.job_terminal_ack_before_restore"))["jobs.job_terminal_ack_before_restore"];
+      return Boolean(shard?.terminal_delivered_at);
+    });
+
+    port.messages.length = 0;
+    port.emit(envelope("reconnect", "reconnect_after_ack_before_restore"));
+    await eventually(() => port.messages.some((message) => message.type === "reconnect"));
+    assert.equal(port.messages.some((message) => (
+      message.type === "job_complete" && message.job_id === "job_terminal_ack_before_restore"
+    )), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker terminal_ack for an unknown job is a silent no-op", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  globalThis.chrome = chromeStub({ port, tabs: {} });
+
+  try {
+    await import(`../src/service-worker.js?terminal_ack_unknown=${Date.now()}`);
+    await eventually(() => port.messages.some((message) => message.type === "hello"));
+    port.messages.length = 0;
+    port.emit(envelope("terminal_ack", "job_terminal_ack_unknown", { sequence: 0 }));
+    await new Promise((resolve) => setTimeout(resolve, 75));
+    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
+    assert.equal(port.messages.some((message) => message.payload?.code === "unsupported_type"), false);
+    assert.equal(port.messages.length, 0);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker replay then terminal_ack then restart does not replay again", async () => {
+  const originalChrome = globalThis.chrome;
+  const firstPort = makePort();
+  const storage = makeStorage();
+  const terminalEnvelope = envelope("job_complete", "job_terminal_ack_restart", {
+    is_final: true,
+    response: "replay then ack",
+    sequence: 0
+  });
+  await storage.set({
+    "jobs.job_terminal_ack_restart": {
+      job_id: "job_terminal_ack_restart",
+      run_id: "run_test",
+      workspace_id: "workspace_test",
+      capability_token: "cap_test",
+      status: "complete",
+      terminal_envelope: terminalEnvelope,
+      terminal_sequence: 0,
+      terminal_delivered_at: null,
+      started_at: Date.now(),
+      updated_at: Date.now()
+    }
+  });
+  globalThis.chrome = chromeStub({ port: firstPort, storage, tabs: {} });
+
+  try {
+    await import(`../src/service-worker.js?terminal_ack_restart_first=${Date.now()}`);
+    await eventually(() => firstPort.messages.some((message) => (
+      message.type === "job_complete" && message.job_id === "job_terminal_ack_restart"
+    )));
+    const afterReplay = (await storage.get("jobs.job_terminal_ack_restart"))["jobs.job_terminal_ack_restart"];
+    assert.equal(afterReplay.terminal_delivered_at, null, "postNative is not a delivery receipt");
+    firstPort.emit(envelope("terminal_ack", "job_terminal_ack_restart", { sequence: 0 }));
+    await eventually(async () => {
+      const shard = (await storage.get("jobs.job_terminal_ack_restart"))["jobs.job_terminal_ack_restart"];
+      return Boolean(shard?.terminal_delivered_at);
+    });
+
+    const secondPort = makePort();
+    globalThis.chrome = chromeStub({ port: secondPort, storage, tabs: {} });
+    await import(`../src/service-worker.js?terminal_ack_restart_second=${Date.now()}`);
+    await eventually(() => secondPort.messages.some((message) => message.type === "hello"));
+    await new Promise((resolve) => setTimeout(resolve, 75));
+    assert.equal(secondPort.messages.some((message) => (
+      message.type === "job_complete" && message.job_id === "job_terminal_ack_restart"
+    )), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker terminal_ack marks a too-large persisted envelope delivered", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const storage = makeStorage();
+  await storage.set({
+    "jobs.job_terminal_ack_too_large": {
+      job_id: "job_terminal_ack_too_large",
+      status: "complete",
+      terminal_envelope_too_large: true,
+      terminal_sequence: 0,
+      terminal_delivered_at: null,
+      started_at: Date.now(),
+      updated_at: Date.now()
+    }
+  });
+  globalThis.chrome = chromeStub({ port, storage, tabs: {} });
+
+  try {
+    await import(`../src/service-worker.js?terminal_ack_too_large=${Date.now()}`);
+    await eventually(() => port.messages.some((message) => message.type === "hello"));
+    assert.equal(port.messages.some((message) => message.job_id === "job_terminal_ack_too_large"), false);
+    port.emit(envelope("terminal_ack", "job_terminal_ack_too_large", { sequence: 0 }));
+    await eventually(async () => {
+      const shard = (await storage.get("jobs.job_terminal_ack_too_large"))["jobs.job_terminal_ack_too_large"];
+      return Boolean(shard?.terminal_delivered_at);
+    });
+    const shard = (await storage.get("jobs.job_terminal_ack_too_large"))["jobs.job_terminal_ack_too_large"];
+    assert.equal(shard.terminal_envelope_too_large, true);
+    assert.equal(shard.terminal_envelope, undefined);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker purges an aged unacked terminal shard instead of replaying it", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const storage = makeStorage();
+  const now = Date.now();
+  const agedAt = now - (3 * 60 * 60 * 1000) - 1000;
+  await storage.set({
+    "jobs.job_terminal_aged": {
+      job_id: "job_terminal_aged",
+      status: "complete",
+      terminal_envelope: envelope("job_complete", "job_terminal_aged", {
+        is_final: true,
+        response: "aged unacked"
+      }),
+      terminal_sequence: 0,
+      terminal_delivered_at: null,
+      terminal_at: agedAt,
+      started_at: agedAt,
+      // Fresh updated_at simulates restore/ACK-path churn so the generic TTL
+      // skip cannot hide an unbounded terminal replay.
+      updated_at: now
+    },
+    "jobs.job_terminal_fresh_unacked": {
+      job_id: "job_terminal_fresh_unacked",
+      status: "complete",
+      terminal_envelope: envelope("job_complete", "job_terminal_fresh_unacked", {
+        is_final: true,
+        response: "fresh unacked"
+      }),
+      terminal_sequence: 0,
+      terminal_delivered_at: null,
+      terminal_at: now,
+      started_at: now,
+      updated_at: now
+    }
+  });
+  globalThis.chrome = chromeStub({ port, storage, tabs: {} });
+
+  try {
+    await import(`../src/service-worker.js?terminal_ack_aged_purge=${Date.now()}`);
+    await eventually(() => port.messages.some((message) => message.type === "hello"));
+    await eventually(() => port.messages.some((message) => (
+      message.type === "job_complete" && message.job_id === "job_terminal_fresh_unacked"
+    )));
+    assert.equal(port.messages.some((message) => (
+      message.type === "job_complete" && message.job_id === "job_terminal_aged"
+    )), false);
+    const aged = (await storage.get("jobs.job_terminal_aged"))["jobs.job_terminal_aged"];
+    const fresh = (await storage.get("jobs.job_terminal_fresh_unacked"))["jobs.job_terminal_fresh_unacked"];
+    assert.equal(aged, undefined);
+    assert.ok(fresh);
+    assert.equal(fresh.terminal_delivered_at, null);
   } finally {
     globalThis.chrome = originalChrome;
   }


### PR DESCRIPTION
## Summary

Extension-side half of #406 (closes it) — completes the terminal-envelope durability protocol whose host half landed in #409:

- Hello advertises the `terminal_ack` capability (identity and fallback paths); outgoing terminals stamp `payload.sequence`.
- `postNative` is no longer treated as a delivery receipt: `terminal_delivered_at` is set only by the host's `terminal_ack` (idempotent handler; unknown job / bad sequence are silent no-ops; size-gated too-large shards still mark delivered; ledger-only jobs get a delivered stub).
- Replay is age-bounded and purging: `terminal_at` is stamped once at envelope creation and is immune to `updated_at` churn; restore purges shards older than `JOB_TTL_MS` instead of replaying, and the heartbeat cleanup uses the same stamp. Fresh unACKed shards still replay; ACK remains the normal closer — so a pre-ACK host cannot cause unbounded replay.

## Review

Two rounds (claude). Round-1 finding D1: the receipt inversion made replay unbounded against pre-ACK hosts — fixed with the age-bound/purge plus a churn-immunity counterexample (aged `terminal_at` + fresh `updated_at` purges; fails on pre-delta code).

## Validation

- Extension suite 359/359; hybrid must-fail proofs (5 ACK fixtures + aged-purge) verified independently by both agents.

Implemented by cursor (grok-46).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbMozs4Nt8Thd5zWRkuNQr