### PR TITLE
fix(extension): guard model-selection tail against stale attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 ### Fixed
 
+- Native-extension model-selection restarts now recheck attempt ownership and
+  job liveness after awaited tail work so a stale attempt cannot resurrect a
+  terminal job or announce bundle readiness.
 - Native-extension GPT-5.6 effort verification now accepts the live two-line
   composer pill while still requiring the exact verified maximum-tier label.
 - Native-extension model selection now closes stale picker state and restarts

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -456,12 +456,12 @@ async function completeModelSelection(job, tabId, attempt, options = {}) {
       reset: options.reset === true
     });
   } catch (error) {
-    if (Number(job.model_selection_attempt) !== attempt) {
+    if (staleSelectionAttempt(job, attempt)) {
       return;
     }
     throw error;
   }
-  if (Number(job.model_selection_attempt) !== attempt) {
+  if (staleSelectionAttempt(job, attempt)) {
     return;
   }
   job.model_used = modelSelection.model_used ?? null;
@@ -496,12 +496,25 @@ async function completeModelSelection(job, tabId, attempt, options = {}) {
   }
 
   await maybeGroupTab(tabId, job);
+  if (staleSelectionAttempt(job, attempt)) {
+    return;
+  }
   job.status = "waiting_for_file";
   job.updated_at = Date.now();
   await persistJob(job);
+  if (staleSelectionAttempt(job, attempt)) {
+    return;
+  }
   if (!postNative(progress(job, "ready_for_file", { tab_id: tabId, message: `${adapter.displayName} tab is ready for bundle upload` }))) {
     await recordTerminalDeliveryLost(job, "upload");
   }
+}
+
+function staleSelectionAttempt(job, attempt) {
+  return Number(job.model_selection_attempt) !== attempt
+    || !jobs.has(job.job_id)
+    || TERMINAL_STATUSES.has(job.status)
+    || job.cancelled;
 }
 
 function modelSelectionFailureDiagnostics(selection) {

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -6350,6 +6350,107 @@ test("service worker keeps the fail-closed model-selection result when bfcache r
   }
 });
 
+test("service worker does not resurrect a terminal model selection from a stale post-configure tail", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  const storage = makeStorage();
+  let runtimeListener = null;
+  let tabId = 0;
+  let configureCalls = 0;
+  let releaseAttemptTwoGrouping;
+  let markAttemptTwoGroupingStarted;
+  const attemptTwoGroupingStarted = new Promise((resolve) => {
+    markAttemptTwoGroupingStarted = resolve;
+  });
+  const failedSelection = {
+    status: "unavailable",
+    model_used: null,
+    requested_model: "gpt-5-6-sol-extra-high",
+    family_status: "unverified",
+    effort_status: "unverified",
+    failure_reason: "model_picker_open_failed",
+    warning: "ChatGPT GPT-5.6 model picker did not open"
+  };
+  let resolveInitialSelection;
+  const chrome = chromeStub({
+    port,
+    storage,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      group: async () => {
+        markAttemptTwoGroupingStarted();
+        return new Promise((resolve) => {
+          releaseAttemptTwoGrouping = () => resolve(1);
+        });
+      },
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            configureCalls += 1;
+            if (configureCalls === 1) {
+              return new Promise((resolve) => {
+                resolveInitialSelection = resolve;
+              });
+            }
+            return {
+              ok: true,
+              payload: configureCalls === 2 ? verifiedSolProSelection() : failedSelection
+            };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+  chrome.runtime.onMessage.addListener = (listener) => {
+    runtimeListener = listener;
+  };
+  globalThis.chrome = chrome;
+
+  try {
+    await import(`../src/service-worker.js?bfcache_model_tail_liveness=${Date.now()}`);
+    const jobId = "job_bfcache_model_tail_liveness";
+    port.emit(envelope("job_start", jobId, { prompt: "prompt" }));
+    await eventually(() => configureCalls === 1);
+    const lifecycle = (event) => new Promise((resolve) => {
+      assert.equal(runtimeListener(
+        { type: "yoetz_content_lifecycle", event, persisted: true, job_ids: [jobId] },
+        { tab: { id: tabId } },
+        resolve
+      ), true);
+    });
+
+    assert.equal((await lifecycle("pagehide")).ok, true);
+    const attemptTwoPageshow = lifecycle("pageshow");
+    await attemptTwoGroupingStarted;
+    assert.equal((await lifecycle("pagehide")).ok, true);
+    assert.equal((await lifecycle("pageshow")).ok, true);
+    await eventually(() => port.messages.some((message) => message.type === "job_error"));
+
+    releaseAttemptTwoGrouping();
+    assert.equal((await attemptTwoPageshow).ok, true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    resolveInitialSelection({ ok: true, payload: verifiedSolProSelection() });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const persisted = await storage.get(`jobs.${jobId}`);
+    assert.equal(persisted[`jobs.${jobId}`].status, "failed");
+    const errorIndex = port.messages.findIndex((message) => message.type === "job_error");
+    assert.notEqual(errorIndex, -1);
+    assert.equal(
+      port.messages.slice(errorIndex + 1).some((message) => message.payload?.phase === "ready_for_file"),
+      false
+    );
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker idempotently rebinds a persisted bfcache restore without replaying side effects", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();


### PR DESCRIPTION
## Summary

Follow-up to #412, from the live acceptance's cross-diff review: the post-configure tail of `completeModelSelection` had no attempt/liveness rechecks after its awaits, so a stale attempt resuming past `maybeGroupTab` could resurrect a terminalized job's shard and post `ready_for_file` after `job_error`. A factored `staleSelectionAttempt` guard (generation mismatch, map absence, terminal status, cancelled) now runs after every await in the tail.

Counterexample fixture reproduces the exact interleaving (attempt 2 blocked in `tabs.group`, attempt 3 fails and terminalizes, attempt 2 resumes): fails on current main, passes here — verified independently by both agents.

## Validation
- Extension 366/366; clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbMozs4Nt8Thd5zWRkuNQr