### PR TITLE
fix(extension): restart model selection after bfcache restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 ### Fixed
 
+- Native-extension model selection now closes stale picker state and restarts
+  from scratch after a persisted bfcache `pageshow`; only the restarted attempt
+  can advance or fail the pre-upload job.
+- Native host: terminal-envelope dedup (first-wins by job id) and
+  capability-gated terminal_ack; unrouted terminals stay replayable.
 - Native-extension ChatGPT/Claude jobs now park on a per-job pageshow gate when
   a submitted tab is in bfcache instead of burning the 20s content-script probe
   loop, and both poller catch paths join in-flight or settled recovery under a

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -422,6 +422,21 @@ export async function configureModelState(root, job = {}) {
   };
 }
 
+export async function resetModelSelectionState(root) {
+  if (!findPickerState(root)) {
+    return { reset: true, picker_was_open: false };
+  }
+  const modelButton = findModelButton(root) ?? root.activeElement ?? root.body;
+  if (!await closeModelPicker(root, modelButton)) {
+    throw chatgptCommandError(
+      "model_picker_close_failed",
+      "ChatGPT model picker remained open while resetting a restored model selection",
+      { phase: "model_selection", side_effect_started: false }
+    );
+  }
+  return { reset: true, picker_was_open: true };
+}
+
 function modelSelectionOptionsForJob(job = {}) {
   const options = {};
   const timeoutMs = Number(job?.model_selection_timeout_ms);

--- a/extensions/chatgpt-native/src/claude-dom.js
+++ b/extensions/chatgpt-native/src/claude-dom.js
@@ -467,6 +467,23 @@ export async function configureModelState(root, job = {}) {
   };
 }
 
+export async function resetModelSelectionState(root) {
+  const modelButton = root.querySelector(MODEL_SELECTOR);
+  if (!modelButton) {
+    return { reset: true, picker_was_open: false };
+  }
+  const pickerWasOpen = modelButton.getAttribute("aria-expanded") === "true"
+    || Boolean(root.querySelector("[role='menu']"));
+  if (pickerWasOpen && !await closeModelMenu(root, modelButton)) {
+    throw commandError(
+      "model_picker_close_failed",
+      "Claude model picker remained open while resetting a restored model selection",
+      { phase: "model_selection", side_effect_started: false }
+    );
+  }
+  return { reset: true, picker_was_open: pickerWasOpen };
+}
+
 export async function clickSend(root, options = {}) {
   const send = await waitForClaudeState(root, () => {
     const candidate = findSendButton(root);

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -64,7 +64,7 @@ async function handleMessage(message) {
     case "yoetz_upload_file":
       return uploadJobFile(message.job, message.file);
     case "yoetz_configure_model":
-      return configureModel(message.job);
+      return configureModel(message.job, { reset: message.reset === true });
     case "yoetz_send_prompt":
       return sendPrompt(message.job, message.prompt);
     case "yoetz_extract_response":
@@ -181,8 +181,13 @@ async function uploadJobFile(job, filePayload) {
   return { filename: file.name, size: file.size };
 }
 
-async function configureModel(job) {
-  const { classifyBlockingState, configureModelState, parseOwnedWindowName } = await domHelpers(job);
+async function configureModel(job, options = {}) {
+  const {
+    classifyBlockingState,
+    configureModelState,
+    parseOwnedWindowName,
+    resetModelSelectionState
+  } = await domHelpers(job);
   const adapter = await siteAdapter(job);
   assertJobOwnership(job, parseOwnedWindowName, ownershipOptionsForJob(job, "model_selection", adapter));
   assertNoBlockingState(classifyBlockingState, {
@@ -190,6 +195,9 @@ async function configureModel(job) {
     side_effect_started: false,
     send_committed: false
   });
+  if (options.reset) {
+    await resetModelSelectionState(document);
+  }
   const selection = await configureModelState(document, job);
   assertNoBlockingState(classifyBlockingState, {
     phase: "model_selection",

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -193,6 +193,29 @@ async function handleContentLifecycle(message, sender) {
 
   let rebound = 0;
   for (const job of ownedJobs) {
+    if (job.status === "selecting_model") {
+      if (!job.content_script_suspended_at) {
+        continue;
+      }
+      const attempt = Number(job.model_selection_attempt ?? 0) + 1;
+      job.model_selection_attempt = attempt;
+      job.content_script_suspended_at = null;
+      job.updated_at = Date.now();
+      await persistJob(job);
+      postNative(progress(job, "model_selection_restarting", {
+        tab_id: tabId,
+        persisted: true,
+        attempt,
+        message: "owned background tab returned from bfcache; restarting model selection from a closed picker"
+      }));
+      try {
+        await completeModelSelection(job, tabId, attempt, { reset: true });
+      } catch (error) {
+        await handlePollerError(job, error);
+      }
+      rebound += 1;
+      continue;
+    }
     if (job.status !== "waiting_response") {
       continue;
     }
@@ -412,9 +435,30 @@ async function startJob(message) {
     return;
   }
   job.status = "selecting_model";
+  job.model_selection_attempt = Number(job.model_selection_attempt ?? 0) + 1;
   job.updated_at = Date.now();
   await persistJob(job);
-  const modelSelection = await sendToTab(tab.id, { type: "yoetz_configure_model", job });
+  await completeModelSelection(job, tab.id, job.model_selection_attempt);
+}
+
+async function completeModelSelection(job, tabId, attempt, options = {}) {
+  const adapter = adapterForJob(job);
+  let modelSelection;
+  try {
+    modelSelection = await sendToTab(tabId, {
+      type: "yoetz_configure_model",
+      job,
+      reset: options.reset === true
+    });
+  } catch (error) {
+    if (Number(job.model_selection_attempt) !== attempt) {
+      return;
+    }
+    throw error;
+  }
+  if (Number(job.model_selection_attempt) !== attempt) {
+    return;
+  }
   job.model_used = modelSelection.model_used ?? null;
   job.model_selection_status = modelSelection.status ?? "unavailable";
   job.warnings = [
@@ -446,11 +490,11 @@ async function startJob(message) {
     return;
   }
 
-  await maybeGroupTab(tab.id, job);
+  await maybeGroupTab(tabId, job);
   job.status = "waiting_for_file";
   job.updated_at = Date.now();
   await persistJob(job);
-  if (!postNative(progress(job, "ready_for_file", { tab_id: tab.id, message: `${adapter.displayName} tab is ready for bundle upload` }))) {
+  if (!postNative(progress(job, "ready_for_file", { tab_id: tabId, message: `${adapter.displayName} tab is ready for bundle upload` }))) {
     await recordTerminalDeliveryLost(job, "upload");
   }
 }

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -12,6 +12,7 @@ import {
   insertPrompt,
   isResponseGenerating,
   modelSelectionDiagnostics,
+  resetModelSelectionState,
   sendAcceptanceBaseline,
   uploadFile,
   waitForSendAccepted
@@ -2246,6 +2247,17 @@ test("GPT-5.6 Sol picker upgrades High effort to Extra High and verifies both pr
   assert.equal(fixture.effortClicks(), 1);
   assert.ok(fixture.mainOpens() >= 2, "selection must reopen the picker to verify");
   assert.equal(fixture.menusOpen(), 0, "verification must leave the picker closed");
+});
+
+test("restored ChatGPT model selection closes an open picker before restart", async () => {
+  const fixture = makeSolPickerFixture({ family: "GPT-5.6 Sol", effort: "High" });
+  fixture.pill.onPointerDown();
+  assert.equal(fixture.menusOpen(), 1);
+
+  const result = await resetModelSelectionState(fixture.doc);
+
+  assert.deepEqual(result, { reset: true, picker_was_open: true });
+  assert.equal(fixture.menusOpen(), 0);
 });
 
 test("GPT-5.6 Sol picker switches GPT-5.5 Instant to Sol Extra High", async () => {

--- a/extensions/chatgpt-native/tests/fake-claude.test.js
+++ b/extensions/chatgpt-native/tests/fake-claude.test.js
@@ -5,6 +5,7 @@ import {
   classifyBlockingState,
   clickSend,
   configureModelState,
+  resetModelSelectionState,
   ensureConversationLoaded,
   ensureFreshChat,
   extractResponse,
@@ -883,6 +884,17 @@ test("fake Claude model picker keeps shared menu visibility semantics for offscr
     globalThis.MouseEvent = previousMouseEvent;
     globalThis.KeyboardEvent = previousKeyboardEvent;
   }
+});
+
+test("restored Claude model selection closes an open picker before restart", async () => {
+  const fixture = makeClaudeModelFixture();
+  fixture.modelButton.click();
+  assert.equal(fixture.modelButton.getAttribute("aria-expanded"), "true");
+
+  const result = await resetModelSelectionState(fixture.root);
+
+  assert.deepEqual(result, { reset: true, picker_was_open: true });
+  assert.equal(fixture.modelButton.getAttribute("aria-expanded"), "false");
 });
 
 test("fake Claude model picker reclassifies credits immediately after Fable selection", async () => {

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -6182,6 +6182,172 @@ test("service worker rebinds owned tab after content script reload during respon
   }
 });
 
+test("service worker restarts model selection from scratch after persisted bfcache pageshow", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  let runtimeListener = null;
+  let tabId = 0;
+  let resolveSuspendedSelection;
+  let markSuspendedSelectionStarted;
+  const suspendedSelectionStarted = new Promise((resolve) => {
+    markSuspendedSelectionStarted = resolve;
+  });
+  const configureCalls = [];
+  const chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            configureCalls.push({ reset: message.reset, attempt: message.job.model_selection_attempt });
+            if (configureCalls.length === 1) {
+              markSuspendedSelectionStarted();
+              return new Promise((resolve) => {
+                resolveSuspendedSelection = resolve;
+              });
+            }
+            return { ok: true, payload: verifiedSolProSelection() };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+  chrome.runtime.onMessage.addListener = (listener) => {
+    runtimeListener = listener;
+  };
+  globalThis.chrome = chrome;
+
+  try {
+    await import(`../src/service-worker.js?bfcache_model_restart=${Date.now()}`);
+    port.emit(envelope("job_start", "job_bfcache_model_restart", { prompt: "prompt" }));
+    await suspendedSelectionStarted;
+
+    const lifecycle = (event) => new Promise((resolve) => {
+      assert.equal(runtimeListener(
+        { type: "yoetz_content_lifecycle", event, persisted: true, job_ids: ["job_bfcache_model_restart"] },
+        { tab: { id: tabId } },
+        resolve
+      ), true);
+    });
+    assert.equal((await lifecycle("pagehide")).ok, true);
+    assert.equal((await lifecycle("pageshow")).ok, true);
+
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    assert.deepEqual(configureCalls, [
+      { reset: false, attempt: 1 },
+      { reset: true, attempt: 2 }
+    ]);
+    assert.equal(
+      port.messages.filter((message) => message.payload?.phase === "model_selection_restarting").length,
+      1
+    );
+
+    resolveSuspendedSelection({
+      ok: true,
+      payload: {
+        status: "unavailable",
+        requested_model: "gpt-5-6-sol-extra-high",
+        failure_reason: "stale_suspended_attempt"
+      }
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(port.messages.filter((message) => message.payload?.phase === "ready_for_file").length, 1);
+    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker keeps the fail-closed model-selection result when bfcache restart fails", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  let runtimeListener = null;
+  let tabId = 0;
+  let resolveSuspendedSelection;
+  let markSuspendedSelectionStarted;
+  const suspendedSelectionStarted = new Promise((resolve) => {
+    markSuspendedSelectionStarted = resolve;
+  });
+  let configureCalls = 0;
+  const failedSelection = {
+    status: "unavailable",
+    model_used: null,
+    requested_model: "gpt-5-6-sol-extra-high",
+    family_status: "unverified",
+    effort_status: "unverified",
+    failure_reason: "model_picker_open_failed",
+    warning: "ChatGPT GPT-5.6 model picker did not open"
+  };
+  const chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            configureCalls += 1;
+            if (configureCalls === 1) {
+              markSuspendedSelectionStarted();
+              return new Promise((resolve) => {
+                resolveSuspendedSelection = resolve;
+              });
+            }
+            assert.equal(message.reset, true);
+            return { ok: true, payload: failedSelection };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+  chrome.runtime.onMessage.addListener = (listener) => {
+    runtimeListener = listener;
+  };
+  globalThis.chrome = chrome;
+
+  try {
+    await import(`../src/service-worker.js?bfcache_model_restart_failed=${Date.now()}`);
+    port.emit(envelope("job_start", "job_bfcache_model_restart_failed", { prompt: "prompt" }));
+    await suspendedSelectionStarted;
+    const lifecycle = (event) => new Promise((resolve) => {
+      assert.equal(runtimeListener(
+        { type: "yoetz_content_lifecycle", event, persisted: true, job_ids: ["job_bfcache_model_restart_failed"] },
+        { tab: { id: tabId } },
+        resolve
+      ), true);
+    });
+    assert.equal((await lifecycle("pagehide")).ok, true);
+    assert.equal((await lifecycle("pageshow")).ok, true);
+
+    await eventually(() => port.messages.some((message) => message.type === "job_error"));
+    const error = port.messages.find((message) => message.type === "job_error");
+    assert.equal(error.payload.code, "model_selection_failed");
+    assert.equal(error.payload.phase, "model_selection");
+    assert.equal(error.payload.side_effect_started, false);
+    assert.equal(error.payload.failure_reason, failedSelection.failure_reason);
+    assert.deepEqual(error.payload.model_selection, failedSelection);
+
+    resolveSuspendedSelection({ ok: true, payload: verifiedSolProSelection() });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(port.messages.some((message) => message.payload?.phase === "ready_for_file"), false);
+    assert.equal(port.messages.filter((message) => message.type === "job_error").length, 1);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker idempotently rebinds a persisted bfcache restore without replaying side effects", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();


### PR DESCRIPTION
## Summary

Closes #405. A bfcache restore during `selecting_model` previously aborted the job (lifecycle recovery only handled `waiting_response`). Now a persisted pageshow on a `selecting_model` job restarts selection cleanly — pre-side-effect, zero replay risk:

- Restart increments a `model_selection_attempt` generation; the in-flight pre-bfcache `yoetz_configure_model` result becomes inert on both success and error paths.
- `reset=true` closes any open picker before the exact rerun (`resetModelSelectionState` in the content script, both ChatGPT and Claude adapters).
- The pageshow branch admits only `selecting_model` beyond `waiting_response` — upload/send statuses keep today's semantics. Double pageshow is idempotent via the suspension marker. Restart failure keeps the fail-closed `model_selection` terminal with `side_effect_started=false`.
- Also adds the missing #406-phase-1 CHANGELOG entry.

## Validation

- Extension 357/357; cargo workspace 768/0; clippy `-D warnings` clean — verified independently by both agents.
- Hybrid must-fail: restart-success and restart-failure fixtures both fail on current main (reproduced independently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbMozs4Nt8Thd5zWRkuNQr