### PR TITLE
fix(extension): match composer pill effort across whitespace boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 ### Fixed
 
+- Native-extension GPT-5.6 effort verification now accepts the live two-line
+  composer pill while still requiring the exact verified maximum-tier label.
 - Native-extension model selection now closes stale picker state and restarts
   from scratch after a persisted bfcache `pageshow`; only the restarted attempt
   can advance or fail the pre-upload job.

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -1021,8 +1021,8 @@ function effortIsMaxTier(state) {
 }
 
 function pillConfirmsEffortLabel(pillText, effortLabel) {
-  const foldedPill = foldedModelText(pillText);
-  const foldedEffort = foldedModelText(effortLabel);
+  const foldedPill = foldedModelText(pillText).replace(/\s+/g, " ");
+  const foldedEffort = foldedModelText(effortLabel).replace(/\s+/g, " ");
   return foldedPill === foldedEffort || foldedPill.endsWith(` ${foldedEffort}`);
 }
 

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -2391,6 +2391,37 @@ test("GPT-5.6 Sol Advanced picker moves the scoped effort slider with End", asyn
   assert.equal(result.pill_text, "Extra High");
 });
 
+test("GPT-5.6 Sol Advanced picker verifies the live two-line composer pill", async () => {
+  const fixture = makeSolSliderFixture({
+    levels: ["Instant", "Medium", "High", "Heavy", "Extra High"],
+    initialValue: 5,
+    pillFamilyLabel: "5.6 Sol"
+  });
+  assert.equal(fixture.pill.innerText, "5.6 Sol\nExtra High");
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "selected");
+  assert.equal(result.effort_control.label, "extra high");
+  assert.equal(result.pill_text, "5.6 Sol\nExtra High");
+});
+
+test("GPT-5.6 Sol Advanced picker upgrades the live two-line Light pill", async () => {
+  const fixture = makeSolSliderFixture({
+    keyboardMode: "end",
+    levels: ["Instant", "Light", "Standard", "Heavy", "Extra High"],
+    initialValue: 2,
+    pillFamilyLabel: "5.6 Sol"
+  });
+  assert.equal(fixture.pill.innerText, "5.6 Sol\nLight");
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "selected");
+  assert.equal(result.effort_control.label, "extra high");
+  assert.equal(result.pill_text, "5.6 Sol\nExtra High");
+});
+
 test("GPT-5.6 Sol Advanced picker accepts Pro at the Enterprise slider maximum", async () => {
   const fixture = makeSolSliderFixture({
     keyboardMode: "end",
@@ -2810,7 +2841,8 @@ function makeSolSliderFixture({
   initialValue = 3,
   includeSpeedRows = false,
   transcriptEffortDecoy = null,
-  familyLabel = "GPT-5.6 Sol"
+  familyLabel = "GPT-5.6 Sol",
+  pillFamilyLabel = ""
 } = {}) {
   let currentValue = initialValue;
   let panel = null;
@@ -2822,6 +2854,7 @@ function makeSolSliderFixture({
   let familyMenu = null;
   let familyValueNode = null;
   const keyAttemptLog = [];
+  const pillTextForEffort = (label) => pillFamilyLabel ? `${pillFamilyLabel}\n${label}` : label;
   const composer = new FakeElement("textarea", { placeholder: "Ask anything" });
   const form = new FakeElement("form", { "data-testid": "composer" }, "").append(composer);
   const body = new FakeElement("body", {}, "Ask anything").append(form);
@@ -2851,8 +2884,8 @@ function makeSolSliderFixture({
       effortLabel.innerText = `${label}, ${currentValue} of 5${valueTextSuffix}`;
       effortLabel.textContent = effortLabel.innerText;
     }
-    pill.innerText = label;
-    pill.textContent = label;
+    pill.innerText = pillTextForEffort(label);
+    pill.textContent = pill.innerText;
   };
   const makeEffortSlider = () => new FakeElement("div", {
     role: "slider",
@@ -3014,7 +3047,7 @@ function makeSolSliderFixture({
       if (event.key === "Escape") closePanel();
       if (animatedReveal && (event.key === "Enter" || event.key === " ")) togglePanel();
     }
-  }, levels[currentValue - 1]);
+  }, pillTextForEffort(levels[currentValue - 1]));
   form.append(pill);
   const doc = new FakeDocument(body);
 


### PR DESCRIPTION
## Summary

Release blocker caught by the pre-release acceptance run: `pillConfirmsEffortLabel` demanded a space-prefixed suffix while the live composer pill is two-line (`5.6 Sol\nExtra High`) and `normalizeText` deliberately preserves newlines — so the pill-confirmation leg (shipped in 0.5.51's dual-variant amendment without live proof) could never match on a live picker sitting at the max tier. Fix collapses whitespace on both folded operands, scoped to this predicate only.

Fixtures use the verbatim live pill strings (already-at-max and transition cases); hybrid must-fail 2/2 on current main.

## Validation
- Extension suite 365/365; clippy `-D warnings` clean — verified independently by both agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbMozs4Nt8Thd5zWRkuNQr