### PR TITLE
fix(cursor): cache discovery per invocation (yz-920)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Cursor model discovery now runs once per Yoetz process and is shared by all
+  council members; a discovery failure fails every Cursor member without
+  re-spawning the CLI.
 - Document agent-facing CLI contracts, browser thread controls, patch apply
   workflow, and the legacy status of the bundled Gemini browser recipe.
 

--- a/crates/yoetz-cli/src/commands/ask.rs
+++ b/crates/yoetz-cli/src/commands/ask.rs
@@ -279,6 +279,7 @@ pub(crate) async fn handle_ask(
                 let call = call_model(
                     &ctx.litellm,
                     ctx.timeout_duration,
+                    &ctx.cursor_discovery,
                     Some(provider),
                     model,
                     &model_prompt,
@@ -302,6 +303,7 @@ pub(crate) async fn handle_ask(
         let result = call_model(
             &ctx.litellm,
             ctx.timeout_duration,
+            &ctx.cursor_discovery,
             Some(provider),
             model,
             &model_prompt,

--- a/crates/yoetz-cli/src/commands/council.rs
+++ b/crates/yoetz-cli/src/commands/council.rs
@@ -223,6 +223,7 @@ pub(crate) async fn handle_council(
             let prompt = std::sync::Arc::clone(&model_prompt);
             let provider = provider.clone();
             let litellm = ctx.litellm.clone();
+            let cursor_discovery = std::sync::Arc::clone(&ctx.cursor_discovery);
             let cursor_timeout = ctx.timeout_duration;
             let semaphore = std::sync::Arc::clone(&semaphore);
             let temperature = args.temperature;
@@ -240,6 +241,7 @@ pub(crate) async fn handle_council(
                 let call = call_model(
                     &litellm,
                     cursor_timeout,
+                    &cursor_discovery,
                     Some(&provider),
                     &model,
                     prompt.as_str(),

--- a/crates/yoetz-cli/src/commands/models.rs
+++ b/crates/yoetz-cli/src/commands/models.rs
@@ -109,7 +109,8 @@ fn normalize_cursor_search(value: &str) -> String {
 }
 
 async fn cursor_registry(ctx: &AppContext) -> Result<ModelRegistry> {
-    let models = providers::cursor::list_models(ctx.timeout_duration).await?;
+    let models =
+        providers::cursor::list_models(ctx.timeout_duration, &ctx.cursor_discovery).await?;
     let mut registry = ModelRegistry::default();
     registry.models = models
         .into_iter()

--- a/crates/yoetz-cli/src/commands/review.rs
+++ b/crates/yoetz-cli/src/commands/review.rs
@@ -140,6 +140,7 @@ async fn handle_review_diff(
         let result = call_model(
             &ctx.litellm,
             ctx.timeout_duration,
+            &ctx.cursor_discovery,
             Some(&provider),
             &model,
             &review_prompt,
@@ -337,6 +338,7 @@ async fn handle_review_file(
         let result = call_model(
             &ctx.litellm,
             ctx.timeout_duration,
+            &ctx.cursor_discovery,
             Some(&provider),
             &model,
             &review_prompt,

--- a/crates/yoetz-cli/src/main.rs
+++ b/crates/yoetz-cli/src/main.rs
@@ -130,6 +130,8 @@ struct AppContext {
     debug: bool,
     allow_unknown: bool,
     timeout_duration: Duration,
+    cursor_discovery:
+        std::sync::Arc<tokio::sync::OnceCell<providers::cursor::CursorDiscoveryOutcome>>,
 }
 
 #[derive(Subcommand)]
@@ -1150,6 +1152,7 @@ async fn main() -> Result<()> {
         debug: cli.debug,
         allow_unknown: cli.allow_unknown,
         timeout_duration: Duration::from_secs(cli.timeout_secs),
+        cursor_discovery: std::sync::Arc::new(tokio::sync::OnceCell::new()),
     };
 
     match cli.command {
@@ -5645,6 +5648,7 @@ mod tests {
             debug: false,
             allow_unknown: false,
             timeout_duration: Duration::from_secs(1),
+            cursor_discovery: Arc::new(tokio::sync::OnceCell::new()),
         }
     }
 
@@ -9151,6 +9155,9 @@ async fn call_litellm(
 async fn call_model(
     litellm: &LiteLLM,
     cursor_timeout: Duration,
+    cursor_discovery: &std::sync::Arc<
+        tokio::sync::OnceCell<providers::cursor::CursorDiscoveryOutcome>,
+    >,
     provider: Option<&str>,
     model: &str,
     prompt: &str,
@@ -9170,7 +9177,8 @@ async fn call_model(
             None,
             None,
         )?;
-        let result = providers::cursor::complete(model, prompt, cursor_timeout).await?;
+        let result =
+            providers::cursor::complete(model, prompt, cursor_timeout, cursor_discovery).await?;
         return Ok(CallResult {
             content: result.content,
             usage: result.usage,

--- a/crates/yoetz-cli/src/providers/cursor.rs
+++ b/crates/yoetz-cli/src/providers/cursor.rs
@@ -4,10 +4,12 @@ use std::ffi::{OsStr, OsString};
 use std::io;
 use std::path::Path;
 use std::process::{Output, Stdio};
+use std::sync::Arc;
 use std::time::Duration;
 use tempfile::TempDir;
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::process::Command;
+use tokio::sync::OnceCell;
 use tokio::time::{timeout, Instant};
 use yoetz_core::types::Usage;
 
@@ -28,6 +30,14 @@ pub(crate) struct CursorCompletion {
     pub response_id: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct CursorDiscovery {
+    binary: OsString,
+    models: Vec<CursorModel>,
+}
+
+pub(crate) type CursorDiscoveryOutcome = std::result::Result<CursorDiscovery, String>;
+
 #[derive(Debug, Deserialize)]
 struct CursorResponse {
     #[serde(rename = "type")]
@@ -47,21 +57,47 @@ struct CursorUsage {
     output_tokens: Option<u64>,
 }
 
-pub(crate) async fn list_models(timeout_duration: Duration) -> Result<Vec<CursorModel>> {
-    let (_binary, output) = discover_cursor(timeout_duration).await?;
-    parse_models(&String::from_utf8_lossy(&output.stdout))
+pub(crate) async fn list_models(
+    timeout_duration: Duration,
+    discovery: &Arc<OnceCell<CursorDiscoveryOutcome>>,
+) -> Result<Vec<CursorModel>> {
+    Ok(cached_discovery(timeout_duration, discovery)
+        .await?
+        .models
+        .clone())
 }
 
 pub(crate) async fn complete(
     model: &str,
     prompt: &str,
     timeout_duration: Duration,
+    discovery: &Arc<OnceCell<CursorDiscoveryOutcome>>,
 ) -> Result<CursorCompletion> {
     let started = Instant::now();
-    let (binary, models_output) = discover_cursor(timeout_duration).await?;
-    let models = parse_models(&String::from_utf8_lossy(&models_output.stdout))?;
+    let discovery = cached_discovery(timeout_duration, discovery).await?;
     let remaining = remaining_timeout(timeout_duration, started.elapsed())?;
-    complete_with_discovered(&binary, &models, model, prompt, remaining).await
+    complete_with_discovered(
+        &discovery.binary,
+        &discovery.models,
+        model,
+        prompt,
+        remaining,
+    )
+    .await
+}
+
+async fn cached_discovery(
+    timeout_duration: Duration,
+    discovery: &Arc<OnceCell<CursorDiscoveryOutcome>>,
+) -> Result<&CursorDiscovery> {
+    let outcome = discovery
+        .get_or_init(|| async {
+            discover_cursor(timeout_duration)
+                .await
+                .map_err(|error| format!("{error:#}"))
+        })
+        .await;
+    outcome.as_ref().map_err(|error| anyhow!("{error}"))
 }
 
 async fn complete_with_discovered(
@@ -117,7 +153,7 @@ fn completion_args(workspace: &Path, model: &str) -> Vec<OsString> {
     ]
 }
 
-async fn discover_cursor(timeout_duration: Duration) -> Result<(OsString, Output)> {
+async fn discover_cursor(timeout_duration: Duration) -> Result<CursorDiscovery> {
     let workspace = TempDir::new().context("create isolated Cursor discovery workspace")?;
     for candidate in CURSOR_BINARIES {
         let args = [OsString::from("models")];
@@ -130,7 +166,11 @@ async fn discover_cursor(timeout_duration: Duration) -> Result<(OsString, Output
         .await?
         {
             Some(output) if output.status.success() => {
-                return Ok((OsString::from(candidate), output));
+                let models = parse_models(&String::from_utf8_lossy(&output.stdout))?;
+                return Ok(CursorDiscovery {
+                    binary: OsString::from(candidate),
+                    models,
+                });
             }
             Some(output) => {
                 return Err(anyhow!(

--- a/crates/yoetz-cli/tests/cursor_cli.rs
+++ b/crates/yoetz-cli/tests/cursor_cli.rs
@@ -22,6 +22,7 @@ struct CursorFixture {
     state_dir: PathBuf,
     bin_dir: PathBuf,
     source_path: PathBuf,
+    invocation_log: PathBuf,
 }
 
 impl CursorFixture {
@@ -60,6 +61,7 @@ impl CursorFixture {
         let state_dir = dir.path().join("state");
         let bin_dir = dir.path().join("bin");
         let source_path = dir.path().join("source.rs");
+        let invocation_log = dir.path().join("cursor-invocations.log");
         fs::create_dir(&bin_dir).unwrap();
         fs::write(&source_path, "fn answer() -> u8 { 42 }\n").unwrap();
         fs::write(
@@ -89,6 +91,9 @@ max_output_tokens = 1024
         fs::write(
             &cursor_agent,
             r#"#!/bin/sh
+if [ -n "$CURSOR_INVOCATION_LOG" ]; then
+  printf '%s\n' "$1" >> "$CURSOR_INVOCATION_LOG"
+fi
 if [ "$1" = "models" ]; then
   printf '%s\n' 'Available models' '' 'cursor-grok-4.6-xhigh - Cursor Grok 4.6 Extra High'
   exit 0
@@ -108,6 +113,7 @@ printf '%s' '{"type":"result","subtype":"success","is_error":false,"result":"cur
             state_dir,
             bin_dir,
             source_path,
+            invocation_log,
         }
     }
 
@@ -118,6 +124,7 @@ printf '%s' '{"type":"result","subtype":"success","is_error":false,"result":"cur
             .env("YOETZ_REGISTRY_PATH", &self.registry_path)
             .env("YOETZ_DIR", &self.state_dir)
             .env("PATH", &self.bin_dir)
+            .env("CURSOR_INVOCATION_LOG", &self.invocation_log)
             .env("MOCK_API_KEY", "test-key")
             .env_remove("OPENAI_API_KEY")
             .env_remove("ANTHROPIC_API_KEY")
@@ -126,6 +133,32 @@ printf '%s' '{"type":"result","subtype":"success","is_error":false,"result":"cur
             .env_remove("XAI_API_KEY")
             .args(["--format", "json"]);
         command
+    }
+
+    fn fail_discovery(&self) {
+        let cursor_agent = self.bin_dir.join("cursor-agent");
+        fs::write(
+            &cursor_agent,
+            r#"#!/bin/sh
+if [ -n "$CURSOR_INVOCATION_LOG" ]; then
+  printf '%s\n' "$1" >> "$CURSOR_INVOCATION_LOG"
+fi
+printf '%s\n' 'discovery unavailable' >&2
+exit 23
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&cursor_agent).unwrap().permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(cursor_agent, permissions).unwrap();
+    }
+
+    fn invocations(&self) -> Vec<String> {
+        fs::read_to_string(&self.invocation_log)
+            .unwrap_or_default()
+            .lines()
+            .map(str::to_string)
+            .collect()
     }
 }
 
@@ -266,6 +299,71 @@ fn council_routes_cursor_prefixed_model() {
         "cursor/cursor-grok-4.6-xhigh"
     );
     assert_eq!(payload["results"][0]["content"], "cursor answer");
+}
+
+#[test]
+fn council_shares_cursor_discovery_across_members() {
+    let fixture = CursorFixture::new();
+    let output = fixture
+        .command()
+        .args([
+            "council",
+            "--models",
+            "cursor/cursor-grok-4.6-xhigh,cursor/cursor-grok-4.6-xhigh,cursor/cursor-grok-4.6-xhigh",
+            "--prompt",
+            "review this",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let invocations = fixture.invocations();
+    assert_eq!(
+        invocations
+            .iter()
+            .filter(|arg| arg.as_str() == "models")
+            .count(),
+        1,
+        "discovery invocations: {invocations:?}"
+    );
+    assert_eq!(
+        invocations
+            .iter()
+            .filter(|arg| arg.as_str() != "models")
+            .count(),
+        3,
+        "consult invocations: {invocations:?}"
+    );
+}
+
+#[test]
+fn council_caches_cursor_discovery_failure_for_all_members() {
+    let fixture = CursorFixture::new();
+    fixture.fail_discovery();
+    let output = fixture
+        .command()
+        .args([
+            "council",
+            "--models",
+            "cursor/cursor-grok-4.6-xhigh,cursor/cursor-grok-4.6-xhigh,cursor/cursor-grok-4.6-xhigh",
+            "--prompt",
+            "review this",
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        stderr
+            .matches("Cursor CLI model discovery failed: discovery unavailable")
+            .count(),
+        3,
+        "stderr: {stderr}"
+    );
+    assert_eq!(fixture.invocations(), vec!["models"]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Cache Cursor discovery success or failure once per Yoetz process with an invocation-scoped Tokio OnceCell.
- Share the cached discovery across council members while preserving each member's remaining timeout budget.
- Add hostile controlled-PATH integration tests for one discovery/three consults and cached failure fan-out.

## Verification
- cargo fmt --all
- cargo clippy -p yoetz --all-targets -- -D warnings
- cargo test -p yoetz --test cursor_cli -- --test-threads=1 (9 passed)
- cargo test -p yoetz providers::cursor::tests -- --test-threads=1 (9 passed)
- cargo test --workspace --quiet (clean non-overlapping run; 652 Yoetz tests, 2 known Chrome-dependent ignores)

Closes yz-920. Based on merged #430.