### PR TITLE
fix(security): fence child-process env from dotenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Document agent-facing CLI contracts, browser thread controls, patch apply
   workflow, and the legacy status of the bundled Gemini browser recipe.
 
+### Security
+
+- CWD dotenv files can no longer override inherited child-process code-loading,
+  dynamic-loader, or TLS-trust settings (`NODE_OPTIONS`, `LD_PRELOAD`,
+  `DYLD_INSERT_LIBRARIES`, and `NODE_EXTRA_CA_CERTS`).
+
 ## [0.5.54] - 2026-08-14
 ### Added
 

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -1040,6 +1040,13 @@ const BASE_PROTECTED_DOTENV_ENV_VARS: &[&str] = &[
     "YOETZ_BROWSER_CDP",
     "YOETZ_BROWSER_TARGET_PATH",
     "YOETZ_BROWSER_PROFILE",
+    // Prevent repo-local dotenv files from injecting code or changing dynamic
+    // loader behavior in inherited child processes.
+    "NODE_OPTIONS",
+    "LD_PRELOAD",
+    "DYLD_INSERT_LIBRARIES",
+    // Prevent a repo-local CA from changing TLS verification for child tools.
+    "NODE_EXTRA_CA_CERTS",
     "OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",
     "GEMINI_API_KEY",
@@ -6264,6 +6271,10 @@ mod tests {
             "YOETZ_BROWSER_CDP",
             "YOETZ_BROWSER_TARGET_PATH",
             "YOETZ_BROWSER_PROFILE",
+            "NODE_OPTIONS",
+            "LD_PRELOAD",
+            "DYLD_INSERT_LIBRARIES",
+            "NODE_EXTRA_CA_CERTS",
             "ZAI_API_KEY",
             "LITELLM_API_KEY",
         ] {


### PR DESCRIPTION
## Summary
- protect NODE_OPTIONS, LD_PRELOAD, DYLD_INSERT_LIBRARIES, and NODE_EXTRA_CA_CERTS from CWD dotenv overrides
- extend the protected dotenv regression list
- document the hardening under Unreleased Security

## Verification
- cargo fmt --all -- --check: passed
- cargo test -p yoetz protected_dotenv_env_vars: attempted; fresh worktree compilation was stopped after prolonged headless_chrome build with no test result
- staged diff reviewed by Claude via AMQ thread pr-428-cursor-backend: PASS
- push workflow: Notify Skills Marketplace skipped; no CI run triggered yet