### PR TITLE
chore(release): v0.5.56

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.5.55",
+  "version": "0.5.56",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yoetz",
-  "version": "0.5.55",
+  "version": "0.5.56",
   "description": "LLM council, bundler, and multimodal gateway - multi-model consensus, code review, image/video generation, and browser fallback for coding agents",
   "author": {
     "name": "Aviv Sinai",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+## [0.5.56] - 2026-08-19
 ### Fixed
 
 - ChatGPT native-extension model selection now recognizes the personal-profile
@@ -18,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - ChatGPT response extraction now recovers assistant markdown that is a sibling
   of its final copy-action row while retaining assistant-ownership and citation
   guards.
+
 
 ## [0.5.55] - 2026-08-17
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3225,7 +3225,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoetz"
-version = "0.5.55"
+version = "0.5.56"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "yoetz-core"
-version = "0.5.55"
+version = "0.5.56"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/yoetz-core", "crates/yoetz-cli"]
 
 [workspace.package]
-version = "0.5.55"
+version = "0.5.56"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/extensions/chatgpt-native/manifest.json
+++ b/extensions/chatgpt-native/manifest.json
@@ -3,7 +3,7 @@
   "name": "Yoetz Native Transport",
   "short_name": "Yoetz Transport",
   "description": "Yoetz native transport for supported web recipe jobs.",
-  "version": "0.5.55",
+  "version": "0.5.56",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAujviQNA7EjHnfqpn3TM5IfgmHzOnvtu5pXg3Y1rS5koNJBT2PSG7FTGi9wD4oqNLVFehKm5h46vq1u1ACsMjAUrqMMUVvf7RUeqieUmfbtKRmx24N2blfz4b8KYpMlNUhf8IZ5TAFbvzy9NEO2KHAHCV6pP84E4lLBW2OQIDhqJd0FfS3Ecn91pbsH3tcsU6Gu+WiPEHLXZjPj85KcgQ+8qL0Xz83V5hEXIocMlCQ0RnMOfQIp5qUEIKgZ7qKqEjW2czNz48s5Fdgzbv95Lf09vat1NWiDHXZtDPWIa6TRjlKAAXIwsz5A/DJibzWiCgKiuOWmCgQPJgDidoyj/7RQIDAQAB",
   "icons": {
     "16": "icons/icon-16.png",

--- a/skills/yoetz/SKILL.md
+++ b/skills/yoetz/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yoetz
-version: 0.5.55
+version: 0.5.56
 description: >
   Fast CLI-first LLM council, bundler, and multimodal gateway. Use ONLY when user
   explicitly mentions "yoetz", "yoetz ask", "yoetz council", "yoetz review",


### PR DESCRIPTION
## Release

- updates `CHANGELOG.md` for `v0.5.56`
- bumps workspace version to `0.5.56`
- aligns skill/plugin metadata to `0.5.56`
- merge triggers .github/workflows/release.yml, which creates the tag and
  publishes the release
- GitHub release notes come from the committed `CHANGELOG.md` entry