### PR TITLE
fix(chatgpt): dual-variant upload commit signals and named context bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `yoetz bundle --name` writes a descriptive, timestamped Markdown artifact;
+  when omitted, the name is derived from the prompt. Contributed by @bnsd55.
+
+### Fixed
+
+- ChatGPT native-extension uploads now support both the legacy enabled-Send
+  commit signal and the disabled-Send empty-composer variant, then require two
+  stable enabled ticks before sending. Contributed by @bnsd55.
+
 ## [0.5.53] - 2026-08-13
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -209,13 +209,16 @@ stale provider names or hand-written wrapper paths.
 ```bash
 yoetz bundle \
   -p "Review the browser transport design" \
+  --name browser-transport-review \
   -f "crates/yoetz-cli/src/browser*.rs" \
   -f recipes/chatgpt.yaml \
   --format json
 ```
 
 The JSON response points to session artifacts under `~/.yoetz/sessions/<id>/`,
-including `bundle.md`.
+including a descriptive Markdown file such as
+`browser-transport-review_20260812-193000Z.md`. If `--name` is omitted, Yoetz
+derives the name from the prompt.
 
 ### Multimodal Input
 
@@ -281,9 +284,9 @@ contract to claude.ai with exactly Fable 5 and Effort Max.
 
 ```bash
 yoetz browser check --format json
-yoetz browser recipe --recipe chatgpt --bundle ~/.yoetz/sessions/<id>/bundle.md --format json
+yoetz browser recipe --recipe chatgpt --bundle ~/.yoetz/sessions/<id>/<named-bundle>.md --format json
 yoetz browser check --claude --format json
-yoetz browser recipe --recipe claude --bundle ~/.yoetz/sessions/<id>/bundle.md --format json
+yoetz browser recipe --recipe claude --bundle ~/.yoetz/sessions/<id>/<named-bundle>.md --format json
 ```
 
 Both recipes support `chrome-devtools-mcp`, `dev-browser`, `agent-browser`, and
@@ -302,13 +305,13 @@ checking it:
 yoetz browser extension setup --chatgpt --open-chrome
 yoetz browser extension doctor --chatgpt
 yoetz browser extension status --chatgpt --format json
-yoetz browser recipe --recipe chatgpt --transport chrome-extension-native --bundle bundle.md --format json
+yoetz browser recipe --recipe chatgpt --transport chrome-extension-native --bundle <named-bundle>.md --format json
 
 yoetz browser extension setup --claude --open-chrome
 yoetz browser extension doctor --claude
 yoetz browser extension status --claude --format json
 yoetz browser extension canary --claude
-yoetz browser recipe --recipe claude --transport chrome-extension-native --bundle bundle.md --format json
+yoetz browser recipe --recipe claude --transport chrome-extension-native --bundle <named-bundle>.md --format json
 ```
 
 Load the managed `$YOETZ_DIR/chatgpt-native-extension` directory unpacked in
@@ -333,7 +336,7 @@ distinct background tabs through overlapping phases and that cancelling one
 does not affect the other. Both sites may run only against one frozen loaded
 artifact.
 Give each parallel recipe its own Yoetz bundle session directory; reusing one
-managed `bundle.md` fails with `session_busy` rather than overwriting that
+managed named Markdown bundle fails with `session_busy` rather than overwriting that
 session's `response.json` or `followup.json`.
 
 Upgrade the installed CLI before another lane runs extension auto-heal after a

--- a/crates/yoetz-cli/src/commands/bundle.rs
+++ b/crates/yoetz-cli/src/commands/bundle.rs
@@ -1,4 +1,5 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
+use time::{format_description::FormatItem, macros::format_description, OffsetDateTime};
 
 use crate::{maybe_write_output, render_bundle_md, resolve_prompt, AppContext, BundleArgs};
 use yoetz_core::bundle::{build_bundle, BundleOptions};
@@ -26,7 +27,9 @@ pub(crate) fn handle_bundle(
     let session = create_session_dir()?;
 
     let bundle_json = session.path.join("bundle.json");
-    let bundle_md = session.path.join("bundle.md");
+    let bundle_md = session
+        .path
+        .join(bundle_file_name(args.name.as_deref(), &prompt)?);
 
     write_json_file(&bundle_json, &bundle)?;
     write_text(&bundle_md, &render_bundle_md(&bundle))?;
@@ -56,5 +59,60 @@ pub(crate) fn handle_bundle(
             println!("Bundle created at `{}`", result.artifacts.session_dir);
             Ok(())
         }
+    }
+}
+
+const BUNDLE_TIMESTAMP_FORMAT: &[FormatItem<'static>] =
+    format_description!("[year][month][day]-[hour][minute][second]Z");
+
+fn bundle_file_name(requested_name: Option<&str>, prompt: &str) -> Result<String> {
+    let source = requested_name
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| prompt.trim());
+    let source = source.strip_suffix(".md").unwrap_or(source);
+    let stem = slugify_bundle_name(source);
+    if stem.is_empty() {
+        bail!("bundle name is empty; pass --name with a descriptive name");
+    }
+    let timestamp = OffsetDateTime::now_utc().format(BUNDLE_TIMESTAMP_FORMAT)?;
+    Ok(format!("{stem}_{timestamp}.md"))
+}
+
+fn slugify_bundle_name(value: &str) -> String {
+    let mut slug = String::new();
+    let mut pending_separator = false;
+    for ch in value.chars() {
+        if ch.is_alphanumeric() {
+            if pending_separator && !slug.is_empty() {
+                slug.push('-');
+            }
+            pending_separator = false;
+            slug.extend(ch.to_lowercase());
+        } else {
+            pending_separator = true;
+        }
+        if slug.chars().count() >= 80 {
+            break;
+        }
+    }
+    slug.trim_end_matches('-').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::bundle_file_name;
+
+    #[test]
+    fn bundle_file_name_uses_agent_name_and_timestamp() {
+        let name = bundle_file_name(Some("TASE market thesis"), "ignored").unwrap();
+        assert!(name.starts_with("tase-market-thesis_"));
+        assert!(name.ends_with("Z.md"));
+    }
+
+    #[test]
+    fn bundle_file_name_derives_a_name_from_prompt() {
+        let name = bundle_file_name(None, "Review quarterly bank earnings").unwrap();
+        assert!(name.starts_with("review-quarterly-bank-earnings_"));
     }
 }

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -241,6 +241,10 @@ struct BundleArgs {
     #[arg(long)]
     prompt_file: Option<PathBuf>,
 
+    /// Descriptive bundle name. A UTC timestamp is appended automatically.
+    #[arg(long, value_name = "NAME")]
+    name: Option<String>,
+
     #[arg(long, short = 'f')]
     files: Vec<String>,
 
@@ -2693,7 +2697,7 @@ fn bundle_prompt_for_recipe(bundle_path: Option<&Path>) -> Result<Option<String>
     let Some(bundle_path) = bundle_path else {
         return Ok(None);
     };
-    if bundle_path.file_name().and_then(|name| name.to_str()) != Some("bundle.md") {
+    if !is_managed_bundle_markdown(bundle_path) {
         return Ok(None);
     }
     let Some(session_dir) = bundle_path.parent() else {
@@ -2711,6 +2715,13 @@ fn bundle_prompt_for_recipe(bundle_path: Option<&Path>) -> Result<Option<String>
         return Ok(None);
     }
     Ok(Some(bundle.prompt))
+}
+
+fn is_managed_bundle_markdown(bundle_path: &Path) -> bool {
+    bundle_path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("md"))
 }
 
 fn prepare_native_thread_run_in(
@@ -3017,9 +3028,8 @@ fn attach_browser_recipe_artifacts(payload: &mut Value, bundle_path: Option<&Pat
 fn browser_recipe_artifact_paths(bundle_path: Option<&Path>) -> Option<ArtifactPaths> {
     let bundle_path = bundle_path?;
     let session_dir = bundle_path.parent()?;
-    let bundle_name = bundle_path.file_name()?.to_string_lossy();
     let sibling_bundle_json = session_dir.join("bundle.json");
-    if bundle_name != "bundle.md" || !sibling_bundle_json.exists() {
+    if !is_managed_bundle_markdown(bundle_path) || !sibling_bundle_json.exists() {
         return None;
     }
     Some(ArtifactPaths {
@@ -3047,18 +3057,18 @@ fn validate_thread_persistence_preflight_in(
     };
     let bundle_path = recipe_args.bundle.as_deref().ok_or_else(|| {
         anyhow!(
-            "thread `{thread_label}` requires a managed bundle session with bundle.md and bundle.json"
+                "thread `{thread_label}` requires a managed bundle session with a named .md file and bundle.json"
         )
     })?;
-    if bundle_path.file_name().and_then(|name| name.to_str()) != Some("bundle.md") {
-        bail!("thread `{thread_label}` bundle must be named bundle.md");
+    if !is_managed_bundle_markdown(bundle_path) {
+        bail!("thread `{thread_label}` bundle must be a Markdown file");
     }
     let session_dir = bundle_path
         .parent()
         .ok_or_else(|| anyhow!("thread `{thread_label}` bundle has no session directory"))?;
     let bundle_json = session_dir.join("bundle.json");
 
-    ensure_regular_file(bundle_path, "bundle.md", thread_label)?;
+    ensure_regular_file(bundle_path, "named bundle Markdown file", thread_label)?;
     ensure_regular_file(&bundle_json, "bundle.json", thread_label)?;
     let canonical_base = fs::canonicalize(sessions_base).with_context(|| {
         format!(
@@ -3171,7 +3181,7 @@ fn write_followup_session_metadata_with_lineage(
     let session_artifacts = browser_recipe_artifact_paths(recipe_args.bundle.as_deref())
         .ok_or_else(|| {
             anyhow!(
-                "followup metadata requires a managed bundle session with bundle.md and bundle.json"
+                "followup metadata requires a managed bundle session with a named .md file and bundle.json"
             )
         })?;
     let conversation_raw = final_conversation_identity(payload)
@@ -6984,7 +6994,9 @@ mod tests {
             &sessions_base,
         )
         .unwrap_err();
-        assert!(err.to_string().contains("bundle.md must be a regular file"));
+        assert!(err
+            .to_string()
+            .contains("named bundle Markdown file must be a regular file"));
 
         let json_dir_session = sessions_base.join("json-dir");
         fs::create_dir_all(json_dir_session.join("bundle.json")).unwrap();

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -6953,9 +6953,10 @@ mod tests {
         let external_session = root.path().join("external").join("session-lookalike");
         fs::create_dir_all(&sessions_base).unwrap();
         fs::create_dir_all(&external_session).unwrap();
-        fs::write(external_session.join("bundle.md"), "# bundle").unwrap();
+        let named_bundle = external_session.join("review-context_20260814T064500Z.md");
+        fs::write(&named_bundle, "# bundle").unwrap();
         fs::write(external_session.join("bundle.json"), "{}").unwrap();
-        let recipe_args = thread_recipe_args(external_session.join("bundle.md"));
+        let recipe_args = thread_recipe_args(named_bundle);
 
         let err =
             acquire_browser_recipe_session_lease_in(&recipe_args, &sessions_base).unwrap_err();
@@ -6969,14 +6970,15 @@ mod tests {
     }
 
     #[test]
-    fn thread_accepts_canonical_managed_session_with_regular_artifacts() {
+    fn thread_accepts_named_bundle_in_canonical_managed_session() {
         let root = TempDir::new().unwrap();
         let sessions_base = root.path().join("sessions");
         let session = sessions_base.join("20260725_120000_abcdef");
         fs::create_dir_all(&session).unwrap();
-        fs::write(session.join("bundle.md"), "# bundle").unwrap();
+        let named_bundle = session.join("review-context_20260814T064500Z.md");
+        fs::write(&named_bundle, "# bundle").unwrap();
         fs::write(session.join("bundle.json"), "{}").unwrap();
-        let recipe_args = thread_recipe_args(session.join("bundle.md"));
+        let recipe_args = thread_recipe_args(named_bundle);
 
         assert!(validate_thread_persistence_preflight_in(&recipe_args, &sessions_base).is_ok());
     }

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -228,8 +228,7 @@ export async function uploadFile(root, file, options = {}) {
   input.files = dataTransfer.files;
   input.dispatchEvent(new Event("input", { bubbles: true }));
   input.dispatchEvent(new Event("change", { bubbles: true }));
-  await waitForUploadComplete(root, file, { ...options, baselineAttachments });
-  return true;
+  return waitForUploadComplete(root, file, { ...options, baselineAttachments });
 }
 
 export async function ensureFreshChat(root = document, job = {}, options = {}) {
@@ -2274,9 +2273,14 @@ async function waitForUploadComplete(root, file, options = {}) {
   const intervalMs = Number(options.intervalMs ?? DEFAULT_WAIT_INTERVAL_MS);
   const baselineAttachments = options.baselineAttachments ?? new Set();
   const requiredStableTicks = Math.max(1, Number(options.requiredStableTicks ?? 2));
+  const emptyComposerVariantStableTicks = Math.max(
+    1,
+    Number(options.emptyComposerVariantStableTicks ?? 8)
+  );
   const startedAt = Date.now();
   let lastState = "";
-  let stableTicks = 0;
+  let enabledTicks = 0;
+  let emptyComposerVariantTicks = 0;
   while (Date.now() - startedAt < timeoutMs) {
     const error = uploadErrorText(root);
     if (error) {
@@ -2284,21 +2288,55 @@ async function waitForUploadComplete(root, file, options = {}) {
     }
     const attached = hasAttachmentNamed(root, file.name, baselineAttachments);
     const pending = hasUploadPending(root);
-    // The attachment chip is the only reliable pre-prompt signal. ChatGPT's
-    // current UI keeps Send disabled while the composer is empty, so using
-    // Send as an upload-commit signal deadlocks before insertPrompt runs.
-    lastState = `attached=${attached}, pending=${pending}, diagnostics=${sendReadinessDiagnostics(root)}`;
+    const sendControl = findSendButtonControl(root, { requireEnabled: false });
+    const sendEnabled = Boolean(sendControl && isEnabled(sendControl));
+    const legacyCommitSignal = uploadCommitted(root);
+    const emptyComposerVariant = Boolean(
+      sendControl
+      && !sendEnabled
+      && !editableText(findComposer(root))
+    );
+    lastState = `attached=${attached}, pending=${pending}, send_enabled=${sendEnabled}, empty_composer_variant=${emptyComposerVariant}, diagnostics=${sendReadinessDiagnostics(root)}`;
     if (attached && !pending) {
-      stableTicks += 1;
-      if (stableTicks >= requiredStableTicks) {
-        return true;
+      // Older ChatGPT variants enable Send once the attachment is committed,
+      // even with an empty composer. Keep that stronger signal as the fast path.
+      if (legacyCommitSignal) {
+        enabledTicks += 1;
+        emptyComposerVariantTicks = 0;
+        if (enabledTicks >= requiredStableTicks) {
+          return { upload_commit_signal: "send_enabled" };
+        }
+      } else if (emptyComposerVariant) {
+        // Newer variants keep Send disabled until prompt text exists. A bounded
+        // run of a committed chip, no pending marker, a present disabled Send,
+        // and an empty composer distinguishes that UI from a transient upload.
+        enabledTicks = 0;
+        emptyComposerVariantTicks += 1;
+        if (emptyComposerVariantTicks >= emptyComposerVariantStableTicks) {
+          return { upload_commit_signal: "empty_composer_variant" };
+        }
+      } else {
+        enabledTicks = 0;
+        emptyComposerVariantTicks = 0;
       }
     } else {
-      stableTicks = 0;
+      enabledTicks = 0;
+      emptyComposerVariantTicks = 0;
     }
     await sleep(intervalMs);
   }
   throw new Error(`ChatGPT file upload did not complete for ${file.name} (${lastState})`);
+}
+
+// Before prompt insertion, older ChatGPT variants expose upload commitment by
+// enabling Send. If a minimal DOM has no Send control, preserve the historical
+// chip-only fallback instead of blocking the upload step indefinitely.
+function uploadCommitted(root) {
+  const present = findSendButtonControl(root, { requireEnabled: false });
+  if (!present) {
+    return true;
+  }
+  return Boolean(findSendButtonControl(root, { requireEnabled: true }));
 }
 
 async function openAttachmentUi(root, options = {}) {

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -1447,15 +1447,22 @@ export async function clickSend(root, options = {}) {
   const minTimeoutMs = Number(options.minTimeoutMs ?? DEFAULT_SEND_MIN_TIMEOUT_MS);
   const timeoutMs = Math.max(requestedTimeoutMs, minTimeoutMs);
   const intervalMs = Number(options.intervalMs ?? DEFAULT_WAIT_INTERVAL_MS);
+  const requiredStableTicks = Math.max(1, Number(options.requiredStableTicks ?? 2));
   const startedAt = Date.now();
   let lastCandidate = null;
+  let enabledTicks = 0;
 
   while (Date.now() - startedAt < timeoutMs) {
     const button = findSendButtonControl(root, { requireEnabled: true });
     if (button) {
-      assertExpectedConversationBeforeSendClick(root, options.expectedConversationId);
-      button.click();
-      return true;
+      enabledTicks += 1;
+      if (enabledTicks >= requiredStableTicks) {
+        assertExpectedConversationBeforeSendClick(root, options.expectedConversationId);
+        button.click();
+        return true;
+      }
+    } else {
+      enabledTicks = 0;
     }
     lastCandidate = findSendButtonControl(root, { requireEnabled: false }) ?? lastCandidate;
     await sleep(intervalMs);
@@ -2277,22 +2284,11 @@ async function waitForUploadComplete(root, file, options = {}) {
     }
     const attached = hasAttachmentNamed(root, file.name, baselineAttachments);
     const pending = hasUploadPending(root);
-    // ChatGPT renders the attachment chip almost immediately (~0.4s), long
-    // before the file finishes uploading server-side (often 10-30s). Returning
-    // at chip-appearance races the prompt-type + send that follow this step:
-    // the send button is briefly clickable (enabled by the typed prompt text)
-    // before ChatGPT re-gates it on the in-flight upload, so the message is
-    // submitted text-only and the attachment is silently dropped. ChatGPT keeps
-    // the send button disabled while an attachment is uploading and only
-    // re-enables it once the upload commits. waitForUploadComplete runs before
-    // any prompt text is inserted (the composer is still empty), so an enabled
-    // send button here is a reliable "upload committed" signal that does not
-    // depend on ChatGPT's progress-spinner markup. Requiring the chip to be
-    // present (`attached`) also rules out the pre-upload window where the send
-    // button is still enabled because ChatGPT has not yet registered the file.
-    const committed = uploadCommitted(root);
-    lastState = `attached=${attached}, pending=${pending}, committed=${committed}, diagnostics=${sendReadinessDiagnostics(root)}`;
-    if (attached && !pending && committed) {
+    // The attachment chip is the only reliable pre-prompt signal. ChatGPT's
+    // current UI keeps Send disabled while the composer is empty, so using
+    // Send as an upload-commit signal deadlocks before insertPrompt runs.
+    lastState = `attached=${attached}, pending=${pending}, diagnostics=${sendReadinessDiagnostics(root)}`;
+    if (attached && !pending) {
       stableTicks += 1;
       if (stableTicks >= requiredStableTicks) {
         return true;
@@ -2303,21 +2299,6 @@ async function waitForUploadComplete(root, file, options = {}) {
     await sleep(intervalMs);
   }
   throw new Error(`ChatGPT file upload did not complete for ${file.name} (${lastState})`);
-}
-
-// Upload commit signal: ChatGPT disables the send control while an attachment
-// uploads and re-enables it once the upload commits. This is checked while the
-// composer is still empty (before insertPrompt), so an enabled send button means
-// the attachment is ready, not that a prompt is ready to send. When ChatGPT
-// exposes no send control at all (an unexpected or minimal DOM), this signal is
-// unavailable and we fall back to treating the attachment chip as sufficient
-// rather than blocking the upload step indefinitely.
-function uploadCommitted(root) {
-  const present = findSendButtonControl(root, { requireEnabled: false });
-  if (!present) {
-    return true;
-  }
-  return Boolean(findSendButtonControl(root, { requireEnabled: true }));
 }
 
 async function openAttachmentUi(root, options = {}) {

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -177,8 +177,14 @@ async function uploadJobFile(job, filePayload) {
     }
     uploadOptions.initialAttachmentTrace = job.attachment_trace;
   }
-  await uploadFile(document, file, uploadOptions);
-  return { filename: file.name, size: file.size };
+  const uploadResult = await uploadFile(document, file, uploadOptions);
+  return {
+    filename: file.name,
+    size: file.size,
+    ...(uploadResult?.upload_commit_signal
+      ? { upload_commit_signal: uploadResult.upload_commit_signal }
+      : {})
+  };
 }
 
 async function configureModel(job, options = {}) {

--- a/extensions/chatgpt-native/src/content-script.js
+++ b/extensions/chatgpt-native/src/content-script.js
@@ -235,7 +235,10 @@ async function sendPrompt(job, prompt) {
     side_effect_started: true,
     send_committed: false
   });
-  const clickOptions = { timeoutMs: Number(job.send_timeout_ms) || 120000 };
+  const clickOptions = {
+    timeoutMs: Number(job.send_timeout_ms) || 120000,
+    requiredStableTicks: 2
+  };
   const expectedConversationId = expectedConversationIdForJob(job);
   if (expectedConversationId) {
     clickOptions.expectedConversationId = expectedConversationId;

--- a/extensions/chatgpt-native/src/service-worker.js
+++ b/extensions/chatgpt-native/src/service-worker.js
@@ -651,7 +651,7 @@ async function runJobWithFile(job, file) {
   job.status = "uploading_file";
   job.updated_at = Date.now();
   await persistJob(job);
-  await sendToTab(job.tab_id, {
+  const uploadResult = await sendToTab(job.tab_id, {
     type: "yoetz_upload_file",
     job,
     file: {
@@ -665,6 +665,9 @@ async function runJobWithFile(job, file) {
   if (!postNative(progress(job, "file_uploaded", {
     filename: file.filename,
     bytes: file.bytes.byteLength,
+    ...(uploadResult?.upload_commit_signal
+      ? { upload_commit_signal: uploadResult.upload_commit_signal }
+      : {}),
     message: `bundle uploaded (${file.bytes.byteLength} bytes); sending prompt`
   }))) {
     await recordTerminalDeliveryLost(job, "upload");

--- a/extensions/chatgpt-native/tests/content-script.test.js
+++ b/extensions/chatgpt-native/tests/content-script.test.js
@@ -106,7 +106,7 @@ export async function uploadFile(_document, file, options) {
   if (hooks.uploadFileError) {
     throw hooks.uploadFileError;
   }
-  return true;
+  return hooks.uploadFileResult ?? { upload_commit_signal: "send_enabled" };
 }
 
 export function configureModelState(_document, job) {
@@ -213,6 +213,7 @@ test("content script resume path skips fresh enforcement and completes on reques
       }
     });
     assert.equal(uploaded.ok, true);
+    assert.equal(uploaded.payload.upload_commit_signal, "send_enabled");
     assert.equal(hooks.uploadFileCalls.length, 1);
 
     const configured = await send({ type: "yoetz_configure_model", job });

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -259,7 +259,7 @@ test("fake ChatGPT page supports prompt upload send and stable extraction", asyn
   }
 });
 
-test("uploadFile waits for the upload to commit before returning", async () => {
+test("uploadFile returns from the attachment stage and clickSend waits for readiness", async () => {
   const previousDataTransfer = globalThis.DataTransfer;
   const previousInputEvent = globalThis.InputEvent;
   globalThis.DataTransfer = FakeDataTransfer;
@@ -272,8 +272,9 @@ test("uploadFile waits for the upload to commit before returning", async () => {
   };
   try {
     const composer = new FakeElement("textarea", { placeholder: "Message ChatGPT" });
-    // ChatGPT renders the chip immediately but keeps the send button disabled
-    // until the upload commits server-side, then re-enables it. Model that race.
+    // ChatGPT renders the chip immediately but keeps Send disabled while the
+    // composer is empty. Model the current UI and let clickSend own the final
+    // readiness gate after insertPrompt has populated the composer.
     const send = new FakeElement("button", { "aria-label": "Send message" }, "Send");
     send.disabled = true;
     let committedAt = null;
@@ -295,14 +296,14 @@ test("uploadFile waits for the upload to commit before returning", async () => {
     await uploadFile(doc, file, { timeoutMs: 5000, intervalMs: 20, requiredStableTicks: 2 });
     const returnedAt = Date.now();
 
-    // The previous implementation returned at chip-appearance, while the send
-    // button was still disabled (upload in flight), which dropped the attachment
-    // on the subsequent send. The fix must not return until the upload commits.
-    assert.equal(send.disabled, false, "uploadFile returned before the upload committed");
+    assert.equal(send.disabled, true, "uploadFile should not use empty-composer Send as its completion signal");
     assert.ok(
-      committedAt !== null && returnedAt >= committedAt,
-      "uploadFile must wait for the send control to re-enable (upload committed)"
+      committedAt === null || returnedAt < committedAt,
+      "uploadFile should return before the delayed Send readiness transition"
     );
+    await clickSend(doc, { timeoutMs: 5000, intervalMs: 20, requiredStableTicks: 2, minTimeoutMs: 0 });
+    assert.equal(send.clicked, true, "clickSend should wait for Send to become enabled");
+    assert.ok(committedAt !== null, "the delayed upload readiness transition should occur");
     assert.equal(upload.files[0].name, "fixture.md");
   } finally {
     globalThis.DataTransfer = previousDataTransfer;

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -259,7 +259,7 @@ test("fake ChatGPT page supports prompt upload send and stable extraction", asyn
   }
 });
 
-test("uploadFile returns from the attachment stage and clickSend waits for readiness", async () => {
+test("uploadFile preserves the legacy enabled-Send upload commit signal", async () => {
   const previousDataTransfer = globalThis.DataTransfer;
   const previousInputEvent = globalThis.InputEvent;
   globalThis.DataTransfer = FakeDataTransfer;
@@ -272,9 +272,7 @@ test("uploadFile returns from the attachment stage and clickSend waits for readi
   };
   try {
     const composer = new FakeElement("textarea", { placeholder: "Message ChatGPT" });
-    // ChatGPT renders the chip immediately but keeps Send disabled while the
-    // composer is empty. Model the current UI and let clickSend own the final
-    // readiness gate after insertPrompt has populated the composer.
+    // The legacy UI enables Send only after the uploaded attachment commits.
     const send = new FakeElement("button", { "aria-label": "Send message" }, "Send");
     send.disabled = true;
     let committedAt = null;
@@ -293,18 +291,106 @@ test("uploadFile returns from the attachment stage and clickSend waits for readi
     const doc = new FakeDocument(body);
 
     const file = new File(["bundle"], "fixture.md", { type: "text/markdown" });
-    await uploadFile(doc, file, { timeoutMs: 5000, intervalMs: 20, requiredStableTicks: 2 });
+    const result = await uploadFile(doc, file, {
+      timeoutMs: 5000,
+      intervalMs: 20,
+      requiredStableTicks: 2
+    });
     const returnedAt = Date.now();
 
-    assert.equal(send.disabled, true, "uploadFile should not use empty-composer Send as its completion signal");
-    assert.ok(
-      committedAt === null || returnedAt < committedAt,
-      "uploadFile should return before the delayed Send readiness transition"
-    );
-    await clickSend(doc, { timeoutMs: 5000, intervalMs: 20, requiredStableTicks: 2, minTimeoutMs: 0 });
-    assert.equal(send.clicked, true, "clickSend should wait for Send to become enabled");
+    assert.deepEqual(result, { upload_commit_signal: "send_enabled" });
     assert.ok(committedAt !== null, "the delayed upload readiness transition should occur");
+    assert.ok(returnedAt >= committedAt, "uploadFile must not outrun the legacy commit signal");
     assert.equal(upload.files[0].name, "fixture.md");
+  } finally {
+    globalThis.DataTransfer = previousDataTransfer;
+    globalThis.InputEvent = previousInputEvent;
+  }
+});
+
+test("uploadFile accepts the disabled-empty composer variant after a bounded stable window", async () => {
+  const previousDataTransfer = globalThis.DataTransfer;
+  globalThis.DataTransfer = FakeDataTransfer;
+  try {
+    const composer = new FakeElement("textarea", { placeholder: "Message ChatGPT" });
+    const send = new FakeElement("button", { "aria-label": "Send message" }, "Send");
+    send.disabled = true;
+    const upload = new FakeElement("input", {
+      type: "file",
+      accept: "text/markdown",
+      onChange: () => body.append(
+        new FakeElement("div", { "data-testid": "attachment-file" }, "fixture.md")
+      )
+    });
+    const body = new FakeElement("body", {}, "Message ChatGPT").append(composer, upload, send);
+    const doc = new FakeDocument(body);
+
+    const startedAt = Date.now();
+    const result = await uploadFile(
+      doc,
+      new File(["bundle"], "fixture.md", { type: "text/markdown" }),
+      { timeoutMs: 1000, intervalMs: 10, emptyComposerVariantStableTicks: 8 }
+    );
+
+    assert.deepEqual(result, { upload_commit_signal: "empty_composer_variant" });
+    assert.equal(send.disabled, true);
+    assert.ok(Date.now() - startedAt >= 60, "the variant fallback must not accept one transient tick");
+  } finally {
+    globalThis.DataTransfer = previousDataTransfer;
+  }
+});
+
+test("new upload variant survives a text-enabled drop race before final Send readiness", async () => {
+  const previousDataTransfer = globalThis.DataTransfer;
+  const previousInputEvent = globalThis.InputEvent;
+  globalThis.DataTransfer = FakeDataTransfer;
+  globalThis.InputEvent = class extends Event {
+    constructor(type, init = {}) {
+      super(type, init);
+      this.inputType = init.inputType;
+      this.data = init.data;
+    }
+  };
+  try {
+    const composer = new FakeElement("textarea", { placeholder: "Message ChatGPT" });
+    const send = new FakeElement("button", { "aria-label": "Send message" }, "Send");
+    send.disabled = true;
+    const upload = new FakeElement("input", {
+      type: "file",
+      accept: "text/markdown",
+      onChange: () => body.append(
+        new FakeElement("div", { "data-testid": "attachment-file" }, "fixture.md")
+      )
+    });
+    const body = new FakeElement("body", {}, "Message ChatGPT").append(composer, upload, send);
+    const doc = new FakeDocument(body);
+
+    const uploadResult = await uploadFile(
+      doc,
+      new File(["bundle"], "fixture.md", { type: "text/markdown" }),
+      { timeoutMs: 1000, intervalMs: 5, emptyComposerVariantStableTicks: 8 }
+    );
+    assert.deepEqual(uploadResult, { upload_commit_signal: "empty_composer_variant" });
+
+    await insertPrompt(doc, "Review this bundle", { timeoutMs: 250, intervalMs: 5 });
+    send.disabled = false;
+    setTimeout(() => {
+      send.disabled = true;
+    }, 4);
+    setTimeout(() => {
+      send.disabled = false;
+    }, 50);
+
+    const sending = clickSend(doc, {
+      timeoutMs: 500,
+      intervalMs: 10,
+      requiredStableTicks: 2,
+      minTimeoutMs: 0
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    assert.equal(send.clicked, false, "clickSend must not accept the text-enabled upload blip");
+    await sending;
+    assert.equal(send.clicked, true, "clickSend should accept two stable ticks after final commit");
   } finally {
     globalThis.DataTransfer = previousDataTransfer;
     globalThis.InputEvent = previousInputEvent;

--- a/extensions/chatgpt-native/tests/service-worker.test.js
+++ b/extensions/chatgpt-native/tests/service-worker.test.js
@@ -3228,7 +3228,14 @@ test("service worker emits low-noise waiting progress while ChatGPT is quiet", a
           case "yoetz_configure_model":
             return { ok: true, payload: verifiedSolProSelection() };
           case "yoetz_upload_file":
-            return { ok: true, payload: { filename: message.file.filename, size: 4 } };
+            return {
+              ok: true,
+              payload: {
+                filename: message.file.filename,
+                size: 4,
+                upload_commit_signal: "empty_composer_variant"
+              }
+            };
           case "yoetz_send_prompt":
             sent = true;
             return { ok: true, payload: { sent: true, conversation_id: "conv-waiting-progress" } };
@@ -3272,6 +3279,7 @@ test("service worker emits low-noise waiting progress while ChatGPT is quiet", a
     assert.equal(opened?.payload.inspect_command, "yoetz browser extension inspect --chatgpt --run-id run_job_waiting_progress");
     assert.match(opened?.payload.message, /https:\/\/chatgpt\.com\/\?_yoetz=run_job_waiting_progress/);
     assert.match(uploaded?.payload.message, /bundle uploaded/);
+    assert.equal(uploaded?.payload.upload_commit_signal, "empty_composer_variant");
     assert.match(sentProgress?.payload.message, /waiting for ChatGPT response/);
     assert.equal(sentProgress?.payload.inspect_command, "yoetz browser extension inspect --chatgpt --run-id run_job_waiting_progress");
     assert.equal(sentProgress?.payload.yoetz_url, "https://chatgpt.com/?_yoetz=run_job_waiting_progress");


### PR DESCRIPTION
## Summary

Supersedes #408 (thanks @bnsd55 — your commit is included with original authorship; this branch adds dual-variant hardening on top). Closes #407.

- **Upload deadlock fix, both UI variants**: ChatGPT A/B-splits its empty-composer Send gating. The upload stage now classifies: legacy variant (Send enables on upload commit — kept as the 2-tick fast path, preserving the historical protection against silently dropped attachments), the new empty-composer variant (present disabled Send + empty composer, 8-tick bounded classification), and the minimal-DOM chip fallback. The selected `upload_commit_signal` is propagated into diagnostics, and `clickSend` requires 2 stable enabled ticks (reset on disable) after prompt insertion — closing the text-enabled drop-race on every variant.
- **`yoetz bundle --name`** (@bnsd55): sanitized, UTC-timestamped context filenames (`upload-acceptance_20260814-070446Z.md`), prompt-derived fallback; browser recipe artifact/thread/lease handling accepts named Markdown bundles while keeping `bundle.md` sessions compatible and the sessions-base direct-child guard intact.

## Review & validation

- Hostile-fixture control: three fixtures (legacy delayed commit, bounded new-variant, text-enabled drop race) fail 3/3 against the contributor-only commit and pass integrated — the drop-race leg reproduced independently by both agents.
- npm 374/374; cargo 770/0; clippy `-D warnings` clean.
- Live acceptance: 2.6MB named bundle, verified Sol+Extra-High, file_upload delivery, exact `UPLOAD-OK` completion (run 20260814T0704xx).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbMozs4Nt8Thd5zWRkuNQr