### PR TITLE
fix(extension): recognize personal ChatGPT Sol Max picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   Faster/Smarter power slider is left untouched. Structural trust still applies
   when the Radix surface is opacity-0 in a background tab, including when
   `aria-controls` names a wrapper whose inner menu holds `data-state=open`.
+  Closed leftover menus and mounted Radix wrappers whose nested menu is closed
+  are not treated as an open picker.
 - ChatGPT response extraction now recovers assistant markdown that is a sibling
   of its final copy-action row while retaining assistant-ownership and citation
   guards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- ChatGPT native-extension model selection now recognizes the personal-profile
+  simple picker (GPT-5.6 Sol plus Effort `Max` / `Extra High` / `Pro`). The
+  Faster/Smarter power slider is left untouched. Structural trust still applies
+  when the Radix surface is opacity-0 in a background tab, including when
+  `aria-controls` names a wrapper whose inner menu holds `data-state=open`.
+- ChatGPT response extraction now recovers assistant markdown that is a sibling
+  of its final copy-action row while retaining assistant-ownership and citation
+  guards.
 
 ## [0.5.55] - 2026-08-17
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,11 +85,11 @@ recipe flows, treat `dev-browser` as a QuickJS/WASM runner, not Node.js:
 ## Browser Architecture
 
 - The built-in ChatGPT recipe pins GPT-5.6 Sol at the account's verified maximum
-  effort tier: `Pro` for the known Enterprise picker or `Extra High` for the
-  validated personal picker observed on 2026-08-12. Selection remains
-  fail-closed on the family, one of those two exact labels, and numeric maximum
-  proofs; unknown top tiers are rejected. Speed stays at the user's default and
-  is never toggled by selection.
+  effort tier: `Pro` for the known Enterprise picker, or `Extra High` / `Max`
+  for the personal picker (`Max` observed on 2026-08-19). Selection remains
+  fail-closed on the family and those exact maximum labels; unknown top tiers
+  are rejected. Speed and the Faster/Smarter power slider stay at the user's
+  default and are never toggled by selection.
 - Treat yoetz as a thin wrapper over the underlying browser transport unless
   yoetz must own behavior for correctness or UX.
 - Extension-free by default. Preferred live-Chrome transport order:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -834,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1943,7 +1943,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2001,7 +2001,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2340,7 +2340,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2941,7 +2941,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -5,7 +5,7 @@ const DEFAULT_WAIT_INTERVAL_MS = 250;
 const DEFAULT_SEND_MIN_TIMEOUT_MS = 120000;
 const CHATGPT_SOL_EXTRA_HIGH_MODEL = "gpt-5-6-sol-extra-high";
 const CHATGPT_SOL_FAMILY_LABEL = "GPT-5.6 Sol";
-const CHATGPT_MAX_EFFORT_LABELS = new Set(["pro", "extra high"]);
+const CHATGPT_MAX_EFFORT_LABELS = new Set(["pro", "extra high", "max"]);
 const MANUAL_HANDOFF_SHELL_SELECTORS = Object.freeze([
   "nav",
   "aside",
@@ -599,7 +599,15 @@ async function selectSolMaxTierModel(root, options = {}) {
   }
 
   if (!effortIsMaxTier(state)) {
-    if (state.shape === "slider") {
+    if (state.shape === "personal") {
+      const selected = await selectPersonalMaxEffort(root, state, options);
+      state = selected.state ?? state;
+      state.effort_move_method = selected.method;
+      if (!selected.ok) {
+        await closeModelPicker(root, modelButton);
+        return selectionFailure(base, modelButton, state, availableFamilies, "Neither Pro, Extra High, nor Max was visible as the GPT-5.6 Sol maximum tier", "effort_control_not_found");
+      }
+    } else if (state.shape === "slider") {
       if (!state.effort_slider) {
         await closeModelPicker(root, modelButton);
         return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol effort slider was not found in the Advanced picker", "effort_control_not_found");
@@ -612,11 +620,12 @@ async function selectSolMaxTierModel(root, options = {}) {
         return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol effort slider did not move to a verified maximum tier", "effort_slider_move_failed");
       }
     } else {
-      const maxOption = state.effort_items.find((item) => foldedModelText(textOf(item)) === "extra high")
+      const maxOption = state.effort_items.find((item) => foldedModelText(textOf(item)) === "max")
+        ?? state.effort_items.find((item) => foldedModelText(textOf(item)) === "extra high")
         ?? state.effort_items.find((item) => foldedModelText(textOf(item)) === "pro");
       if (!maxOption) {
         await closeModelPicker(root, modelButton);
-        return selectionFailure(base, modelButton, state, availableFamilies, "Neither Pro nor Extra High was visible as the GPT-5.6 Sol maximum tier", "effort_control_not_found");
+        return selectionFailure(base, modelButton, state, availableFamilies, "Neither Pro, Extra High, nor Max was visible as the GPT-5.6 Sol maximum tier", "effort_control_not_found");
       }
       realClick(maxOption);
       await sleep(Number(options.actionSettleMs ?? 250));
@@ -639,20 +648,22 @@ async function selectSolMaxTierModel(root, options = {}) {
   const effortVerified = effortIsMaxTier(state);
   if (!familyVerified || !effortVerified) {
     await closeModelPicker(root, modelButton);
-    return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol at a verified maximum tier (Pro or Extra High) could not be confirmed in one picker pass", "model_selection_verification_failed");
+    return selectionFailure(base, modelButton, state, availableFamilies, "GPT-5.6 Sol at a verified maximum tier (Pro, Extra High, or Max) could not be confirmed in one picker pass", "model_selection_verification_failed");
   }
   if (!await closeModelPicker(root, modelButton)) {
     return selectionFailure(base, modelButton, state, availableFamilies, "ChatGPT model picker remained open after verification", "model_picker_close_failed");
   }
   modelButton = await waitForModelButton(root, options);
   const pillText = modelControlLabel(modelButton);
-  const verifiedEffortLabel = state.shape === "slider"
-    ? sliderEffortSnapshot(state.effort_slider, state.surface)?.display_label
+  const verifiedEffortLabel = state.shape === "personal"
+    ? state.effort_label
+    : state.shape === "slider"
+      ? sliderEffortSnapshot(state.effort_slider, state.surface)?.display_label
     : normalizeText(textOf(state.effort_items.find((item) => itemIsChecked(item))));
-  if (state.shape === "slider" && !pillConfirmsFamilyLabel(pillText, state.family_label)) {
+  if ((state.shape === "slider" || state.shape === "personal") && !pillConfirmsFamilyLabel(pillText, state.family_label)) {
     return selectionFailure(base, modelButton, state, availableFamilies, "ChatGPT composer model pill did not confirm GPT-5.6 Sol after closing the slider picker", "family_composer_pill_unverified");
   }
-  if (state.shape === "slider" && !pillConfirmsEffortLabel(pillText, verifiedEffortLabel)) {
+  if ((state.shape === "slider" || state.shape === "personal") && !pillConfirmsEffortLabel(pillText, verifiedEffortLabel)) {
     return selectionFailure(base, modelButton, state, availableFamilies, "ChatGPT composer model pill did not confirm the verified maximum tier after closing the slider picker", "effort_composer_pill_unverified");
   }
 
@@ -664,7 +675,7 @@ async function selectSolMaxTierModel(root, options = {}) {
     effort_status: "verified",
     picker_shape: state.shape,
     surface_trust: state.surface_trust,
-    effort_control: state.shape === "slider" ? sliderEffortDiagnostics(state.effort_slider, state.surface) : null,
+    effort_control: effortControlDiagnostics(state),
     effort_move_method: state.effort_move_method ?? null,
     pill_text: pillText,
     family_label: state.family_label,
@@ -717,6 +728,9 @@ async function openModelPicker(root, modelButton, options = {}) {
   const openedOrTriggered = () => opened() || modelPickerTriggerIsOpen(modelButton);
   if (opened()) {
     return true;
+  }
+  if (modelPickerTriggerIsOpen(modelButton)) {
+    return Boolean(await waitForPickerState(root, options));
   }
   const activators = [openWithPointerEvents, pressEnter, pressSpace];
   for (const activate of activators) {
@@ -879,6 +893,8 @@ function findPickerState(root) {
   if (menu) return readMenuPickerState(menu, false);
   const slider = readSliderPickerState(root);
   if (slider) return slider;
+  const personal = findPersonalPickerSurface(root);
+  if (personal) return readPersonalPickerState(personal, false);
   const controlledSurface = structurallyOpenControlledSurface(root);
   return controlledSurface ? readStructurallyTrustedPickerState(controlledSurface) : null;
 }
@@ -893,18 +909,122 @@ function structurallyOpenControlledSurfaceForTrigger(root, trigger) {
   const controlledId = trigger?.getAttribute?.("aria-controls");
   if (!controlledId) return null;
   const surface = root.getElementById?.(controlledId);
-  return surface?.getAttribute?.("data-state") === "open" ? surface : null;
+  if (!surface) return null;
+  if (surface.getAttribute?.("data-state") === "open") return surface;
+  const openChild = Array.from(surface.querySelectorAll?.('[role="menu"], [role="dialog"]') ?? [])
+    .find((node) => node.getAttribute?.("data-state") === "open");
+  return openChild ? surface : null;
 }
 
 function readStructurallyTrustedPickerState(surface) {
-  const labels = menuRadioItems(surface, true).map((item) => foldedModelText(textOf(item)));
+  const direct = classifyPickerSurface(surface, true);
+  if (direct) return direct;
+  for (const nested of Array.from(surface.querySelectorAll?.('[role="menu"], [role="dialog"]') ?? [])) {
+    const classified = classifyPickerSurface(nested, true);
+    if (classified) return classified;
+  }
+  return null;
+}
+
+function classifyPickerSurface(surface, structurallyTrusted) {
+  if (!surface) return null;
+  const labels = menuRadioItems(surface, structurallyTrusted).map((item) => foldedModelText(textOf(item)));
   if (labels.includes("medium") && labels.includes("high") && labels.includes("extra high")) {
-    return readMenuPickerState(surface, true);
+    return readMenuPickerState(surface, structurallyTrusted);
   }
   const text = normalizeText(textOf(surface));
   if (/\bAdvanced\b/i.test(text) && /\bEffort\b/i.test(text)
     && surface.querySelectorAll?.('[role="slider"]')?.length > 0) {
-    return readSliderPickerState(surface.ownerDocument, surface);
+    return readSliderPickerState(surface.ownerDocument ?? surface, structurallyTrusted ? surface : null);
+  }
+  if (looksLikePersonalPicker(surface)) {
+    return readPersonalPickerState(surface, structurallyTrusted);
+  }
+  return null;
+}
+
+function looksLikePersonalPicker(node) {
+  const text = normalizeText(textOf(node));
+  return /\bFaster\b/i.test(text)
+    && /\bSmarter\b/i.test(text)
+    && /\bModel\b/i.test(text)
+    && /\bEffort\b/i.test(text)
+    && /\bSpeed\b/i.test(text)
+    && !/\bAdvanced\b/i.test(text);
+}
+
+function findPersonalPickerSurface(root) {
+  const candidates = Array.from(root.querySelectorAll('div, [role="menu"], [role="dialog"]'))
+    .filter((node) => node.getAttribute?.("data-state") !== "closed"
+      && isVisible(node, { allowDisabled: true }) && looksLikePersonalPicker(node));
+  return candidates.sort((left, right) => (
+    left.querySelectorAll?.("*")?.length ?? 0
+  ) - (
+    right.querySelectorAll?.("*")?.length ?? 0
+  ))[0] ?? null;
+}
+
+function readPersonalPickerState(surface, structurallyTrusted = false) {
+  const controls = Array.from(surface.querySelectorAll?.('[role="menuitem"], button') ?? []);
+  let familyEvidence = null;
+  const familyTrigger = controls.find((item) => {
+    const evidence = structuralFamilyEvidence(item);
+    if (evidence.label || evidence.ambiguous) familyEvidence = evidence;
+    return Boolean(evidence.label || evidence.ambiguous);
+  }) ?? controls.find((item) => /\bModel\b/i.test(textOf(item)) && item.getAttribute?.("aria-haspopup") === "menu") ?? null;
+  const effortRow = controls.find((item) => /\bEffort\b/i.test(textOf(item))) ?? null;
+  const effortLabel = labeledRowValue(effortRow, "Effort");
+  const familyLabel = familyEvidence?.label || labeledRowValue(familyTrigger, "Model");
+  if (!familyTrigger || !effortRow || !effortLabel || (!familyLabel && !familyEvidence?.ambiguous)) return null;
+  return {
+    shape: "personal",
+    menu: null,
+    surface,
+    family_trigger: familyTrigger,
+    family_label: familyLabel,
+    family_label_candidates: familyEvidence?.labels ?? (familyLabel ? [familyLabel] : []),
+    family_label_source: familyEvidence?.source ?? (familyLabel ? "labeled_row" : null),
+    family_label_ambiguous: familyEvidence?.ambiguous ?? false,
+    effort_row: effortRow,
+    effort_label: effortLabel,
+    effort_items: [],
+    effort_slider: null,
+    effort_move_method: null,
+    surface_trust: structurallyTrusted ? "aria_controls_structural" : "visible"
+  };
+}
+
+function labeledRowValue(row, label) {
+  const text = normalizeText(textOf(row)).replace(/\s+/g, " ");
+  const match = text.match(new RegExp(`^${label}\\s+(.+)$`, "i"));
+  return normalizeText(match?.[1] ?? "");
+}
+
+async function selectPersonalMaxEffort(root, initialState, options = {}) {
+  const settleMs = Number(options.actionSettleMs ?? 250);
+  if (!initialState?.effort_row) return { ok: false, state: initialState, method: null };
+  realClick(initialState.effort_row);
+  await sleep(settleMs);
+  let state = findPickerState(root) ?? initialState;
+  const maxOption = findPersonalMaxEffortOption(root, state);
+  if (!maxOption) return { ok: false, state, method: null };
+  realClick(maxOption);
+  await sleep(settleMs);
+  state = findPickerState(root) ?? state;
+  return { ok: effortIsMaxTier(state), state, method: "effort_row_select" };
+}
+
+function findPersonalMaxEffortOption(root, state) {
+  const scopes = [];
+  if (state?.surface) scopes.push(state.surface);
+  scopes.push(...Array.from(root.querySelectorAll?.('[role="menu"]') ?? []));
+  for (const scope of uniqueElements(scopes)) {
+    const items = Array.from(scope.querySelectorAll?.('[role="menuitemradio"], [role="menuitem"]') ?? []);
+    const max = ["max", "extra high", "pro"]
+      .map((label) => items.find((item) => foldedModelText(textOf(item)).replace(/\s+/g, " ") === label
+        && !/^effort\b/i.test(normalizeText(textOf(item)))))
+      .find(Boolean);
+    if (max) return max;
   }
   return null;
 }
@@ -1047,6 +1167,9 @@ function familyMenuRadios(menu, structurallyTrusted = false) {
 }
 
 function effortIsMaxTier(state) {
+  if (state?.shape === "personal") {
+    return CHATGPT_MAX_EFFORT_LABELS.has(foldedModelText(state.effort_label).replace(/\s+/g, " "));
+  }
   if (state?.shape === "slider") {
     const snapshot = sliderEffortSnapshot(state.effort_slider, state.surface);
     return Boolean(snapshot && CHATGPT_MAX_EFFORT_LABELS.has(snapshot.label) && snapshot.now === snapshot.max);
@@ -1144,6 +1267,21 @@ function sliderEffortDiagnostics(slider, surface = null) {
     value_min: snapshot.min,
     value_max: snapshot.max
   } : null;
+}
+
+function personalEffortDiagnostics(state) {
+  if (!state?.effort_label) return null;
+  return {
+    role: "menuitem",
+    label: foldedModelText(state.effort_label).replace(/\s+/g, " "),
+    value_text: state.effort_label
+  };
+}
+
+function effortControlDiagnostics(state) {
+  if (state?.shape === "personal") return personalEffortDiagnostics(state);
+  if (state?.shape === "slider") return sliderEffortDiagnostics(state.effort_slider, state.surface);
+  return null;
 }
 
 async function moveEffortSliderToMaxTier(root, initialState, options = {}) {
@@ -1340,7 +1478,7 @@ function selectionFailure(base, modelButton, state, availableFamilies, warning, 
     advanced_rows: advancedViewRows(state?.surface),
     checkbox_probe: state?.checkbox_probe ?? null,
     family_menu_probe: state?.family_menu_probe ?? null,
-    effort_control: state?.shape === "slider" ? sliderEffortDiagnostics(state.effort_slider, state.surface) : null,
+    effort_control: effortControlDiagnostics(state),
     effort_move_method: state?.effort_move_method ?? null,
     pill_text: modelControlLabel(modelButton),
     family_label: state?.family_label ?? null,
@@ -1409,9 +1547,10 @@ function classTokens(node) {
 }
 
 function modelPillSummaryMatches(value) {
-  const folded = foldedModelText(value);
-  return /^(instant|medium|high|extra high|pro)$/.test(folded)
-    || /^\d+(?:\.\d+)+ (instant|medium|high|extra high|pro)$/.test(folded)
+  const folded = foldedModelText(value).replace(/\s+/g, " ");
+  const effort = "instant|medium|high|extra high|pro|max";
+  return new RegExp(`^(?:${effort})$`).test(folded)
+    || new RegExp(`^\\d+(?:\\.\\d+)+(?: sol)? (?:${effort})$`).test(folded)
     || /\bgpt[\s.-]*\d/.test(folded);
 }
 
@@ -1587,6 +1726,24 @@ export function extractResponse(root = document) {
     };
   }
 
+  const copyScopedStandalone = latestCopyScopedStandaloneMarkdown(root, userTurns, assistantTurns, copyButtons);
+  if (copyScopedStandalone) {
+    const assistantCount = Math.max(assistantTurns.length, 1);
+    return {
+      method: "copy_scope_dom_fallback",
+      text: copyScopedStandalone.text,
+      is_generating: isResponseGenerating(root),
+      assistant_count: assistantCount,
+      user_count: userTurns.length,
+      preceding_user_count: precedingTurnCount(root, copyScopedStandalone.node, userTurns),
+      copy_button_count: Math.max(copyButtonCount, 1),
+      has_copy_button: true,
+      turn_index: assistantCount - 1,
+      model_slug: messageModelSlug(copyScopedStandalone.node),
+      diagnostics
+    };
+  }
+
   return {
     method: "page_text_fallback",
     text: normalizeText(getPageText(root)),
@@ -1600,6 +1757,35 @@ export function extractResponse(root = document) {
     model_slug: messageModelSlug(latestAssistant),
     diagnostics
   };
+}
+
+function latestCopyScopedStandaloneMarkdown(root, userTurns, assistantTurns, copyButtons) {
+  if (assistantTurns.length === 0) return null;
+  const latestUser = userTurns.at(-1);
+  if (!latestUser) return null;
+  const conversation = conversationScope(latestUser);
+  if (!conversation) return null;
+  const ordered = flattenTree(root.documentElement ?? root.body ?? root);
+  const userIndex = ordered.indexOf(latestUser);
+  if (userIndex < 0) return null;
+  for (const copy of [...copyButtons].reverse()) {
+    if (!isCopyControl(copy) || !containsNode(conversation, copy) || isInsideUserTurn(copy)) continue;
+    const copyIndex = ordered.indexOf(copy);
+    if (copyIndex <= userIndex) continue;
+    const markdown = leafNodes(Array.from(conversation.querySelectorAll?.('[class*="markdown"]') ?? []))
+      .filter((node) => {
+        const nodeIndex = ordered.indexOf(node);
+        return nodeIndex > userIndex && nodeIndex < copyIndex
+          && isVisible(node, { allowDisabled: true, allowNoLayout: true })
+          && !isInsideUserTurn(node) && !isNonConversationChrome(node)
+          && !isCitationSourceAffordance(node);
+      })
+      .at(-1);
+    if (!markdown) continue;
+    const text = cleanAssistantText(markdown, { preserveContentStatusText: true });
+    if (text) return { node: markdown, text };
+  }
+  return null;
 }
 
 function latestTextBearingAssistantTurn(assistantTurns) {
@@ -2016,9 +2202,9 @@ function isAssistantControlLine(line, options = {}) {
 
 function isModelStatusText(text) {
   const value = normalizeText(text);
-  const effort = "instant|medium|high|extra high|pro";
-  return /^(sol|instant|medium|high|extra high|pro|pro thinking|thinking)$/i.test(value)
-    || new RegExp(`^\\d+(?:\\.\\d+)+\\s+(?:${effort})$`, "i").test(value)
+  const effort = "instant|medium|high|extra high|pro|max";
+  return new RegExp(`^(sol|${effort}|pro thinking|thinking)$`, "i").test(value)
+    || new RegExp(`^\\d+(?:\\.\\d+)+(?:\\s+sol)?\\s+(?:${effort})$`, "i").test(value)
     || new RegExp(`^gpt[\\s.-]*\\d+(?:[\\s.-]*\\d+)*(?:\\s+sol)?(?:\\s+(?:${effort}|thinking))?$`, "i").test(value);
 }
 
@@ -2978,7 +3164,7 @@ export function modelSelectionDiagnostics(root = document) {
     family_label: state?.family_label ?? null,
     picker_shape: state?.shape ?? null,
     surface_trust: state?.surface_trust ?? null,
-    effort_control: state?.shape === "slider" ? sliderEffortDiagnostics(state.effort_slider, state.surface) : null,
+    effort_control: effortControlDiagnostics(state),
     model_button: modelButton ? elementSummary(modelButton) : null,
     model_button_wiring: modelButton ? {
       aria_expanded: modelButton.getAttribute?.("aria-expanded") ?? null,

--- a/extensions/chatgpt-native/src/chatgpt-dom.js
+++ b/extensions/chatgpt-native/src/chatgpt-dom.js
@@ -953,9 +953,17 @@ function looksLikePersonalPicker(node) {
     && !/\bAdvanced\b/i.test(text);
 }
 
+function personalPickerSurfaceIsOpen(node) {
+  const state = node?.getAttribute?.("data-state");
+  if (state === "open") return true;
+  if (state === "closed") return false;
+  return Array.from(node.querySelectorAll?.('[role="menu"], [role="dialog"]') ?? [])
+    .some((child) => child.getAttribute?.("data-state") === "open");
+}
+
 function findPersonalPickerSurface(root) {
   const candidates = Array.from(root.querySelectorAll('div, [role="menu"], [role="dialog"]'))
-    .filter((node) => node.getAttribute?.("data-state") !== "closed"
+    .filter((node) => personalPickerSurfaceIsOpen(node)
       && isVisible(node, { allowDisabled: true }) && looksLikePersonalPicker(node));
   return candidates.sort((left, right) => (
     left.querySelectorAll?.("*")?.length ?? 0

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -611,6 +611,23 @@ test("extractResponse can use ChatGPT markdown assistant content without role ma
   assert.equal(extraction.assistant_count, 1);
 });
 
+test("extractResponse scopes sibling markdown to a later copy control", () => {
+  const user = new FakeElement("article", { "data-message-author-role": "user" }, "Review this bundle");
+  const answer = new FakeElement("div", { class: "markdown prose" }, "Complete answer from the personal profile");
+  const actions = new FakeElement("article", {}, "Copy")
+    .append(new FakeElement("button", { "aria-label": "Copy" }, "Copy"));
+  const conversation = new FakeElement("main", { role: "main" }, "")
+    .append(user, answer, actions);
+  const doc = new FakeDocument(new FakeElement("body", {}, "").append(conversation));
+
+  const extraction = extractResponse(doc);
+
+  assert.equal(extraction.method, "copy_scope_dom_fallback");
+  assert.equal(extraction.text, "Complete answer from the personal profile");
+  assert.equal(extraction.assistant_count, 1);
+  assert.equal(extraction.copy_button_count, 1);
+});
+
 test("extractResponse promotes assistant role marker to enclosing turn content", () => {
   const roleMarker = new FakeElement("div", { "data-message-author-role": "assistant" }, "");
   const markdown = new FakeElement("div", { class: "markdown prose" }, "Sibling markdown answer");
@@ -694,7 +711,7 @@ test("extractResponse ignores ChatGPT model status text when assistant content i
 });
 
 test("extractResponse recognizes new GPT-5.6 picker labels only as whole-line status chrome", () => {
-  for (const status of ["Sol", "Instant", "Medium", "High", "Extra High", "Pro", "GPT-5.6 Sol", "5.6 Pro", "5.5 Extra High"]) {
+  for (const status of ["Sol", "Instant", "Medium", "High", "Extra High", "Pro", "Max", "GPT-5.6 Sol", "5.6 Pro", "5.5 Extra High", "5.6 Sol Max"]) {
     const assistant = new FakeElement("article", { "data-message-author-role": "assistant" }, status)
       .append(new FakeElement("button", { "aria-label": "Copy" }, "Copy"));
     const doc = new FakeDocument(new FakeElement("body", {}, status).append(assistant));
@@ -2524,6 +2541,77 @@ test("GPT-5.6 Sol Advanced picker accepts Pro at the Enterprise slider maximum",
   assert.equal(result.pill_text, "5.6 Sol\nPro");
 });
 
+test("GPT-5.6 Sol personal picker verifies Effort Max without moving the power slider", async () => {
+  const fixture = makePersonalPickerFixture();
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "selected", JSON.stringify(result));
+  assert.equal(result.picker_shape, "personal");
+  assert.equal(result.surface_trust, "aria_controls_structural");
+  assert.equal(result.family_label, "GPT-5.6 Sol");
+  assert.equal(result.model_used, "GPT-5.6 Sol Max");
+  assert.equal(result.effort_control.value_text, "Max");
+  assert.equal(result.effort_move_method, null);
+  assert.deepEqual(fixture.keyAttempts(), []);
+  assert.equal(fixture.sliderValue(), 2);
+  assert.equal(fixture.pickerOpen(), false);
+});
+
+test("GPT-5.6 Sol personal picker trusts a Radix wrapper whose inner menu is open", async () => {
+  const fixture = makePersonalPickerFixture({ wrappedRadix: true, startsOpen: true });
+
+  const result = await configureModelState(fixture.doc, { pickerTimeoutMs: 200, intervalMs: 25 });
+
+  assert.equal(result.status, "selected", JSON.stringify(result));
+  assert.equal(result.picker_shape, "personal");
+  assert.equal(result.surface_trust, "aria_controls_structural");
+  assert.equal(result.model_used, "GPT-5.6 Sol Max");
+  assert.deepEqual(fixture.keyAttempts(), []);
+  assert.equal(fixture.sliderValue(), 2);
+});
+
+test("GPT-5.6 Sol personal picker classifies a visible simple picker", async () => {
+  const fixture = makePersonalPickerFixture({ backgroundFrozen: false });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "selected", JSON.stringify(result));
+  assert.equal(result.picker_shape, "personal");
+  assert.equal(result.surface_trust, "visible");
+  assert.equal(result.model_used, "GPT-5.6 Sol Max");
+  assert.deepEqual(fixture.keyAttempts(), []);
+});
+
+test("GPT-5.6 Sol personal picker upgrades High effort via the Effort row", async () => {
+  const fixture = makePersonalPickerFixture({
+    effort: "High",
+    effortOptions: ["Standard", "High", "Max"]
+  });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "selected", JSON.stringify(result));
+  assert.equal(result.model_used, "GPT-5.6 Sol Max");
+  assert.equal(result.effort_move_method, "effort_row_select");
+  assert.equal(fixture.effortClicks(), 1);
+  assert.deepEqual(fixture.keyAttempts(), []);
+  assert.equal(fixture.sliderValue(), 2);
+});
+
+test("GPT-5.6 Sol personal picker rejects an unknown Effort label", async () => {
+  const fixture = makePersonalPickerFixture({ effort: "Expert" });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "unavailable");
+  assert.equal(result.failure_reason, "effort_control_not_found");
+  assert.equal(result.effort_control.value_text, "Expert");
+  assert.deepEqual(fixture.keyAttempts(), []);
+  assert.equal(fixture.sliderValue(), 2);
+  assert.equal(fixture.pickerOpen(), false);
+});
+
 test("GPT-5.6 Sol Advanced picker waits for an expanded Radix surface to finish animating", async () => {
   const fixture = makeSolSliderFixture({ keyboardMode: "end", animatedReveal: true });
 
@@ -3202,6 +3290,154 @@ function makeSolSliderFixture({
     panel: () => panel,
     familyClicks: () => familyClickCount,
     familyMenuOpen: () => Boolean(familyMenu)
+  };
+}
+
+function makePersonalPickerFixture({
+  effort = "Max",
+  backgroundFrozen = true,
+  wrappedRadix = false,
+  startsOpen = false,
+  effortOptions = null
+} = {}) {
+  let panel = null;
+  let currentValue = 2;
+  let currentEffort = effort;
+  let effortClicks = 0;
+  let effortMenu = null;
+  const keyAttempts = [];
+  const composer = new FakeElement("div", {
+    id: "prompt-textarea",
+    contenteditable: "true",
+    role: "textbox",
+    "aria-label": "Chat with ChatGPT",
+    class: "ProseMirror"
+  });
+  const form = new FakeElement("form", { class: "group/composer" }, "").append(composer);
+  const body = new FakeElement("body", {}, "").append(form);
+  const pickerText = () => [
+    "Light, 2 of 5.",
+    "Use Left and Right arrow keys to adjust power.",
+    "Reset to default",
+    "Faster",
+    "Smarter",
+    "Consumes usage limits faster",
+    "Model",
+    "GPT-5.6 Sol",
+    "Effort",
+    currentEffort,
+    "Speed",
+    "Standard"
+  ].join("\n");
+  const frozenStyle = backgroundFrozen ? "opacity:0; pointer-events:auto" : "";
+  const closeEffortMenu = () => {
+    if (!effortMenu) return;
+    body.children = body.children.filter((child) => child !== effortMenu);
+    effortMenu.parentElement = null;
+    effortMenu = null;
+  };
+  const closePanel = () => {
+    closeEffortMenu();
+    if (!panel) return;
+    body.children = body.children.filter((child) => child !== panel);
+    panel.parentElement = null;
+    panel = null;
+    pill.setAttribute("aria-expanded", "false");
+    pill.setAttribute("data-state", "closed");
+  };
+  let slider = null;
+  let effortRow = null;
+  const openEffortMenu = () => {
+    closeEffortMenu();
+    if (!effortOptions) return;
+    effortMenu = new FakeElement("div", { id: "effort-picker", role: "menu", "data-state": "open" });
+    for (const label of effortOptions) {
+      effortMenu.append(new FakeElement("div", {
+        role: "menuitemradio",
+        "aria-checked": label === currentEffort ? "true" : "false",
+        onPointerDown: () => {
+          currentEffort = label;
+          effortRow.innerText = `Effort ${label}`;
+          effortRow.textContent = effortRow.innerText;
+          pill.innerText = `5.6 Sol\n${label}`;
+          pill.textContent = pill.innerText;
+          closeEffortMenu();
+        }
+      }, label));
+    }
+    body.append(effortMenu);
+  };
+  const openPanel = () => {
+    closePanel();
+    slider = new FakeElement("span", {
+      role: "slider",
+      "aria-hidden": "true",
+      style: "pointer-events:none",
+      "aria-valuemin": "1",
+      "aria-valuemax": "5",
+      "aria-valuenow": String(currentValue),
+      "aria-valuetext": `Light, ${currentValue} of 5.`,
+      onKeyDown: (event) => {
+        keyAttempts.push(event.key);
+      }
+    });
+    const family = new FakeElement("div", {
+      role: "menuitem",
+      "aria-haspopup": "menu"
+    }, "Model GPT-5.6 Sol").append(
+      new FakeElement("span", {}, "Model"),
+      new FakeElement("span", { "data-state": "checked" }, "GPT-5.6 Sol")
+    );
+    effortRow = new FakeElement("div", {
+      role: "menuitem",
+      ...(effortOptions ? { "aria-haspopup": "menu" } : {}),
+      onPointerDown: () => {
+        effortClicks += 1;
+        openEffortMenu();
+      }
+    }, `Effort ${currentEffort}`);
+    const speedRow = new FakeElement("div", { role: "menuitem" }, "Speed Standard");
+    const menu = new FakeElement("div", {
+      role: "menu",
+      "data-state": "open",
+      style: frozenStyle
+    }, pickerText());
+    menu.append(slider, family, effortRow, speedRow);
+    if (wrappedRadix) {
+      panel = new FakeElement("div", {
+        id: "personal-picker",
+        class: "z-50 popover",
+        style: frozenStyle
+      }, pickerText());
+      panel.append(menu);
+    } else {
+      menu.setAttribute("id", "personal-picker");
+      panel = menu;
+    }
+    body.append(panel);
+    pill.setAttribute("aria-expanded", "true");
+    pill.setAttribute("data-state", "open");
+  };
+  const pill = new FakeElement("button", {
+    class: "__composer-pill __composer-pill--neutral",
+    "aria-haspopup": "menu",
+    "aria-controls": "personal-picker",
+    "aria-expanded": "false",
+    "data-state": "closed",
+    onPointerDown: openPanel,
+    onKeyDown: (event) => {
+      if (event.key === "Escape") closePanel();
+    }
+  }, `5.6 Sol\n${currentEffort}`);
+  form.append(pill);
+  const doc = new FakeDocument(body);
+  if (startsOpen) openPanel();
+  return {
+    doc,
+    keyAttempts: () => [...keyAttempts],
+    sliderValue: () => currentValue,
+    effortClicks: () => effortClicks,
+    pickerOpen: () => Boolean(panel)
   };
 }
 

--- a/extensions/chatgpt-native/tests/fake-chatgpt.test.js
+++ b/extensions/chatgpt-native/tests/fake-chatgpt.test.js
@@ -2612,6 +2612,48 @@ test("GPT-5.6 Sol personal picker rejects an unknown Effort label", async () => 
   assert.equal(fixture.pickerOpen(), false);
 });
 
+test("GPT-5.6 Sol personal picker ignores a retained closed menu sibling", async () => {
+  const fixture = makePersonalPickerFixture();
+  const decoy = new FakeElement("div", {
+    role: "menu",
+    "data-state": "closed",
+    style: "opacity:1; pointer-events:auto"
+  }, "Faster\nSmarter\nModel\nGPT-5.6 Sol\nEffort\nExpert\nSpeed\nStandard").append(
+    new FakeElement("div", { role: "menuitem", "aria-haspopup": "menu" }, "Model GPT-5.6 Sol").append(
+      new FakeElement("span", {}, "Model"),
+      new FakeElement("span", { "data-state": "checked" }, "GPT-5.6 Sol")
+    ),
+    new FakeElement("div", { role: "menuitem" }, "Effort Expert"),
+    new FakeElement("div", { role: "menuitem" }, "Speed Standard")
+  );
+  fixture.doc.body.append(decoy);
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "selected", JSON.stringify(result));
+  assert.equal(result.picker_shape, "personal");
+  assert.equal(result.model_used, "GPT-5.6 Sol Max");
+  assert.equal(result.effort_control.value_text, "Max");
+  assert.equal(modelSelectionDiagnostics(fixture.doc).picker_shape, null);
+});
+
+test("GPT-5.6 Sol personal picker does not rediscover a mounted closed Radix wrapper", async () => {
+  const fixture = makePersonalPickerFixture({
+    wrappedRadix: true,
+    retainMountedWrapper: true
+  });
+
+  const result = await configureModelState(fixture.doc, {});
+
+  assert.equal(result.status, "selected", JSON.stringify(result));
+  assert.equal(result.picker_shape, "personal");
+  assert.equal(result.model_used, "GPT-5.6 Sol Max");
+  assert.equal(result.failure_reason, null);
+  assert.equal(fixture.wrapperMounted(), true);
+  assert.equal(fixture.nestedMenuState(), "closed");
+  assert.equal(modelSelectionDiagnostics(fixture.doc).picker_shape, null);
+});
+
 test("GPT-5.6 Sol Advanced picker waits for an expanded Radix surface to finish animating", async () => {
   const fixture = makeSolSliderFixture({ keyboardMode: "end", animatedReveal: true });
 
@@ -3298,9 +3340,11 @@ function makePersonalPickerFixture({
   backgroundFrozen = true,
   wrappedRadix = false,
   startsOpen = false,
+  retainMountedWrapper = false,
   effortOptions = null
 } = {}) {
   let panel = null;
+  let menuNode = null;
   let currentValue = 2;
   let currentEffort = effort;
   let effortClicks = 0;
@@ -3336,12 +3380,22 @@ function makePersonalPickerFixture({
     effortMenu.parentElement = null;
     effortMenu = null;
   };
-  const closePanel = () => {
+  const detachPanel = () => {
     closeEffortMenu();
     if (!panel) return;
     body.children = body.children.filter((child) => child !== panel);
     panel.parentElement = null;
     panel = null;
+    menuNode = null;
+  };
+  const closePanel = () => {
+    closeEffortMenu();
+    if (panel && retainMountedWrapper) {
+      menuNode?.setAttribute("data-state", "closed");
+      panel.setAttribute("style", "opacity:1; pointer-events:auto");
+    } else {
+      detachPanel();
+    }
     pill.setAttribute("aria-expanded", "false");
     pill.setAttribute("data-state", "closed");
   };
@@ -3368,7 +3422,7 @@ function makePersonalPickerFixture({
     body.append(effortMenu);
   };
   const openPanel = () => {
-    closePanel();
+    detachPanel();
     slider = new FakeElement("span", {
       role: "slider",
       "aria-hidden": "true",
@@ -3397,22 +3451,22 @@ function makePersonalPickerFixture({
       }
     }, `Effort ${currentEffort}`);
     const speedRow = new FakeElement("div", { role: "menuitem" }, "Speed Standard");
-    const menu = new FakeElement("div", {
+    menuNode = new FakeElement("div", {
       role: "menu",
       "data-state": "open",
       style: frozenStyle
     }, pickerText());
-    menu.append(slider, family, effortRow, speedRow);
+    menuNode.append(slider, family, effortRow, speedRow);
     if (wrappedRadix) {
       panel = new FakeElement("div", {
         id: "personal-picker",
         class: "z-50 popover",
         style: frozenStyle
       }, pickerText());
-      panel.append(menu);
+      panel.append(menuNode);
     } else {
-      menu.setAttribute("id", "personal-picker");
-      panel = menu;
+      menuNode.setAttribute("id", "personal-picker");
+      panel = menuNode;
     }
     body.append(panel);
     pill.setAttribute("aria-expanded", "true");
@@ -3437,7 +3491,10 @@ function makePersonalPickerFixture({
     keyAttempts: () => [...keyAttempts],
     sliderValue: () => currentValue,
     effortClicks: () => effortClicks,
-    pickerOpen: () => Boolean(panel)
+    pickerOpen: () => menuNode?.getAttribute("data-state") === "open"
+      || panel?.getAttribute("data-state") === "open",
+    wrapperMounted: () => Boolean(panel),
+    nestedMenuState: () => menuNode?.getAttribute("data-state") ?? null
   };
 }
 


### PR DESCRIPTION
## Summary

Personal ChatGPT Pro composer DOM drifted from the Extra High Advanced slider to a simple Sol + Effort Max picker. Native selection now classifies that shape, verifies Max/Pro/Extra High, and leaves the Faster/Smarter power slider untouched so pinned consults no longer fail with `model_picker_open_failed`.

## Changes

- Recognize `shape=personal` (visible and structurally trusted, including `aria-controls` wrappers whose inner menu is `data-state=open`)
- Fail closed on unknown Effort labels; upgrade High via the Effort row
- Recover copy-scoped sibling markdown used on the same personal profile
- Document Max as a verified personal maximum tier

## Testing

- [x] `node --test extensions/chatgpt-native/tests/*.test.js` (380/380)
- [ ] `cargo test` passes
- [ ] `cargo clippy` passes without warnings
- [ ] `cargo fmt` applied
- [x] New tests added for new functionality

## Release Impact

- [x] This change needs a release entry / next `chore(release): vX.Y.Z`
- [x] This change affects packaged binaries, Homebrew/Scoop, or skill metadata

## Related Issues

Live inspect: `yoetz browser extension inspect --chatgpt --run-id 20260819T182357Z_ab7f86`


Made with [Cursor](https://cursor.com)