### PR TITLE
fix(extension): retry model selection once after transient content-script loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- Native-extension model selection now runs one bounded content-script recovery
+  when a `selecting_model` configure send hits a recoverable port error, then
+  retries selection exactly once instead of terminalizing the pre-upload job.
 
 ## [0.5.52] - 2026-08-13
 ### Fixed

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -201,6 +201,7 @@ async function handleContentLifecycle(message, sender) {
       }
       const attempt = Number(job.model_selection_attempt ?? 0) + 1;
       job.model_selection_attempt = attempt;
+      openSuspensionGate(job);
       job.content_script_suspended_at = null;
       job.updated_at = Date.now();
       await persistJob(job);
@@ -459,7 +460,36 @@ async function completeModelSelection(job, tabId, attempt, options = {}) {
     if (staleSelectionAttempt(job, attempt)) {
       return;
     }
-    throw error;
+    if (
+      options.selectionRecoveryRetried
+      || !isRecoverableContentScriptError(error)
+    ) {
+      throw error;
+    }
+    try {
+      await recoverContentScriptJob(job, error, { source: "model_selection" });
+    } catch (recoveryError) {
+      if (staleSelectionAttempt(job, attempt)) {
+        return;
+      }
+      throw recoveryError;
+    }
+    forgetSettledSuccessfulRecovery(job.job_id);
+    if (staleSelectionAttempt(job, attempt)) {
+      return;
+    }
+    const retryAttempt = Number(job.model_selection_attempt ?? 0) + 1;
+    job.model_selection_attempt = retryAttempt;
+    job.updated_at = Date.now();
+    await persistJob(job);
+    if (staleSelectionAttempt(job, retryAttempt)) {
+      return;
+    }
+    return completeModelSelection(job, tabId, retryAttempt, {
+      ...options,
+      reset: true,
+      selectionRecoveryRetried: true
+    });
   }
   if (staleSelectionAttempt(job, attempt)) {
     return;

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -6267,6 +6267,183 @@ test("service worker restarts model selection from scratch after persisted bfcac
   }
 });
 
+test("service worker retries model selection once after a transient content-script loss", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  let tabId = 0;
+  const tabMessages = [];
+  const configureAttempts = [];
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        tabMessages.push(message.type);
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            configureAttempts.push(message.job.model_selection_attempt);
+            if (configureAttempts.length === 1) {
+              throw new Error("Could not establish connection. Receiving end does not exist.");
+            }
+            return { ok: true, payload: verifiedSolProSelection() };
+          case "yoetz_bind_job":
+            return { ok: true, payload: { url: "https://chatgpt.com/", title: "ChatGPT" } };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?selecting_model_transient_cs=${Date.now()}`);
+    port.emit(envelope("job_start", "job_selecting_model_transient_cs", { prompt: "prompt" }));
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    assert.deepEqual(configureAttempts, [1, 2]);
+    assert.ok(tabMessages.includes("yoetz_bind_job"));
+    assert.equal(port.messages.filter((message) => message.payload?.phase === "ready_for_file").length, 1);
+    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker fail-closes model selection after one content-script recovery retry", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  let tabId = 0;
+  let configureCalls = 0;
+  globalThis.chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            configureCalls += 1;
+            throw new Error("Could not establish connection. Receiving end does not exist.");
+          case "yoetz_bind_job":
+            return { ok: true, payload: { url: "https://chatgpt.com/", title: "ChatGPT" } };
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+
+  try {
+    await import(`../src/service-worker.js?selecting_model_persistent_cs=${Date.now()}`);
+    port.emit(envelope("job_start", "job_selecting_model_persistent_cs", { prompt: "prompt" }));
+    await eventually(() => port.messages.some((message) => message.type === "job_error"));
+    assert.equal(configureCalls, 2);
+    assert.equal(port.messages.filter((message) => message.type === "job_error").length, 1);
+    assert.equal(port.messages.some((message) => message.payload?.phase === "ready_for_file"), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
+test("service worker keeps one live model-selection attempt when recovery retry races a pageshow restart", async () => {
+  const originalChrome = globalThis.chrome;
+  const port = makePort();
+  let runtimeListener = null;
+  let tabId = 0;
+  let releaseBind;
+  let resolveSecondConfigure;
+  let markBindStarted;
+  let markSecondConfigureStarted;
+  const bindStarted = new Promise((resolve) => {
+    markBindStarted = resolve;
+  });
+  const secondConfigureStarted = new Promise((resolve) => {
+    markSecondConfigureStarted = resolve;
+  });
+  let bindCalls = 0;
+  const configureCalls = [];
+  const chrome = chromeStub({
+    port,
+    tabs: {
+      create: async (opts) => ({ id: ++tabId, ...opts }),
+      get: async (id) => ({ id, status: "complete", url: "https://chatgpt.com/" }),
+      sendMessage: async (_id, message) => {
+        switch (message.type) {
+          case "yoetz_probe":
+            return { ok: true, payload: {} };
+          case "yoetz_prepare_job":
+            return { ok: true, payload: { manual_handoff: null } };
+          case "yoetz_configure_model":
+            configureCalls.push(message.job.model_selection_attempt);
+            if (configureCalls.length === 1) {
+              throw new Error("Could not establish connection. Receiving end does not exist.");
+            }
+            if (configureCalls.length === 2) {
+              markSecondConfigureStarted();
+              return new Promise((resolve) => {
+                resolveSecondConfigure = () => resolve({ ok: true, payload: verifiedSolProSelection() });
+              });
+            }
+            return { ok: true, payload: verifiedSolProSelection() };
+          case "yoetz_bind_job":
+            bindCalls += 1;
+            markBindStarted();
+            return new Promise((resolve) => {
+              releaseBind = () => resolve({ ok: true, payload: { url: "https://chatgpt.com/", title: "ChatGPT" } });
+            });
+          default:
+            throw new Error(`unexpected tab message ${message.type}`);
+        }
+      }
+    }
+  });
+  chrome.runtime.onMessage.addListener = (listener) => {
+    runtimeListener = listener;
+  };
+  globalThis.chrome = chrome;
+
+  try {
+    await import(`../src/service-worker.js?selecting_model_pageshow_race=${Date.now()}`);
+    const jobId = "job_selecting_model_pageshow_race";
+    port.emit(envelope("job_start", jobId, { prompt: "prompt" }));
+    await Promise.race([
+      bindStarted,
+      new Promise((_, reject) => setTimeout(() => reject(new Error("content-script bind did not start")), 5000))
+    ]);
+
+    const lifecycle = (event) => new Promise((resolve) => {
+      assert.equal(runtimeListener(
+        { type: "yoetz_content_lifecycle", event, persisted: true, job_ids: [jobId] },
+        { tab: { id: tabId } },
+        resolve
+      ), true);
+    });
+    assert.equal((await lifecycle("pagehide")).ok, true);
+    const firstPageshow = lifecycle("pageshow");
+    await secondConfigureStarted;
+    assert.equal((await lifecycle("pagehide")).ok, true);
+    assert.equal((await lifecycle("pageshow")).ok, true);
+    await eventually(() => port.messages.some((message) => message.payload?.phase === "ready_for_file"));
+    releaseBind();
+    resolveSecondConfigure();
+    assert.equal((await firstPageshow).ok, true);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    assert.ok(bindCalls >= 1);
+    assert.equal(port.messages.filter((message) => message.payload?.phase === "ready_for_file").length, 1);
+    assert.equal(port.messages.some((message) => message.type === "job_error"), false);
+  } finally {
+    globalThis.chrome = originalChrome;
+  }
+});
+
 test("service worker keeps the fail-closed model-selection result when bfcache restart fails", async () => {
   const originalChrome = globalThis.chrome;
   const port = makePort();


### PR DESCRIPTION
## Summary

Closes #414. A recoverable content-script port loss during `yoetz_configure_model` (content script reloading right after a persisted pageshow) previously terminalized the job even though selection is pre-side-effect. Now: one bounded content-script recovery (routed through the existing park machinery, so suspension semantics hold and the pageshow gate opens parked recoveries), then exactly one selection retry on a fresh attempt with `reset=true` — every await guarded by `staleSelectionAttempt` from #415, the fulfilled recovery forgotten after use so a second failure keeps today's fail-closed terminal. Non-recoverable errors are unchanged.

## Validation
- Extension 369/369; clippy `-D warnings` clean — verified independently by both agents.
- Hybrid must-fail (3 fixtures) vs current main: transient-loss completion, exactly-one-retry, and the retry-vs-second-pageshow race — reproduced independently.

Implemented by cursor (grok-46).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbMozs4Nt8Thd5zWRkuNQr